### PR TITLE
Replaced all instances of `better.files.*` functions

### DIFF
--- a/console/src/main/scala/io/joern/console/BridgeBase.scala
+++ b/console/src/main/scala/io/joern/console/BridgeBase.scala
@@ -6,7 +6,7 @@ import io.shiftleft.codepropertygraph.generated.Languages
 import org.apache.commons.text.StringEscapeUtils
 import replpp.scripting.ScriptRunner
 
-import java.nio.file.{Files, Path}
+import java.nio.file.{Files, Path, Paths}
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
 import scala.util.Try
@@ -335,7 +335,7 @@ trait PluginHandling { this: BridgeBase =>
   private def loadOrCreateCpg(config: Config, productName: String): String = {
 
     val bundleName = config.pluginToRun.get
-    val srcRaw     = better.files.File(config.src.get).path.toAbsolutePath.toString
+    val srcRaw     = Paths.get(config.src.get).absolutePathAsString
     val src        = StringEscapeUtils.escapeJava(srcRaw)
     val language   = languageFromConfig(config, src)
 

--- a/console/src/main/scala/io/joern/console/BridgeBase.scala
+++ b/console/src/main/scala/io/joern/console/BridgeBase.scala
@@ -1,8 +1,8 @@
 package io.joern.console
 
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Languages
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.apache.commons.text.StringEscapeUtils
 import replpp.scripting.ScriptRunner
 

--- a/console/src/main/scala/io/joern/console/Console.scala
+++ b/console/src/main/scala/io/joern/console/Console.scala
@@ -1,6 +1,5 @@
 package io.joern.console
 
-import better.files.File
 import dotty.tools.repl.State
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.cpgloading.CpgLoader
@@ -18,11 +17,11 @@ import io.joern.x2cpg.utils.FileUtil
 import io.joern.x2cpg.utils.FileUtil.*
 import io.shiftleft.semanticcpg.utils.ExternalCommand
 
-import java.nio.file.{Paths, StandardCopyOption}
+import java.nio.file.{Files, Path, Paths, StandardCopyOption}
 import scala.util.control.NoStackTrace
 import scala.util.{Failure, Success, Try}
 
-class Console[T <: Project](loader: WorkspaceLoader[T], baseDir: File = File.currentWorkingDirectory)(implicit
+class Console[T <: Project](loader: WorkspaceLoader[T], baseDir: Path = Paths.get(""))(implicit
   availableWidthProvider: AvailableWidthProvider
 ) extends Reporting {
 
@@ -33,7 +32,7 @@ class Console[T <: Project](loader: WorkspaceLoader[T], baseDir: File = File.cur
   def console: Console[T]   = this
 
   protected var workspaceManager: WorkspaceManager[T] = scala.compiletime.uninitialized
-  switchWorkspace(baseDir.path.resolve("workspace").toString)
+  switchWorkspace(baseDir.resolve("workspace").toString)
   protected def workspacePathName: String = workspaceManager.getPath
 
   private val nameOfCpgInProject = "cpg.bin"
@@ -200,7 +199,7 @@ class Console[T <: Project](loader: WorkspaceLoader[T], baseDir: File = File.cur
                  |"""
   )
   def openForInputPath(inputPath: String): Option[Project] = {
-    val absInputPath = File(inputPath).path.toAbsolutePath.toString
+    val absInputPath = Paths.get(inputPath).absolutePathAsString
     workspace.projects
       .filter(x => x.inputPath == absInputPath)
       .map(_.name)
@@ -337,9 +336,9 @@ class Console[T <: Project](loader: WorkspaceLoader[T], baseDir: File = File.cur
   def importCpg(inputPath: String, projectName: String = "", enhance: Boolean = true): Option[Cpg] = {
     val name =
       Option(projectName).filter(_.nonEmpty).getOrElse(deriveNameFromInputPath(inputPath, workspace))
-    val cpgFile = File(inputPath)
+    val cpgFile = Paths.get(inputPath)
 
-    if (!cpgFile.exists) {
+    if (!Files.exists(cpgFile)) {
       report(s"CPG at $inputPath does not exist. Bailing out.")
       return None
     }
@@ -355,13 +354,13 @@ class Console[T <: Project](loader: WorkspaceLoader[T], baseDir: File = File.cur
 
     val cpgDestinationPath = cpgDestinationPathOpt.get
 
-    val isProtoFormat      = CpgLoader.isProtoFormat(cpgFile.path)
-    val isOverflowDbFormat = CpgLoader.isOverflowDbFormat(cpgFile.path)
+    val isProtoFormat      = CpgLoader.isProtoFormat(cpgFile)
+    val isOverflowDbFormat = CpgLoader.isOverflowDbFormat(cpgFile)
     if (isProtoFormat || isOverflowDbFormat) {
       if (isProtoFormat) report("You have provided a legacy proto CPG. Attempting conversion.")
       else if (isOverflowDbFormat) report("You have provided a legacy overflowdb CPG. Attempting conversion.")
       try {
-        val cpg = CpgLoader.load(cpgFile.path, cpgDestinationPath)
+        val cpg = CpgLoader.load(cpgFile, cpgDestinationPath)
         cpg.close()
       } catch {
         case exc: Exception =>
@@ -369,7 +368,7 @@ class Console[T <: Project](loader: WorkspaceLoader[T], baseDir: File = File.cur
           return None
       }
     } else {
-      cpgFile.copyTo(cpgDestinationPath, overwrite = true)
+      cpgFile.copyTo(cpgDestinationPath, StandardCopyOption.REPLACE_EXISTING)
     }
 
     val cpgOpt = open(name).flatMap(_.cpg)
@@ -440,7 +439,8 @@ class Console[T <: Project](loader: WorkspaceLoader[T], baseDir: File = File.cur
       if (projectOpt.get.appliedOverlays.contains(creator.overlayName)) {
         report(s"Overlay ${creator.overlayName} already exists - skipping")
       } else {
-        File(overlayDirName).createDirectories()
+        val overlayDir = Paths.get(overlayDirName)
+        Files.createDirectories(overlayDir)
         runCreator(creator, Some(overlayDirName))
       }
     }
@@ -475,7 +475,7 @@ object Console {
   val nameOfLegacyCpgInProject = "cpg.bin.zip"
 
   def deriveNameFromInputPath[T <: Project](inputPath: String, workspace: WorkspaceManager[T]): String = {
-    val name    = File(inputPath).name
+    val name    = Paths.get(inputPath).fileName
     val project = workspace.project(name)
     if (project.isDefined && project.exists(_.inputPath != inputPath)) {
       var i = 1

--- a/console/src/main/scala/io/joern/console/Console.scala
+++ b/console/src/main/scala/io/joern/console/Console.scala
@@ -13,9 +13,8 @@ import io.shiftleft.semanticcpg.language.dotextension.ImageViewer
 import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext}
 import io.shiftleft.codepropertygraph.generated.help.Doc
 import flatgraph.help.Table.AvailableWidthProvider
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
-import io.shiftleft.semanticcpg.utils.ExternalCommand
+import io.shiftleft.semanticcpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.{ExternalCommand, FileUtil}
 
 import java.nio.file.{Files, Path, Paths, StandardCopyOption}
 import scala.util.control.NoStackTrace

--- a/console/src/main/scala/io/joern/console/Console.scala
+++ b/console/src/main/scala/io/joern/console/Console.scala
@@ -21,7 +21,7 @@ import java.nio.file.{Files, Path, Paths, StandardCopyOption}
 import scala.util.control.NoStackTrace
 import scala.util.{Failure, Success, Try}
 
-class Console[T <: Project](loader: WorkspaceLoader[T], baseDir: Path = Paths.get(""))(implicit
+class Console[T <: Project](loader: WorkspaceLoader[T], baseDir: Path = FileUtil.currentWorkingDirectory)(implicit
   availableWidthProvider: AvailableWidthProvider
 ) extends Reporting {
 

--- a/console/src/main/scala/io/joern/console/ConsoleConfig.scala
+++ b/console/src/main/scala/io/joern/console/ConsoleConfig.scala
@@ -1,7 +1,7 @@
 package io.joern.console
 
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 
 import java.nio.file.{Path, Paths}
 import scala.annotation.tailrec

--- a/console/src/main/scala/io/joern/console/ConsoleConfig.scala
+++ b/console/src/main/scala/io/joern/console/ConsoleConfig.scala
@@ -1,7 +1,8 @@
 package io.joern.console
 
-import better.files.*
+import io.joern.x2cpg.utils.FileUtil.*
 
+import java.nio.file.{Path, Paths}
 import scala.annotation.tailrec
 import scala.collection.mutable
 
@@ -20,14 +21,14 @@ class InstallConfig(environment: Map[String, String] = sys.env) {
     *     joern-cli/target/universal/stage; ./joern`)
     *   - running a unit/integration test (note: the jars would be in the local cache, e.g. in ~/.coursier/cache)
     */
-  lazy val rootPath: File = {
+  lazy val rootPath: Path = {
     if (environment.contains("SHIFTLEFT_OCULAR_INSTALL_DIR")) {
-      environment("SHIFTLEFT_OCULAR_INSTALL_DIR").toFile
+      Paths.get(environment("SHIFTLEFT_OCULAR_INSTALL_DIR"))
     } else {
       val uriToLibDir  = classOf[io.joern.console.InstallConfig].getProtectionDomain.getCodeSource.getLocation.toURI
-      val pathToLibDir = File(uriToLibDir).parent
+      val pathToLibDir = Paths.get(uriToLibDir).getParent
       findRootDirectory(pathToLibDir).getOrElse {
-        val cwd = File.currentWorkingDirectory
+        val cwd = Paths.get("")
         findRootDirectory(cwd).getOrElse(throw new AssertionError(s"""unable to find root installation directory
                                    | context: tried to find marker file `$rootDirectoryMarkerFilename`
                                    | started search in both $pathToLibDir and $cwd and searched 
@@ -40,11 +41,11 @@ class InstallConfig(environment: Map[String, String] = sys.env) {
   private val maxSearchDepth              = 10
 
   @tailrec
-  private def findRootDirectory(currentSearchDir: File, currentSearchDepth: Int = 0): Option[File] = {
-    if (currentSearchDir.list.map(_.name).contains(rootDirectoryMarkerFilename))
+  private def findRootDirectory(currentSearchDir: Path, currentSearchDepth: Int = 0): Option[Path] = {
+    if (currentSearchDir.listFiles().map(_.fileName).contains(rootDirectoryMarkerFilename))
       Some(currentSearchDir)
     else if (currentSearchDepth < maxSearchDepth && currentSearchDir.parentOption.isDefined)
-      findRootDirectory(currentSearchDir.parent)
+      findRootDirectory(currentSearchDir.getParent)
     else
       None
   }

--- a/console/src/main/scala/io/joern/console/ConsoleConfig.scala
+++ b/console/src/main/scala/io/joern/console/ConsoleConfig.scala
@@ -1,5 +1,6 @@
 package io.joern.console
 
+import io.joern.x2cpg.utils.FileUtil
 import io.joern.x2cpg.utils.FileUtil.*
 
 import java.nio.file.{Path, Paths}
@@ -28,7 +29,7 @@ class InstallConfig(environment: Map[String, String] = sys.env) {
       val uriToLibDir  = classOf[io.joern.console.InstallConfig].getProtectionDomain.getCodeSource.getLocation.toURI
       val pathToLibDir = Paths.get(uriToLibDir).getParent
       findRootDirectory(pathToLibDir).getOrElse {
-        val cwd = Paths.get("")
+        val cwd = FileUtil.currentWorkingDirectory
         findRootDirectory(cwd).getOrElse(throw new AssertionError(s"""unable to find root installation directory
                                    | context: tried to find marker file `$rootDirectoryMarkerFilename`
                                    | started search in both $pathToLibDir and $cwd and searched 

--- a/console/src/main/scala/io/joern/console/PluginManager.scala
+++ b/console/src/main/scala/io/joern/console/PluginManager.scala
@@ -1,7 +1,7 @@
 package io.joern.console
 
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 
 import java.nio.file.{Path, Paths, Files}
 import scala.util.{Failure, Success, Try}

--- a/console/src/main/scala/io/joern/console/cpgcreation/CpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/CpgGenerator.scala
@@ -1,8 +1,9 @@
 package io.joern.console.cpgcreation
 
-import better.files.File
 import io.shiftleft.semanticcpg.utils.ExternalCommand
 import io.shiftleft.codepropertygraph.generated.Cpg
+
+import java.nio.file.{Files, Paths}
 import scala.util.Try
 
 /** A CpgGenerator generates Code Property Graphs from code. Each supported language implements a Generator, e.g.,
@@ -26,7 +27,7 @@ abstract class CpgGenerator() {
 
   protected def runShellCommand(program: String, arguments: Seq[String]): Try[Unit] =
     Try {
-      assert(File(program).exists, s"CPG generator does not exist at: $program")
+      assert(Files.exists(Paths.get(program)), s"CPG generator does not exist at: $program")
 
       val cmd       = Seq(program) ++ maxMemoryParameter ++ arguments
       val cmdString = cmd.mkString(" ")

--- a/console/src/main/scala/io/joern/console/cpgcreation/CpgGeneratorFactory.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/CpgGeneratorFactory.scala
@@ -1,10 +1,10 @@
 package io.joern.console.cpgcreation
 
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.cpgloading.CpgLoader
 import io.shiftleft.codepropertygraph.generated.Languages
 import io.joern.console.{ConsoleConfig, CpgConverter}
-import io.joern.x2cpg.utils.FileUtil
+import io.shiftleft.semanticcpg.utils.FileUtil
 
 import java.nio.file.{Files, Path, Paths, StandardCopyOption}
 import scala.util.Try

--- a/console/src/main/scala/io/joern/console/cpgcreation/CpgGeneratorFactory.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/CpgGeneratorFactory.scala
@@ -1,12 +1,12 @@
 package io.joern.console.cpgcreation
 
-import better.files.Dsl.*
-import better.files.File
+import io.joern.x2cpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.cpgloading.CpgLoader
 import io.shiftleft.codepropertygraph.generated.Languages
 import io.joern.console.{ConsoleConfig, CpgConverter}
+import io.joern.x2cpg.utils.FileUtil
 
-import java.nio.file.Path
+import java.nio.file.{Files, Path, Paths, StandardCopyOption}
 import scala.util.Try
 
 object CpgGeneratorFactory {
@@ -36,7 +36,7 @@ class CpgGeneratorFactory(config: ConsoleConfig) {
   def forCodeAt(inputPath: String): Option[CpgGenerator] =
     for {
       language     <- guessLanguage(inputPath)
-      cpgGenerator <- cpgGeneratorForLanguage(language, config.frontend, config.install.rootPath.path, args = Nil)
+      cpgGenerator <- cpgGeneratorForLanguage(language, config.frontend, config.install.rootPath, args = Nil)
     } yield {
       report(s"Using generator for language: $language: ${cpgGenerator.getClass.getSimpleName}")
       cpgGenerator
@@ -48,20 +48,20 @@ class CpgGeneratorFactory(config: ConsoleConfig) {
     Option(language)
       .filter(languageIsKnown)
       .flatMap { lang =>
-        cpgGeneratorForLanguage(lang, config.frontend, config.install.rootPath.path, args = Nil)
+        cpgGeneratorForLanguage(lang, config.frontend, config.install.rootPath, args = Nil)
       }
   }
 
   def languageIsKnown(language: String): Boolean = CpgGeneratorFactory.KNOWN_LANGUAGES.contains(language)
 
   def runGenerator(generator: CpgGenerator, inputPath: String, outputPath: String): Try[Path] = {
-    val outputFileOpt: Try[File] =
-      generator.generate(inputPath, outputPath).map(File(_))
+    val outputFileOpt: Try[Path] =
+      generator.generate(inputPath, outputPath).map(Paths.get(_))
     outputFileOpt.map { outFile =>
-      val parentPath = outFile.parent.path.toAbsolutePath
-      if (CpgLoader.isProtoFormat(outFile.path)) {
+      val parentPath = outFile.getParent.toAbsolutePath
+      if (CpgLoader.isProtoFormat(outFile)) {
         report("Creating database from bin.zip")
-        val srcFilename = outFile.path.toAbsolutePath.toString
+        val srcFilename = outFile.absolutePathAsString
         val dstFilename = parentPath.resolve("cpg.bin").toAbsolutePath.toString
         // MemoryHelper.hintForInsufficientMemory(srcFilename).map(report)
         convertProtoCpgToFlatgraph(srcFilename, dstFilename)
@@ -69,7 +69,12 @@ class CpgGeneratorFactory(config: ConsoleConfig) {
         report("moving cpg.bin.zip to cpg.bin because it is already a database file")
         val srcPath = parentPath.resolve("cpg.bin.zip")
         if (srcPath.toFile.exists()) {
-          mv(srcPath, parentPath.resolve("cpg.bin"))
+          val cpgBinPath = parentPath.resolve("cpg.bin")
+          if (Files.isDirectory(cpgBinPath)) {
+            Files.move(srcPath, cpgBinPath)
+          } else {
+            Files.move(srcPath, cpgBinPath, StandardCopyOption.REPLACE_EXISTING)
+          }
         }
       }
       parentPath
@@ -82,7 +87,7 @@ class CpgGeneratorFactory(config: ConsoleConfig) {
 
   def convertProtoCpgToFlatgraph(srcFilename: String, dstFilename: String): Unit = {
     CpgConverter.convertProtoCpgToFlatgraph(srcFilename, dstFilename)
-    File(srcFilename).delete()
+    FileUtil.delete(Paths.get(srcFilename))
   }
 
   private def report(str: String): Unit = System.err.println(str)

--- a/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
@@ -105,7 +105,7 @@ class ImportCode[T <: Project](console: io.joern.console.Console[T])(implicit
       io.joern.console.cpgcreation.cpgGeneratorForLanguage(language, config, rootPath, args)
 
     def isAvailable: Boolean =
-      cpgGeneratorForLanguage(language, config.frontend, config.install.rootPath.path, args = Nil).exists(_.isAvailable)
+      cpgGeneratorForLanguage(language, config.frontend, config.install.rootPath, args = Nil).exists(_.isAvailable)
 
     protected def fromFile(inputPath: String, projectName: String = "", args: List[String] = List()): Cpg = {
       checkInputPath(inputPath)
@@ -122,7 +122,7 @@ class ImportCode[T <: Project](console: io.joern.console.Console[T])(implicit
     }
 
     def apply(inputPath: String, projectName: String = "", args: List[String] = List()): Cpg = {
-      val frontend = cpgGeneratorForLanguage(language, config.frontend, config.install.rootPath.path, args)
+      val frontend = cpgGeneratorForLanguage(language, config.frontend, config.install.rootPath, args)
         .getOrElse(throw new ConsoleException(s"no cpg generator for language=$language available!"))
       new ImportCode(console).apply(frontend, inputPath, projectName)
     }

--- a/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
@@ -6,9 +6,8 @@ import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.Languages
 import flatgraph.help.Table
 import flatgraph.help.Table.AvailableWidthProvider
-
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 
 import java.nio.file.{Path, Files, Paths}
 

--- a/console/src/main/scala/io/joern/console/cpgcreation/JsSrcCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/JsSrcCpgGenerator.scala
@@ -3,7 +3,7 @@ package io.joern.console.cpgcreation
 import io.joern.console.FrontendConfig
 import io.joern.x2cpg.frontendspecific.jssrc2cpg
 import io.joern.x2cpg.passes.frontend.XTypeRecoveryConfig
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Cpg
 
 import java.nio.file.{Files, Path, Paths}

--- a/console/src/main/scala/io/joern/console/cpgcreation/SwiftSrcCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/SwiftSrcCpgGenerator.scala
@@ -3,7 +3,7 @@ package io.joern.console.cpgcreation
 import io.joern.console.FrontendConfig
 import io.joern.x2cpg.frontendspecific.swiftsrc2cpg
 import io.joern.x2cpg.passes.frontend.XTypeRecoveryConfig
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Cpg
 
 import java.nio.file.{Path, Paths, Files}

--- a/console/src/main/scala/io/joern/console/cpgcreation/SwiftSrcCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/SwiftSrcCpgGenerator.scala
@@ -1,6 +1,5 @@
 package io.joern.console.cpgcreation
 
-import better.files.File
 import io.joern.console.FrontendConfig
 import io.joern.x2cpg.frontendspecific.swiftsrc2cpg
 import io.joern.x2cpg.passes.frontend.XTypeRecoveryConfig
@@ -34,7 +33,7 @@ case class SwiftSrcCpgGenerator(config: FrontendConfig, rootPath: Path) extends 
   }
 
   override def isAvailable: Boolean =
-    command.toFile.exists
+    Files.exists(command)
 
   override def applyPostProcessingPasses(cpg: Cpg): Cpg = {
     swiftsrc2cpg.postProcessingPasses(cpg, typeRecoveryConfig).foreach(_.createAndApply())

--- a/console/src/main/scala/io/joern/console/cpgcreation/package.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/package.scala
@@ -1,8 +1,8 @@
 package io.joern.console
 
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Languages
+import io.shiftleft.semanticcpg.utils.FileUtil
 
 import java.nio.file.{Path, Paths, Files}
 import scala.collection.mutable

--- a/console/src/main/scala/io/joern/console/cpgcreation/package.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/package.scala
@@ -1,6 +1,5 @@
 package io.joern.console
 
-import better.files.File as BetterFile
 import io.joern.x2cpg.utils.FileUtil
 import io.joern.x2cpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Languages
@@ -46,8 +45,8 @@ package object cpgcreation {
   /** Heuristically determines language by inspecting file/dir at path.
     */
   def guessLanguage(path: String): Option[String] = {
-    val file = BetterFile(path)
-    if (file.isDirectory) {
+    val file = Paths.get(path)
+    if (Files.isDirectory(file)) {
       guessMajorityLanguageInDir(file)
     } else {
       guessLanguageForRegularFile(file)
@@ -58,13 +57,13 @@ package object cpgcreation {
     * files. Rationale: many projects contain files from different languages, but most often one language is standing
     * out in numbers.
     */
-  private def guessMajorityLanguageInDir(directory: BetterFile): Option[String] = {
-    assert(directory.isDirectory, s"$directory must be a directory, but wasn't")
+  private def guessMajorityLanguageInDir(directory: Path): Option[String] = {
+    assert(Files.isDirectory(directory), s"$directory must be a directory, but wasn't")
     val groupCount = mutable.Map.empty[String, Int].withDefaultValue(0)
 
     for {
-      file <- directory.listRecursively
-      if file.isRegularFile
+      file <- directory.walk().filterNot(_ == directory)
+      if Files.isRegularFile(file)
       guessedLanguage <- guessLanguageForRegularFile(file)
     } {
       val oldValue = groupCount(guessedLanguage)
@@ -95,8 +94,8 @@ package object cpgcreation {
   private def isCFile(filename: String): Boolean =
     Seq(".c", ".cc", ".cpp", ".h", ".hpp", ".hh").exists(filename.endsWith)
 
-  private def guessLanguageForRegularFile(file: BetterFile): Option[String] = {
-    file.name.toLowerCase match {
+  private def guessLanguageForRegularFile(file: Path): Option[String] = {
+    file.fileName.toLowerCase match {
       case f if isJavaBinary(f)      => Some(Languages.JAVA)
       case f if isCsharpFile(f)      => Some(Languages.CSHARPSRC)
       case f if isGoFile(f)          => Some(Languages.GOLANG)

--- a/console/src/main/scala/io/joern/console/workspacehandling/Project.scala
+++ b/console/src/main/scala/io/joern/console/workspacehandling/Project.scala
@@ -1,12 +1,11 @@
 package io.joern.console.workspacehandling
 
-import better.files.Dsl.*
-import better.files.File
 import io.joern.x2cpg.utils.FileUtil
+import io.joern.x2cpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.semanticcpg.Overlays
 
-import java.nio.file.Path
+import java.nio.file.{Path, Paths}
 
 object Project {
   val workCpgFileName       = "cpg.bin.tmp"
@@ -35,11 +34,11 @@ case class Project(projectFile: ProjectFile, var path: Path, var cpg: Option[Cpg
   }
 
   def availableOverlays: List[String] = {
-    File(path.resolve("overlays")).list.map(_.name).toList
+    path.resolve("overlays").listFiles().map(_.fileName).toList
   }
 
-  def overlayDirs: Seq[File] = {
-    val overlayDir = File(path.resolve("overlays"))
+  def overlayDirs: Seq[Path] = {
+    val overlayDir = path.resolve("overlays")
     appliedOverlays.map(o => overlayDir / o)
   }
 

--- a/console/src/main/scala/io/joern/console/workspacehandling/Project.scala
+++ b/console/src/main/scala/io/joern/console/workspacehandling/Project.scala
@@ -1,9 +1,9 @@
 package io.joern.console.workspacehandling
 
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.semanticcpg.Overlays
+import io.shiftleft.semanticcpg.utils.FileUtil
 
 import java.nio.file.{Path, Paths}
 

--- a/console/src/main/scala/io/joern/console/workspacehandling/WorkspaceLoader.scala
+++ b/console/src/main/scala/io/joern/console/workspacehandling/WorkspaceLoader.scala
@@ -1,10 +1,8 @@
 package io.joern.console.workspacehandling
 
-import better.files.Dsl.mkdirs
-import better.files.File
 import flatgraph.help.Table.AvailableWidthProvider
 
-import java.nio.file.Path
+import java.nio.file.{Files, Path, Paths}
 import scala.collection.mutable.ListBuffer
 import scala.util.{Failure, Success, Try}
 
@@ -17,10 +15,11 @@ abstract class WorkspaceLoader[ProjectType <: Project](implicit availableWidthPr
     *   path to the directory
     */
   def load(path: String): Workspace[ProjectType] = {
-    val dirFile = File(path)
-    val dirPath = dirFile.path.toAbsolutePath
+    val dirFile = Paths.get(path)
+    val dirPath = dirFile.toAbsolutePath
 
-    mkdirs(dirFile)
+    Files.createDirectories(Paths.get(path))
+
     new Workspace(ListBuffer.from(loadProjectsFromFs(dirPath)))
   }
 

--- a/console/src/main/scala/io/joern/console/workspacehandling/WorkspaceManager.scala
+++ b/console/src/main/scala/io/joern/console/workspacehandling/WorkspaceManager.scala
@@ -335,7 +335,7 @@ class WorkspaceManager[ProjectType <: Project](path: String, loader: WorkspaceLo
   }
 
   private def unloadCpgIfExists(name: String): Unit = {
-    projectByName(projectDir(name).getFileName.toString)
+    projectByName(projectDir(name).fileName)
       .flatMap(_.cpg)
       .foreach { c =>
         try {
@@ -409,9 +409,9 @@ object WorkspaceManager {
     Paths
       .get(dirName)
       .listFiles()
-      .filter(f => Files.isRegularFile(f) && f.getFileName.toString != BASE_CPG_FILENAME)
+      .filter(f => Files.isRegularFile(f) && f.fileName != BASE_CPG_FILENAME)
       .toList
-      .sortBy(_.getFileName.toString)
+      .sortBy(_.fileName)
   }
 
 }

--- a/console/src/main/scala/io/joern/console/workspacehandling/WorkspaceManager.scala
+++ b/console/src/main/scala/io/joern/console/workspacehandling/WorkspaceManager.scala
@@ -3,10 +3,10 @@ package io.joern.console.workspacehandling
 import io.joern.console
 import io.joern.console.defaultAvailableWidthProvider
 import io.joern.console.Reporting
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.cpgloading.CpgLoader
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.json4s.DefaultFormats
 import org.json4s.native.Serialization.write as jsonWrite
 

--- a/console/src/test/scala/io/joern/console/ConsoleConfigTest.scala
+++ b/console/src/test/scala/io/joern/console/ConsoleConfigTest.scala
@@ -10,7 +10,7 @@ class ConsoleConfigTest extends AnyWordSpec with Matchers {
   "An InstallConfig" should {
     "set the rootPath to directory containing `.installation_root` by default" in {
       val config = new InstallConfig(environment = Map.empty)
-      config.rootPath shouldBe ProjectRoot.find
+      config.rootPath shouldBe ProjectRoot.find.path
     }
 
     "set the rootPath to SHIFTLEFT_OCULAR_INSTALL_DIR if it is defined" in {

--- a/console/src/test/scala/io/joern/console/ConsoleConfigTest.scala
+++ b/console/src/test/scala/io/joern/console/ConsoleConfigTest.scala
@@ -1,9 +1,10 @@
 package io.joern.console
 
-import better.files.File
 import io.shiftleft.utils.ProjectRoot
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import java.nio.file.Paths
 
 class ConsoleConfigTest extends AnyWordSpec with Matchers {
   "An InstallConfig" should {
@@ -14,7 +15,7 @@ class ConsoleConfigTest extends AnyWordSpec with Matchers {
 
     "set the rootPath to SHIFTLEFT_OCULAR_INSTALL_DIR if it is defined" in {
       val config = new InstallConfig(environment = Map("SHIFTLEFT_OCULAR_INSTALL_DIR" -> "/tmp"))
-      config.rootPath shouldBe File("/tmp")
+      config.rootPath shouldBe Paths.get("/tmp")
     }
 
     "copy config with params correctly" in {

--- a/console/src/test/scala/io/joern/console/ConsoleTests.scala
+++ b/console/src/test/scala/io/joern/console/ConsoleTests.scala
@@ -6,11 +6,11 @@ import io.joern.x2cpg.layers.Base
 import io.joern.x2cpg.layers.CallGraph
 import io.joern.x2cpg.layers.ControlFlow
 import io.joern.x2cpg.layers.TypeRelations
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.layers.LayerCreator
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.Ignore

--- a/console/src/test/scala/io/joern/console/ConsoleTests.scala
+++ b/console/src/test/scala/io/joern/console/ConsoleTests.scala
@@ -1,6 +1,5 @@
 package io.joern.console
 
-import better.files.File
 import io.joern.console.testing.*
 import io.joern.x2cpg.X2Cpg.defaultOverlayCreators
 import io.joern.x2cpg.layers.{Base, CallGraph, ControlFlow, TypeRelations}
@@ -385,7 +384,7 @@ class ConsoleTests extends AnyWordSpec with Matchers {
       overlayDirs.foreach { dir =>
         Files.isDirectory(Paths.get(dir.getPath)) shouldBe true
         Paths.get(dir.getPath).listFiles().foreach { file =>
-          Try { file.getFileName.toString.split("_").head.toInt }.isSuccess shouldBe true
+          Try { file.fileName.split("_").head.toInt }.isSuccess shouldBe true
           isZipFile(file) shouldBe true
         }
       }

--- a/console/src/test/scala/io/joern/console/LanguageHelperTests.scala
+++ b/console/src/test/scala/io/joern/console/LanguageHelperTests.scala
@@ -2,8 +2,8 @@ package io.joern.console
 
 import io.shiftleft.codepropertygraph.generated.Languages
 import io.joern.console.cpgcreation.{LlvmCpgGenerator, guessLanguage}
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/console/src/test/scala/io/joern/console/PluginManagerTests.scala
+++ b/console/src/test/scala/io/joern/console/PluginManagerTests.scala
@@ -1,6 +1,5 @@
 package io.joern.console
 
-import better.files.*
 import io.shiftleft.utils.ProjectRoot
 import io.joern.x2cpg.utils.FileUtil
 import io.joern.x2cpg.utils.FileUtil.*
@@ -9,8 +8,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.Ignore
 import org.scalatest.Tag
 
-import java.nio.file.Files
-
+import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
 import java.nio.file.attribute.PosixFilePermission
 
@@ -52,10 +50,10 @@ class PluginManagerTests extends AnyWordSpec with Matchers {
     "remove existing plugin" taggedAs OnlyUnderUnix in Fixture() { manager =>
       val testZipFileName = ProjectRoot.relativise("console/src/test/resources/test.zip")
       manager.add(testZipFileName)
-      manager.rm("test").map(x => File(x).name).toSet shouldBe Set("joernext-test-foo.jar")
+      manager.rm("test").map(x => Paths.get(x).fileName).toSet shouldBe Set("joernext-test-foo.jar")
       manager.listPlugins() shouldBe List()
       manager.add(testZipFileName)
-      manager.rm("test").map(x => File(x).name).toSet shouldBe Set("joernext-test-foo.jar")
+      manager.rm("test").map(x => Paths.get(x).fileName).toSet shouldBe Set("joernext-test-foo.jar")
       manager.listPlugins() shouldBe List()
     }
 
@@ -89,7 +87,7 @@ object Fixture {
     Files.writeString(extender, extenderContents)
     Files.setPosixFilePermissions(extender, Set(PosixFilePermission.OWNER_EXECUTE).asJava)
 
-    val result = f(new PluginManager(File(dir)))
+    val result = f(new PluginManager(dir))
     FileUtil.delete(dir)
     result
   }

--- a/console/src/test/scala/io/joern/console/PluginManagerTests.scala
+++ b/console/src/test/scala/io/joern/console/PluginManagerTests.scala
@@ -1,8 +1,8 @@
 package io.joern.console
 
 import io.shiftleft.utils.ProjectRoot
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.Ignore

--- a/console/src/test/scala/io/joern/console/testing/ConsoleFixture.scala
+++ b/console/src/test/scala/io/joern/console/testing/ConsoleFixture.scala
@@ -5,9 +5,9 @@ import io.joern.console.workspacehandling.{Project, ProjectFile, WorkspaceLoader
 import io.joern.console.{Console, ConsoleConfig, FrontendConfig, InstallConfig}
 import io.joern.console.cpgcreation.{JsSrcCpgGenerator, SwiftSrcCpgGenerator}
 import io.joern.console.cpgcreation.guessLanguage
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Languages
+import io.shiftleft.semanticcpg.utils.FileUtil
 import io.shiftleft.utils.ProjectRoot
 
 import java.nio.file.{Files, Path, Paths}

--- a/console/src/test/scala/io/joern/console/testing/package.scala
+++ b/console/src/test/scala/io/joern/console/testing/package.scala
@@ -2,7 +2,7 @@ package io.joern.console
 
 import io.joern.console.workspacehandling.Project
 import flatgraph.help.Table.{AvailableWidthProvider, ConstantWidth}
-import io.joern.x2cpg.utils.FileUtil
+import io.shiftleft.semanticcpg.utils.FileUtil
 
 import java.nio.file.Path
 import scala.util.Try

--- a/console/src/test/scala/io/joern/console/workspacehandling/WorkspaceLoaderTests.scala
+++ b/console/src/test/scala/io/joern/console/workspacehandling/WorkspaceLoaderTests.scala
@@ -1,7 +1,7 @@
 package io.joern.console.workspacehandling
 
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 
 import java.nio.file.Files
 import org.scalatest.matchers.should.Matchers

--- a/console/src/test/scala/io/joern/console/workspacehandling/WorkspaceManagerTests.scala
+++ b/console/src/test/scala/io/joern/console/workspacehandling/WorkspaceManagerTests.scala
@@ -1,8 +1,8 @@
 package io.joern.console.workspacehandling
 
 import io.shiftleft.codepropertygraph.generated.Cpg
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/console/src/test/scala/io/joern/console/workspacehandling/WorkspaceManagerTests.scala
+++ b/console/src/test/scala/io/joern/console/workspacehandling/WorkspaceManagerTests.scala
@@ -35,7 +35,7 @@ class WorkspaceManagerTests extends AnyWordSpec with Matchers {
         val project       = pathToProject.flatMap(TestLoader().loadProject(_)).get
         FileUtil.delete(inputFile1)
         FileUtil.delete(inputFile2)
-        Paths.get(project.inputPath).getFileName.toString shouldBe inputFile2.getFileName.toString
+        Paths.get(project.inputPath).fileName shouldBe inputFile2.fileName
         manager.numberOfProjects shouldBe 1
       }
     }

--- a/console/src/test/scala/io/joern/console/workspacehandling/WorkspaceTests.scala
+++ b/console/src/test/scala/io/joern/console/workspacehandling/WorkspaceTests.scala
@@ -1,9 +1,9 @@
 package io.joern.console.workspacehandling
 
 import io.joern.console.testing.availableWidthProvider
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.semanticcpg.testing.MockCpg
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/console/src/test/scala/io/joern/console/workspacehandling/WorkspaceTests.scala
+++ b/console/src/test/scala/io/joern/console/workspacehandling/WorkspaceTests.scala
@@ -1,7 +1,5 @@
 package io.joern.console.workspacehandling
 
-import better.files.Dsl.*
-import better.files.File
 import io.joern.console.testing.availableWidthProvider
 import io.joern.x2cpg.utils.FileUtil
 import io.joern.x2cpg.utils.FileUtil.*
@@ -25,13 +23,13 @@ class WorkspaceTests extends AnyWordSpec with Matchers {
       FileUtil.usingTemporaryDirectory("project") { project =>
         Files.createDirectory(project / "overlays")
         val inputPath   = "/input/path"
-        val projectFile = ProjectFile(inputPath, project.getFileName.toString)
+        val projectFile = ProjectFile(inputPath, project.fileName)
         val cpg         = MockCpg().withMetaData("C", List("foo", "bar")).cpg
         val projects    = ListBuffer(Project(projectFile, project, Some(cpg)))
         val workspace   = new Workspace(projects)
         val output      = workspace.toString
 
-        output should include(project.getFileName.toString)
+        output should include(project.fileName)
         output should include(inputPath)
 
         // This relies on the file system and only works in a staged joern environment, not our workspace
@@ -46,7 +44,7 @@ class WorkspaceTests extends AnyWordSpec with Matchers {
 
 object WorkspaceTests {
 
-  def createFakeProject(workspaceFile: Path, projectName: String): File = {
+  def createFakeProject(workspaceFile: Path, projectName: String): Path = {
     Files.createDirectory(workspaceFile / projectName)
     Files.createDirectory(workspaceFile / projectName / "overlays")
 

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/layers/dataflows/DumpCpg14.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/layers/dataflows/DumpCpg14.scala
@@ -1,11 +1,13 @@
 package io.joern.dataflowengineoss.layers.dataflows
 
-import better.files.File
+import io.joern.x2cpg.utils.FileUtil.*
 import io.joern.dataflowengineoss.DefaultSemantics
 import io.joern.dataflowengineoss.language.*
 import io.joern.dataflowengineoss.semanticsloader.Semantics
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext, LayerCreatorOptions}
+
+import java.nio.file.{Files, Paths}
 
 case class Cpg14DumpOptions(var outDir: String) extends LayerCreatorOptions {}
 
@@ -26,8 +28,9 @@ class DumpCpg14(options: Cpg14DumpOptions)(implicit semantics: Semantics = Defau
   override def create(context: LayerCreatorContext): Unit = {
     val cpg = context.cpg
     cpg.method.zipWithIndex.foreach { case (method, i) =>
-      val str = method.dotCpg14.head
-      (File(options.outDir) / s"$i-cpg.dot").write(str)
+      val str        = method.dotCpg14.head
+      val outputPath = Paths.get(options.outDir) / s"$i-cpg.dot"
+      Files.writeString(outputPath, str)
     }
   }
 }

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/layers/dataflows/DumpCpg14.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/layers/dataflows/DumpCpg14.scala
@@ -1,6 +1,6 @@
 package io.joern.dataflowengineoss.layers.dataflows
 
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.joern.dataflowengineoss.DefaultSemantics
 import io.joern.dataflowengineoss.language.*
 import io.joern.dataflowengineoss.semanticsloader.Semantics

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/layers/dataflows/DumpDdg.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/layers/dataflows/DumpDdg.scala
@@ -1,11 +1,13 @@
 package io.joern.dataflowengineoss.layers.dataflows
 
-import better.files.File
+import io.joern.x2cpg.utils.FileUtil.*
 import io.joern.dataflowengineoss.DefaultSemantics
 import io.joern.dataflowengineoss.language.*
 import io.joern.dataflowengineoss.semanticsloader.Semantics
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext, LayerCreatorOptions}
+
+import java.nio.file.{Files, Paths}
 
 case class DdgDumpOptions(var outDir: String) extends LayerCreatorOptions {}
 
@@ -26,8 +28,9 @@ class DumpDdg(options: DdgDumpOptions)(implicit semantics: Semantics = DefaultSe
   override def create(context: LayerCreatorContext): Unit = {
     val cpg = context.cpg
     cpg.method.zipWithIndex.foreach { case (method, i) =>
-      val str = method.dotDdg.head
-      (File(options.outDir) / s"$i-ddg.dot").write(str)
+      val str        = method.dotDdg.head
+      val outputPath = Paths.get(options.outDir) / s"$i-ddg.dot"
+      Files.writeString(outputPath, str)
     }
   }
 }

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/layers/dataflows/DumpDdg.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/layers/dataflows/DumpDdg.scala
@@ -1,6 +1,6 @@
 package io.joern.dataflowengineoss.layers.dataflows
 
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.joern.dataflowengineoss.DefaultSemantics
 import io.joern.dataflowengineoss.language.*
 import io.joern.dataflowengineoss.semanticsloader.Semantics

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/layers/dataflows/DumpPdg.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/layers/dataflows/DumpPdg.scala
@@ -1,11 +1,14 @@
 package io.joern.dataflowengineoss.layers.dataflows
 
-import better.files.File
+import io.joern.x2cpg.utils.FileUtil
+import io.joern.x2cpg.utils.FileUtil.*
 import io.joern.dataflowengineoss.DefaultSemantics
 import io.joern.dataflowengineoss.language.*
 import io.joern.dataflowengineoss.semanticsloader.Semantics
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext, LayerCreatorOptions}
+
+import java.nio.file.{Files, Paths}
 
 case class PdgDumpOptions(var outDir: String) extends LayerCreatorOptions {}
 
@@ -26,8 +29,9 @@ class DumpPdg(options: PdgDumpOptions)(implicit semantics: Semantics = DefaultSe
   override def create(context: LayerCreatorContext): Unit = {
     val cpg = context.cpg
     cpg.method.zipWithIndex.foreach { case (method, i) =>
-      val str = method.dotPdg.head
-      (File(options.outDir) / s"$i-pdg.dot").write(str)
+      val str        = method.dotPdg.head
+      val outputPath = Paths.get(options.outDir) / s"$i-pdg.dot"
+      Files.writeString(outputPath, str)
     }
   }
 }

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/layers/dataflows/DumpPdg.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/layers/dataflows/DumpPdg.scala
@@ -1,12 +1,12 @@
 package io.joern.dataflowengineoss.layers.dataflows
 
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.joern.dataflowengineoss.DefaultSemantics
 import io.joern.dataflowengineoss.language.*
 import io.joern.dataflowengineoss.semanticsloader.Semantics
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext, LayerCreatorOptions}
+import io.shiftleft.semanticcpg.utils.FileUtil
 
 import java.nio.file.{Files, Paths}
 

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/slicing/UsageSlicing.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/slicing/UsageSlicing.scala
@@ -7,6 +7,7 @@ import io.shiftleft.codepropertygraph.generated.{Operators, Properties}
 import io.shiftleft.semanticcpg.language.*
 import org.slf4j.LoggerFactory
 
+import java.nio.file.{Files, Paths}
 import java.util.concurrent.*
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.regex.Pattern
@@ -71,7 +72,7 @@ object UsageSlicing {
       .map { case (method, slices) =>
         MethodUsageSlice(
           code =
-            if (config.excludeMethodSource || !better.files.File(method.filename).exists) ""
+            if (config.excludeMethodSource || !Files.exists(Paths.get(method.filename))) ""
             else Try(dump(method.location, language, root, highlight = false, withArrow = false)).getOrElse(""),
           fullName = method.fullName,
           fileName = method.filename,

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/slicing/package.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/slicing/package.scala
@@ -1,6 +1,5 @@
 package io.joern.dataflowengineoss
 
-import better.files.File
 import io.shiftleft.codepropertygraph.generated.Properties
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.*
@@ -10,13 +9,15 @@ import upickle.default.*
 import java.util.concurrent.{ExecutorService, Executors}
 import java.util.regex.Pattern
 
+import java.nio.file.{Files, Path, Paths}
+
 package object slicing {
 
   trait BaseConfig[T <: BaseConfig[T]] {
 
-    var inputPath: File = File("cpg.bin")
+    var inputPath: Path = Paths.get("cpg.bin")
 
-    var outputSliceFile: File = File("slices")
+    var outputSliceFile: Path = Paths.get("slices")
 
     var dummyTypesEnabled: Boolean = false
 
@@ -30,12 +31,12 @@ package object slicing {
 
     var parallelism: Option[Int] = None
 
-    def withInputPath(x: File): T = {
+    def withInputPath(x: Path): T = {
       this.inputPath = x
       this.asInstanceOf[T]
     }
 
-    def withOutputSliceFile(x: File): T = {
+    def withOutputSliceFile(x: Path): T = {
       this.outputSliceFile = x
       this.asInstanceOf[T]
     }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CdtParser.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CdtParser.scala
@@ -2,9 +2,9 @@ package io.joern.c2cpg.parser
 
 import io.joern.c2cpg.Config
 import io.joern.c2cpg.parser.JSONCompilationDatabaseParser.CommandObject
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.joern.x2cpg.SourceFiles
+import io.shiftleft.semanticcpg.utils.FileUtil
 import io.shiftleft.utils.IOUtils
 import org.eclipse.cdt.core.dom.ast.IASTPreprocessorStatement
 import org.eclipse.cdt.core.dom.ast.IASTTranslationUnit

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/HeaderFileFinder.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/HeaderFileFinder.scala
@@ -21,7 +21,6 @@ class HeaderFileFinder(config: Config) {
     .map(p => Paths.get(p))
     .groupMap(_.fileName)(_.toString)
 
-
   /** Given an unresolved header file, given as a non-existing absolute path, determine whether a header file with the
     * same name can be found anywhere in the code base.
     */

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/HeaderFileFinder.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/HeaderFileFinder.scala
@@ -1,6 +1,6 @@
 package io.joern.c2cpg.parser
 
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.joern.c2cpg.C2Cpg.DefaultIgnoredFolders
 import io.joern.c2cpg.Config
 import io.joern.x2cpg.SourceFiles

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/HeaderFileFinder.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/HeaderFileFinder.scala
@@ -1,10 +1,12 @@
 package io.joern.c2cpg.parser
 
-import better.files.*
+import io.joern.x2cpg.utils.FileUtil.*
 import io.joern.c2cpg.C2Cpg.DefaultIgnoredFolders
 import io.joern.c2cpg.Config
 import io.joern.x2cpg.SourceFiles
 import org.jline.utils.Levenshtein
+
+import java.nio.file.Paths
 
 class HeaderFileFinder(config: Config) {
 
@@ -17,8 +19,8 @@ class HeaderFileFinder(config: Config) {
       ignoredFilesPath = Option(config.ignoredFiles)
     )
     .map { p =>
-      val file = File(p)
-      (file.name, file.pathAsString)
+      val file = Paths.get(p)
+      (file.fileName, file.toString)
     }
     .groupBy(_._1)
     .map(x => (x._1, x._2.map(_._2)))
@@ -26,7 +28,7 @@ class HeaderFileFinder(config: Config) {
   /** Given an unresolved header file, given as a non-existing absolute path, determine whether a header file with the
     * same name can be found anywhere in the code base.
     */
-  def find(path: String): Option[String] = File(path).nameOption.flatMap { name =>
+  def find(path: String): Option[String] = Paths.get(path).nameOption.flatMap { name =>
     val matches = nameToPathMap.getOrElse(name, List())
     matches.sortBy(x => Levenshtein.distance(x, path)).headOption
   }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/utils/IncludeAutoDiscovery.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/utils/IncludeAutoDiscovery.scala
@@ -1,9 +1,8 @@
 package io.joern.c2cpg.utils
 
 import io.joern.c2cpg.Config
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
-import io.shiftleft.semanticcpg.utils.ExternalCommand
+import io.shiftleft.semanticcpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.{ExternalCommand, FileUtil}
 import org.slf4j.LoggerFactory
 
 import java.nio.file.{Path, Paths, Files}

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/utils/IncludeAutoDiscovery.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/utils/IncludeAutoDiscovery.scala
@@ -1,12 +1,12 @@
 package io.joern.c2cpg.utils
 
-import better.files.File
 import io.joern.c2cpg.Config
+import io.joern.x2cpg.utils.FileUtil
+import io.joern.x2cpg.utils.FileUtil.*
 import io.shiftleft.semanticcpg.utils.ExternalCommand
 import org.slf4j.LoggerFactory
 
-import java.nio.file.Path
-import java.nio.file.Paths
+import java.nio.file.{Path, Paths, Files}
 import scala.collection.mutable
 import scala.util.Failure
 import scala.util.Success
@@ -134,9 +134,9 @@ object IncludeAutoDiscovery {
 
   private def isMSVCProject(config: Config): Boolean = {
     if (!IsWin) return false
-    val projectDir = File(config.inputPath)
-    List(projectDir / ".vs", projectDir / ".vscode").exists(_.exists) ||
-    projectDir.list.exists(_.`extension`(includeDot = false).exists(ext => ext == "sln" || ext == "vcxproj"))
+    val projectDir = Paths.get(config.inputPath)
+    List(projectDir / ".vs", projectDir / ".vscode").exists(Files.exists(_)) ||
+    projectDir.listFiles().exists(_.extension(includeDot = false).exists(ext => ext == "sln" || ext == "vcxproj"))
   }
 
   def discoverIncludePathsCPP(config: Config): mutable.LinkedHashSet[Path] = {

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/io/C2CpgHTTPServerTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/io/C2CpgHTTPServerTests.scala
@@ -1,11 +1,11 @@
 package io.joern.c2cpg.io
 
 import io.joern.x2cpg.utils.server.FrontendHTTPClient
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 
 import io.shiftleft.codepropertygraph.cpgloading.CpgLoader
 import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/io/CodeDumperFromFileTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/io/CodeDumperFromFileTests.scala
@@ -1,10 +1,10 @@
 package io.joern.c2cpg.io
 
 import io.joern.c2cpg.testfixtures.C2CpgSuite
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.semanticcpg.codedumper.CodeDumper
 import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 
 import java.nio.file.{Files, Paths}
 import java.util.regex.Pattern

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/io/CodeDumperFromFileTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/io/CodeDumperFromFileTests.scala
@@ -1,10 +1,12 @@
 package io.joern.c2cpg.io
 
-import better.files.File
 import io.joern.c2cpg.testfixtures.C2CpgSuite
+import io.joern.x2cpg.utils.FileUtil
+import io.joern.x2cpg.utils.FileUtil.*
 import io.shiftleft.semanticcpg.codedumper.CodeDumper
 import io.shiftleft.semanticcpg.language.*
 
+import java.nio.file.{Files, Paths}
 import java.util.regex.Pattern
 
 class CodeDumperFromFileTests extends C2CpgSuite {
@@ -20,19 +22,19 @@ class CodeDumperFromFileTests extends C2CpgSuite {
 
   private val cpg = code(codeString, "test.c")
 
-  private val path = File(cpg.metaData.root.head) / "test.c"
+  private val path = Paths.get(cpg.metaData.root.head) / "test.c"
 
   override def beforeAll(): Unit = {
     super.beforeAll()
     // we have to restore the input file because CPG creation in C2CpgSuite
     // deletes it right after the CPG is ready.
-    path.createFileIfNotExists(createParents = true)
-    path.writeText(codeString)
+    path.createWithParentsIfNotExists(createParents = true)
+    Files.writeString(path, codeString)
   }
 
   override def afterAll(): Unit = {
     super.afterAll()
-    path.delete(swallowIOExceptions = true)
+    FileUtil.delete(path, swallowIoExceptions = true)
   }
 
   "dumping code" should {

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/io/DumpCpg14Tests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/io/DumpCpg14Tests.scala
@@ -3,9 +3,9 @@ package io.joern.c2cpg.io
 import io.joern.c2cpg.testfixtures.DataFlowCodeToCpgSuite
 import io.joern.dataflowengineoss.layers.dataflows.Cpg14DumpOptions
 import io.joern.dataflowengineoss.layers.dataflows.DumpCpg14
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
+import io.shiftleft.semanticcpg.utils.FileUtil
 
 import java.nio.file.Files
 

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/io/DumpDdgTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/io/DumpDdgTests.scala
@@ -1,6 +1,5 @@
 package io.joern.c2cpg.io
 
-import better.files.File
 import io.joern.c2cpg.testfixtures.DataFlowCodeToCpgSuite
 import io.joern.dataflowengineoss.layers.dataflows.DdgDumpOptions
 import io.joern.dataflowengineoss.layers.dataflows.DumpDdg

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/io/DumpDdgTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/io/DumpDdgTests.scala
@@ -3,9 +3,9 @@ package io.joern.c2cpg.io
 import io.joern.c2cpg.testfixtures.DataFlowCodeToCpgSuite
 import io.joern.dataflowengineoss.layers.dataflows.DdgDumpOptions
 import io.joern.dataflowengineoss.layers.dataflows.DumpDdg
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
+import io.shiftleft.semanticcpg.utils.FileUtil
 
 import java.nio.file.Files
 

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/io/DumpPdgTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/io/DumpPdgTests.scala
@@ -3,9 +3,9 @@ package io.joern.c2cpg.io
 import io.joern.c2cpg.testfixtures.DataFlowCodeToCpgSuite
 import io.joern.dataflowengineoss.layers.dataflows.DumpPdg
 import io.joern.dataflowengineoss.layers.dataflows.PdgDumpOptions
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
+import io.shiftleft.semanticcpg.utils.FileUtil
 
 import java.nio.file.Files
 

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/io/ExcludeTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/io/ExcludeTests.scala
@@ -3,10 +3,10 @@ package io.joern.c2cpg.io
 import io.joern.c2cpg.Config
 import io.joern.c2cpg.C2Cpg
 import io.joern.x2cpg.X2Cpg
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.language.types.structure.FileTraversal
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.wordspec.AnyWordSpec

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/io/FileHandlingTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/io/FileHandlingTests.scala
@@ -1,11 +1,10 @@
 package io.joern.c2cpg.io
 
-import better.files.File
 import io.joern.c2cpg.parser.FileDefaults
 import io.joern.c2cpg.testfixtures.CDefaultTestCpg
 import io.joern.dataflowengineoss.DefaultSemantics
-import io.joern.dataflowengineoss.semanticsloader.NoSemantics
 import io.joern.x2cpg.testfixtures.Code2CpgFixture
+import io.joern.x2cpg.utils.FileUtil
 import io.shiftleft.semanticcpg.language.*
 
 import java.nio.file.Files
@@ -22,12 +21,14 @@ class FileHandlingTests
       new CDefaultTestCpg(FileDefaults.CExt) {
         override def codeFilePreProcessing(codeFile: Path): Unit = {
           if (codeFile.toString.endsWith(FileHandlingTests.brokenLinkedFile)) {
-            File(codeFile).delete().symbolicLinkTo(File("does/not/exist.c"))
+            FileUtil.delete(codeFile)
+            Files.createSymbolicLink(codeFile, Paths.get("does/not/exist.c"))
           }
           if (codeFile.toString.endsWith(FileHandlingTests.cyclicLinkedFile)) {
-            val dir         = File(codeFile).delete().parent
-            val folderA     = Paths.get(dir.toString(), "FolderA")
-            val folderB     = Paths.get(dir.toString(), "FolderB")
+            FileUtil.delete(codeFile)
+            val dir         = codeFile.getParent
+            val folderA     = Paths.get(dir.toString, "FolderA")
+            val folderB     = Paths.get(dir.toString, "FolderB")
             val symlinkAtoB = folderA.resolve("LinkToB")
             val symlinkBtoA = folderB.resolve("LinkToA")
             Files.createDirectory(folderA)

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/io/FileHandlingTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/io/FileHandlingTests.scala
@@ -4,8 +4,8 @@ import io.joern.c2cpg.parser.FileDefaults
 import io.joern.c2cpg.testfixtures.CDefaultTestCpg
 import io.joern.dataflowengineoss.DefaultSemantics
 import io.joern.x2cpg.testfixtures.Code2CpgFixture
-import io.joern.x2cpg.utils.FileUtil
 import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 
 import java.nio.file.Files
 import java.nio.file.Path

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/io/JSONCompilationDatabaseParserTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/io/JSONCompilationDatabaseParserTests.scala
@@ -7,8 +7,8 @@ import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.language.types.structure.FileTraversal
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 
 import java.nio.file.{Files, Paths, Path}
 

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/PreprocessorPassTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/PreprocessorPassTests.scala
@@ -1,8 +1,8 @@
 package io.joern.c2cpg.passes
 
 import io.joern.c2cpg.Config
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/AstC2CpgFrontend.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/AstC2CpgFrontend.scala
@@ -6,8 +6,8 @@ import io.joern.c2cpg.passes.FunctionDeclNodePass
 import io.joern.x2cpg.testfixtures.LanguageFrontend
 import io.joern.x2cpg.ValidationMode
 import io.joern.x2cpg.X2Cpg.newEmptyCpg
-import io.joern.x2cpg.utils.FileUtil
 import io.shiftleft.codepropertygraph.generated.Cpg
+import io.shiftleft.semanticcpg.utils.FileUtil
 
 trait AstC2CpgFrontend extends LanguageFrontend {
   def execute(sourceCodePath: java.io.File): Cpg = {

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/C2CpgFrontend.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/C2CpgFrontend.scala
@@ -1,6 +1,5 @@
 package io.joern.c2cpg.testfixtures
 
-import better.files.File
 import io.joern.c2cpg.C2Cpg
 import io.joern.c2cpg.Config
 import io.joern.x2cpg.testfixtures.LanguageFrontend

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/C2CpgFrontend.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/C2CpgFrontend.scala
@@ -3,8 +3,8 @@ package io.joern.c2cpg.testfixtures
 import io.joern.c2cpg.C2Cpg
 import io.joern.c2cpg.Config
 import io.joern.x2cpg.testfixtures.LanguageFrontend
-import io.joern.x2cpg.utils.FileUtil
 import io.shiftleft.codepropertygraph.generated.Cpg
+import io.shiftleft.semanticcpg.utils.FileUtil
 
 trait C2CpgFrontend extends LanguageFrontend {
   def execute(sourceCodePath: java.io.File): Cpg = {

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/CSharpSrc2Cpg.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/CSharpSrc2Cpg.scala
@@ -16,11 +16,12 @@ import io.joern.x2cpg.astgen.AstGenRunner.AstGenRunnerResult
 import io.joern.x2cpg.astgen.ParserResult
 import io.joern.x2cpg.passes.callgraph.NaiveCallLinker
 import io.joern.x2cpg.passes.frontend.{MetaDataPass, TypeNodePass}
-import io.joern.x2cpg.utils.{ConcurrentTaskUtil, Environment, FileUtil, HashUtil, Report}
+import io.joern.x2cpg.utils.{ConcurrentTaskUtil, Environment, HashUtil, Report}
 import io.joern.x2cpg.{SourceFiles, X2CpgFrontend}
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.Languages
 import io.shiftleft.passes.CpgPassBase
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.slf4j.LoggerFactory
 
 import java.nio.file.Paths

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/datastructures/CSharpProgramSummary.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/datastructures/CSharpProgramSummary.scala
@@ -1,6 +1,5 @@
 package io.joern.csharpsrc2cpg.datastructures
 
-import better.files.File.VisitOptions
 import io.joern.csharpsrc2cpg.Constants
 import io.joern.x2cpg.SourceFiles
 import io.joern.x2cpg.datastructures.{FieldLike, MethodLike, OverloadableMethod, ProgramSummary, TypeLike}
@@ -115,7 +114,7 @@ object CSharpProgramSummary {
     CSharpProgramSummary(fromExternalJsons(paths))
 
   private def fromExternalJsons(paths: Set[String]): NamespaceToTypeMap = {
-    val jsonFiles = paths.flatMap(SourceFiles.determine(_, Set(".json"))(VisitOptions.default)).toList
+    val jsonFiles = paths.flatMap(SourceFiles.determine(_, Set(".json"))(Seq.empty)).toList
     val inputStreams = jsonFiles.flatMap { path =>
       Try(java.io.FileInputStream(path)) match {
         case Success(stream) => Some(stream)

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/parser/DotNetJsonParser.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/parser/DotNetJsonParser.scala
@@ -1,6 +1,7 @@
 package io.joern.csharpsrc2cpg.parser
 
 import io.joern.x2cpg.astgen.ParserResult
+import io.joern.x2cpg.utils.FileUtil.*
 import io.shiftleft.utils.IOUtils
 import org.slf4j.LoggerFactory
 import ujson.Value.Value
@@ -15,7 +16,7 @@ object DotNetJsonParser {
     val fullFilePath      = json(ParserKeys.FileName).str
     val filePath          = Paths.get(fullFilePath)
     val sourceFileContent = IOUtils.readEntireFile(filePath)
-    ParserResult(filePath.getFileName.toString, fullFilePath, json, sourceFileContent)
+    ParserResult(filePath.fileName, fullFilePath, json, sourceFileContent)
   }
 
 }

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/parser/DotNetJsonParser.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/parser/DotNetJsonParser.scala
@@ -1,7 +1,7 @@
 package io.joern.csharpsrc2cpg.parser
 
 import io.joern.x2cpg.astgen.ParserResult
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.utils.IOUtils
 import org.slf4j.LoggerFactory
 import ujson.Value.Value

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/passes/DependencyPass.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/passes/DependencyPass.scala
@@ -1,7 +1,7 @@
 package io.joern.csharpsrc2cpg.passes
 
 import io.joern.semanticcpg.utils.SecureXmlParsing
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.NewDependency
 import io.shiftleft.passes.ForkJoinParallelCpgPass

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/passes/DependencyPass.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/passes/DependencyPass.scala
@@ -1,23 +1,24 @@
 package io.joern.csharpsrc2cpg.passes
 
-import better.files.File
 import io.joern.semanticcpg.utils.SecureXmlParsing
+import io.joern.x2cpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.NewDependency
 import io.shiftleft.passes.ForkJoinParallelCpgPass
 import org.slf4j.LoggerFactory
 
+import java.nio.file.{Files, Path, Paths}
 import scala.util.{Failure, Try}
 
 class DependencyPass(cpg: Cpg, buildFiles: List[String], registerPackageId: String => ?)
-    extends ForkJoinParallelCpgPass[File](cpg) {
+    extends ForkJoinParallelCpgPass[Path](cpg) {
 
   private val logger = LoggerFactory.getLogger(getClass)
 
-  override def generateParts(): Array[File] = buildFiles.map(x => File(x)).toArray
+  override def generateParts(): Array[Path] = buildFiles.map(x => Paths.get(x)).toArray
 
-  override def runOnPart(builder: DiffGraphBuilder, part: File): Unit = {
-    SecureXmlParsing.parseXml(part.contentAsString) match {
+  override def runOnPart(builder: DiffGraphBuilder, part: Path): Unit = {
+    SecureXmlParsing.parseXml(part.fileContent) match {
       case Some(xml) if xml.label == "Project" =>
         // Find packageId (useful for monoliths)
         xml.child
@@ -55,7 +56,7 @@ class DependencyPass(cpg: Cpg, buildFiles: List[String], registerPackageId: Stri
               }
           }
       case Some(_) =>
-      case None    => logger.error(s"Failed to parse build file ${part.pathAsString}")
+      case None    => logger.error(s"Failed to parse build file ${part.toString}")
     }
   }
 

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/utils/DependencyDownloader.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/utils/DependencyDownloader.scala
@@ -2,11 +2,11 @@ package io.joern.csharpsrc2cpg.utils
 
 import io.joern.csharpsrc2cpg.Config
 import io.joern.csharpsrc2cpg.datastructures.CSharpProgramSummary
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.Dependency
 import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.slf4j.LoggerFactory
 import upickle.default.*
 

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/utils/DependencyDownloader.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/utils/DependencyDownloader.scala
@@ -1,9 +1,9 @@
 package io.joern.csharpsrc2cpg.utils
 
-import better.files.File
 import io.joern.csharpsrc2cpg.Config
 import io.joern.csharpsrc2cpg.datastructures.CSharpProgramSummary
-import io.joern.x2cpg.astgen.AstGenRunner.DefaultAstGenRunnerResult
+import io.joern.x2cpg.utils.FileUtil
+import io.joern.x2cpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.Dependency
 import io.shiftleft.semanticcpg.language.*
@@ -12,6 +12,7 @@ import upickle.default.*
 
 import java.io.FileOutputStream
 import java.net.{HttpURLConnection, URI, URL, URLConnection}
+import java.nio.file.{Files, Paths, Path}
 import java.util.zip.{GZIPInputStream, InflaterInputStream, ZipEntry}
 import scala.util.{Failure, Success, Try, Using}
 
@@ -39,7 +40,7 @@ class DependencyDownloader(
     *   the dependencies' summary combined with the given internal program summary.
     */
   def download(): CSharpProgramSummary = {
-    File.temporaryDirectory("joern-csharpsrc2cpg").apply { dir =>
+    FileUtil.usingTemporaryDirectory("joern-csharpsrc2cpg") { dir =>
       cpg.dependency.filterNot(isAlreadySummarized).foreach(downloadDependency(dir, _))
       unzipDependencies(dir)
       summarizeDependencies(dir) ++= internalProgramSummary
@@ -72,7 +73,7 @@ class DependencyDownloader(
     * @return
     *   a disposable version of the directory where the dependencies live.
     */
-  private def downloadDependency(targetDir: File, dependency: Dependency): Unit = {
+  private def downloadDependency(targetDir: Path, dependency: Dependency): Unit = {
 
     val dependencyName = dependency.name.strip()
     def getVersion(packageName: String): Option[String] = Try {
@@ -120,7 +121,7 @@ class DependencyDownloader(
     * @return
     *   the package version.
     */
-  private def downloadPackage(targetDir: File, dependency: Dependency, url: Option[URL]): Unit = {
+  private def downloadPackage(targetDir: Path, dependency: Dependency, url: Option[URL]): Unit = {
     var connection: Option[HttpURLConnection] = None
     url.foreach { validUrl =>
       {
@@ -140,7 +141,7 @@ class DependencyDownloader(
               }
 
               Try {
-                Using.resources(inputStream, new FileOutputStream(fileName.pathAsString)) { (is, fos) =>
+                Using.resources(inputStream, new FileOutputStream(fileName.toString)) { (is, fos) =>
                   val buffer = new Array[Byte](4096)
                   Iterator
                     .continually(is.read(buffer))
@@ -176,28 +177,28 @@ class DependencyDownloader(
     * @param targetDir
     *   the temporary directory containing all of the successfully downloaded dependencies.
     */
-  private def unzipDependencies(targetDir: File): Unit = {
+  private def unzipDependencies(targetDir: Path): Unit = {
 
     def zipFilter(zipEntry: ZipEntry): Boolean = {
       val isZipSlip = zipEntry.getName.contains("..")
       !isZipSlip && (zipEntry.isDirectory || zipEntry.getName.matches(".*lib.*\\.(dll|xml|pdb)$"))
     }
 
-    targetDir.list.foreach { pkg =>
+    targetDir.listFiles().foreach { pkg =>
       // Will unzip to `targetDir/lib` and clean-up
       pkg.unzipTo(targetDir, zipFilter)
-      pkg.delete(swallowIOExceptions = true)
+      FileUtil.delete(pkg, swallowIoExceptions = true)
     }
 
     // Move and merge files
     val libDir = targetDir / "lib"
-    if (libDir.isDirectory) {
+    if (Files.isDirectory(libDir)) {
       // Sometimes these dependencies will include DLLs for multiple version of dotnet, we only want one
-      libDir.listRecursively.filterNot(_.isDirectory).distinctBy(_.name).foreach { f =>
-        f.copyTo(targetDir / f.name)
+      libDir.walk().filterNot(_ == libDir).filterNot(Files.isDirectory(_)).distinctBy(_.fileName).foreach { f =>
+        f.copyTo(targetDir / f.fileName)
       }
       // Clean-up lib dir
-      libDir.delete(swallowIOExceptions = true)
+      FileUtil.delete(libDir, swallowIoExceptions = true)
     }
   }
 
@@ -207,13 +208,13 @@ class DependencyDownloader(
     * @return
     *   a summary of all the dependencies.
     */
-  private def summarizeDependencies(targetDir: File): CSharpProgramSummary = {
-    val astGenRunner       = new DotNetAstGenRunner(config.withInputPath(targetDir.pathAsString))
+  private def summarizeDependencies(targetDir: Path): CSharpProgramSummary = {
+    val astGenRunner       = new DotNetAstGenRunner(config.withInputPath(targetDir.toString))
     val astGenRunnerResult = astGenRunner.execute(targetDir)
     val summaries = astGenRunnerResult.parsedFiles
-      .map(x => File(x))
+      .map(x => Paths.get(x))
       .flatMap { f =>
-        Using.resource(f.newFileInputStream) { fis =>
+        Using.resource(Files.newInputStream(f)) { fis =>
           CSharpProgramSummary.jsonToInitialMapping(fis) match {
             case Failure(exception) =>
               logger.error(s"Unable to parse JSON program summary at $f", exception)

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/utils/DotNetAstGenRunner.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/utils/DotNetAstGenRunner.scala
@@ -1,6 +1,5 @@
 package io.joern.csharpsrc2cpg.utils
 
-import better.files.File
 import io.joern.csharpsrc2cpg.Config
 import io.joern.x2cpg.SourceFiles
 import io.joern.x2cpg.astgen.AstGenRunner.{AstGenProgramMetaData, getClass}
@@ -8,6 +7,7 @@ import io.joern.x2cpg.astgen.AstGenRunnerBase
 import io.shiftleft.semanticcpg.utils.ExternalCommand
 import org.slf4j.LoggerFactory
 
+import java.nio.file.Path
 import scala.collection.mutable
 import scala.util.Try
 
@@ -20,15 +20,15 @@ class DotNetAstGenRunner(config: Config) extends AstGenRunnerBase(config) {
   override val WinArm: String   = WinX86
   override val LinuxArm: String = "linux-arm64"
 
-  override def fileFilter(file: String, out: File): Boolean = {
-    file.stripSuffix(".json").replace(out.pathAsString, config.inputPath) match {
+  override def fileFilter(file: String, out: Path): Boolean = {
+    file.stripSuffix(".json").replace(out.toString, config.inputPath) match {
       case filePath if isIgnoredByUserConfig(filePath) => false
       case filePath if filePath.endsWith(".csproj")    => false
       case _                                           => true
     }
   }
 
-  override def skippedFiles(in: File, astGenOut: List[String]): List[String] = {
+  override def skippedFiles(in: Path, astGenOut: List[String]): List[String] = {
     val diagnosticMap = mutable.LinkedHashMap.empty[String, Seq[String]]
 
     def addReason(reason: String, lastFile: Option[String] = None): Unit = {
@@ -44,13 +44,13 @@ class DotNetAstGenRunner(config: Config) extends AstGenRunnerBase(config) {
 
     astGenOut.map(_.strip()).foreach {
       case s"info: DotNetAstGen.Program[0] Parsing file: $fileName" =>
-        diagnosticMap.put(SourceFiles.toRelativePath(fileName, in.pathAsString), Nil)
+        diagnosticMap.put(SourceFiles.toRelativePath(fileName, in.toString), Nil)
       case s"fail: DotNetAstGen.Program[0] Error(s) encountered while parsing: $_" => // ignore
       case s"fail: DotNetAstGen.Program[0] $reason"                                => addReason(reason)
       case s"warn: DotNetAstGen.Program[0] $filename does $reason, skipping..." =>
         addReason(s"does $reason", Option(filename))
       case s"info: DotNetAstGen.Program[0] Skipping file: $fileName" =>
-        addReason("Skipped", Option(SourceFiles.toRelativePath(fileName, in.pathAsString)))
+        addReason("Skipped", Option(SourceFiles.toRelativePath(fileName, in.toString)))
       case _ => // ignore
     }
 
@@ -64,7 +64,7 @@ class DotNetAstGenRunner(config: Config) extends AstGenRunnerBase(config) {
     }.toList
   }
 
-  override def runAstGenNative(in: String, out: File, exclude: String, include: String)(implicit
+  override def runAstGenNative(in: String, out: Path, exclude: String, include: String)(implicit
     metaData: AstGenProgramMetaData
   ): Try[Seq[String]] = {
     val excludeCommand = if (exclude.isEmpty) Seq.empty else Seq("-e", exclude)

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/utils/ImplicitUsingsCollector.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/utils/ImplicitUsingsCollector.scala
@@ -2,7 +2,7 @@ package io.joern.csharpsrc2cpg.utils
 
 import io.joern.semanticcpg.utils.SecureXmlParsing
 
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 
 import java.nio.file.Paths
 import scala.xml.{Elem, Node}

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/utils/ImplicitUsingsCollector.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/utils/ImplicitUsingsCollector.scala
@@ -1,8 +1,10 @@
 package io.joern.csharpsrc2cpg.utils
 
-import better.files.File
 import io.joern.semanticcpg.utils.SecureXmlParsing
 
+import io.joern.x2cpg.utils.FileUtil.*
+
+import java.nio.file.Paths
 import scala.xml.{Elem, Node}
 
 /** Depending on the project type defined in `.csproj` files, different sets of global usings are turned on by default.
@@ -19,7 +21,7 @@ object ImplicitUsingsCollector {
     */
   def collect(buildFiles: List[String]): List[String] = {
     buildFiles.flatMap { csproj =>
-      SecureXmlParsing.parseXml(File(csproj).contentAsString) match
+      SecureXmlParsing.parseXml(Paths.get(csproj).fileContent) match
         case Some(xml) => from(xml)
         case None      => List.empty
     }

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/io/CSharp2CpgHTTPServerTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/io/CSharp2CpgHTTPServerTests.scala
@@ -2,10 +2,10 @@ package io.joern.csharpsrc2cpg.io
 
 import io.joern.csharpsrc2cpg.testfixtures.CSharpCode2CpgFixture
 import io.joern.x2cpg.utils.server.FrontendHTTPClient
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.cpgloading.CpgLoader
 import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.scalatest.BeforeAndAfterAll
 
 import java.nio.file.{Files, Path}

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/io/ProjectParseTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/io/ProjectParseTests.scala
@@ -6,10 +6,11 @@ import io.joern.csharpsrc2cpg.passes.AstCreationPass
 import io.joern.csharpsrc2cpg.testfixtures.CSharpCode2CpgFixture
 import io.joern.csharpsrc2cpg.utils.DotNetAstGenRunner
 import io.joern.x2cpg.X2Cpg.newEmptyCpg
-import io.joern.x2cpg.utils.{Report, FileUtil}
-import io.joern.x2cpg.utils.FileUtil.*
+import io.joern.x2cpg.utils.Report
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.scalatest.BeforeAndAfterAll
 
 import java.nio.file.{Files, Path}

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/Ghidra2Cpg.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/Ghidra2Cpg.scala
@@ -20,10 +20,10 @@ import io.joern.ghidra2cpg.passes.x86.{ReturnEdgesPass, X86FunctionPass}
 import io.joern.ghidra2cpg.utils.Decompiler
 import io.joern.x2cpg.passes.frontend.{MetaDataPass, TypeNodePass}
 import io.joern.x2cpg.{X2Cpg, X2CpgFrontend}
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.Languages
+import io.shiftleft.semanticcpg.utils.FileUtil
 import utilities.util.FileUtilities
 
 import java.io.File

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/GoSrc2Cpg.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/GoSrc2Cpg.scala
@@ -1,17 +1,14 @@
 package io.joern.gosrc2cpg
 
-import better.files.File
 import io.joern.gosrc2cpg.datastructures.GoGlobal
 import io.joern.gosrc2cpg.model.GoModHelper
 import io.joern.gosrc2cpg.parser.GoAstJsonParser
 import io.joern.gosrc2cpg.passes.*
 import io.joern.gosrc2cpg.utils.AstGenRunner
-import io.joern.gosrc2cpg.utils.AstGenRunner.GoAstGenRunnerResult
 import io.joern.x2cpg.X2Cpg.withNewEmptyCpg
 import io.joern.x2cpg.X2CpgFrontend
 import io.joern.x2cpg.passes.frontend.MetaDataPass
 import io.joern.x2cpg.utils.{Report, FileUtil}
-import io.joern.x2cpg.utils.FileUtil.*
 
 import io.shiftleft.codepropertygraph.generated.{Cpg, Languages}
 

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/GoSrc2Cpg.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/GoSrc2Cpg.scala
@@ -8,9 +8,10 @@ import io.joern.gosrc2cpg.utils.AstGenRunner
 import io.joern.x2cpg.X2Cpg.withNewEmptyCpg
 import io.joern.x2cpg.X2CpgFrontend
 import io.joern.x2cpg.passes.frontend.MetaDataPass
-import io.joern.x2cpg.utils.{Report, FileUtil}
+import io.joern.x2cpg.utils.Report
 
 import io.shiftleft.codepropertygraph.generated.{Cpg, Languages}
+import io.shiftleft.semanticcpg.utils.FileUtil
 
 import java.nio.file.Paths
 import scala.util.Try

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/parser/GoAstJsonParser.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/parser/GoAstJsonParser.scala
@@ -2,7 +2,7 @@ package io.joern.gosrc2cpg.parser
 
 import io.joern.gosrc2cpg.model.GoMod
 import io.joern.x2cpg.astgen.ParserResult
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.utils.IOUtils
 import org.slf4j.LoggerFactory
 import ujson.Value.Value

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/parser/GoAstJsonParser.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/parser/GoAstJsonParser.scala
@@ -2,6 +2,7 @@ package io.joern.gosrc2cpg.parser
 
 import io.joern.gosrc2cpg.model.GoMod
 import io.joern.x2cpg.astgen.ParserResult
+import io.joern.x2cpg.utils.FileUtil.*
 import io.shiftleft.utils.IOUtils
 import org.slf4j.LoggerFactory
 import ujson.Value.Value
@@ -20,7 +21,7 @@ object GoAstJsonParser {
     val fullFilePath      = json(ParserKeys.NodeFileName).str
     val filePath          = Paths.get(fullFilePath)
     val sourceFileContent = IOUtils.readEntireFile(filePath)
-    ParserResult(filePath.getFileName.toString, fullFilePath, json, sourceFileContent)
+    ParserResult(filePath.fileName, fullFilePath, json, sourceFileContent)
   }
 
   def readModFile(file: Path): Option[GoMod] = {

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/passes/AstCreationPass.scala
@@ -1,6 +1,5 @@
 package io.joern.gosrc2cpg.passes
 
-import better.files.File
 import io.joern.gosrc2cpg.Config
 import io.joern.gosrc2cpg.astcreation.AstCreator
 import io.joern.gosrc2cpg.datastructures.GoGlobal
@@ -14,7 +13,7 @@ import io.shiftleft.passes.ForkJoinParallelCpgPass
 import io.shiftleft.utils.IOUtils
 import org.slf4j.{Logger, LoggerFactory}
 
-import java.nio.file.Paths
+import java.nio.file.{Path, Paths}
 import scala.util.{Failure, Success, Try}
 
 class AstCreationPass(
@@ -23,7 +22,7 @@ class AstCreationPass(
   config: Config,
   goMod: GoModHelper,
   goGlobal: GoGlobal,
-  tmpDir: File,
+  tmpDir: Path,
   report: Report
 ) extends BasePassForAstProcessing(cpg, astFiles, config, goMod, goGlobal, tmpDir) {
   private val logger: Logger = LoggerFactory.getLogger(classOf[AstCreationPass])

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/passes/BasePassForAstProcessing.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/passes/BasePassForAstProcessing.scala
@@ -1,6 +1,5 @@
 package io.joern.gosrc2cpg.passes
 
-import better.files.File
 import io.joern.gosrc2cpg.Config
 import io.joern.gosrc2cpg.astcreation.AstCreator
 import io.joern.gosrc2cpg.datastructures.GoGlobal
@@ -10,13 +9,15 @@ import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.passes.ForkJoinParallelCpgPass
 import org.slf4j.{Logger, LoggerFactory}
 
+import java.nio.file.Path
+
 abstract class BasePassForAstProcessing(
   cpg: Cpg,
   astFiles: List[String],
   config: Config,
   goMod: GoModHelper,
   goGlobal: GoGlobal,
-  tmpDir: File
+  tmpDir: Path
 ) extends ForkJoinParallelCpgPass[String](cpg) {
   protected val logger: Logger                = LoggerFactory.getLogger(classOf[BasePassForAstProcessing])
   override def generateParts(): Array[String] = astFiles.toArray
@@ -24,7 +25,7 @@ abstract class BasePassForAstProcessing(
     try {
       processAst(
         diffGraph,
-        new AstCreator(ast, SourceFiles.toRelativePath(ast, tmpDir.pathAsString).replace(".json", ""), goMod, goGlobal)(
+        new AstCreator(ast, SourceFiles.toRelativePath(ast, tmpDir.toString).replace(".json", ""), goMod, goGlobal)(
           config.schemaValidation
         )
       )

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/passes/DependencySrcProcessorPass.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/passes/DependencySrcProcessorPass.scala
@@ -1,6 +1,5 @@
 package io.joern.gosrc2cpg.passes
 
-import better.files.File
 import io.joern.gosrc2cpg.Config
 import io.joern.gosrc2cpg.astcreation.AstCreator
 import io.joern.gosrc2cpg.datastructures.GoGlobal
@@ -8,6 +7,7 @@ import io.joern.gosrc2cpg.model.GoModHelper
 import io.shiftleft.codepropertygraph.generated.Cpg
 import org.slf4j.{Logger, LoggerFactory}
 
+import java.nio.file.Path
 import scala.util.{Failure, Success, Try}
 
 class DependencySrcProcessorPass(
@@ -16,7 +16,7 @@ class DependencySrcProcessorPass(
   config: Config,
   goMod: GoModHelper,
   goGlobal: GoGlobal,
-  tmpDir: File
+  tmpDir: Path
 ) extends BasePassForAstProcessing(cpg, astFiles, config, goMod, goGlobal, tmpDir) {
   protected override val logger: Logger = LoggerFactory.getLogger(classOf[DependencySrcProcessorPass])
 

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/passes/DownloadDependenciesPass.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/passes/DownloadDependenciesPass.scala
@@ -6,8 +6,7 @@ import io.joern.gosrc2cpg.model.{GoModDependency, GoModHelper}
 import io.joern.gosrc2cpg.parser.GoAstJsonParser
 import io.joern.gosrc2cpg.utils.AstGenRunner
 import io.joern.gosrc2cpg.utils.AstGenRunner.{GoAstGenRunnerResult, getClass}
-import io.joern.x2cpg.utils.FileUtil
-import io.shiftleft.semanticcpg.utils.ExternalCommand
+import io.shiftleft.semanticcpg.utils.{ExternalCommand, FileUtil}
 import io.shiftleft.codepropertygraph.generated.Cpg
 import org.slf4j.LoggerFactory
 

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/passes/InitialMainSrcPass.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/passes/InitialMainSrcPass.scala
@@ -1,6 +1,5 @@
 package io.joern.gosrc2cpg.passes
 
-import better.files.File
 import io.joern.gosrc2cpg.Config
 import io.joern.gosrc2cpg.astcreation.AstCreator
 import io.joern.gosrc2cpg.datastructures.GoGlobal
@@ -8,6 +7,7 @@ import io.joern.gosrc2cpg.model.GoModHelper
 import io.shiftleft.codepropertygraph.generated.Cpg
 import org.slf4j.{Logger, LoggerFactory}
 
+import java.nio.file.Path
 import scala.util.{Failure, Success, Try}
 
 class InitialMainSrcPass(
@@ -16,7 +16,7 @@ class InitialMainSrcPass(
   config: Config,
   goMod: GoModHelper,
   goGlobal: GoGlobal,
-  tmpDir: File
+  tmpDir: Path
 ) extends BasePassForAstProcessing(cpg, astFiles, config, goMod, goGlobal, tmpDir) {
   protected override val logger: Logger = LoggerFactory.getLogger(classOf[InitialMainSrcPass])
 

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/utils/AstGenRunner.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/utils/AstGenRunner.scala
@@ -6,9 +6,9 @@ import io.joern.x2cpg.astgen.AstGenRunner.{AstGenProgramMetaData, AstGenRunnerRe
 import io.joern.x2cpg.astgen.AstGenRunnerBase
 import io.joern.x2cpg.utils.Environment.ArchitectureType.ArchitectureType
 import io.joern.x2cpg.utils.Environment.OperatingSystemType.OperatingSystemType
-import io.joern.x2cpg.utils.{Environment, FileUtil}
-import io.joern.x2cpg.utils.FileUtil.*
-import io.shiftleft.semanticcpg.utils.ExternalCommand
+import io.joern.x2cpg.utils.Environment
+import io.shiftleft.semanticcpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.{ExternalCommand, FileUtil}
 import org.slf4j.LoggerFactory
 
 import java.nio.file.{Path, Paths}

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/io/GoSrc2CpgHTTPServerTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/io/GoSrc2CpgHTTPServerTests.scala
@@ -1,10 +1,10 @@
 package io.joern.go2cpg.io
 
 import io.joern.x2cpg.utils.server.FrontendHTTPClient
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.cpgloading.CpgLoader
 import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/model/GoModTest.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/model/GoModTest.scala
@@ -2,6 +2,7 @@ package io.joern.go2cpg.model;
 
 import io.joern.gosrc2cpg.Config
 import io.joern.gosrc2cpg.model.{GoMod, GoModDependency, GoModHelper, GoModModule}
+import io.joern.x2cpg.utils.FileUtil
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -14,11 +15,11 @@ import scala.language.postfixOps
 class GoModTest extends AnyWordSpec with Matchers with BeforeAndAfterAll {
   "go project without .mod file" in {
     val goMod     = new GoModHelper()
-    val namespace = goMod.getNameSpace(Paths.get("").toString, "main")
+    val namespace = goMod.getNameSpace(FileUtil.currentWorkingDirectory.toString, "main")
     namespace shouldBe "main"
   }
   "invalid compilation file unit with main pkg" in {
-    val inputPath = Paths.get("").toString
+    val inputPath = FileUtil.currentWorkingDirectory.toString
     val goMod = new GoModHelper(
       Some(inputPath),
       Some(
@@ -37,7 +38,7 @@ class GoModTest extends AnyWordSpec with Matchers with BeforeAndAfterAll {
 
   }
   "with .mod file and main pkg 1 use case" in {
-    val inputPath = Paths.get("").toAbsolutePath.normalize().toString
+    val inputPath = FileUtil.currentWorkingDirectory.toString
     val goMod = new GoModHelper(
       Some(inputPath),
       Some(
@@ -54,7 +55,7 @@ class GoModTest extends AnyWordSpec with Matchers with BeforeAndAfterAll {
   }
 
   "with .mod file and main pkg 2 use case" in {
-    val inputPath = Paths.get("").toAbsolutePath.normalize().toString + JFile.separator
+    val inputPath = FileUtil.currentWorkingDirectory.toString + JFile.separator
     val goMod = new GoModHelper(
       Some(inputPath),
       Some(
@@ -71,7 +72,7 @@ class GoModTest extends AnyWordSpec with Matchers with BeforeAndAfterAll {
   }
 
   "with .mod file and main pkg 3 use case" in {
-    val inputPath = Paths.get("").toAbsolutePath.normalize().toString + JFile.separator
+    val inputPath = FileUtil.currentWorkingDirectory.toString + JFile.separator
     val goMod = new GoModHelper(
       Some(inputPath),
       Some(
@@ -88,7 +89,7 @@ class GoModTest extends AnyWordSpec with Matchers with BeforeAndAfterAll {
   }
 
   "with .mod file and pkg other than main matching with folder" in {
-    val inputPath = Paths.get("").toAbsolutePath.normalize().toString + JFile.separator
+    val inputPath = FileUtil.currentWorkingDirectory.toString + JFile.separator
     val goMod = new GoModHelper(
       Some(inputPath),
       Some(
@@ -105,7 +106,7 @@ class GoModTest extends AnyWordSpec with Matchers with BeforeAndAfterAll {
   }
 
   "with .mod file, pkg other than main, one level child folder, and package matching with last folder" in {
-    val inputPath = Paths.get("").toAbsolutePath.normalize().toString + JFile.separator
+    val inputPath = FileUtil.currentWorkingDirectory.toString + JFile.separator
     val goMod = new GoModHelper(
       Some(inputPath),
       Some(
@@ -122,7 +123,7 @@ class GoModTest extends AnyWordSpec with Matchers with BeforeAndAfterAll {
   }
 
   "with .mod file and pkg other than main and not matching with folder" in {
-    val inputPath = Paths.get("").toAbsolutePath.normalize().toString + JFile.separator
+    val inputPath = FileUtil.currentWorkingDirectory.toString + JFile.separator
     val goMod = new GoModHelper(
       Some(inputPath),
       Some(
@@ -139,7 +140,7 @@ class GoModTest extends AnyWordSpec with Matchers with BeforeAndAfterAll {
   }
 
   "with .mod file, pkg other than main, one level child folder, and package not matching with last folder" in {
-    val inputPath = Paths.get("").toAbsolutePath.normalize().toString + JFile.separator
+    val inputPath = FileUtil.currentWorkingDirectory.toString + JFile.separator
     val goMod = new GoModHelper(
       Some(inputPath),
       Some(

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/model/GoModTest.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/model/GoModTest.scala
@@ -8,7 +8,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import io.joern.x2cpg.utils.FileUtil.*
 
 import java.io.File as JFile
-import java.nio.file.{Files, Paths, Path}
+import java.nio.file.{Files, Path, Paths}
 import scala.language.postfixOps
 
 class GoModTest extends AnyWordSpec with Matchers with BeforeAndAfterAll {
@@ -37,7 +37,7 @@ class GoModTest extends AnyWordSpec with Matchers with BeforeAndAfterAll {
 
   }
   "with .mod file and main pkg 1 use case" in {
-    val inputPath = Paths.get("").toString
+    val inputPath = Paths.get("").toAbsolutePath.normalize().toString
     val goMod = new GoModHelper(
       Some(inputPath),
       Some(
@@ -54,7 +54,7 @@ class GoModTest extends AnyWordSpec with Matchers with BeforeAndAfterAll {
   }
 
   "with .mod file and main pkg 2 use case" in {
-    val inputPath = Paths.get("").toString + JFile.separator
+    val inputPath = Paths.get("").toAbsolutePath.normalize().toString + JFile.separator
     val goMod = new GoModHelper(
       Some(inputPath),
       Some(
@@ -71,7 +71,7 @@ class GoModTest extends AnyWordSpec with Matchers with BeforeAndAfterAll {
   }
 
   "with .mod file and main pkg 3 use case" in {
-    val inputPath = Paths.get("").toString + JFile.separator
+    val inputPath = Paths.get("").toAbsolutePath.normalize().toString + JFile.separator
     val goMod = new GoModHelper(
       Some(inputPath),
       Some(
@@ -88,7 +88,7 @@ class GoModTest extends AnyWordSpec with Matchers with BeforeAndAfterAll {
   }
 
   "with .mod file and pkg other than main matching with folder" in {
-    val inputPath = Paths.get("").toString + JFile.separator
+    val inputPath = Paths.get("").toAbsolutePath.normalize().toString + JFile.separator
     val goMod = new GoModHelper(
       Some(inputPath),
       Some(
@@ -105,7 +105,7 @@ class GoModTest extends AnyWordSpec with Matchers with BeforeAndAfterAll {
   }
 
   "with .mod file, pkg other than main, one level child folder, and package matching with last folder" in {
-    val inputPath = Paths.get("").toString + JFile.separator
+    val inputPath = Paths.get("").toAbsolutePath.normalize().toString + JFile.separator
     val goMod = new GoModHelper(
       Some(inputPath),
       Some(
@@ -122,7 +122,7 @@ class GoModTest extends AnyWordSpec with Matchers with BeforeAndAfterAll {
   }
 
   "with .mod file and pkg other than main and not matching with folder" in {
-    val inputPath = Paths.get("").toString + JFile.separator
+    val inputPath = Paths.get("").toAbsolutePath.normalize().toString + JFile.separator
     val goMod = new GoModHelper(
       Some(inputPath),
       Some(
@@ -139,7 +139,7 @@ class GoModTest extends AnyWordSpec with Matchers with BeforeAndAfterAll {
   }
 
   "with .mod file, pkg other than main, one level child folder, and package not matching with last folder" in {
-    val inputPath = Paths.get("").toString + JFile.separator
+    val inputPath = Paths.get("").toAbsolutePath.normalize().toString + JFile.separator
     val goMod = new GoModHelper(
       Some(inputPath),
       Some(

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/model/GoModTest.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/model/GoModTest.scala
@@ -1,28 +1,29 @@
 package io.joern.go2cpg.model;
 
-import better.files.File
 import io.joern.gosrc2cpg.Config
 import io.joern.gosrc2cpg.model.{GoMod, GoModDependency, GoModHelper, GoModModule}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import io.joern.x2cpg.utils.FileUtil.*
 
 import java.io.File as JFile
+import java.nio.file.{Files, Paths, Path}
 import scala.language.postfixOps
 
 class GoModTest extends AnyWordSpec with Matchers with BeforeAndAfterAll {
   "go project without .mod file" in {
     val goMod     = new GoModHelper()
-    val namespace = goMod.getNameSpace(File.currentWorkingDirectory.toString(), "main")
+    val namespace = goMod.getNameSpace(Paths.get("").toString, "main")
     namespace shouldBe "main"
   }
   "invalid compilation file unit with main pkg" in {
-    val inputPath = File.currentWorkingDirectory.toString()
+    val inputPath = Paths.get("").toString
     val goMod = new GoModHelper(
       Some(inputPath),
       Some(
         GoMod(
-          fileFullPath = File(inputPath) / "go.mod" pathAsString,
+          fileFullPath = (Paths.get(inputPath) / "go.mod").toString,
           module = GoModModule("joern.io/trial"),
           dependencies = List[GoModDependency]()
         )
@@ -36,121 +37,121 @@ class GoModTest extends AnyWordSpec with Matchers with BeforeAndAfterAll {
 
   }
   "with .mod file and main pkg 1 use case" in {
-    val inputPath = File.currentWorkingDirectory.toString()
+    val inputPath = Paths.get("").toString
     val goMod = new GoModHelper(
       Some(inputPath),
       Some(
         GoMod(
-          fileFullPath = File(inputPath) / "go.mod" pathAsString,
+          fileFullPath = (Paths.get(inputPath) / "go.mod").toString,
           module = GoModModule("joern.io/trial"),
           dependencies = List[GoModDependency]()
         )
       )
     )
     val namespace =
-      goMod.getNameSpace(File(inputPath) / "first" / "second" / "test.go" pathAsString, "main")
+      goMod.getNameSpace((Paths.get(inputPath) / "first" / "second" / "test.go").toString, "main")
     namespace shouldBe "first/second/main"
   }
 
   "with .mod file and main pkg 2 use case" in {
-    val inputPath = File.currentWorkingDirectory.toString() + JFile.separator
+    val inputPath = Paths.get("").toString + JFile.separator
     val goMod = new GoModHelper(
       Some(inputPath),
       Some(
         GoMod(
-          fileFullPath = File(inputPath) / "go.mod" pathAsString,
+          fileFullPath = (Paths.get(inputPath) / "go.mod").toString,
           module = GoModModule("joern.io/trial"),
           dependencies = List[GoModDependency]()
         )
       )
     )
     val namespace =
-      goMod.getNameSpace(File(inputPath) / "first" / "second" / "test.go" pathAsString, "main")
+      goMod.getNameSpace((Paths.get(inputPath) / "first" / "second" / "test.go").toString, "main")
     namespace shouldBe "first/second/main"
   }
 
   "with .mod file and main pkg 3 use case" in {
-    val inputPath = File.currentWorkingDirectory.toString() + JFile.separator
+    val inputPath = Paths.get("").toString + JFile.separator
     val goMod = new GoModHelper(
       Some(inputPath),
       Some(
         GoMod(
-          fileFullPath = File(inputPath) / "go.mod" pathAsString,
+          fileFullPath = (Paths.get(inputPath) / "go.mod").toString,
           module = GoModModule("joern.io/trial"),
           dependencies = List[GoModDependency]()
         )
       )
     )
     val namespace =
-      goMod.getNameSpace(File(inputPath) / "test.go" pathAsString, "main")
+      goMod.getNameSpace((Paths.get(inputPath) / "test.go").toString, "main")
     namespace shouldBe "main"
   }
 
   "with .mod file and pkg other than main matching with folder" in {
-    val inputPath = File.currentWorkingDirectory.toString() + JFile.separator
+    val inputPath = Paths.get("").toString + JFile.separator
     val goMod = new GoModHelper(
       Some(inputPath),
       Some(
         GoMod(
-          fileFullPath = File(inputPath) / "go.mod" pathAsString,
+          fileFullPath = (Paths.get(inputPath) / "go.mod").toString,
           module = GoModModule("joern.io/trial"),
           dependencies = List[GoModDependency]()
         )
       )
     )
     val namespace =
-      goMod.getNameSpace(File(inputPath) / "test.go" pathAsString, "trial")
+      goMod.getNameSpace((Paths.get(inputPath) / "test.go").toString, "trial")
     namespace shouldBe "joern.io/trial"
   }
 
   "with .mod file, pkg other than main, one level child folder, and package matching with last folder" in {
-    val inputPath = File.currentWorkingDirectory.toString() + JFile.separator
+    val inputPath = Paths.get("").toString + JFile.separator
     val goMod = new GoModHelper(
       Some(inputPath),
       Some(
         GoMod(
-          fileFullPath = File(inputPath) / "go.mod" pathAsString,
+          fileFullPath = (Paths.get(inputPath) / "go.mod").toString,
           module = GoModModule("joern.io/trial"),
           dependencies = List[GoModDependency]()
         )
       )
     )
     val namespace =
-      goMod.getNameSpace(File(inputPath) / "first" / "test.go" pathAsString, "first")
+      goMod.getNameSpace((Paths.get(inputPath) / "first" / "test.go").toString, "first")
     namespace shouldBe "joern.io/trial/first"
   }
 
   "with .mod file and pkg other than main and not matching with folder" in {
-    val inputPath = File.currentWorkingDirectory.toString() + JFile.separator
+    val inputPath = Paths.get("").toString + JFile.separator
     val goMod = new GoModHelper(
       Some(inputPath),
       Some(
         GoMod(
-          fileFullPath = File(inputPath) / "go.mod" pathAsString,
+          fileFullPath = (Paths.get(inputPath) / "go.mod").toString,
           module = GoModModule("joern.io/trial"),
           dependencies = List[GoModDependency]()
         )
       )
     )
     val namespace =
-      goMod.getNameSpace(File(inputPath) / "test.go" pathAsString, "foo")
+      goMod.getNameSpace((Paths.get(inputPath) / "test.go").toString, "foo")
     namespace shouldBe "joern.io/trial"
   }
 
   "with .mod file, pkg other than main, one level child folder, and package not matching with last folder" in {
-    val inputPath = File.currentWorkingDirectory.toString() + JFile.separator
+    val inputPath = Paths.get("").toString + JFile.separator
     val goMod = new GoModHelper(
       Some(inputPath),
       Some(
         GoMod(
-          fileFullPath = File(inputPath) / "go.mod" pathAsString,
+          fileFullPath = (Paths.get(inputPath) / "go.mod").toString,
           module = GoModModule("joern.io/trial"),
           dependencies = List[GoModDependency]()
         )
       )
     )
     val namespace =
-      goMod.getNameSpace(File(inputPath) / "first" / "test.go" pathAsString, "bar")
+      goMod.getNameSpace((Paths.get(inputPath) / "first" / "test.go").toString, "bar")
     namespace shouldBe "joern.io/trial/first"
   }
 }

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/model/GoModTest.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/model/GoModTest.scala
@@ -2,11 +2,11 @@ package io.joern.go2cpg.model;
 
 import io.joern.gosrc2cpg.Config
 import io.joern.gosrc2cpg.model.{GoMod, GoModDependency, GoModHelper, GoModModule}
-import io.joern.x2cpg.utils.FileUtil
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 
 import java.io.File as JFile
 import java.nio.file.{Files, Path, Paths}

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/testfixtures/GoCodeToCpgSuite.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/testfixtures/GoCodeToCpgSuite.scala
@@ -1,6 +1,5 @@
 package io.joern.go2cpg.testfixtures
 
-import better.files.File
 import io.joern.dataflowengineoss.DefaultSemantics
 import io.joern.dataflowengineoss.semanticsloader.{FlowSemantic, Semantics}
 import io.joern.dataflowengineoss.testfixtures.{SemanticCpgTestFixture, SemanticTestCpg}

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/testfixtures/GoCodeToCpgSuite.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/testfixtures/GoCodeToCpgSuite.scala
@@ -7,9 +7,9 @@ import io.joern.gosrc2cpg.datastructures.GoGlobal
 import io.joern.gosrc2cpg.model.GoModHelper
 import io.joern.gosrc2cpg.{Config, GoSrc2Cpg}
 import io.joern.x2cpg.testfixtures.{Code2CpgFixture, DefaultTestCpg}
-import io.joern.x2cpg.utils.FileUtil
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.semanticcpg.language.{ICallResolver, NoResolve}
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.scalatest.Inside
 class DefaultTestCpgWithGo(val fileSuffix: String) extends DefaultTestCpg with SemanticTestCpg {
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
@@ -21,12 +21,12 @@ import io.joern.javasrc2cpg.util.{Delombok, SourceParser}
 import io.joern.javasrc2cpg.{Config, JavaSrc2Cpg}
 import io.joern.x2cpg.SourceFiles
 import io.joern.x2cpg.datastructures.Global
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.joern.x2cpg.passes.frontend.XTypeRecoveryConfig
 import io.joern.x2cpg.utils.dependency.DependencyResolver
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.passes.ForkJoinParallelCpgPass
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.slf4j.LoggerFactory
 
 import java.net.URLClassLoader

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/JmodClassPath.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/JmodClassPath.scala
@@ -1,18 +1,18 @@
 package io.joern.javasrc2cpg.typesolvers
 
-import better.files.File
 import io.joern.javasrc2cpg.typesolvers.JmodClassPath.*
 import javassist.ClassPath
 
 import scala.jdk.CollectionConverters.*
 import scala.util.Try
 import java.io.InputStream
+import java.nio.file.{Files, Path, Paths}
 import java.net.URL
 import java.util.jar.{JarEntry, JarFile}
 
 class JmodClassPath(jmodPath: String) extends ClassPath {
   private val jarfile    = new JarFile(jmodPath)
-  private val jarfileURL = File(jmodPath).url.toString
+  private val jarfileURL = Paths.get(jmodPath).toUri.toURL.toString
   private val entries    = getEntriesMap(jarfile)
 
   private def entryToClassName(entry: JarEntry): String = {

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/noncaching/JdkJarTypeSolver.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/noncaching/JdkJarTypeSolver.scala
@@ -8,7 +8,6 @@ import io.joern.javasrc2cpg.typesolvers.JdkJarTypeSolver.*
 import io.joern.x2cpg.SourceFiles
 import javassist.{ClassPath, CtClass}
 import org.slf4j.LoggerFactory
-import better.files.File.VisitOptions
 
 import java.io.IOException
 import java.util.jar.JarFile
@@ -142,7 +141,7 @@ object JdkJarTypeSolver {
   private def determineJarPaths(jdkPath: String): List[String] = {
     // not following symlinks, because some setups might have a loop, e.g. AWS's Corretto
     // see https://github.com/joernio/joern/pull/3871
-    val jarPaths = SourceFiles.determine(jdkPath, Set(JarExtension, JmodExtension))(VisitOptions.default)
+    val jarPaths = SourceFiles.determine(jdkPath, Set(JarExtension, JmodExtension))(Seq.empty)
     if (jarPaths.isEmpty) {
       throw new IllegalArgumentException(s"No .jar or .jmod files found at JDK path ${jdkPath}")
     }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Delombok.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Delombok.scala
@@ -82,7 +82,7 @@ object Delombok {
       else relativePackageRoot.toString
     val inputDir = projectDir.resolve(relativePackageRoot)
 
-    val childPath = delombokTempDir / relativeOutputPath
+    val childPath = (delombokTempDir / relativeOutputPath).toAbsolutePath.normalize()
 
     Try(childPath.createWithParentsIfNotExists(asDirectory = true)).flatMap { packageOutputDir =>
       ExternalCommand

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Delombok.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Delombok.scala
@@ -1,9 +1,8 @@
 package io.joern.javasrc2cpg.util
 
 import io.joern.javasrc2cpg.util.Delombok.DelombokMode.*
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
-import io.shiftleft.semanticcpg.utils.ExternalCommand
+import io.shiftleft.semanticcpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.{ExternalCommand, FileUtil}
 import org.slf4j.LoggerFactory
 
 import java.nio.file.{Files, Path, Paths}

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/PackageRootFinder.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/PackageRootFinder.scala
@@ -1,10 +1,7 @@
 package io.joern.javasrc2cpg.util
 
-import better.files.File
-
 import java.nio.file.Path
 import scala.collection.mutable
-import scala.util.matching.Regex
 
 object PackageRootFinder {
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/SourceParser.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/SourceParser.scala
@@ -8,8 +8,8 @@ import io.joern.javasrc2cpg.util.Delombok.DelombokMode
 import io.joern.javasrc2cpg.util.SourceParser.fileIfExists
 import io.joern.javasrc2cpg.{Config, JavaSrc2Cpg}
 import io.joern.x2cpg.SourceFiles
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 import io.shiftleft.utils.IOUtils
 import org.slf4j.LoggerFactory
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/SourceParser.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/SourceParser.scala
@@ -1,6 +1,5 @@
 package io.joern.javasrc2cpg.util
 
-import better.files.File
 import com.github.javaparser.{JavaParser, ParserConfiguration}
 import com.github.javaparser.ParserConfiguration.LanguageLevel
 import com.github.javaparser.ast.CompilationUnit
@@ -9,11 +8,13 @@ import io.joern.javasrc2cpg.util.Delombok.DelombokMode
 import io.joern.javasrc2cpg.util.SourceParser.fileIfExists
 import io.joern.javasrc2cpg.{Config, JavaSrc2Cpg}
 import io.joern.x2cpg.SourceFiles
+import io.joern.x2cpg.utils.FileUtil
+import io.joern.x2cpg.utils.FileUtil.*
 import io.shiftleft.utils.IOUtils
 import org.slf4j.LoggerFactory
 
 import java.nio.charset.{Charset, StandardCharsets}
-import java.nio.file.Path
+import java.nio.file.{Files, Path, Paths}
 import scala.jdk.CollectionConverters.*
 import scala.jdk.OptionConverters.RichOptional
 import scala.util.Try
@@ -45,9 +46,9 @@ class SourceParser(
       val compilationUnit = parse(file, storeTokens = true)
       val fileContent = Option
         .when(saveFileContent) {
-          Try(IOUtils.readEntireFile(file.path))
-            .orElse(Try(file.contentAsString(Charset.defaultCharset())))
-            .orElse(Try(file.contentAsString(StandardCharsets.ISO_8859_1)))
+          Try(IOUtils.readEntireFile(file))
+            .orElse(Try(file.fileContent(Charset.defaultCharset())))
+            .orElse(Try(file.fileContent(StandardCharsets.ISO_8859_1)))
             .toOption
         }
         .flatten
@@ -67,17 +68,17 @@ class SourceParser(
     fileIfExists(typesFilename).flatMap(parse(_, storeTokens = false))
   }
 
-  private def parse(file: File, storeTokens: Boolean): Option[CompilationUnit] = {
+  private def parse(file: Path, storeTokens: Boolean): Option[CompilationUnit] = {
     val javaParserConfig =
       new ParserConfiguration()
         .setLanguageLevel(LanguageLevel.BLEEDING_EDGE)
         .setStoreTokens(storeTokens)
-    val parseResult = new JavaParser(javaParserConfig).parse(file.toJava)
+    val parseResult = new JavaParser(javaParserConfig).parse(file)
 
     parseResult.getProblems.asScala.toList match {
       case Nil => // Just carry on as usual
       case problems =>
-        logger.warn(s"Encountered problems while parsing file ${file.name}:")
+        logger.warn(s"Encountered problems while parsing file ${file.fileName}:")
         problems.foreach { problem =>
           logger.warn(s"- ${problem.getMessage}")
         }
@@ -86,13 +87,13 @@ class SourceParser(
     parseResult.getResult.toScala match {
       case Some(result) if result.getParsed == Parsedness.PARSED => Some(result)
       case _ =>
-        logger.warn(s"Failed to parse file ${file.name}")
+        logger.warn(s"Failed to parse file ${file.fileName}")
         None
     }
   }
 
   def cleanupDelombokOutput(): Unit = {
-    dirToDelete.foreach(path => File(path).delete())
+    dirToDelete.foreach(FileUtil.delete(_))
   }
 
 }
@@ -107,7 +108,7 @@ object SourceParser {
     def getFileInfo(inputDir: Path, filename: String): Option[FileInfo] = {
       fileIfExists(filename).map { file =>
         val relativePath = inputDir.relativize(Path.of(filename))
-        val content      = file.contentAsString
+        val content      = file.fileContent
 
         val packageName = PackageNameRegex.findFirstMatchIn(content).map(_.group(1))
 
@@ -120,21 +121,20 @@ object SourceParser {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
 
-  private def checkExists(file: File): Option[File] = {
-    if (file.exists) {
+  private def checkExists(file: Path): Option[Path] = {
+    if (Files.exists(file)) {
       Option(file)
     } else {
-      logger.warn(s"Attempting to open file, but it does not exist: ${file.pathAsString}")
+      logger.warn(s"Attempting to open file, but it does not exist: ${file.toString}")
       None
     }
   }
-  private[util] def fileIfExists(path: Path): Option[File] = {
-    val file = File(path)
-    checkExists(file)
+  private[util] def fileIfExists(path: Path): Option[Path] = {
+    checkExists(path)
   }
 
-  private[util] def fileIfExists(filename: String): Option[File] = {
-    val file = File(filename)
+  private[util] def fileIfExists(filename: String): Option[Path] = {
+    val file = Paths.get(filename)
     checkExists(file)
   }
 

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/io/JavaSrc2CpgHTTPServerTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/io/JavaSrc2CpgHTTPServerTests.scala
@@ -1,10 +1,10 @@
 package io.joern.javasrc2cpg.io
 
 import io.joern.x2cpg.utils.server.FrontendHTTPClient
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.cpgloading.CpgLoader
 import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/passes/ConfigFileCreationPassTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/passes/ConfigFileCreationPassTests.scala
@@ -3,7 +3,7 @@ package io.joern.javasrc2cpg.passes
 import flatgraph.misc.TestUtils.*
 import io.joern.javasrc2cpg.testfixtures.JavaSrcCode2CpgFixture
 import io.joern.x2cpg.passes.frontend.JavaConfigFileCreationPass
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.NewMetaData
 import io.shiftleft.semanticcpg.language.*

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/passes/ConfigFileCreationPassTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/passes/ConfigFileCreationPassTests.scala
@@ -1,9 +1,9 @@
 package io.joern.javasrc2cpg.passes
 
-import better.files.File
 import flatgraph.misc.TestUtils.*
 import io.joern.javasrc2cpg.testfixtures.JavaSrcCode2CpgFixture
 import io.joern.x2cpg.passes.frontend.JavaConfigFileCreationPass
+import io.joern.x2cpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.NewMetaData
 import io.shiftleft.semanticcpg.language.*
@@ -19,8 +19,8 @@ class ConfigFileCreationPassTests extends JavaSrcCode2CpgFixture {
   "it should find the correct config files" in {
     val cpg = Cpg.from(_.addNode(NewMetaData().root(testConfigDir)))
 
-    val foundFiles        = new JavaConfigFileCreationPass(cpg).generateParts().map(_.canonicalPath)
-    val absoluteConfigDir = File(testConfigDir).canonicalPath
+    val foundFiles        = new JavaConfigFileCreationPass(cpg).generateParts().map(_.absolutePathAsString)
+    val absoluteConfigDir = Paths.get(testConfigDir).absolutePathAsString
     foundFiles should contain theSameElementsAs Array(
       Paths.get(absoluteConfigDir, "application.conf").toString,
       Paths.get(absoluteConfigDir, "basic.jsp").toString,

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
@@ -7,9 +7,9 @@ import io.joern.x2cpg.X2Cpg.withNewEmptyCpg
 import io.joern.x2cpg.X2CpgFrontend
 import io.joern.x2cpg.datastructures.Global
 import io.joern.x2cpg.passes.frontend.{JavaConfigFileCreationPass, MetaDataPass, TypeNodePass}
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Cpg
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.slf4j.LoggerFactory
 import soot.options.Options
 import soot.{G, Scene}

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
@@ -1,6 +1,5 @@
 package io.joern.jimple2cpg
 
-import better.files.File
 import io.joern.jimple2cpg.passes.{AstCreationPass, DeclarationRefPass, SootAstCreationPass}
 import io.joern.jimple2cpg.util.Decompiler
 import io.joern.jimple2cpg.util.ProgramHandlingUtil.{ClassFile, extractClassesInPackageLayout}
@@ -100,7 +99,7 @@ class Jimple2Cpg extends X2CpgFrontend[Config] {
     val input = Paths.get(config.inputPath)
     configureSoot(config, tmpDir)
     new MetaDataPass(cpg, language, config.inputPath).createAndApply()
-    val globalFromAstCreation: () => Global = input.extension match {
+    val globalFromAstCreation: () => Global = input.extension() match {
       case Some(".apk" | ".dex") if Files.isRegularFile(input) =>
         sootLoadApk(input, config.android)
         { () =>
@@ -151,8 +150,8 @@ class Jimple2Cpg extends X2CpgFrontend[Config] {
   override def createCpg(config: Config): Try[Cpg] =
     try {
       withNewEmptyCpg(config.outputPath, config: Config) { (cpg, config) =>
-        File.temporaryDirectory("jimple2cpg-").apply { tmpDir =>
-          cpgApplyPasses(cpg, config, tmpDir.path)
+        FileUtil.usingTemporaryDirectory("jimple2cpg-") { tmpDir =>
+          cpgApplyPasses(cpg, config, tmpDir)
         }
       }
     } finally {

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreationPass.scala
@@ -4,7 +4,7 @@ import io.joern.jimple2cpg.Config
 import io.joern.jimple2cpg.astcreation.AstCreator
 import io.joern.jimple2cpg.util.ProgramHandlingUtil.ClassFile
 import io.joern.x2cpg.datastructures.Global
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.passes.ForkJoinParallelCpgPass
 import org.slf4j.LoggerFactory

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreationPass.scala
@@ -8,11 +8,11 @@ import io.joern.x2cpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.passes.ForkJoinParallelCpgPass
 import org.slf4j.LoggerFactory
-import better.files.{DefaultCharset, File}
 import io.shiftleft.utils.IOUtils
 import soot.Scene
 
 import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Paths}
 import scala.util.Try
 
 /** Creates the AST layer from the given class file and stores all types in the given global parameter.
@@ -34,13 +34,13 @@ class AstCreationPass(classFiles: List[ClassFile], cpg: Cpg, config: Config)
       val sootClass = Scene.v().loadClassAndSupport(classFile.fullyQualifiedClassName.get)
       sootClass.setApplicationClass()
 
-      val file = File(classFile.file.toString.replace(".class", ".java"))
+      val file = Paths.get(classFile.file.toString.replace(".class", ".java"))
 
       val fileContent = Option
-        .when(!config.disableFileContent && file.exists) {
-          Try(IOUtils.readEntireFile(file.path))
-            .orElse(Try(file.contentAsString(DefaultCharset)))
-            .orElse(Try(file.contentAsString(StandardCharsets.ISO_8859_1)))
+        .when(!config.disableFileContent && Files.exists(file)) {
+          Try(IOUtils.readEntireFile(file))
+            .orElse(Try(file.fileContent()))
+            .orElse(Try(file.fileContent(StandardCharsets.ISO_8859_1)))
             .toOption
         }
         .flatten

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/util/Decompiler.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/util/Decompiler.scala
@@ -1,6 +1,5 @@
 package io.joern.jimple2cpg.util
 
-import better.files.File
 import org.benf.cfr.reader.api.OutputSinkFactory.{Sink, SinkClass, SinkType}
 import org.benf.cfr.reader.api.SinkReturns.Decompiled
 import org.benf.cfr.reader.api.{CfrDriver, OutputSinkFactory}
@@ -8,10 +7,11 @@ import org.slf4j.LoggerFactory
 
 import java.util
 import java.util.{Collection, Collections}
+import java.nio.file.{Files, Path, Paths}
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
 
-class Decompiler(classFile: List[File]) {
+class Decompiler(classFile: List[Path]) {
 
   private val logger                                                   = LoggerFactory.getLogger(getClass)
   private val classToDecompiledSource: mutable.HashMap[String, String] = mutable.HashMap.empty;
@@ -20,7 +20,7 @@ class Decompiler(classFile: List[File]) {
     */
   def decompile(): mutable.HashMap[String, String] = {
     val driver = new CfrDriver.Builder().withOutputSink(outputSink).build()
-    driver.analyse(SeqHasAsJava(classFile.map(_.pathAsString)).asJava)
+    driver.analyse(SeqHasAsJava(classFile.map(_.toString)).asJava)
     classToDecompiledSource
   }
 

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/util/ProgramHandlingUtil.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/util/ProgramHandlingUtil.scala
@@ -1,7 +1,7 @@
 package io.joern.jimple2cpg.util
 
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 
 import java.io.{BufferedInputStream, FileInputStream}
 import java.nio.file.StandardCopyOption

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/util/ProgramHandlingUtil.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/util/ProgramHandlingUtil.scala
@@ -1,11 +1,10 @@
 package io.joern.jimple2cpg.util
 
+import io.joern.x2cpg.utils.FileUtil
 import io.joern.x2cpg.utils.FileUtil.*
 
 import java.io.{BufferedInputStream, FileInputStream}
-import java.nio.file.StandardCopyOption;
-
-import better.files.*
+import java.nio.file.StandardCopyOption
 import org.objectweb.asm.ClassReader.SKIP_CODE
 import org.objectweb.asm.{ClassReader, ClassVisitor, Opcodes}
 import org.slf4j.LoggerFactory
@@ -14,7 +13,7 @@ import java.io.InputStream
 import java.nio.file.{Files, Path, Paths}
 import java.util.zip.{ZipEntry, ZipFile, ZipInputStream}
 import scala.util.{Failure, Left, Success, Try, Using}
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 /** Responsible for handling JAR unpacking and handling the temporary build directory.
   */
@@ -30,8 +29,8 @@ object ProgramHandlingUtil {
     def this(file: Path) = this(Left(file))
     def this(entry: ZipEntry, parentArchive: ZipFile) = this(Right(entry), Option(parentArchive))
     private def file: Path          = entry.fold(identity, e => Paths.get(e.getName))
-    def name: String                = file.getFileName.toString
-    def extension: Option[String]   = file.extension
+    def name: String                = file.fileName
+    def extension: Option[String]   = file.extension()
     def isDirectory: Boolean        = entry.fold(Files.isDirectory(_), _.isDirectory)
     def maybeRegularFile(): Boolean = entry.fold(Files.isRegularFile(_), !_.isDirectory)
 
@@ -48,9 +47,9 @@ object ProgramHandlingUtil {
       case Right(zipEntry: ZipEntry) if !isZipSlip =>
         parentArchive.exists { f =>
           Using.resource(f.getInputStream(zipEntry)) { is =>
-            File.temporaryFile("jimple2cpg-", ".zip").apply { f =>
-              f.writeBytes(is.readAllBytes().iterator)
-              isValidZipFile(f.path)
+            FileUtil.usingTemporaryFile("jimple2cpg-", ".zip") { f =>
+              FileUtil.writeBytes(f, is.readAllBytes())
+              isValidZipFile(f)
             }
           }
         }
@@ -82,7 +81,7 @@ object ProgramHandlingUtil {
     def isConfigFile: Boolean = {
       val configExt = Set(".xml", ".properties", ".yaml", ".yml", ".tf", ".tfvars", ".vm", ".jsp", ".conf", ".mf")
 
-      def hasConfigExt(f: Path): Boolean = configExt.exists(f.extension.map(_.toLowerCase).contains(_))
+      def hasConfigExt(f: Path): Boolean = configExt.exists(f.extension().map(_.toLowerCase).contains(_))
 
       if (isDirectory) { false }
       else {
@@ -289,7 +288,7 @@ object ProgramHandlingUtil {
 
   private sealed class ConfigFile(val file: Path) extends EntryFile {
 
-    def packagePath: Option[String] = Option(file.getFileName.toString)
+    def packagePath: Option[String] = Option(file.fileName)
 
   }
 
@@ -332,13 +331,12 @@ object ProgramHandlingUtil {
     recurse: Boolean,
     depth: Int
   ): List[ClassFile] =
-    File
-      .temporaryDirectory("extract-classes-")
-      .apply(tmpDir =>
-        extractClassesToTmp(src, tmpDir.path, isArchive, isClass, isConfigFile, recurse: Boolean, depth: Int).iterator
+    FileUtil
+      .usingTemporaryDirectory("extract-classes-") { tmpDir =>
+        extractClassesToTmp(src, tmpDir, isArchive, isClass, isConfigFile, recurse: Boolean, depth: Int).iterator
           .flatMap(_.copyToPackageLayoutIn(destDir))
           .collect { case x: ClassFile => x }
           .toList
-      )
+      }
 
 }

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/io/Jimple2CpgHTTPServerTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/io/Jimple2CpgHTTPServerTests.scala
@@ -3,10 +3,10 @@ package io.joern.jimple2cpg.io
 import io.joern.jimple2cpg.testfixtures.JimpleCode2CpgFixture
 import io.joern.jimple2cpg.testfixtures.JimpleCodeToCpgFixture
 import io.joern.x2cpg.utils.server.FrontendHTTPClient
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.cpgloading.CpgLoader
 import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.scalatest.BeforeAndAfterAll
 
 import java.nio.file.{Files, Path}

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/testfixtures/JimpleCodeToCpgFixture.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/testfixtures/JimpleCodeToCpgFixture.scala
@@ -6,7 +6,7 @@ import io.joern.dataflowengineoss.testfixtures.{SemanticCpgTestFixture, Semantic
 import io.joern.jimple2cpg.{Config, Jimple2Cpg}
 import io.joern.x2cpg.X2Cpg
 import io.joern.x2cpg.testfixtures.{Code2CpgFixture, DefaultTestCpg, LanguageFrontend, TestCpg}
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Cpg
 
 import java.io.File

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/unpacking/JarUnpackingTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/unpacking/JarUnpackingTests.scala
@@ -1,7 +1,7 @@
 package io.joern.jimple2cpg.unpacking
 
 import io.joern.jimple2cpg.{Config, Jimple2Cpg}
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.utils.ProjectRoot

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/unpacking/JarUnpackingTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/unpacking/JarUnpackingTests.scala
@@ -1,8 +1,7 @@
 package io.joern.jimple2cpg.unpacking
 
-import better.files.File
 import io.joern.jimple2cpg.{Config, Jimple2Cpg}
-import io.joern.jimple2cpg.util.ProgramHandlingUtil
+import io.joern.x2cpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.utils.ProjectRoot
@@ -47,10 +46,11 @@ class JarUnpackingTests extends AnyWordSpec with Matchers with BeforeAndAfterAll
 
   "'resources/unpacking' should contain 'HelloWorld.jar' and 'NestedHelloWorld.jar'" in {
     val targetDir = ProjectRoot.relativise("joern-cli/frontends/jimple2cpg/src/test/resources/unpacking")
-    File(targetDir)
+    Paths
+      .get(targetDir)
       .walk()
-      .filter(f => f.isRegularFile && f.extension.exists(_ == ".jar"))
-      .map(_.name)
+      .filter(f => Files.isRegularFile(f) && f.extension().exists(_ == ".jar"))
+      .map(_.fileName)
       .toSet shouldBe Set("HelloWorld.jar", "NestedHelloWorld.jar")
   }
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/JsSrc2Cpg.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/JsSrc2Cpg.scala
@@ -8,10 +8,11 @@ import io.joern.x2cpg.X2CpgFrontend
 import io.joern.x2cpg.frontendspecific.jssrc2cpg.postProcessingPasses
 import io.joern.x2cpg.passes.callgraph.NaiveCallLinker
 import io.joern.x2cpg.passes.frontend.XTypeRecoveryConfig
-import io.joern.x2cpg.utils.{FileUtil, HashUtil, Report}
+import io.joern.x2cpg.utils.{HashUtil, Report}
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.passes.CpgPassBase
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
+import io.shiftleft.semanticcpg.utils.FileUtil
 
 import java.nio.file.Paths
 import scala.util.Try

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptMetaDataPass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptMetaDataPass.scala
@@ -1,15 +1,17 @@
 package io.joern.jssrc2cpg.passes
 
-import better.files.File
+import io.joern.x2cpg.utils.FileUtil.PathExt
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.NewMetaData
 import io.shiftleft.codepropertygraph.generated.Languages
 import io.shiftleft.passes.CpgPass
 
+import java.nio.file.Paths
+
 class JavaScriptMetaDataPass(cpg: Cpg, hash: String, inputPath: String) extends CpgPass(cpg) {
 
   override def run(diffGraph: DiffGraphBuilder): Unit = {
-    val absolutePathToRoot = File(inputPath).path.toAbsolutePath.toString
+    val absolutePathToRoot = Paths.get(inputPath).absolutePathAsString
     val metaNode           = NewMetaData().language(Languages.JSSRC).root(absolutePathToRoot).hash(hash).version("0.1")
     diffGraph.addNode(metaNode)
   }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptMetaDataPass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/JavaScriptMetaDataPass.scala
@@ -1,6 +1,6 @@
 package io.joern.jssrc2cpg.passes
 
-import io.joern.x2cpg.utils.FileUtil.PathExt
+import io.shiftleft.semanticcpg.utils.FileUtil.PathExt
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.NewMetaData
 import io.shiftleft.codepropertygraph.generated.Languages

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/PrivateKeyFilePass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/PrivateKeyFilePass.scala
@@ -1,11 +1,11 @@
 package io.joern.jssrc2cpg.passes
 
-import better.files.File
 import io.joern.jssrc2cpg.Config
 import io.joern.x2cpg.utils.Report
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.utils.IOUtils
 
+import java.nio.file.Path
 import scala.util.matching.Regex
 
 class PrivateKeyFilePass(cpg: Cpg, config: Config, report: Report = new Report())
@@ -16,12 +16,12 @@ class PrivateKeyFilePass(cpg: Cpg, config: Config, report: Report = new Report()
   override val allExtensions: Set[String]      = Set(".key")
   override val selectedExtensions: Set[String] = Set(".key")
 
-  override def fileContent(file: File): Seq[String] =
+  override def fileContent(file: Path): Seq[String] =
     Seq("Content omitted for security reasons.")
 
-  override def generateParts(): Array[File] =
+  override def generateParts(): Array[Path] =
     configFiles(config, selectedExtensions).toArray.filter(p =>
-      IOUtils.readLinesInFile(p.path).exists(PrivateKeyRegex.matches)
+      IOUtils.readLinesInFile(p).exists(PrivateKeyRegex.matches)
     )
 
 }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/utils/AstGenRunner.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/utils/AstGenRunner.scala
@@ -1,17 +1,17 @@
 package io.joern.jssrc2cpg.utils
 
-import better.files.File
 import com.typesafe.config.ConfigFactory
 import io.joern.jssrc2cpg.Config
 import io.joern.jssrc2cpg.preprocessing.EjsPreprocessor
 import io.joern.x2cpg.SourceFiles
-import io.joern.x2cpg.utils.Environment
+import io.joern.x2cpg.utils.{Environment, FileUtil}
+import io.joern.x2cpg.utils.FileUtil.*
 import io.shiftleft.semanticcpg.utils.ExternalCommand
 import io.shiftleft.utils.IOUtils
 import org.slf4j.LoggerFactory
 import versionsort.VersionHelper
 
-import java.nio.file.Paths
+import java.nio.file.{Files, Path, Paths}
 import java.util.regex.Pattern
 import scala.util.Failure
 import scala.util.Success
@@ -89,9 +89,9 @@ object AstGenRunner {
 
   // full path to the astgen binary from the env var ASTGEN_BIN
   private val AstGenBin: Option[String] = scala.util.Properties.envOrNone("ASTGEN_BIN").flatMap {
-    case path if File(path).isDirectory => Some((File(path) / "astgen").pathAsString)
-    case path if File(path).exists      => Some(File(path).pathAsString)
-    case _                              => None
+    case path if Files.isDirectory(Paths.get(path)) => Some((Paths.get(path) / "astgen").toString)
+    case path if Files.exists(Paths.get(path))      => Some(Paths.get(path).toString)
+    case _                                          => None
   }
 
   lazy private val executableName = (Environment.operatingSystem, Environment.architecture) match {
@@ -123,7 +123,7 @@ object AstGenRunner {
 
   private def hasCompatibleAstGenVersionAtPath(astGenVersion: String, path: Option[String]): Boolean = {
     val astGenCommand = path.getOrElse("astgen")
-    val localPath     = path.flatMap(File(_).parentOption.map(_.pathAsString)).getOrElse(".")
+    val localPath     = path.flatMap(Paths.get(_).parentOption.map(_.toString)).getOrElse(".")
     val debugMsgPath  = path.getOrElse("PATH")
     ExternalCommand
       .run(Seq(astGenCommand, "--version"), Option(localPath))
@@ -213,8 +213,8 @@ class AstGenRunner(config: Config) {
 
   private def isIgnoredByUserConfig(filePath: String): Boolean = {
     lazy val isInIgnoredFiles = config.ignoredFiles.exists {
-      case ignorePath if File(ignorePath).isDirectory => filePath.startsWith(ignorePath)
-      case ignorePath                                 => filePath == ignorePath
+      case ignorePath if Files.isDirectory(Paths.get(ignorePath)) => filePath.startsWith(ignorePath)
+      case ignorePath                                             => filePath == ignorePath
     }
     lazy val isInIgnoredFileRegex = config.ignoredFilesRegex.matches(filePath)
     if (isInIgnoredFiles || isInIgnoredFileRegex) {
@@ -227,8 +227,8 @@ class AstGenRunner(config: Config) {
 
   private def isMinifiedFile(filePath: String): Boolean = filePath match {
     case p if MinifiedPathRegex.matches(p) => true
-    case p if File(p).exists && p.endsWith(".js") =>
-      val lines             = IOUtils.readLinesInFile(File(filePath).path)
+    case p if Files.exists(Paths.get(p)) && p.endsWith(".js") =>
+      val lines             = IOUtils.readLinesInFile(Paths.get(filePath))
       val linesOfCode       = lines.size
       val longestLineLength = if (lines.isEmpty) 0 else lines.map(_.length).max
       if (longestLineLength >= LineLengthThreshold && linesOfCode <= 50) {
@@ -251,17 +251,20 @@ class AstGenRunner(config: Config) {
   }
 
   private def isTranspiledFile(filePath: String): Boolean = {
-    val file = File(filePath)
+    val file = Paths.get(filePath)
     // We ignore files iff:
     // - they are *.js files and
     // - they contain a //sourceMappingURL comment or have an associated source map file and
     // - a file with the same name is located directly next to them
-    lazy val isJsFile            = file.exists && file.extension.contains(".js")
-    lazy val hasSourceMapComment = IOUtils.readLinesInFile(file.path).exists(_.contains("//sourceMappingURL"))
-    lazy val hasSourceMapFile    = File(s"$filePath.map").exists
+    lazy val isJsFile            = Files.exists(file) && file.extension().contains(".js")
+    lazy val hasSourceMapComment = IOUtils.readLinesInFile(file).exists(_.contains("//sourceMappingURL"))
+    lazy val hasSourceMapFile    = Files.exists(Paths.get(s"$filePath.map"))
     lazy val hasSourceMap        = hasSourceMapComment || hasSourceMapFile
     lazy val hasFileWithSameName =
-      file.siblings.exists(_.nameWithoutExtension(includeAll = false) == file.nameWithoutExtension)
+      file.getParent
+        .listFiles()
+        .filterNot(_ == file)
+        .exists(_.nameWithoutExtension(includeAll = false) == file.nameWithoutExtension())
     if (isJsFile && hasSourceMap && hasFileWithSameName) {
       logger.debug(s"'$filePath' ignored by default (seems to be the result of transpilation)")
       true
@@ -271,10 +274,10 @@ class AstGenRunner(config: Config) {
 
   }
 
-  private def filterFiles(files: List[String], out: File): List[String] = {
+  private def filterFiles(files: List[String], out: Path): List[String] = {
     files.filter { file =>
       Try {
-        file.stripSuffix(".json").replace(out.pathAsString, config.inputPath) match {
+        file.stripSuffix(".json").replace(out.toString, config.inputPath) match {
           // We are not interested in JS / TS type definition files at this stage.
           // TODO: maybe we can enable that later on and use the type definitions there
           //  for enhancing the CPG with additional type information for functions
@@ -297,24 +300,31 @@ class AstGenRunner(config: Config) {
   /** Changes the file-extension by renaming this file; if file does not have an extension, it adds the extension. If
     * file does not exist (or is a directory) no change is done and the current file is returned.
     */
-  private def changeExtensionTo(file: File, extension: String): File = {
+  private def changeExtensionTo(file: Path, extension: String): Path = {
     val newName = s"${file.nameWithoutExtension(includeAll = false)}.${extension.stripPrefix(".")}"
-    if (file.isRegularFile) file.renameTo(newName) else if (file.notExists) File(newName) else file
+    if (Files.isRegularFile(file)) Files.move(file, file.resolveSibling(newName))
+    else if (Files.notExists(file)) Paths.get(newName)
+    else file
+
   }
 
-  private def processEjsFiles(in: File, out: File, ejsFiles: List[String]): Try[Seq[String]] = {
+  private def processEjsFiles(in: Path, out: Path, ejsFiles: List[String]): Try[Seq[String]] = {
     val tmpJsFiles = ejsFiles.map { ejsFilePath =>
-      val ejsFile             = File(ejsFilePath)
-      val maybeTranspiledFile = File(s"${ejsFilePath.stripSuffix(".ejs")}.js")
-      if (isTranspiledFile(maybeTranspiledFile.pathAsString)) {
+      val ejsFile             = Paths.get(ejsFilePath)
+      val maybeTranspiledFile = Paths.get(s"${ejsFilePath.stripSuffix(".ejs")}.js")
+      if (isTranspiledFile(maybeTranspiledFile.toString)) {
         maybeTranspiledFile
       } else {
-        val sourceFileContent = IOUtils.readEntireFile(ejsFile.path)
+        val sourceFileContent = IOUtils.readEntireFile(ejsFile)
         val preprocessContent = new EjsPreprocessor().preprocess(sourceFileContent)
-        (out / in.relativize(ejsFile).toString).parent.createDirectoryIfNotExists(createParents = true)
-        val newEjsFile = ejsFile.copyTo(out / in.relativize(ejsFile).toString)
-        val jsFile     = changeExtensionTo(newEjsFile, ".js").writeText(preprocessContent)
-        newEjsFile.createFile().writeText(sourceFileContent)
+        (out / in.relativize(ejsFile).toString).getParent
+          .createWithParentsIfNotExists(asDirectory = true, createParents = true)
+        val newEjsFile = out / in.relativize(ejsFile).toString
+        ejsFile.copyTo(newEjsFile)
+
+        val jsFile  = Files.writeString(changeExtensionTo(newEjsFile, ".js"), preprocessContent)
+        val newFile = Files.createFile(newEjsFile)
+        Files.writeString(newFile, sourceFileContent)
         jsFile
       }
     }
@@ -322,13 +332,13 @@ class AstGenRunner(config: Config) {
     val result =
       ExternalCommand.run(
         (astGenCommand +: executableArgs) ++ Seq("-t", "ts", "-o", out.toString),
-        Option(out.toString())
+        Option(out.toString)
       )
 
     val jsons = SourceFiles.determine(out.toString(), Set(".json"))
     jsons.foreach { jsonPath =>
-      val jsonFile        = File(jsonPath)
-      val jsonContent     = IOUtils.readEntireFile(jsonFile.path)
+      val jsonFile        = Paths.get(jsonPath)
+      val jsonContent     = IOUtils.readEntireFile(jsonFile)
       val json            = ujson.read(jsonContent)
       val fullName        = json("fullName").str
       val relativeName    = json("relativeName").str
@@ -336,17 +346,17 @@ class AstGenRunner(config: Config) {
       val newRelativeName = relativeName.patch(relativeName.lastIndexOf(".js"), ".ejs", 3)
       json("relativeName") = newRelativeName
       json("fullName") = newFullName
-      jsonFile.writeText(json.toString())
+      Files.writeString(jsonFile, json.toString)
     }
 
-    tmpJsFiles.foreach(_.delete())
+    tmpJsFiles.foreach(FileUtil.delete(_))
     result.toTry
   }
 
-  private def ejsFiles(in: File, out: File): Try[Seq[String]] = {
+  private def ejsFiles(in: Path, out: Path): Try[Seq[String]] = {
     val files =
       SourceFiles.determine(
-        in.pathAsString,
+        in.toString,
         Set(".ejs"),
         ignoredDefaultRegex = Some(AstGenDefaultIgnoreRegex),
         ignoredFilesRegex = Some(config.ignoredFilesRegex),
@@ -356,9 +366,9 @@ class AstGenRunner(config: Config) {
     else Success(Seq.empty)
   }
 
-  private def vueFiles(in: File, out: File): Try[Seq[String]] = {
+  private def vueFiles(in: Path, out: Path): Try[Seq[String]] = {
     val files = SourceFiles.determine(
-      in.pathAsString,
+      in.toString,
       Set(".vue"),
       ignoredDefaultRegex = Some(AstGenDefaultIgnoreRegex),
       ignoredFilesRegex = Some(config.ignoredFilesRegex),
@@ -366,32 +376,32 @@ class AstGenRunner(config: Config) {
     )
     if (files.nonEmpty) {
       ExternalCommand
-        .run((astGenCommand +: executableArgs) ++ Seq("-t", "vue", "-o", out.toString), Option(in.toString()))
+        .run((astGenCommand +: executableArgs) ++ Seq("-t", "vue", "-o", out.toString), Option(in.toString))
         .toTry
     } else {
       Success(Seq.empty)
     }
   }
 
-  private def jsFiles(in: File, out: File): Try[Seq[String]] = {
+  private def jsFiles(in: Path, out: Path): Try[Seq[String]] = {
     ExternalCommand
-      .run((astGenCommand +: executableArgs) ++ Seq("-t", "ts", "-o", out.toString), Option(in.toString()))
+      .run((astGenCommand +: executableArgs) ++ Seq("-t", "ts", "-o", out.toString), Option(in.toString))
       .toTry
   }
 
-  private def runAstGenNative(in: File, out: File): Try[Seq[String]] = for {
+  private def runAstGenNative(in: Path, out: Path): Try[Seq[String]] = for {
     ejsResult <- ejsFiles(in, out)
     vueResult <- vueFiles(in, out)
     jsResult  <- jsFiles(in, out)
   } yield jsResult ++ vueResult ++ ejsResult
 
-  private def checkParsedFiles(files: List[String], in: File): List[String] = {
+  private def checkParsedFiles(files: List[String], in: Path): List[String] = {
     val numOfParsedFiles = files.size
     logger.info(s"Parsed $numOfParsedFiles files.")
     if (numOfParsedFiles == 0) {
       logger.warn("You may want to check the DEBUG logs for a list of files that are ignored by default.")
       SourceFiles.determine(
-        in.pathAsString,
+        in.toString,
         Set(".js", ".ts", ".vue", ".ejs", ".jsx", ".cjs", ".mjs", ".tsx"),
         ignoredDefaultRegex = Option(AstGenDefaultIgnoreRegex)
       )
@@ -399,18 +409,18 @@ class AstGenRunner(config: Config) {
     files
   }
 
-  def execute(out: File): AstGenRunnerResult = {
-    val in = File(config.inputPath)
+  def execute(out: Path): AstGenRunnerResult = {
+    val in = Paths.get(config.inputPath)
     runAstGenNative(in, out) match {
       case Success(result) =>
-        val parsed  = checkParsedFiles(filterFiles(SourceFiles.determine(out.toString(), Set(".json")), out), in)
+        val parsed  = checkParsedFiles(filterFiles(SourceFiles.determine(out.toString, Set(".json")), out), in)
         val skipped = skippedFiles(result.toList)
-        AstGenRunnerResult(parsed.map((in.toString(), _)), skipped.map((in.toString(), _)))
+        AstGenRunnerResult(parsed.map((in.toString, _)), skipped.map((in.toString, _)))
       case Failure(f) =>
         logger.error("\t- running astgen failed!", f)
-        val parsed  = checkParsedFiles(filterFiles(SourceFiles.determine(out.toString(), Set(".json")), out), in)
+        val parsed  = checkParsedFiles(filterFiles(SourceFiles.determine(out.toString, Set(".json")), out), in)
         val skipped = List.empty
-        AstGenRunnerResult(parsed.map((in.toString(), _)), skipped.map((in.toString(), _)))
+        AstGenRunnerResult(parsed.map((in.toString, _)), skipped.map((in.toString, _)))
     }
   }
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/utils/AstGenRunner.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/utils/AstGenRunner.scala
@@ -4,9 +4,9 @@ import com.typesafe.config.ConfigFactory
 import io.joern.jssrc2cpg.Config
 import io.joern.jssrc2cpg.preprocessing.EjsPreprocessor
 import io.joern.x2cpg.SourceFiles
-import io.joern.x2cpg.utils.{Environment, FileUtil}
-import io.joern.x2cpg.utils.FileUtil.*
-import io.shiftleft.semanticcpg.utils.ExternalCommand
+import io.joern.x2cpg.utils.Environment
+import io.shiftleft.semanticcpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.{ExternalCommand, FileUtil}
 import io.shiftleft.utils.IOUtils
 import org.slf4j.LoggerFactory
 import versionsort.VersionHelper

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/io/CodeDumperFromFileTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/io/CodeDumperFromFileTests.scala
@@ -1,10 +1,12 @@
 package io.joern.jssrc2cpg.io
 
-import better.files.File
+import io.joern.x2cpg.utils.FileUtil
+import io.joern.x2cpg.utils.FileUtil.*
 import io.joern.jssrc2cpg.testfixtures.JsSrc2CpgSuite
 import io.shiftleft.semanticcpg.codedumper.CodeDumper
 import io.shiftleft.semanticcpg.language.*
 
+import java.nio.file.{Files, Paths}
 import java.util.regex.Pattern
 
 class CodeDumperFromFileTests extends JsSrc2CpgSuite {
@@ -20,19 +22,19 @@ class CodeDumperFromFileTests extends JsSrc2CpgSuite {
 
   private val cpg = code(codeString, "index.js")
 
-  private val path = File(cpg.metaData.root.head) / "index.js"
+  private val path = Paths.get(cpg.metaData.root.head) / "index.js"
 
   override def beforeAll(): Unit = {
     super.beforeAll()
     // we have to restore the input file because CPG creation in JsSrc2CpgSuite
     // deletes it right after the CPG is ready.
-    path.createFileIfNotExists(createParents = true)
-    path.writeText(codeString)
+    path.createWithParentsIfNotExists(createParents = true)
+    Files.writeString(path, codeString)
   }
 
   override def afterAll(): Unit = {
     super.afterAll()
-    path.delete(swallowIOExceptions = true)
+    FileUtil.delete(path, swallowIoExceptions = true)
   }
 
   "dumping code" should {

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/io/CodeDumperFromFileTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/io/CodeDumperFromFileTests.scala
@@ -1,10 +1,10 @@
 package io.joern.jssrc2cpg.io
 
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.joern.jssrc2cpg.testfixtures.JsSrc2CpgSuite
 import io.shiftleft.semanticcpg.codedumper.CodeDumper
 import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 
 import java.nio.file.{Files, Paths}
 import java.util.regex.Pattern

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/io/ExcludeTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/io/ExcludeTests.scala
@@ -5,9 +5,9 @@ import io.joern.jssrc2cpg.passes.AstCreationPass
 import io.joern.jssrc2cpg.utils.AstGenRunner
 import io.joern.x2cpg.ValidationMode
 import io.joern.x2cpg.X2Cpg.newEmptyCpg
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.wordspec.AnyWordSpec

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/io/JsSrc2CpgHTTPServerTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/io/JsSrc2CpgHTTPServerTests.scala
@@ -1,10 +1,10 @@
 package io.joern.jssrc2cpg.io
 
 import io.joern.x2cpg.utils.server.FrontendHTTPClient
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.cpgloading.CpgLoader
 import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/io/ProjectParseTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/io/ProjectParseTests.scala
@@ -6,10 +6,10 @@ import io.joern.jssrc2cpg.passes.AstCreationPass
 import io.joern.jssrc2cpg.utils.AstGenRunner
 import io.joern.x2cpg.ValidationMode
 import io.joern.x2cpg.X2Cpg.newEmptyCpg
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.scalatest.BeforeAndAfterAll
 
 import java.nio.file.{Files, Path}

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ConfigPassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ConfigPassTests.scala
@@ -2,10 +2,10 @@ package io.joern.jssrc2cpg.passes
 
 import io.joern.jssrc2cpg.Config
 import io.joern.x2cpg.frontendspecific.jssrc2cpg.Defines
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/DependenciesPassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/DependenciesPassTests.scala
@@ -6,8 +6,8 @@ import io.joern.jssrc2cpg.utils.PackageJsonParser
 import io.joern.jssrc2cpg.Config
 import io.joern.jssrc2cpg.testfixtures.JsSrc2CpgSuite
 import io.joern.x2cpg.X2Cpg.newEmptyCpg
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 
 import java.nio.file.{Files, Path}
 

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/testfixtures/AstJsSrc2CpgFrontend.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/testfixtures/AstJsSrc2CpgFrontend.scala
@@ -1,6 +1,5 @@
 package io.joern.jssrc2cpg.testfixtures
 
-import better.files.File
 import io.joern.jssrc2cpg.Config
 import io.joern.jssrc2cpg.passes.AstCreationPass
 import io.joern.jssrc2cpg.passes.JavaScriptTypeNodePass
@@ -10,6 +9,8 @@ import io.joern.x2cpg.ValidationMode
 import io.joern.x2cpg.X2Cpg.newEmptyCpg
 import io.joern.x2cpg.utils.FileUtil
 import io.shiftleft.codepropertygraph.generated.Cpg
+
+import java.nio.file.Paths
 
 trait AstJsSrc2CpgFrontend extends LanguageFrontend {
   def execute(sourceCodePath: java.io.File): Cpg = {
@@ -21,7 +22,7 @@ trait AstJsSrc2CpgFrontend extends LanguageFrontend {
       .fold(Config())(_.asInstanceOf[Config])
       .withInputPath(pathAsString)
       .withOutputPath(pathAsString)
-    val astGenResult    = new AstGenRunner(config).execute(File(pathAsString))
+    val astGenResult    = new AstGenRunner(config).execute(Paths.get(pathAsString))
     val astCreationPass = new AstCreationPass(cpg, astGenResult, config)(ValidationMode.Enabled)
     astCreationPass.createAndApply()
     JavaScriptTypeNodePass.withRegisteredTypes(astCreationPass.typesSeen(), cpg).createAndApply()

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/testfixtures/AstJsSrc2CpgFrontend.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/testfixtures/AstJsSrc2CpgFrontend.scala
@@ -7,8 +7,8 @@ import io.joern.jssrc2cpg.utils.AstGenRunner
 import io.joern.x2cpg.testfixtures.LanguageFrontend
 import io.joern.x2cpg.ValidationMode
 import io.joern.x2cpg.X2Cpg.newEmptyCpg
-import io.joern.x2cpg.utils.FileUtil
 import io.shiftleft.codepropertygraph.generated.Cpg
+import io.shiftleft.semanticcpg.utils.FileUtil
 
 import java.nio.file.Paths
 

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/testfixtures/JsSrc2CpgFrontend.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/testfixtures/JsSrc2CpgFrontend.scala
@@ -1,6 +1,5 @@
 package io.joern.jssrc2cpg.testfixtures
 
-import better.files.File
 import io.joern.jssrc2cpg.Config
 import io.joern.jssrc2cpg.JsSrc2Cpg
 import io.joern.x2cpg.testfixtures.LanguageFrontend

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/testfixtures/JsSrc2CpgFrontend.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/testfixtures/JsSrc2CpgFrontend.scala
@@ -3,8 +3,8 @@ package io.joern.jssrc2cpg.testfixtures
 import io.joern.jssrc2cpg.Config
 import io.joern.jssrc2cpg.JsSrc2Cpg
 import io.joern.x2cpg.testfixtures.LanguageFrontend
-import io.joern.x2cpg.utils.FileUtil
 import io.shiftleft.codepropertygraph.generated.Cpg
+import io.shiftleft.semanticcpg.utils.FileUtil
 
 trait JsSrc2CpgFrontend extends LanguageFrontend {
   def execute(sourceCodePath: java.io.File): Cpg = {

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Kotlin2Cpg.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Kotlin2Cpg.scala
@@ -15,11 +15,11 @@ import io.joern.x2cpg.passes.frontend.TypeNodePass
 import io.joern.x2cpg.utils.dependency.DependencyResolver
 import io.joern.x2cpg.utils.dependency.DependencyResolverParams
 import io.joern.x2cpg.utils.dependency.GradleConfigKeys
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.joern.x2cpg.SourceFiles.filterFile
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.Languages
+import io.shiftleft.semanticcpg.utils.FileUtil
 import io.shiftleft.utils.IOUtils
 import org.jetbrains.kotlin.cli.jvm.compiler.{KotlinCoreEnvironment, KotlinToJVMBytecodeCompiler}
 import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/ContentSourcesPicker.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/ContentSourcesPicker.scala
@@ -1,6 +1,8 @@
 package io.joern.kotlin2cpg.types
 
-import better.files.File
+import java.nio.file.{Files, Paths}
+import io.joern.x2cpg.utils.FileUtil
+import io.joern.x2cpg.utils.FileUtil.*
 
 object ContentSourcesPicker {
 
@@ -18,20 +20,22 @@ object ContentSourcesPicker {
   //  `Seq("dir1/dir2/dir3")` and nothing else.
 
   def dirsForRoot(rootDir: String): Seq[String] = {
-    val dir        = File(rootDir)
-    val hasSubDirs = dir.list.exists(_.isDirectory)
+    val dir        = Paths.get(rootDir)
+    val hasSubDirs = dir.listFiles().exists(Files.isDirectory(_))
     if (!hasSubDirs) {
       return Seq(rootDir)
     }
-    dir.listRecursively
-      .filter(_.isDirectory)
+    dir
+      .walk()
+      .filterNot(_ == dir)
+      .filter(Files.isDirectory(_))
       .flatMap { f =>
-        val hasKtsFile = f.listRecursively.exists { f => f.hasExtension && f.pathAsString.endsWith(".kts") }
-        val dirsPicked = f.list.filter(_.isDirectory).filterNot { d =>
-          d.listRecursively.filter(_.hasExtension).exists(_.pathAsString.endsWith(".kts"))
+        val hasKtsFile = f.walk().filterNot(_ == f).exists { f => f.hasExtension && f.toString.endsWith(".kts") }
+        val dirsPicked = f.listFiles().filter(Files.isDirectory(_)).filterNot { d =>
+          d.walk().filterNot(_ == d).filter(_.hasExtension).exists(_.toString.endsWith(".kts"))
         }
-        if (hasKtsFile) Some(dirsPicked.map(_.pathAsString))
-        else Some(Seq(f.pathAsString))
+        if (hasKtsFile) Some(dirsPicked.map(_.toString))
+        else Some(Seq(f.toString))
       }
       .flatten
       .toSeq

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/ContentSourcesPicker.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/ContentSourcesPicker.scala
@@ -1,8 +1,8 @@
 package io.joern.kotlin2cpg.types
 
 import java.nio.file.{Files, Paths}
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 
 object ContentSourcesPicker {
 

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/compiler/CompilerAPITests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/compiler/CompilerAPITests.scala
@@ -1,11 +1,12 @@
 package io.joern.kotlin2cpg.compiler
 
-import better.files.File
 import io.joern.kotlin2cpg.Config
 import io.joern.kotlin2cpg.DefaultContentRootJarPath
 import io.joern.kotlin2cpg.Kotlin2Cpg
 import io.shiftleft.semanticcpg.utils.ExternalCommand
 import io.joern.x2cpg.Defines
+import io.joern.x2cpg.utils.FileUtil
+import io.joern.x2cpg.utils.FileUtil.*
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.utils.ProjectRoot
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
@@ -49,10 +50,11 @@ class CompilerAPITests extends AnyFreeSpec with Matchers {
         DefaultContentRootJarPath("jars/kotlin-stdlib-jdk8-1.9.0.jar", isResource = true)
       )
 
-      val defaultContentRootJarsDir = File(projectDependenciesPath)
-      val contentRoots = defaultContentRootJarsDir.listRecursively
-        .filter(_.pathAsString.endsWith("jar"))
-        .map { f => DefaultContentRootJarPath(f.pathAsString, false) }
+      val contentRoots = projectDependenciesPath
+        .walk()
+        .filterNot(_ == projectDependenciesPath)
+        .filter(_.toString.endsWith("jar"))
+        .map { f => DefaultContentRootJarPath(f.toString, false) }
         .toSeq ++ jarResources
       val messageCollector = new ErrorCountMessageCollector()
       val environment      = CompilerAPI.makeEnvironment(Seq(projectDirPath), Seq(), contentRoots, messageCollector)

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/compiler/CompilerAPITests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/compiler/CompilerAPITests.scala
@@ -3,10 +3,9 @@ package io.joern.kotlin2cpg.compiler
 import io.joern.kotlin2cpg.Config
 import io.joern.kotlin2cpg.DefaultContentRootJarPath
 import io.joern.kotlin2cpg.Kotlin2Cpg
-import io.shiftleft.semanticcpg.utils.ExternalCommand
+import io.shiftleft.semanticcpg.utils.{ExternalCommand, FileUtil}
 import io.joern.x2cpg.Defines
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import FileUtil.*
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.utils.ProjectRoot
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/io/Kotlin2CpgHTTPServerTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/io/Kotlin2CpgHTTPServerTests.scala
@@ -1,10 +1,10 @@
 package io.joern.kotlin2cpg.io
 
 import io.joern.x2cpg.utils.server.FrontendHTTPClient
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.cpgloading.CpgLoader
 import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/testfixtures/KotlinCodeToCpgFixture.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/testfixtures/KotlinCodeToCpgFixture.scala
@@ -1,6 +1,5 @@
 package io.joern.kotlin2cpg.testfixtures
 
-import better.files.File as BFile
 import io.joern.dataflowengineoss.DefaultSemantics
 import io.joern.dataflowengineoss.language.*
 import io.joern.dataflowengineoss.semanticsloader.{FlowSemantic, Semantics}
@@ -11,20 +10,22 @@ import io.joern.kotlin2cpg.Kotlin2Cpg
 import io.joern.x2cpg.testfixtures.Code2CpgFixture
 import io.joern.x2cpg.testfixtures.DefaultTestCpg
 import io.joern.x2cpg.testfixtures.LanguageFrontend
+import io.joern.x2cpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.utils.ProjectRoot
 
 import java.io.File
+import java.nio.file.Paths
 
 trait KotlinFrontend extends LanguageFrontend {
   protected val withTestResourcePaths: Boolean
 
   override val fileSuffix: String = ".kt"
   private lazy val defaultContentRoot =
-    BFile(ProjectRoot.relativise("joern-cli/frontends/kotlin2cpg/src/test/resources/jars/"))
+    Paths.get(ProjectRoot.relativise("joern-cli/frontends/kotlin2cpg/src/test/resources/jars/"))
   private lazy val defaultConfig: Config =
     Config(
-      classpath = if (withTestResourcePaths) Set(defaultContentRoot.path.toAbsolutePath.toString) else Set(),
+      classpath = if (withTestResourcePaths) Set(defaultContentRoot.absolutePathAsString) else Set(),
       includeJavaSourceFiles = true
     )
 

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/testfixtures/KotlinCodeToCpgFixture.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/testfixtures/KotlinCodeToCpgFixture.scala
@@ -10,7 +10,7 @@ import io.joern.kotlin2cpg.Kotlin2Cpg
 import io.joern.x2cpg.testfixtures.Code2CpgFixture
 import io.joern.x2cpg.testfixtures.DefaultTestCpg
 import io.joern.x2cpg.testfixtures.LanguageFrontend
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.utils.ProjectRoot
 

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/ClassParser.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/ClassParser.scala
@@ -1,7 +1,6 @@
 package io.joern.php2cpg.parser
-import io.joern.x2cpg.utils.FileUtil
-import io.shiftleft.semanticcpg.utils.ExternalCommand
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.{ExternalCommand, FileUtil}
+import FileUtil.*
 import org.slf4j.LoggerFactory
 
 import scala.io.Source

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/PhpParser.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/PhpParser.scala
@@ -2,9 +2,8 @@ package io.joern.php2cpg.parser
 
 import io.joern.php2cpg.Config
 import io.joern.php2cpg.parser.Domain.PhpFile
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
-import io.shiftleft.semanticcpg.utils.ExternalCommand
+import io.shiftleft.semanticcpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.{ExternalCommand, FileUtil}
 import org.slf4j.LoggerFactory
 
 import java.nio.file.{Files, Path, Paths}

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/AstCreationPass.scala
@@ -1,14 +1,15 @@
 package io.joern.php2cpg.passes
 
-import better.files.File
 import io.joern.php2cpg.Config
 import io.joern.php2cpg.astcreation.AstCreator
 import io.joern.php2cpg.parser.PhpParser
 import io.joern.x2cpg.{SourceFiles, ValidationMode}
+import io.joern.x2cpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.passes.ForkJoinParallelCpgPass
 import org.slf4j.LoggerFactory
 
+import java.nio.file.Paths
 import scala.jdk.CollectionConverters.*
 
 class AstCreationPass(config: Config, cpg: Cpg, parser: PhpParser)(implicit withSchemaValidation: ValidationMode)
@@ -48,9 +49,9 @@ class AstCreationPass(config: Config, cpg: Cpg, parser: PhpParser)(implicit with
       parseResult match {
         case Some(parseResult) =>
           val relativeFilename = if (filename == config.inputPath) {
-            File(filename).name
+            Paths.get(filename).fileName
           } else {
-            File(config.inputPath).relativize(File(filename)).toString
+            Paths.get(config.inputPath).relativize(Paths.get(filename)).toString
           }
           diffGraph.absorb(
             new AstCreator(relativeFilename, filename, parseResult, config.disableFileContent)(config.schemaValidation)

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/AstCreationPass.scala
@@ -4,7 +4,7 @@ import io.joern.php2cpg.Config
 import io.joern.php2cpg.astcreation.AstCreator
 import io.joern.php2cpg.parser.PhpParser
 import io.joern.x2cpg.{SourceFiles, ValidationMode}
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.passes.ForkJoinParallelCpgPass
 import org.slf4j.LoggerFactory

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/DependencySymbolsPass.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/DependencySymbolsPass.scala
@@ -1,6 +1,5 @@
 package io.joern.php2cpg.passes
 
-import better.files.File
 import io.joern.php2cpg.parser.ClassParser
 import io.joern.php2cpg.parser.ClassParser.*
 import io.joern.x2cpg.ValidationMode.Disabled

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/utils/DependencyDownloader.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/utils/DependencyDownloader.scala
@@ -1,6 +1,5 @@
 package io.joern.php2cpg.utils
 
-import better.files.File
 import com.github.sh4869.semver_parser.{Range, SemVer}
 import io.joern.php2cpg.Config
 import io.joern.php2cpg.parser.Domain.PhpOperators
@@ -14,7 +13,7 @@ import org.slf4j.LoggerFactory
 import upickle.default.*
 
 import java.io.{FileOutputStream, IOException}
-import java.nio.file.{CopyOption, Files, Path, Paths, StandardCopyOption}
+import java.nio.file.{CopyOption, Files, Path, StandardCopyOption}
 import java.net.{HttpURLConnection, URI, URL, URLConnection}
 import java.util.zip.ZipEntry
 import javax.json.JsonException
@@ -178,7 +177,7 @@ class DependencyDownloader(cpg: Cpg, config: Config) {
       val fullPathPrefix = targetDir / pathPrefix.replace("/", java.io.File.separator)
 
       Files.list(fullPathPrefix).forEach { x =>
-        Files.move(x, fullTargetNamespace / x.getFileName.toString)
+        Files.move(x, fullTargetNamespace / x.fileName)
       }
       FileUtil.delete(fullPathPrefix, swallowIoExceptions = true)
     }
@@ -189,7 +188,7 @@ class DependencyDownloader(cpg: Cpg, config: Config) {
 
       targetDir
         .listFiles()
-        .filter(f => Files.isDirectory(f) && f.getFileName.toString.startsWith(vendor.replace("\\", "-")))
+        .filter(f => Files.isDirectory(f) && f.fileName.startsWith(vendor.replace("\\", "-")))
         .foreach { unpackedDest =>
           unpackedDest.mergeDirectory(targetDir, copyOptions = StandardCopyOption.REPLACE_EXISTING)
           FileUtil.delete(unpackedDest, swallowIoExceptions = true)
@@ -199,7 +198,7 @@ class DependencyDownloader(cpg: Cpg, config: Config) {
     targetDir
       .walk()
       .collectFirst {
-        case x if x.getFileName.toString == "composer.json" =>
+        case x if x.fileName == "composer.json" =>
           Using.resource(Files.newInputStream(x)) { is =>
             read[Composer](ujson.Readable.fromByteArray(is.readAllBytes()))
           }

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/utils/DependencyDownloader.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/utils/DependencyDownloader.scala
@@ -4,11 +4,11 @@ import com.github.sh4869.semver_parser.{Range, SemVer}
 import io.joern.php2cpg.Config
 import io.joern.php2cpg.parser.Domain.PhpOperators
 import io.joern.php2cpg.passes.{Composer, PsrArray, PsrString}
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.Dependency
 import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.slf4j.LoggerFactory
 import upickle.default.*
 

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/io/Php2CpgHTTPServerTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/io/Php2CpgHTTPServerTests.scala
@@ -1,10 +1,10 @@
 package io.joern.php2cpg.io
 
 import io.joern.x2cpg.utils.server.FrontendHTTPClient
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.cpgloading.CpgLoader
 import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ConfigFileCreationPass.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ConfigFileCreationPass.scala
@@ -1,13 +1,14 @@
 package io.joern.pysrc2cpg
 
-import better.files.File
 import io.joern.x2cpg.passes.frontend.XConfigFileCreationPass
 import io.shiftleft.codepropertygraph.generated.Cpg
+
+import java.nio.file.Path
 
 class ConfigFileCreationPass(cpg: Cpg, requirementsTxt: String = "requirement.txt")
     extends XConfigFileCreationPass(cpg) {
 
-  override val configFileFilters: List[File => Boolean] = List(
+  override val configFileFilters: List[Path => Boolean] = List(
     // TOML files
     extensionFilter(".toml"),
     // INI files

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/config/VenvExcludeTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/config/VenvExcludeTests.scala
@@ -2,10 +2,10 @@ package io.joern.pysrc2cpg.config
 
 import io.joern.pysrc2cpg.Py2CpgOnFileSystem
 import io.joern.pysrc2cpg.Py2CpgOnFileSystemConfig
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 
 import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.wordspec.AnyWordSpec

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/io/PySrc2CpgHTTPServerTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/io/PySrc2CpgHTTPServerTests.scala
@@ -1,10 +1,10 @@
 package io.joern.pysrc2cpg.io
 
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.joern.x2cpg.utils.server.FrontendHTTPClient
 import io.shiftleft.codepropertygraph.cpgloading.CpgLoader
 import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
@@ -16,11 +16,12 @@ import io.joern.x2cpg.frontendspecific.rubysrc2cpg.*
 import io.joern.x2cpg.passes.base.AstLinkerPass
 import io.joern.x2cpg.passes.callgraph.NaiveCallLinker
 import io.joern.x2cpg.passes.frontend.{MetaDataPass, TypeNodePass, XTypeRecoveryConfig}
-import io.joern.x2cpg.utils.{ConcurrentTaskUtil, FileUtil}
+import io.joern.x2cpg.utils.ConcurrentTaskUtil
 import io.joern.x2cpg.{SourceFiles, X2CpgFrontend}
 import io.shiftleft.codepropertygraph.generated.{Cpg, Languages}
 import io.shiftleft.passes.CpgPassBase
 import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.slf4j.LoggerFactory
 import upickle.default.*
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyProgramSummary.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyProgramSummary.scala
@@ -1,19 +1,21 @@
 package io.joern.rubysrc2cpg.datastructures
 
-import better.files.File
 import io.joern.x2cpg.Defines as XDefines
 import io.joern.x2cpg.datastructures.{FieldLike, MethodLike, ProgramSummary, StubbedType, TypeLike}
 import io.joern.x2cpg.typestub.{TypeStubMetaData, TypeStubUtil}
+import io.joern.x2cpg.utils.FileUtil
+import io.joern.x2cpg.utils.FileUtil.*
 import org.slf4j.LoggerFactory
 import io.joern.rubysrc2cpg.passes.Defines
 import upickle.default.*
 
-import java.io.{ByteArrayInputStream, InputStream}
+import java.io.{ByteArrayInputStream, FileInputStream, InputStream}
 import java.util.zip.ZipInputStream
 import scala.annotation.targetName
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
-import scala.util.{Failure, Success, Try}
+import scala.util.{Failure, Success, Try, Using}
+import java.nio.file.{Files, Path, Paths}
 
 type NamespaceToTypeMap = mutable.Map[String, mutable.Set[RubyType]]
 
@@ -38,8 +40,8 @@ object RubyProgramSummary {
   private val logger = LoggerFactory.getLogger(getClass)
 
   def BuiltinTypes(implicit typeStubMetaData: TypeStubMetaData): NamespaceToTypeMap = {
-    val typeStubDir = File(typeStubMetaData.packagePath)
-    if (!typeStubDir.exists || !typeStubDir.isDirectory) {
+    val typeStubDir = Paths.get(typeStubMetaData.packagePath.toURI)
+    if (!Files.exists(typeStubDir) || !Files.isDirectory(typeStubDir)) {
       logger.warn("No builtin type stubs provided, continuing with types provided by the project")
       mutable.Map.empty
     } else if (typeStubMetaData.useTypeStubs) {
@@ -60,10 +62,10 @@ object RubyProgramSummary {
     val classLoader = getClass.getClassLoader
     val typeStubDir = TypeStubUtil.typeStubDir
 
-    val typeStubFiles: Seq[File] =
+    val typeStubFiles: Seq[Path] =
       typeStubDir
         .walk()
-        .filter(f => f.isRegularFile && f.name.startsWith("rubysrc") && f.`extension`.contains(".zip"))
+        .filter(f => Files.isRegularFile(f) && f.fileName.startsWith("rubysrc") && f.extension().contains(".zip"))
         .toSeq
 
     if (typeStubFiles.isEmpty) {
@@ -72,8 +74,9 @@ object RubyProgramSummary {
     } else {
       val mergedMpksObj = ListBuffer[collection.mutable.Map[String, Set[RubyStubbedType]]]()
       typeStubFiles.foreach { f =>
-        f.fileInputStream { fis =>
-          val zis = new ZipInputStream(fis)
+        Using.Manager { use =>
+          val fis = use(new FileInputStream(new java.io.File(f.absolutePathAsString)))
+          val zis = use(new ZipInputStream(fis))
 
           LazyList.continually(zis.getNextEntry).takeWhile(_ != null).foreach { file =>
             val mpkObj =

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyProgramSummary.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyProgramSummary.scala
@@ -3,10 +3,10 @@ package io.joern.rubysrc2cpg.datastructures
 import io.joern.x2cpg.Defines as XDefines
 import io.joern.x2cpg.datastructures.{FieldLike, MethodLike, ProgramSummary, StubbedType, TypeLike}
 import io.joern.x2cpg.typestub.{TypeStubMetaData, TypeStubUtil}
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import org.slf4j.LoggerFactory
 import io.joern.rubysrc2cpg.passes.Defines
+import io.shiftleft.semanticcpg.utils.FileUtil
 import upickle.default.*
 
 import java.io.{ByteArrayInputStream, FileInputStream, InputStream}

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
@@ -1,14 +1,16 @@
 package io.joern.rubysrc2cpg.datastructures
 
-import better.files.File
 import io.joern.rubysrc2cpg.passes.{GlobalTypes, Defines as RubyDefines}
 import io.joern.x2cpg.Defines
 import io.joern.x2cpg.datastructures.*
+import io.joern.x2cpg.utils.FileUtil
+import io.joern.x2cpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.NodeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.{DeclarationNew, NewLocal, NewMethodParameterIn}
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 
 import java.io.File as JFile
+import java.nio.file.{Files, Paths}
 import scala.collection.mutable
 import scala.reflect.ClassTag
 import scala.collection.mutable
@@ -157,7 +159,7 @@ class RubyScope(summary: RubyProgramSummary, projectRoot: Option[String])
     // NB: Tracking whatever has been added to $LOADER is dynamic and requires post-processing step!
     val resolvedPath =
       if (isRelative) {
-        Try((File(currentFilePath).parent / path).pathAsString).toOption
+        Try((Paths.get(currentFilePath).getParent / path).toString).toOption
           .map(_.stripPrefix(s"$projectRoot${JFile.separator}"))
           .getOrElse(path)
       } else {
@@ -166,12 +168,11 @@ class RubyScope(summary: RubyProgramSummary, projectRoot: Option[String])
 
     val pathsToImport =
       if (isWildCard) {
-        val dir = File(projectRoot) / resolvedPath
-        if (dir.isDirectory)
-          dir.list
-            .map(
-              _.pathAsString.stripPrefix(s"$projectRoot${JFile.separator}").stripSuffix(".rb").replaceAll("\\\\", "/")
-            )
+        val dir = Paths.get(projectRoot) / resolvedPath
+        if (Files.isDirectory(dir))
+          dir
+            .listFiles()
+            .map(_.toString.stripPrefix(s"$projectRoot${JFile.separator}").stripSuffix(".rb").replaceAll("\\\\", "/"))
             .toList
         else Nil
       } else {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
@@ -159,7 +159,7 @@ class RubyScope(summary: RubyProgramSummary, projectRoot: Option[String])
     // NB: Tracking whatever has been added to $LOADER is dynamic and requires post-processing step!
     val resolvedPath =
       if (isRelative) {
-        Try((Paths.get(currentFilePath).getParent / path).toString).toOption
+        Try((Paths.get(currentFilePath).getParent / path).toAbsolutePath.normalize().toString).toOption
           .map(_.stripPrefix(s"$projectRoot${JFile.separator}"))
           .getOrElse(path)
       } else {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
@@ -3,11 +3,11 @@ package io.joern.rubysrc2cpg.datastructures
 import io.joern.rubysrc2cpg.passes.{GlobalTypes, Defines as RubyDefines}
 import io.joern.x2cpg.Defines
 import io.joern.x2cpg.datastructures.*
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.NodeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.{DeclarationNew, NewLocal, NewMethodParameterIn}
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
+import io.shiftleft.semanticcpg.utils.FileUtil
 
 import java.io.File as JFile
 import java.nio.file.{Files, Paths}

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyAstGenRunner.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyAstGenRunner.scala
@@ -1,6 +1,5 @@
 package io.joern.rubysrc2cpg.parser
 
-import better.files.File
 import io.joern.rubysrc2cpg.Config
 import io.joern.rubysrc2cpg.parser.RubyAstGenRunner.ExecutionEnvironment
 import io.joern.x2cpg.SourceFiles
@@ -58,8 +57,8 @@ class RubyAstGenRunner(config: Config) extends AstGenRunnerBase(config) with Aut
     }
   }
 
-  override def fileFilter(file: String, out: File): Boolean = {
-    file.stripSuffix(".json").replace(out.pathAsString, config.inputPath) match {
+  override def fileFilter(file: String, out: Path): Boolean = {
+    file.stripSuffix(".json").replace(out.toString, config.inputPath) match {
       case filePath if isIgnoredByUserConfig(filePath)   => false
       case filePath if isIgnoredByDefaultRegex(filePath) => false
       case filePath if filePath.endsWith(".csproj")      => false
@@ -71,7 +70,7 @@ class RubyAstGenRunner(config: Config) extends AstGenRunnerBase(config) with Aut
     config.defaultIgnoredFilesRegex.exists(_.matches(filePath))
   }
 
-  override def skippedFiles(in: File, astGenOut: List[String]): List[String] = {
+  override def skippedFiles(in: Path, astGenOut: List[String]): List[String] = {
     val diagnosticMap = mutable.LinkedHashMap.empty[String, Seq[String]]
 
     def addReason(reason: String, lastFile: Option[String] = None) = {
@@ -107,7 +106,7 @@ class RubyAstGenRunner(config: Config) extends AstGenRunnerBase(config) with Aut
     }.toList
   }
 
-  override def runAstGenNative(in: String, out: File, exclude: String, include: String)(implicit
+  override def runAstGenNative(in: String, out: Path, exclude: String, include: String)(implicit
     metaData: AstGenProgramMetaData
   ): Try[Seq[String]] = {
     val scriptTarget = Files.createTempFile("ruby_driver", ".rb")
@@ -145,16 +144,16 @@ class RubyAstGenRunner(config: Config) extends AstGenRunnerBase(config) with Aut
     }
   }
 
-  override def execute(out: File): AstGenRunnerResult = {
+  override def execute(out: Path): AstGenRunnerResult = {
     execute(out, config)
   }
 
   /** Extends the interfaces' `execute` function to account for possibly varying configurations when running this runner
     * for multiple executions.
     */
-  def execute(out: File, specifiedConfig: Config): AstGenRunnerResult = {
+  def execute(out: Path, specifiedConfig: Config): AstGenRunnerResult = {
     implicit val metaData: AstGenProgramMetaData = specifiedConfig.astGenMetaData
-    val in                                       = File(config.inputPath)
+    val in                                       = Paths.get(config.inputPath)
     logger.info(s"Running ${metaData.name} on '${specifiedConfig.inputPath}'")
 
     val combineIgnoreRegex =

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/ConfigFileCreationPass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/ConfigFileCreationPass.scala
@@ -1,10 +1,10 @@
 package io.joern.rubysrc2cpg.passes
 
 import io.joern.x2cpg.passes.frontend.XConfigFileCreationPass
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 
 import java.nio.file.{Path, Paths}
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/ConfigFileCreationPass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/ConfigFileCreationPass.scala
@@ -1,9 +1,12 @@
 package io.joern.rubysrc2cpg.passes
 
-import better.files.File
 import io.joern.x2cpg.passes.frontend.XConfigFileCreationPass
+import io.joern.x2cpg.utils.FileUtil
+import io.joern.x2cpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.semanticcpg.language.*
+
+import java.nio.file.{Path, Paths}
 
 import scala.util.Try
 
@@ -11,12 +14,12 @@ import scala.util.Try
   */
 class ConfigFileCreationPass(cpg: Cpg) extends XConfigFileCreationPass(cpg) {
 
-  private val validGemfilePaths = Try(File(cpg.metaData.root.headOption.getOrElse(""))).toOption match {
+  private val validGemfilePaths = Try(Paths.get(cpg.metaData.root.headOption.getOrElse(""))).toOption match {
     case Some(rootPath) => Seq("Gemfile", "Gemfile.lock").map(rootPath / _)
     case None           => Seq()
   }
 
-  override protected val configFileFilters: List[File => Boolean] = List(
+  override protected val configFileFilters: List[Path => Boolean] = List(
     // Gemfiles
     validGemfilePaths.contains,
     extensionFilter(".ini"),

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/utils/DependencyDownloader.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/utils/DependencyDownloader.scala
@@ -1,6 +1,5 @@
 package io.joern.rubysrc2cpg.utils
 
-import better.files.File
 import io.joern.x2cpg.utils.FileUtil.*
 import io.joern.rubysrc2cpg.datastructures.RubyProgramSummary
 import io.joern.rubysrc2cpg.parser.RubyAstGenRunner
@@ -37,7 +36,7 @@ class DependencyDownloader(cpg: Cpg) {
     *   the dependencies' summary combined with the given internal program summary.
     */
   def download(): RubyProgramSummary = {
-    File.temporaryDirectory("joern-rubysrc2cpg").apply { dir =>
+    FileUtil.usingTemporaryDirectory("joern-rubysrc2cpg") { dir =>
       cpg.dependency
         .filterNot(dep =>
           dep.name == Defines.Resolver ||
@@ -45,10 +44,10 @@ class DependencyDownloader(cpg: Cpg) {
         )
         .foreach { dependency =>
           Try(Thread.sleep(100)) // Rate limit
-          downloadDependency(dir.path, dependency)
+          downloadDependency(dir, dependency)
         }
-      untarDependencies(dir.path)
-      summarizeDependencies(dir.path / "lib")
+      untarDependencies(dir)
+      summarizeDependencies(dir / "lib")
     }
   }
 
@@ -172,7 +171,7 @@ class DependencyDownloader(cpg: Cpg) {
                   )
                   .foreach { rubyFile =>
                     try {
-                      val fName  = s"lib/${pkgDir.getFileName.toString}/${rubyFile.getName.stripPrefix("lib/")}"
+                      val fName  = s"lib/${pkgDir.fileName}/${rubyFile.getName.stripPrefix("lib/")}"
                       val target = targetDir / fName
                       target.createWithParentsIfNotExists(createParents = true)
                       Using.resource(new FileOutputStream(target.toString)) { fos =>

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/utils/DependencyDownloader.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/utils/DependencyDownloader.scala
@@ -1,14 +1,15 @@
 package io.joern.rubysrc2cpg.utils
 
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.joern.rubysrc2cpg.datastructures.RubyProgramSummary
 import io.joern.rubysrc2cpg.parser.RubyAstGenRunner
 import io.joern.rubysrc2cpg.passes.{Defines, DependencyPass}
 import io.joern.rubysrc2cpg.{Config, RubySrc2Cpg, parser}
-import io.joern.x2cpg.utils.{ConcurrentTaskUtil, FileUtil}
+import io.joern.x2cpg.utils.ConcurrentTaskUtil
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.Dependency
 import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
 import org.slf4j.LoggerFactory
 import upickle.default.*

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/io/RubySrc2CpgHTTPServerTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/io/RubySrc2CpgHTTPServerTests.scala
@@ -1,10 +1,10 @@
 package io.joern.rubysrc2cpg.io
 
 import io.joern.x2cpg.utils.server.FrontendHTTPClient
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.cpgloading.CpgLoader
 import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/SwiftSrc2Cpg.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/SwiftSrc2Cpg.scala
@@ -7,9 +7,10 @@ import io.joern.x2cpg.X2Cpg.withNewEmptyCpg
 import io.joern.x2cpg.X2CpgFrontend
 import io.joern.x2cpg.frontendspecific.swiftsrc2cpg
 import io.joern.x2cpg.passes.frontend.XTypeRecoveryConfig
-import io.joern.x2cpg.utils.{FileUtil, HashUtil, Report}
+import io.joern.x2cpg.utils.{HashUtil, Report}
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
+import io.shiftleft.semanticcpg.utils.FileUtil
 
 import java.nio.file.Paths
 import scala.util.Try

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/passes/SwiftMetaDataPass.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/passes/SwiftMetaDataPass.scala
@@ -4,7 +4,7 @@ import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.NewMetaData
 import io.shiftleft.codepropertygraph.generated.Languages
 import io.shiftleft.passes.CpgPass
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import java.nio.file.Paths
 class SwiftMetaDataPass(cpg: Cpg, hash: String, inputPath: String) extends CpgPass(cpg) {
 

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/passes/SwiftMetaDataPass.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/passes/SwiftMetaDataPass.scala
@@ -1,15 +1,15 @@
 package io.joern.swiftsrc2cpg.passes
 
-import better.files.File
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.NewMetaData
 import io.shiftleft.codepropertygraph.generated.Languages
 import io.shiftleft.passes.CpgPass
-
+import io.joern.x2cpg.utils.FileUtil.*
+import java.nio.file.Paths
 class SwiftMetaDataPass(cpg: Cpg, hash: String, inputPath: String) extends CpgPass(cpg) {
 
   override def run(diffGraph: DiffGraphBuilder): Unit = {
-    val absolutePathToRoot = File(inputPath).path.toAbsolutePath.toString
+    val absolutePathToRoot = Paths.get(inputPath).absolutePathAsString
     val metaNode = NewMetaData().language(Languages.SWIFTSRC).root(absolutePathToRoot).hash(hash).version("0.1")
     diffGraph.addNode(metaNode)
   }

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/utils/AstGenRunner.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/utils/AstGenRunner.scala
@@ -1,12 +1,12 @@
 package io.joern.swiftsrc2cpg.utils
 
-import better.files.File
 import io.joern.swiftsrc2cpg.Config
 import io.joern.x2cpg.SourceFiles
-import io.joern.x2cpg.utils.Environment
+import io.joern.x2cpg.utils.{Environment, FileUtil}
+import io.joern.x2cpg.utils.FileUtil.*
 import org.slf4j.LoggerFactory
 
-import java.nio.file.Paths
+import java.nio.file.{Files, Path, Paths}
 import java.util.regex.Pattern
 import scala.util.Failure
 import scala.util.Success
@@ -31,9 +31,9 @@ object AstGenRunner {
 
   // full path to the SwiftAstGen binary from the env var SWIFTASTGEN_BIN
   private val AstGenBin: Option[String] = scala.util.Properties.envOrNone("SWIFTASTGEN_BIN").flatMap {
-    case path if File(path).isDirectory => Option((File(path) / "SwiftAstGen").pathAsString)
-    case path if File(path).exists      => Option(File(path).pathAsString)
-    case _                              => None
+    case path if Files.isDirectory(Paths.get(path)) => Option((Paths.get(path) / "SwiftAstGen").toString)
+    case path if Files.exists(Paths.get(path))      => Option(Paths.get(path).toString)
+    case _                                          => None
   }
 
   lazy private val executableName = Environment.operatingSystem match {
@@ -63,7 +63,7 @@ object AstGenRunner {
 
   private def hasCompatibleAstGenVersionAtPath(path: Option[String]): Boolean = {
     val astGenCommand = path.getOrElse("SwiftAstGen")
-    val localPath     = path.flatMap(File(_).parentOption.map(_.pathAsString)).getOrElse(".")
+    val localPath     = path.flatMap(Paths.get(_).parentOption.map(_.toString)).getOrElse(".")
     val debugMsgPath  = path.getOrElse("PATH")
     ExternalCommand.run(Seq(astGenCommand, "-h"), localPath).toOption match {
       case Some(_) =>
@@ -118,8 +118,8 @@ class AstGenRunner(config: Config) {
 
   private def isIgnoredByUserConfig(filePath: String): Boolean = {
     lazy val isInIgnoredFiles = config.ignoredFiles.exists {
-      case ignorePath if File(ignorePath).isDirectory => filePath.startsWith(ignorePath)
-      case ignorePath                                 => filePath == ignorePath
+      case ignorePath if Files.isDirectory(Paths.get(ignorePath)) => filePath.startsWith(ignorePath)
+      case ignorePath                                             => filePath == ignorePath
     }
     lazy val isInIgnoredFileRegex = config.ignoredFilesRegex.matches(filePath)
     if (isInIgnoredFiles || isInIgnoredFileRegex) {
@@ -130,34 +130,34 @@ class AstGenRunner(config: Config) {
     }
   }
 
-  private def filterFiles(files: List[String], out: File): List[String] = {
+  private def filterFiles(files: List[String], out: Path): List[String] = {
     files.filter { file =>
-      file.stripSuffix(".json").replace(out.pathAsString, config.inputPath) match {
+      file.stripSuffix(".json").replace(out.toString, config.inputPath) match {
         case filePath if isIgnoredByUserConfig(filePath) => false
         case _                                           => true
       }
     }
   }
 
-  private def runAstGenNative(in: File, out: File): Try[Seq[String]] =
-    ExternalCommand.run(Seq(astGenCommand, "-o", out.toString), in.toString())
+  private def runAstGenNative(in: Path, out: Path): Try[Seq[String]] =
+    ExternalCommand.run(Seq(astGenCommand, "-o", out.toString), in.toString)
 
-  private def checkParsedFiles(files: List[String], in: File): List[String] = {
+  private def checkParsedFiles(files: List[String], in: Path): List[String] = {
     val numOfParsedFiles = files.size
     logger.info(s"Parsed $numOfParsedFiles files.")
     if (numOfParsedFiles == 0) {
       logger.warn("You may want to check the DEBUG logs for a list of files that are ignored by default.")
-      SourceFiles.determine(in.pathAsString, Set(".swift"), ignoredDefaultRegex = Option(AstGenDefaultIgnoreRegex))
+      SourceFiles.determine(in.toString, Set(".swift"), ignoredDefaultRegex = Option(AstGenDefaultIgnoreRegex))
     }
     files
   }
 
-  def execute(out: File): AstGenRunnerResult = {
-    val in = File(config.inputPath)
+  def execute(out: Path): AstGenRunnerResult = {
+    val in = Paths.get(config.inputPath)
     logger.info(s"Running SwiftAstGen in '$in' ...")
     runAstGenNative(in, out) match {
       case Success(result) =>
-        val parsed  = checkParsedFiles(filterFiles(SourceFiles.determine(out.toString(), Set(".json")), out), in)
+        val parsed  = checkParsedFiles(filterFiles(SourceFiles.determine(out.toString, Set(".json")), out), in)
         val skipped = skippedFiles(result.toList)
         AstGenRunnerResult(parsed, skipped)
       case Failure(f) =>

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/utils/AstGenRunner.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/utils/AstGenRunner.scala
@@ -2,8 +2,9 @@ package io.joern.swiftsrc2cpg.utils
 
 import io.joern.swiftsrc2cpg.Config
 import io.joern.x2cpg.SourceFiles
-import io.joern.x2cpg.utils.{Environment, FileUtil}
-import io.joern.x2cpg.utils.FileUtil.*
+import io.joern.x2cpg.utils.Environment
+import io.shiftleft.semanticcpg.utils.FileUtil
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import org.slf4j.LoggerFactory
 
 import java.nio.file.{Files, Path, Paths}

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/io/CodeDumperFromFileTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/io/CodeDumperFromFileTests.scala
@@ -1,11 +1,10 @@
 package io.joern.swiftsrc2cpg.io
 
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.joern.swiftsrc2cpg.testfixtures.SwiftSrc2CpgSuite
-import io.joern.x2cpg.utils.FileUtil
 import io.shiftleft.semanticcpg.codedumper.CodeDumper
 import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 
 import java.nio.file.{Files, Paths}
 import java.util.regex.Pattern

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/io/CodeDumperFromFileTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/io/CodeDumperFromFileTests.scala
@@ -1,10 +1,13 @@
 package io.joern.swiftsrc2cpg.io
 
-import better.files.File
+import io.joern.x2cpg.utils.FileUtil
+import io.joern.x2cpg.utils.FileUtil.*
 import io.joern.swiftsrc2cpg.testfixtures.SwiftSrc2CpgSuite
+import io.joern.x2cpg.utils.FileUtil
 import io.shiftleft.semanticcpg.codedumper.CodeDumper
 import io.shiftleft.semanticcpg.language.*
 
+import java.nio.file.{Files, Paths}
 import java.util.regex.Pattern
 
 class CodeDumperFromFileTests extends SwiftSrc2CpgSuite {
@@ -19,19 +22,19 @@ class CodeDumperFromFileTests extends SwiftSrc2CpgSuite {
 
   private val cpg = code(codeString, "test.swift")
 
-  private val path = File(cpg.metaData.root.head) / "test.swift"
+  private val path = Paths.get(cpg.metaData.root.head) / "test.swift"
 
   override def beforeAll(): Unit = {
     super.beforeAll()
     // we have to restore the input file because CPG creation in SwiftSrc2CpgSuite
     // deletes it right after the CPG is ready.
-    path.createFileIfNotExists(createParents = true)
-    path.writeText(codeString)
+    path.createWithParentsIfNotExists(createParents = true)
+    Files.writeString(path, codeString)
   }
 
   override def afterAll(): Unit = {
     super.afterAll()
-    path.delete(swallowIOExceptions = true)
+    FileUtil.delete(path, swallowIoExceptions = true)
   }
 
   "dumping code from file" should {

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/io/ExcludeTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/io/ExcludeTests.scala
@@ -5,9 +5,9 @@ import io.joern.swiftsrc2cpg.passes.AstCreationPass
 import io.joern.swiftsrc2cpg.utils.AstGenRunner
 import io.joern.x2cpg.ValidationMode
 import io.joern.x2cpg.X2Cpg.newEmptyCpg
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.wordspec.AnyWordSpec

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/io/SwiftSrc2CpgHTTPServerTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/io/SwiftSrc2CpgHTTPServerTests.scala
@@ -1,10 +1,10 @@
 package io.joern.swiftsrc2cpg.io
 
 import io.joern.x2cpg.utils.server.FrontendHTTPClient
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.cpgloading.CpgLoader
 import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/testfixtures/AstSwiftSrc2CpgFrontend.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/testfixtures/AstSwiftSrc2CpgFrontend.scala
@@ -7,8 +7,8 @@ import io.joern.swiftsrc2cpg.utils.AstGenRunner
 import io.joern.x2cpg.testfixtures.LanguageFrontend
 import io.joern.x2cpg.ValidationMode
 import io.joern.x2cpg.X2Cpg.newEmptyCpg
-import io.joern.x2cpg.utils.FileUtil
 import io.shiftleft.codepropertygraph.generated.Cpg
+import io.shiftleft.semanticcpg.utils.FileUtil
 
 import java.nio.file.Paths
 

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/testfixtures/AstSwiftSrc2CpgFrontend.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/testfixtures/AstSwiftSrc2CpgFrontend.scala
@@ -1,6 +1,5 @@
 package io.joern.swiftsrc2cpg.testfixtures
 
-import better.files.File
 import io.joern.swiftsrc2cpg.passes.AstCreationPass
 import io.joern.swiftsrc2cpg.passes.SwiftTypeNodePass
 import io.joern.swiftsrc2cpg.Config
@@ -10,6 +9,8 @@ import io.joern.x2cpg.ValidationMode
 import io.joern.x2cpg.X2Cpg.newEmptyCpg
 import io.joern.x2cpg.utils.FileUtil
 import io.shiftleft.codepropertygraph.generated.Cpg
+
+import java.nio.file.Paths
 
 trait AstSwiftSrc2CpgFrontend extends LanguageFrontend {
   def execute(sourceCodePath: java.io.File): Cpg = {
@@ -24,7 +25,7 @@ trait AstSwiftSrc2CpgFrontend extends LanguageFrontend {
     if (definedConfig.isDefined) {
       config = definedConfig.get
     }
-    val astGenResult    = new AstGenRunner(config).execute(File(pathAsString))
+    val astGenResult    = new AstGenRunner(config).execute(Paths.get(pathAsString))
     val astCreationPass = new AstCreationPass(cpg, astGenResult, config)(ValidationMode.Enabled)
     astCreationPass.createAndApply()
     SwiftTypeNodePass.withRegisteredTypes(astCreationPass.typesSeen(), cpg).createAndApply()

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/testfixtures/SwiftSrc2CpgFrontend.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/testfixtures/SwiftSrc2CpgFrontend.scala
@@ -2,8 +2,8 @@ package io.joern.swiftsrc2cpg.testfixtures
 
 import io.joern.swiftsrc2cpg.{Config, SwiftSrc2Cpg}
 import io.joern.x2cpg.testfixtures.LanguageFrontend
-import io.joern.x2cpg.utils.FileUtil
 import io.shiftleft.codepropertygraph.generated.Cpg
+import io.shiftleft.semanticcpg.utils.FileUtil
 
 trait SwiftSrc2CpgFrontend extends LanguageFrontend {
   def execute(sourceCodePath: java.io.File): Cpg = {

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstCreatorBase.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstCreatorBase.scala
@@ -3,7 +3,7 @@ package io.joern.x2cpg
 import io.joern.x2cpg.passes.frontend.MetaDataPass
 import io.joern.x2cpg.utils.IntervalKeyPool
 import io.joern.x2cpg.utils.NodeBuilders.{newFieldIdentifierNode, newMethodReturnNode, newOperatorCallNode}
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, Cpg, DiffGraphBuilder, ModifierTypes, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstCreatorBase.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstCreatorBase.scala
@@ -377,7 +377,7 @@ abstract class AstCreatorBase(filename: String)(implicit withSchemaValidation: V
   /** Absolute path for the given file name
     */
   def absolutePath(filename: String): String =
-    Paths.get(filename).absolutePathAsString
+    Paths.get(filename).toAbsolutePath.normalize().toString
 
   /** @return
     *   the next available name for a closure in this context

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstCreatorBase.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstCreatorBase.scala
@@ -3,9 +3,12 @@ package io.joern.x2cpg
 import io.joern.x2cpg.passes.frontend.MetaDataPass
 import io.joern.x2cpg.utils.IntervalKeyPool
 import io.joern.x2cpg.utils.NodeBuilders.{newFieldIdentifierNode, newMethodReturnNode, newOperatorCallNode}
+import io.joern.x2cpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, Cpg, DiffGraphBuilder, ModifierTypes, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
+
+import java.nio.file.Paths
 
 abstract class AstCreatorBase(filename: String)(implicit withSchemaValidation: ValidationMode) {
   val diffGraph: DiffGraphBuilder = Cpg.newDiffGraphBuilder
@@ -374,7 +377,7 @@ abstract class AstCreatorBase(filename: String)(implicit withSchemaValidation: V
   /** Absolute path for the given file name
     */
   def absolutePath(filename: String): String =
-    better.files.File(filename).path.toAbsolutePath.normalize().toString
+    Paths.get(filename).absolutePathAsString
 
   /** @return
     *   the next available name for a closure in this context

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/SourceFiles.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/SourceFiles.scala
@@ -42,7 +42,7 @@ object SourceFiles {
 
     private val seenFiles = scala.collection.mutable.ArrayBuffer.empty[Path]
 
-    def files(): Array[Path] = seenFiles.toArray
+    def files(): Array[Path] = seenFiles.map(_.toAbsolutePath.normalize()).toArray
 
     override def preVisitDirectory(dir: Path, attrs: BasicFileAttributes): FileVisitResult = {
       if (filterFile(dir.toString, inputPath, ignoredDefaultRegex, ignoredFilesRegex, ignoredFilesPath)) {

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/SourceFiles.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/SourceFiles.scala
@@ -1,6 +1,6 @@
 package io.joern.x2cpg
 
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import org.slf4j.LoggerFactory
 
 import java.io.FileNotFoundException

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
@@ -1,9 +1,9 @@
 package io.joern.x2cpg
 
-import better.files.File
 import io.joern.x2cpg.X2Cpg.{applyDefaultOverlays, withErrorsToConsole}
 import io.joern.x2cpg.frontendspecific.FrontendArgsDelimitor
 import io.joern.x2cpg.layers.{Base, CallGraph, ControlFlow, TypeRelations}
+import io.joern.x2cpg.utils.FileUtil
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext}
 import org.slf4j.LoggerFactory
@@ -141,7 +141,7 @@ abstract class X2CpgMain[T <: X2CpgConfig[T], X <: X2CpgFrontend[T]](
     if (X2CpgConfig.defaultOutputPath == outputPath) {
       // We only log the output path of no explicit path was given by the user.
       // Otherwise, the user obviously knows the path.
-      logger.info(s"The resulting CPG will be stored at ${File(outputPath)}")
+      logger.info(s"The resulting CPG will be stored at ${Paths.get(outputPath).toString}")
     }
   }
 
@@ -328,12 +328,12 @@ object X2Cpg {
   def newEmptyCpg(optionalOutputPath: Option[String] = None): Cpg = {
     optionalOutputPath match {
       case Some(outputPath) =>
-        lazy val outFile = File(outputPath)
-        if (outputPath != "" && outFile.exists) {
+        lazy val outFile = Paths.get(outputPath)
+        if (outputPath != "" && Files.exists(outFile)) {
           logger.info("Output file exists, removing: " + outputPath)
-          outFile.delete()
+          FileUtil.delete(outFile)
         }
-        Cpg.withStorage(outFile.path)
+        Cpg.withStorage(outFile)
       case None => Cpg.empty
     }
   }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
@@ -3,9 +3,9 @@ package io.joern.x2cpg
 import io.joern.x2cpg.X2Cpg.{applyDefaultOverlays, withErrorsToConsole}
 import io.joern.x2cpg.frontendspecific.FrontendArgsDelimitor
 import io.joern.x2cpg.layers.{Base, CallGraph, ControlFlow, TypeRelations}
-import io.joern.x2cpg.utils.FileUtil
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext}
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.slf4j.LoggerFactory
 import scopt.OParser
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/astgen/AstGenRunner.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/astgen/AstGenRunner.scala
@@ -1,17 +1,16 @@
 package io.joern.x2cpg.astgen
 
-import better.files.File
 import com.typesafe.config.ConfigFactory
 import io.joern.x2cpg.utils.Environment.ArchitectureType.ArchitectureType
 import io.joern.x2cpg.utils.Environment.OperatingSystemType.OperatingSystemType
-import io.joern.x2cpg.utils.{Environment}
+import io.joern.x2cpg.utils.Environment
 import io.shiftleft.semanticcpg.utils.ExternalCommand
 import io.joern.x2cpg.{SourceFiles, X2CpgConfig}
 import org.slf4j.LoggerFactory
 import versionsort.VersionHelper
 
 import java.net.URL
-import java.nio.file.Paths
+import java.nio.file.{Files, Path, Paths}
 import scala.util.{Failure, Success, Try}
 
 object AstGenRunner {
@@ -131,8 +130,8 @@ trait AstGenRunnerBase(config: X2CpgConfig[?] & AstGenConfig[?]) {
 
   protected def isIgnoredByUserConfig(filePath: String): Boolean = {
     lazy val isInIgnoredFiles = config.ignoredFiles.exists {
-      case ignorePath if File(ignorePath).isDirectory => filePath.startsWith(ignorePath)
-      case ignorePath                                 => filePath == ignorePath
+      case ignorePath if Files.isDirectory(Paths.get(ignorePath)) => filePath.startsWith(ignorePath)
+      case ignorePath                                             => filePath == ignorePath
     }
     lazy val isInIgnoredFileRegex = config.ignoredFilesRegex.matches(filePath)
     if (isInIgnoredFiles || isInIgnoredFileRegex) {
@@ -143,18 +142,18 @@ trait AstGenRunnerBase(config: X2CpgConfig[?] & AstGenConfig[?]) {
     }
   }
 
-  protected def filterFiles(files: List[String], out: File): List[String] = files.filter(fileFilter(_, out))
+  protected def filterFiles(files: List[String], out: Path): List[String] = files.filter(fileFilter(_, out))
 
-  protected def fileFilter(file: String, out: File): Boolean = {
-    file.stripSuffix(".json").replace(out.pathAsString, config.inputPath) match {
+  protected def fileFilter(file: String, out: Path): Boolean = {
+    file.stripSuffix(".json").replace(out.toString, config.inputPath) match {
       case filePath if isIgnoredByUserConfig(filePath) => false
       case _                                           => true
     }
   }
 
-  protected def skippedFiles(in: File, astGenOut: List[String]): List[String]
+  protected def skippedFiles(in: Path, astGenOut: List[String]): List[String]
 
-  protected def runAstGenNative(in: String, out: File, exclude: String, include: String)(implicit
+  protected def runAstGenNative(in: String, out: Path, exclude: String, include: String)(implicit
     metaData: AstGenProgramMetaData
   ): Try[Seq[String]]
 
@@ -168,14 +167,14 @@ trait AstGenRunnerBase(config: X2CpgConfig[?] & AstGenConfig[?]) {
     }
   }
 
-  def execute(out: File): AstGenRunnerResult = {
+  def execute(out: Path): AstGenRunnerResult = {
     implicit val metaData: AstGenProgramMetaData = config.astGenMetaData
-    val in                                       = File(config.inputPath)
+    val in                                       = Paths.get(config.inputPath)
     logger.info(s"Running ${metaData.name} on '${config.inputPath}'")
     runAstGenNative(config.inputPath, out, config.ignoredFilesRegex.toString(), "") match {
       case Success(result) =>
         val srcFiles = SourceFiles.determine(
-          out.toString(),
+          out.toString,
           Set(".json"),
           ignoredFilesRegex = Option(config.ignoredFilesRegex),
           ignoredFilesPath = Option(config.ignoredFiles)

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/jssrc2cpg/JavaScriptImportResolverPass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/jssrc2cpg/JavaScriptImportResolverPass.scala
@@ -36,9 +36,12 @@ class JavaScriptImportResolverPass(cpg: Cpg) extends XImportResolverPass(cpg) {
     // TODO: At times there is an operation inside of a require, e.g. path.resolve(__dirname + "/../config/env/all.js")
     //  this tries to recover the string but does not perform string constant propagation
     val entity = if (matcher.find()) matcher.group(1) else rawEntity
+
     val resolvedPath = Try(
       Paths
         .get(currentFile.stripSuffix(currentFile.split(sep).last), entity.split(pathSep).head)
+        .toAbsolutePath
+        .normalize()
         .toString
         .stripPrefix(root)
     ).getOrElse(entity)

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/jssrc2cpg/JavaScriptImportResolverPass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/jssrc2cpg/JavaScriptImportResolverPass.scala
@@ -8,6 +8,7 @@ import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.language.importresolver.*
 
 import java.io.File as JFile
+import java.nio.file.Paths
 import java.util.regex.{Matcher, Pattern}
 import scala.util.{Failure, Success, Try}
 
@@ -36,9 +37,9 @@ class JavaScriptImportResolverPass(cpg: Cpg) extends XImportResolverPass(cpg) {
     //  this tries to recover the string but does not perform string constant propagation
     val entity = if (matcher.find()) matcher.group(1) else rawEntity
     val resolvedPath = Try(
-      better.files
-        .File(currentFile.stripSuffix(currentFile.split(sep).last), entity.split(pathSep).head)
-        .pathAsString
+      Paths
+        .get(currentFile.stripSuffix(currentFile.split(sep).last), entity.split(pathSep).head)
+        .toString
         .stripPrefix(root)
     ).getOrElse(entity)
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/php2cpg/PhpTypeStubsParser.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/php2cpg/PhpTypeStubsParser.scala
@@ -1,6 +1,5 @@
 package io.joern.x2cpg.frontendspecific.php2cpg
 
-import better.files.File
 import io.joern.x2cpg.X2CpgConfig
 import io.joern.x2cpg.passes.frontend.{TypeStubsParserConfig, XTypeStubsParserConfig}
 import io.shiftleft.codepropertygraph.generated.{Cpg, Operators, PropertyNames}
@@ -11,8 +10,6 @@ import io.shiftleft.semanticcpg.language.operatorextension.OpNodes
 import org.slf4j.{Logger, LoggerFactory}
 import scopt.OParser
 
-import java.io.File as JFile
-import java.nio.file.Paths
 import scala.io.Source
 
 // Corresponds to a parsed row in the known functions file

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/pysrc2cpg/PythonImportResolverPass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/pysrc2cpg/PythonImportResolverPass.scala
@@ -1,13 +1,15 @@
 package io.joern.x2cpg.frontendspecific.pysrc2cpg
 
-import better.files.File
 import io.joern.x2cpg.passes.frontend.XImportResolverPass
+import io.joern.x2cpg.utils.FileUtil
+import io.joern.x2cpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.language.importresolver.*
 
 import java.io.File as JFile
+import java.nio.file.{Files, Paths}
 import java.util.regex.Matcher
 import scala.collection.mutable
 
@@ -57,15 +59,15 @@ class PythonImportResolverPass(cpg: Cpg) extends XImportResolverPass(cpg) {
     importedAs: String,
     diffGraph: DiffGraphBuilder
   ): Unit = {
-    val currDir = File(codeRootDir) / fileName match
-      case x if x.isDirectory => x
-      case x                  => x.parent
+    val currDir = Paths.get(codeRootDir) / fileName match
+      case x if Files.isDirectory(x) => x
+      case x                         => x.getParent
 
     val importedEntityAsFullyQualifiedImport =
       // If the path/entity uses Python's `from .import x` syntax, we will need to remove these
       fileToPythonImportNotation(importedEntity.replaceFirst("^\\.+", ""))
     val importedEntityAsRelativeImport = Seq(
-      fileToPythonImportNotation(currDir.pathAsString.stripPrefix(codeRootDir).stripPrefix(JFile.separator)),
+      fileToPythonImportNotation(currDir.toString.stripPrefix(codeRootDir).stripPrefix(JFile.separator)),
       importedEntityAsFullyQualifiedImport
     ).filterNot(_.isBlank).mkString(".")
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/pysrc2cpg/PythonImportResolverPass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/pysrc2cpg/PythonImportResolverPass.scala
@@ -1,12 +1,12 @@
 package io.joern.x2cpg.frontendspecific.pysrc2cpg
 
 import io.joern.x2cpg.passes.frontend.XImportResolverPass
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.language.importresolver.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 
 import java.io.File as JFile
 import java.nio.file.{Files, Paths}

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/rubysrc2cpg/RubyImportResolverPass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/rubysrc2cpg/RubyImportResolverPass.scala
@@ -1,6 +1,5 @@
 package io.joern.x2cpg.frontendspecific.rubysrc2cpg
 
-import better.files.File
 import io.joern.x2cpg.frontendspecific.rubysrc2cpg.Constants.*
 import io.joern.x2cpg.passes.frontend.XImportResolverPass
 import io.shiftleft.codepropertygraph.generated.Cpg
@@ -10,6 +9,7 @@ import io.shiftleft.semanticcpg.language.importresolver.*
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 
 import java.io.File as JFile
+import java.nio.file.Paths
 import java.util.regex.{Matcher, Pattern}
 class RubyImportResolverPass(cpg: Cpg) extends XImportResolverPass(cpg) {
 
@@ -78,12 +78,12 @@ class RubyImportResolverPass(cpg: Cpg) extends XImportResolverPass(cpg) {
     val root        = s"$codeRootDir${JFile.separator}"
     val currentFile = s"$root$fileName"
     val entity      = if (matcher.find()) matcher.group(1) else rawEntity
-    val resolvedPath = better.files
-      .File(
+    val resolvedPath = Paths
+      .get(
         currentFile.stripSuffix(currentFile.split(sep).lastOption.getOrElse("")),
         entity.split("\\.").headOption.getOrElse(entity)
       )
-      .pathAsString match {
+      .toString match {
       case resPath if entity.endsWith(".rb") => s"$resPath.rb"
       case resPath                           => resPath
     }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/layers/DumpAst.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/layers/DumpAst.scala
@@ -1,6 +1,6 @@
 package io.joern.x2cpg.layers
 
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext, LayerCreatorOptions}
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/layers/DumpAst.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/layers/DumpAst.scala
@@ -1,9 +1,10 @@
 package io.joern.x2cpg.layers
 
-import better.files.File
+import io.joern.x2cpg.utils.FileUtil.*
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext, LayerCreatorOptions}
 
+import java.nio.file.{Files, Paths}
 case class AstDumpOptions(var outDir: String) extends LayerCreatorOptions {}
 
 object DumpAst {
@@ -23,8 +24,9 @@ class DumpAst(options: AstDumpOptions) extends LayerCreator {
   override def create(context: LayerCreatorContext): Unit = {
     val cpg = context.cpg
     cpg.method.zipWithIndex.foreach { case (method, i) =>
-      val str = method.dotAst.head
-      (File(options.outDir) / s"$i-ast.dot").write(str)
+      val str        = method.dotAst.head
+      val outputPath = (Paths.get(options.outDir) / s"$i-ast.dot")
+      Files.writeString(outputPath, str)
     }
   }
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/layers/DumpCdg.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/layers/DumpCdg.scala
@@ -2,7 +2,7 @@ package io.joern.x2cpg.layers
 
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext, LayerCreatorOptions}
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 
 import java.nio.file.{Files, Path, Paths}
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/layers/DumpCdg.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/layers/DumpCdg.scala
@@ -1,8 +1,10 @@
 package io.joern.x2cpg.layers
 
-import better.files.File
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext, LayerCreatorOptions}
+import io.joern.x2cpg.utils.FileUtil.*
+
+import java.nio.file.{Files, Path, Paths}
 
 case class CdgDumpOptions(var outDir: String) extends LayerCreatorOptions {}
 
@@ -23,8 +25,9 @@ class DumpCdg(options: CdgDumpOptions) extends LayerCreator {
   override def create(context: LayerCreatorContext): Unit = {
     val cpg = context.cpg
     cpg.method.zipWithIndex.foreach { case (method, i) =>
-      val str = method.dotCdg.head
-      (File(options.outDir) / s"$i-cdg.dot").write(str)
+      val str        = method.dotCdg.head
+      val outputPath = Paths.get(options.outDir) / s"$i-cdg.dot"
+      Files.writeString(outputPath, str)
     }
   }
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/layers/DumpCfg.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/layers/DumpCfg.scala
@@ -1,8 +1,10 @@
 package io.joern.x2cpg.layers
 
-import better.files.File
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext, LayerCreatorOptions}
+import io.joern.x2cpg.utils.FileUtil.*
+
+import java.nio.file.{Files, Paths}
 
 case class CfgDumpOptions(var outDir: String) extends LayerCreatorOptions {}
 
@@ -23,8 +25,9 @@ class DumpCfg(options: CfgDumpOptions) extends LayerCreator {
   override def create(context: LayerCreatorContext): Unit = {
     val cpg = context.cpg
     cpg.method.zipWithIndex.foreach { case (method, i) =>
-      val str = method.dotCfg.head
-      (File(options.outDir) / s"$i-cfg.dot").write(str)
+      val str        = method.dotCfg.head
+      val outputPath = Paths.get(options.outDir) / s"$i-cfg.dot"
+      Files.writeString(outputPath, str)
     }
   }
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/layers/DumpCfg.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/layers/DumpCfg.scala
@@ -2,7 +2,7 @@ package io.joern.x2cpg.layers
 
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext, LayerCreatorOptions}
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 
 import java.nio.file.{Files, Paths}
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/MetaDataPass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/MetaDataPass.scala
@@ -4,7 +4,7 @@ import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{NewMetaData, NewNamespaceBlock}
 import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language.types.structure.{FileTraversal, NamespaceTraversal}
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 
 import java.nio.file.Paths
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/MetaDataPass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/MetaDataPass.scala
@@ -1,10 +1,12 @@
 package io.joern.x2cpg.passes.frontend
 
-import better.files.File
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{NewMetaData, NewNamespaceBlock}
 import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language.types.structure.{FileTraversal, NamespaceTraversal}
+import io.joern.x2cpg.utils.FileUtil.*
+
+import java.nio.file.Paths
 
 /** A pass that creates a MetaData node, specifying that this is a CPG for language, and a NamespaceBlock for anything
   * that cannot be assigned to any other namespace.
@@ -12,7 +14,7 @@ import io.shiftleft.semanticcpg.language.types.structure.{FileTraversal, Namespa
 class MetaDataPass(cpg: Cpg, language: String, root: String, hash: Option[String] = None) extends CpgPass(cpg) {
   override def run(diffGraph: DiffGraphBuilder): Unit = {
     def addMetaDataNode(diffGraph: DiffGraphBuilder): Unit = {
-      val absolutePathToRoot = File(root).path.toAbsolutePath.toString
+      val absolutePathToRoot = Paths.get(root).absolutePathAsString
       val metaNode           = NewMetaData().language(language).root(absolutePathToRoot).version("0.1").hash(hash)
       diffGraph.addNode(metaNode)
     }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XConfigFileCreationPass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XConfigFileCreationPass.scala
@@ -1,6 +1,7 @@
 package io.joern.x2cpg.passes.frontend
 
-import better.files.File
+import io.joern.x2cpg.utils.FileUtil
+import io.joern.x2cpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.NewConfigFile
 import io.shiftleft.passes.ForkJoinParallelCpgPass
@@ -8,26 +9,28 @@ import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.utils.IOUtils
 import org.slf4j.LoggerFactory
 
-import java.nio.file.Paths
+import java.nio.file.{Files, Path, Paths}
 import scala.util.{Failure, Success, Try}
 
 /** Scans for and inserts configuration files into the CPG. Relies on the MetaData's `ROOT` property to provide the path
   * to scan, but alternatively one can specify a directory on the `rootDir` parameter.
   */
 abstract class XConfigFileCreationPass(cpg: Cpg, private val rootDir: Option[String] = None)
-    extends ForkJoinParallelCpgPass[File](cpg) {
+    extends ForkJoinParallelCpgPass[Path](cpg) {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
 
   // File filters to override by the implementing class
-  protected val configFileFilters: List[File => Boolean]
+  protected val configFileFilters: List[Path => Boolean]
 
-  override def generateParts(): Array[File] = {
+  override def generateParts(): Array[Path] = {
     rootDir.orElse(cpg.metaData.root.headOption) match {
       case Some(root) =>
-        Try(File(root)) match {
-          case Success(file) if file.isDirectory =>
-            file.listRecursively
+        Try(Paths.get(root)) match {
+          case Success(file) if Files.isDirectory(file) =>
+            file
+              .walk()
+              .filterNot(_ == file)
               .filter(isConfigFile)
               .toArray
 
@@ -41,8 +44,8 @@ abstract class XConfigFileCreationPass(cpg: Cpg, private val rootDir: Option[Str
     }
   }
 
-  override def runOnPart(diffGraph: DiffGraphBuilder, file: File): Unit = {
-    Try(IOUtils.readEntireFile(file.path)) match {
+  override def runOnPart(diffGraph: DiffGraphBuilder, file: Path): Unit = {
+    Try(IOUtils.readEntireFile(file)) match {
       case Success(content) =>
         val name       = configFileName(file)
         val configNode = NewConfigFile().name(name).content(content)
@@ -50,25 +53,25 @@ abstract class XConfigFileCreationPass(cpg: Cpg, private val rootDir: Option[Str
         diffGraph.addNode(configNode)
 
       case Failure(error) =>
-        logger.warn(s"Unable to create config file node for ${file.canonicalPath}: $error")
+        logger.warn(s"Unable to create config file node for ${file.toAbsolutePath}: $error")
     }
   }
 
-  private def configFileName(configFile: File): String = {
+  private def configFileName(configFile: Path): String = {
     Try(Paths.get(rootDir.getOrElse(cpg.metaData.root.head)).toAbsolutePath)
-      .map(_.relativize(configFile.path.toAbsolutePath).toString)
-      .getOrElse(configFile.name)
+      .map(_.relativize(configFile.toAbsolutePath).toString)
+      .getOrElse(configFile.fileName)
   }
 
-  protected def extensionFilter(extension: String)(file: File): Boolean = {
-    file.extension.contains(extension)
+  protected def extensionFilter(extension: String)(file: Path): Boolean = {
+    file.extension().contains(extension)
   }
 
-  protected def pathEndFilter(pathEnd: String)(file: File): Boolean = {
-    file.canonicalPath.endsWith(pathEnd)
+  protected def pathEndFilter(pathEnd: String)(file: Path): Boolean = {
+    file.absolutePathAsString.endsWith(pathEnd)
   }
 
-  private def isConfigFile(file: File): Boolean = {
+  private def isConfigFile(file: Path): Boolean = {
     configFileFilters.exists(predicate => predicate(file))
   }
 }
@@ -79,7 +82,7 @@ abstract class XConfigFileCreationPass(cpg: Cpg, private val rootDir: Option[Str
 class JavaConfigFileCreationPass(cpg: Cpg, rootDir: Option[String] = None)
     extends XConfigFileCreationPass(cpg, rootDir) {
 
-  override val configFileFilters: List[File => Boolean] = List(
+  override val configFileFilters: List[Path => Boolean] = List(
     // JAVA_INTERNAL
     extensionFilter(".properties"),
     pathEndFilter("MANIFEST.MF"),
@@ -119,8 +122,8 @@ class JavaConfigFileCreationPass(cpg: Cpg, rootDir: Option[String] = None)
     pathEndFilter("pom.xml")
   )
 
-  private def mybatisFilter(file: File): Boolean = {
-    file.canonicalPath.contains("batis") && file.extension.contains(".xml")
+  private def mybatisFilter(file: Path): Boolean = {
+    file.absolutePathAsString.contains("batis") && file.extension().contains(".xml")
   }
 
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XConfigFileCreationPass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XConfigFileCreationPass.scala
@@ -1,11 +1,11 @@
 package io.joern.x2cpg.passes.frontend
 
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.NewConfigFile
 import io.shiftleft.passes.ForkJoinParallelCpgPass
 import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 import io.shiftleft.utils.IOUtils
 import org.slf4j.LoggerFactory
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XImportResolverPass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XImportResolverPass.scala
@@ -1,6 +1,5 @@
 package io.joern.x2cpg.passes.frontend
 
-import better.files.File
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Import, Tag}
 import io.shiftleft.passes.ForkJoinParallelCpgPass
@@ -10,16 +9,16 @@ import org.slf4j.{Logger, LoggerFactory}
 
 import java.io.File as JFile
 import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Paths}
 import java.util.Base64
 
 abstract class XImportResolverPass(cpg: Cpg) extends ForkJoinParallelCpgPass[Import](cpg) {
 
   protected val logger: Logger = LoggerFactory.getLogger(this.getClass)
-  protected val codeRootDir: String = File(
-    cpg.metaData.root.headOption.getOrElse(JFile.separator).stripSuffix(JFile.separator)
-  ) match
-    case f if f.isDirectory => f.pathAsString
-    case f                  => f.parent.pathAsString
+  protected val codeRootDir: String =
+    Paths.get(cpg.metaData.root.headOption.getOrElse(JFile.separator).stripSuffix(JFile.separator)) match
+      case f if Files.isDirectory(f) => f.toString
+      case f                         => f.getParent.toString
 
   override def generateParts(): Array[Import] = cpg.imports.toArray
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/typestub/TypeStubUtil.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/typestub/TypeStubUtil.scala
@@ -23,7 +23,7 @@ object TypeStubUtil {
         "."
       }
     }
-    Paths.get(fixedDir, "/type_stubs").toAbsolutePath.normalize()
+    Paths.get(fixedDir, "type_stubs")
   }
 
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/typestub/TypeStubUtil.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/typestub/TypeStubUtil.scala
@@ -1,8 +1,6 @@
 package io.joern.x2cpg.typestub
 
-import better.files.File
-
-import java.nio.file.Paths
+import java.nio.file.{Path, Paths}
 
 object TypeStubUtil {
 
@@ -12,7 +10,7 @@ object TypeStubUtil {
     * @return
     *   the directory where type stubs are.
     */
-  def typeStubDir(implicit metaData: TypeStubMetaData): File = {
+  def typeStubDir(implicit metaData: TypeStubMetaData): Path = {
     val dir        = metaData.packagePath.toString
     val indexOfLib = dir.lastIndexOf("lib")
     val fixedDir = if (indexOfLib != -1) {
@@ -25,7 +23,7 @@ object TypeStubUtil {
         "."
       }
     }
-    File(Paths.get(fixedDir, "/type_stubs").toAbsolutePath)
+    Paths.get(fixedDir, "/type_stubs").toAbsolutePath
   }
 
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/typestub/TypeStubUtil.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/typestub/TypeStubUtil.scala
@@ -23,7 +23,7 @@ object TypeStubUtil {
         "."
       }
     }
-    Paths.get(fixedDir, "/type_stubs").toAbsolutePath
+    Paths.get(fixedDir, "/type_stubs").toAbsolutePath.normalize()
   }
 
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/FileUtil.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/FileUtil.scala
@@ -7,10 +7,11 @@ import java.nio.file.{
   LinkOption,
   NoSuchFileException,
   Path,
+  Paths,
   SimpleFileVisitor,
   StandardCopyOption
 }
-import java.nio.file.attribute.{BasicFileAttributes}
+import java.nio.file.attribute.BasicFileAttributes
 import java.nio.charset.Charset
 import java.util.zip.{ZipEntry, ZipFile}
 import scala.annotation.tailrec
@@ -18,6 +19,8 @@ import scala.jdk.CollectionConverters.*
 import scala.util.Using
 
 object FileUtil {
+  def currentWorkingDirectory: Path = Paths.get("").toAbsolutePath.normalize()
+
   def newTemporaryFile(prefix: String = "", suffix: String = "", parent: Option[Path] = None): Path = {
     parent match {
       case Some(dir) => Files.createTempFile(dir, prefix, suffix)
@@ -223,35 +226,21 @@ object FileUtil {
         .sum
     }
 
-    def listFiles(): Iterator[Path] = {
-      Files.list(p).iterator().asScala
-    }
+    def listFiles(): Iterator[Path] = Files.list(p).iterator().asScala
 
-    def walk(): Iterator[Path] = {
-      Files.walk(p).iterator().asScala
-    }
+    def walk(): Iterator[Path] = Files.walk(p).iterator().asScala
 
-    def hasExtension: Boolean = {
-      (Files.isRegularFile(p) || Files.notExists(p)) && p.fileName.contains(".")
-    }
+    def hasExtension: Boolean = (Files.isRegularFile(p) || Files.notExists(p)) && p.fileName.contains(".")
 
-    def fileName: String = {
-      p.getFileName.toString
-    }
+    def fileName: String = p.getFileName.toString
 
     def fileContent: String = fileContent()
 
-    def fileContent(charset: Charset = Charset.defaultCharset()): String = {
-      new String(Files.readAllBytes(p), charset)
-    }
+    def fileContent(charset: Charset = Charset.defaultCharset()): String = new String(Files.readAllBytes(p), charset)
 
-    def nameOption: Option[String] = {
-      Option(p.fileName)
-    }
+    def nameOption: Option[String] = Option(p.fileName)
 
-    def parentOption: Option[Path] = {
-      Option(p.getParent)
-    }
+    def parentOption: Option[Path] = Option(p.getParent)
 
     def nameWithoutExtension(includeAll: Boolean = true): String =
       if (hasExtension) p.fileName.substring(0, indexOfExtension(includeAll)) else p.fileName
@@ -266,9 +255,8 @@ object FileUtil {
       }
     }
 
-    private def indexOfExtension(includeAll: Boolean): Int = {
+    private def indexOfExtension(includeAll: Boolean): Int =
       if (includeAll) p.fileName.indexOf(".") else p.fileName.lastIndexOf(".")
-    }
 
     // Taken from better.files implementation
     @tailrec final def pipeTo(in: InputStream, out: OutputStream, buffer: Array[Byte]): OutputStream = {

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/FileUtil.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/FileUtil.scala
@@ -114,7 +114,7 @@ object FileUtil {
     def absolutePathAsString: String = p.toAbsolutePath.toString
 
     def /(child: String): Path = {
-      p.resolve(child)
+      p.resolve(child).toAbsolutePath.normalize()
     }
 
     def copyToDirectory(destination: Path): Unit = {

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/DependencyResolver.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/DependencyResolver.scala
@@ -1,9 +1,8 @@
 package io.joern.x2cpg.utils.dependency
 
-import io.shiftleft.semanticcpg.utils.ExternalCommand
+import io.shiftleft.semanticcpg.utils.{ExternalCommand, FileUtil}
 import io.joern.x2cpg.utils.dependency.GradleConfigKeys.GradleConfigKey
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import FileUtil.*
 import org.slf4j.LoggerFactory
 
 import java.nio.file.{Files, Path}

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/GradleDependencies.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/GradleDependencies.scala
@@ -439,7 +439,7 @@ object GradleDependencies {
         .iterator()
         .asScala
         .filterNot(_ == outDir)
-        .filter(_.getFileName.toString == jarInsideAarFileName)
+        .filter(_.fileName == jarInsideAarFileName)
         .toList
     if (classesJarEntries.size != 1) {
       logger.warn(s"Found aar file without `classes.jar` inside at path ${aar}")

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/GradleDependencies.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/GradleDependencies.scala
@@ -1,7 +1,7 @@
 package io.joern.x2cpg.utils.dependency
 
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 
 import java.nio.charset.Charset
 import org.gradle.tooling.{GradleConnector, ProjectConnection}

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/SourceFilesTests.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/SourceFilesTests.scala
@@ -1,7 +1,8 @@
 package io.joern.x2cpg
 
-import io.joern.x2cpg.utils.{IgnoreInWindows, FileUtil}
-import io.joern.x2cpg.utils.FileUtil.*
+import io.joern.x2cpg.utils.IgnoreInWindows
+import io.shiftleft.semanticcpg.utils.FileUtil
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 
 import io.shiftleft.utils.ProjectRoot
 import org.scalatest.matchers.should.Matchers

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/X2CpgTests.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/X2CpgTests.scala
@@ -1,7 +1,7 @@
 package io.joern.x2cpg
 
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/X2CpgTests.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/X2CpgTests.scala
@@ -1,6 +1,5 @@
 package io.joern.x2cpg
 
-import better.files.File
 import io.joern.x2cpg.utils.FileUtil
 import io.joern.x2cpg.utils.FileUtil.*
 import org.scalatest.matchers.should.Matchers

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/layers/DumpAstTests.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/layers/DumpAstTests.scala
@@ -1,9 +1,9 @@
 package io.joern.x2cpg.layers
 
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
 import io.shiftleft.semanticcpg.testing.MockCpg
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/layers/DumpCdgTests.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/layers/DumpCdgTests.scala
@@ -1,9 +1,9 @@
 package io.joern.x2cpg.layers
 
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
 import io.shiftleft.semanticcpg.testing.MockCpg
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/layers/DumpCfgTests.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/layers/DumpCfgTests.scala
@@ -1,9 +1,9 @@
 package io.joern.x2cpg.layers
 
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
 import io.shiftleft.semanticcpg.testing.MockCpg
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/ExternalCommandTest.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/ExternalCommandTest.scala
@@ -10,7 +10,7 @@ import scala.util.{Failure, Success}
 
 class ExternalCommandTest extends AnyWordSpec with Matchers {
 
-  private def cwd = Paths.get("").toString
+  private def cwd = FileUtil.currentWorkingDirectory.toString
 
   "ExternalCommand.run" should {
     "be able to run `ls` successfully" in {

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/ExternalCommandTest.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/ExternalCommandTest.scala
@@ -1,17 +1,16 @@
 package io.joern.x2cpg.utils
 
-import better.files.File
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-
 import io.shiftleft.semanticcpg.utils.ExternalCommand
 
+import java.nio.file.Paths
 import scala.util.Properties.isWin
 import scala.util.{Failure, Success}
 
 class ExternalCommandTest extends AnyWordSpec with Matchers {
 
-  private def cwd = File.currentWorkingDirectory.pathAsString
+  private def cwd = Paths.get("").toString
 
   "ExternalCommand.run" should {
     "be able to run `ls` successfully" in {

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/ExternalCommandTest.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/ExternalCommandTest.scala
@@ -2,7 +2,7 @@ package io.joern.x2cpg.utils
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import io.shiftleft.semanticcpg.utils.ExternalCommand
+import io.shiftleft.semanticcpg.utils.{ExternalCommand, FileUtil}
 
 import java.nio.file.Paths
 import scala.util.Properties.isWin

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/TestCodeWriter.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/TestCodeWriter.scala
@@ -1,6 +1,7 @@
 package io.joern.x2cpg.utils
 
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path}

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/dependency/DependencyResolverTests.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/dependency/DependencyResolverTests.scala
@@ -1,8 +1,7 @@
 package io.joern.x2cpg.utils.dependency
 
-import io.shiftleft.semanticcpg.utils.ExternalCommand
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.{ExternalCommand, FileUtil}
+import FileUtil.*
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/joern-cli/src/main/scala/io/joern/joerncli/CpgBasedTool.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/CpgBasedTool.scala
@@ -1,12 +1,13 @@
 package io.joern.joerncli
 
-import better.files.File
 import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
 import io.joern.dataflowengineoss.semanticsloader.Semantics
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.codepropertygraph.cpgloading.CpgLoader
+
+import java.nio.file.{Files, Paths}
 
 object CpgBasedTool {
 
@@ -36,7 +37,7 @@ object CpgBasedTool {
   /** Create an informational string for the user that informs of a successfully generated CPG.
     */
   def newCpgCreatedString(path: String): String = {
-    val absolutePath = File(path).path.toAbsolutePath
+    val absolutePath = Paths.get(path).toAbsolutePath
     s"Successfully wrote graph to: $absolutePath\n" +
       s"To load the graph, type `joern $absolutePath`"
   }
@@ -55,9 +56,9 @@ object CpgBasedTool {
   }
 
   def exitIfInvalid(outDir: String, cpgFileName: String): Unit = {
-    if (File(outDir).exists)
+    if (Files.exists(Paths.get(outDir)))
       exitWithError(s"Output directory `$outDir` already exists.")
-    if (File(cpgFileName).notExists)
+    if (Files.notExists(Paths.get(cpgFileName)))
       exitWithError(s"CPG at $cpgFileName does not exist.")
   }
 

--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernExport.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernExport.scala
@@ -1,7 +1,5 @@
 package io.joern.joerncli
 
-import better.files.Dsl.*
-import better.files.File
 import flatgraph.{Accessors, Edge, GNode}
 import flatgraph.formats.ExportResult
 import flatgraph.formats.dot.DotExporter
@@ -18,9 +16,8 @@ import io.shiftleft.codepropertygraph.generated.NodeTypes
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.layers.*
 
-import java.nio.file.{Path, Paths}
+import java.nio.file.{Files, Path, Paths}
 import scala.collection.mutable
-import scala.jdk.CollectionConverters.IteratorHasAsScala
 import scala.util.Using
 
 object JoernExport {
@@ -62,10 +59,11 @@ object JoernExport {
     parseConfig(args).foreach { config =>
       val outDir = config.outDir
       exitIfInvalid(outDir, config.cpgFileName)
-      mkdir(File(outDir))
+      val outDirPath = Paths.get(outDir)
+      Files.createDirectory(outDirPath)
 
       Using.resource(CpgBasedTool.loadFromFile(config.cpgFileName)) { cpg =>
-        exportCpg(cpg, config.repr, config.format, Paths.get(outDir).toAbsolutePath)
+        exportCpg(cpg, config.repr, config.format, outDirPath.toAbsolutePath)
       }
     }
   }

--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernParse.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernParse.scala
@@ -1,12 +1,12 @@
 package io.joern.joerncli
 
-import better.files.File
 import io.joern.console.cpgcreation.{CpgGenerator, cpgGeneratorForLanguage, guessLanguage}
 import io.joern.console.{FrontendConfig, InstallConfig}
 import io.joern.joerncli.CpgBasedTool.newCpgCreatedString
 import io.joern.x2cpg.frontendspecific.FrontendArgsDelimitor
 import io.shiftleft.codepropertygraph.generated.Languages
 
+import java.nio.file.{Files, Paths}
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
 import scala.util.{Failure, Success, Try}
@@ -96,7 +96,7 @@ object JoernParse {
       if (config.inputPath == "") {
         println(optionParser.usage)
         throw new AssertionError(s"Input path required")
-      } else if (!File(config.inputPath).exists)
+      } else if (!Files.exists(Paths.get(config.inputPath)))
         throw new AssertionError(s"Input path does not exist at `${config.inputPath}`, exiting.")
       else ()
     }
@@ -136,12 +136,7 @@ object JoernParse {
       println(s"Parsing code at: ${config.inputPath} - language: `$language`")
       println("[+] Running language frontend")
       Try {
-        cpgGeneratorForLanguage(
-          language.toUpperCase,
-          FrontendConfig(),
-          installConfig.rootPath.path,
-          frontendArgs.toList
-        ).get
+        cpgGeneratorForLanguage(language.toUpperCase, FrontendConfig(), installConfig.rootPath, frontendArgs.toList).get
       }.flatMap { newGenerator =>
         generator = newGenerator
         generator

--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernScan.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernScan.scala
@@ -7,11 +7,11 @@ import io.joern.dataflowengineoss.semanticsloader.{NoSemantics, Semantics}
 import io.joern.joerncli.JoernScan.getQueriesFromQueryDb
 import io.joern.joerncli.Scan.{allTag, defaultTag}
 import io.joern.joerncli.console.ReplBridge
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Languages
 import io.shiftleft.semanticcpg.language.{DefaultNodeExtensionFinder, NodeExtensionFinder}
 import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext, LayerCreatorOptions}
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.json4s.native.Serialization
 import org.json4s.{Formats, NoTypeHints}
 

--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernScan.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernScan.scala
@@ -16,7 +16,7 @@ import org.json4s.native.Serialization
 import org.json4s.{Formats, NoTypeHints}
 
 import java.io.FileNotFoundException
-import java.nio.file.{Files, NoSuchFileException, Path}
+import java.nio.file.{Files, NoSuchFileException, Path, Paths}
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
 
@@ -134,9 +134,8 @@ object JoernScan extends BridgeBase {
     implicit val engineContext: EngineContext = EngineContext(NoSemantics)
     implicit val formats: AnyRef & Formats    = Serialization.formats(NoTypeHints)
     val queryDb                               = new QueryDatabase(new JoernDefaultArgumentProvider(0))
-    better.files
-      .File(outFileName)
-      .write(Serialization.write(queryDb.allQueries))
+    val outFile                               = Paths.get(outFileName)
+    Files.writeString(outFile, Serialization.write(queryDb.allQueries))
     println(s"Queries written to: $outFileName")
   }
 

--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernSlice.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernSlice.scala
@@ -1,14 +1,16 @@
 package io.joern.joerncli
 
-import better.files.File
 import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
 import io.joern.joerncli.JoernParse.ParserConfig
 import io.joern.x2cpg.X2Cpg
 import io.joern.x2cpg.layers.Base
 import io.joern.x2cpg.utils.FileUtil
+import io.joern.x2cpg.utils.FileUtil.*
+
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
 
+import java.nio.file.{Files, Path, Paths}
 import scala.language.postfixOps
 import scala.util.{Try, Using}
 
@@ -22,15 +24,15 @@ object JoernSlice {
     arg[String]("cpg")
       .text("input CPG file name, or source code - defaults to `cpg.bin`")
       .optional()
-      .action((x, c) => c.withInputPath(File(x)))
+      .action((x, c) => c.withInputPath(Paths.get(x)))
       .validate { x =>
-        val path = File(x)
-        if (path.isRegularFile || path.isDirectory) success
+        val path = Paths.get(x)
+        if (Files.isRegularFile(path) || Files.isDirectory(path)) success
         else failure(s"File at '$x' not found or not regular, e.g. a directory or source file.")
       }
     opt[String]('o', "out")
       .text("the output file to write slices to - defaults to `slices`. The file is suffixed based on the mode.")
-      .action((x, c) => c.withOutputSliceFile(File(x)))
+      .action((x, c) => c.withOutputSliceFile(Paths.get(x)))
     opt[Unit]("dummy-types")
       .text(s"for generating CPGs that use type recovery, enables the use of dummy types - defaults to false.")
       .action((_, c) => c.withDummyTypesEnabled(true))
@@ -115,13 +117,13 @@ object JoernSlice {
       } else {
         val inputCpgPath =
           if (
-            config.inputPath.isDirectory || !config.inputPath
+            Files.isDirectory(config.inputPath) || !config.inputPath
               .extension(includeDot = false)
               .exists(_.matches("(bin|cpg)"))
           ) {
             generateTempCpg(config).get
           } else {
-            config.inputPath.pathAsString
+            config.inputPath.toString
           }
         Using.resource(CpgBasedTool.loadFromFile(inputCpgPath)) { cpg =>
           checkAndApplyOverlays(cpg)
@@ -156,11 +158,11 @@ object JoernSlice {
 
   private def generateTempCpg(config: BaseConfig[?]): Try[String] = {
     val tmpFile = FileUtil.newTemporaryFile("joern-slice", ".bin")
-    println(s"Generating CPG from code at ${config.inputPath.pathAsString}")
+    println(s"Generating CPG from code at ${config.inputPath.toString}")
 
     JoernParse
       .run(
-        ParserConfig(config.inputPath.pathAsString, outputCpgFile = tmpFile.toString),
+        ParserConfig(config.inputPath.toString, outputCpgFile = tmpFile.toString),
         if (config.dummyTypesEnabled) List.empty else List("--no-dummyTypes")
       )
       .map { _ =>
@@ -173,17 +175,19 @@ object JoernSlice {
   private def parseConfig(args: Array[String]): Option[BaseConfig[?]] =
     configParser.parse(args, DefaultSliceConfig())
 
-  private def saveSlice(outFile: File, programSlice: ProgramSlice): Unit = {
+  private def saveSlice(outFile: Path, programSlice: ProgramSlice): Unit = {
 
     def normalizePath(path: String, ext: String): String =
       if (path.endsWith(ext)) path
       else path + ext
 
     val finalOutputPath =
-      File(normalizePath(outFile.pathAsString, ".json"))
-        .createFileIfNotExists()
-        .write(programSlice.toJsonPretty)
-        .pathAsString
+      Paths
+        .get(normalizePath(outFile.toString, ".json"))
+        .createWithParentsIfNotExists()
+
+    Files.writeString(finalOutputPath, programSlice.toJsonPretty)
+    finalOutputPath.toString
     println(s"Slices have been successfully generated and written to $finalOutputPath")
   }
 

--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernSlice.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernSlice.scala
@@ -4,11 +4,11 @@ import io.joern.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOpti
 import io.joern.joerncli.JoernParse.ParserConfig
 import io.joern.x2cpg.X2Cpg
 import io.joern.x2cpg.layers.Base
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
+import io.shiftleft.semanticcpg.utils.FileUtil
 
 import java.nio.file.{Files, Path, Paths}
 import scala.language.postfixOps

--- a/joern-cli/src/main/scala/io/joern/joerncli/console/JoernConsole.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/console/JoernConsole.scala
@@ -1,6 +1,5 @@
 package io.joern.joerncli.console
 
-import better.files.*
 import io.joern.console.defaultAvailableWidthProvider
 import io.joern.console.workspacehandling.{ProjectFile, WorkspaceLoader}
 import io.joern.console.{Console, ConsoleConfig, InstallConfig}

--- a/joern-cli/src/test/scala/io/joern/joerncli/AbstractJoernCliTest.scala
+++ b/joern-cli/src/test/scala/io/joern/joerncli/AbstractJoernCliTest.scala
@@ -4,9 +4,9 @@ import io.joern.console.FrontendConfig
 import io.joern.console.cpgcreation.{CCpgGenerator, JsSrcCpgGenerator}
 import io.joern.x2cpg.frontendspecific.jssrc2cpg
 import io.joern.x2cpg.passes.frontend.XTypeRecoveryConfig
-import io.joern.x2cpg.utils.FileUtil
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.Languages
+import io.shiftleft.semanticcpg.utils.FileUtil
 import io.shiftleft.utils.ProjectRoot
 
 import java.nio.file.Path

--- a/joern-cli/src/test/scala/io/joern/joerncli/AbstractJoernCliTest.scala
+++ b/joern-cli/src/test/scala/io/joern/joerncli/AbstractJoernCliTest.scala
@@ -1,6 +1,5 @@
 package io.joern.joerncli
 
-import better.files.File
 import io.joern.console.FrontendConfig
 import io.joern.console.cpgcreation.{CCpgGenerator, JsSrcCpgGenerator}
 import io.joern.x2cpg.frontendspecific.jssrc2cpg
@@ -15,11 +14,11 @@ import scala.util.Failure
 
 trait AbstractJoernCliTest {
 
-  protected def withTestCpg[T](file: File, language: String = Languages.C)(f: ((Cpg, String)) => T): T = {
+  protected def withTestCpg[T](file: Path, language: String = Languages.C)(f: ((Cpg, String)) => T): T = {
     f(loadTestCpg(file, language))
   }
 
-  private def loadTestCpg(file: File, language: String = Languages.C): (Cpg, String) = {
+  private def loadTestCpg(file: Path, language: String = Languages.C): (Cpg, String) = {
     val tmpFile        = FileUtil.newTemporaryFile("cpg", "bin")
     val cpgOutFileName = tmpFile.toString
     FileUtil.delete(tmpFile)
@@ -28,7 +27,7 @@ trait AbstractJoernCliTest {
       case Languages.C | Languages.CSHARP         => CCpgGenerator(new FrontendConfig(), relativePath("c2cpg"))
       case Languages.JSSRC | Languages.JAVASCRIPT => JsSrcCpgGenerator(new FrontendConfig(), relativePath("jssrc2cpg"))
     }
-    cpgGenerator.generate(inputPath = file.pathAsString, outputPath = cpgOutFileName) match {
+    cpgGenerator.generate(inputPath = file.toString, outputPath = cpgOutFileName) match {
       case Failure(exception) => throw new AssertionError("error while invoking cpgGenerator", exception)
       case _                  =>
     }

--- a/joern-cli/src/test/scala/io/joern/joerncli/ConsoleTests.scala
+++ b/joern-cli/src/test/scala/io/joern/joerncli/ConsoleTests.scala
@@ -1,7 +1,7 @@
 package io.joern.joerncli
 
-import io.joern.x2cpg.utils.FileUtil
-import io.joern.x2cpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/joern-cli/src/test/scala/io/joern/joerncli/GenerationTests.scala
+++ b/joern-cli/src/test/scala/io/joern/joerncli/GenerationTests.scala
@@ -1,15 +1,16 @@
 package io.joern.joerncli
 
-import better.files.File
 import io.shiftleft.semanticcpg.language.*
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import java.nio.file.Paths
 
 /** Test code that shows how code property graphs can be generated using the c2cpg language frontend */
 class GenerationTests extends AnyWordSpec with Matchers with AbstractJoernCliTest {
 
   "should generate and load CPG for example code" in withTestCpg(
-    File(getClass.getClassLoader.getResource("testcode/free"))
+    Paths.get(getClass.getClassLoader.getResource("testcode/free").toURI)
   ) { case (cpg, _) =>
     // Query to retrieve all method names
     cpg.method.name.l should not be empty

--- a/joern-cli/src/test/scala/io/joern/joerncli/JoernExportTests.scala
+++ b/joern-cli/src/test/scala/io/joern/joerncli/JoernExportTests.scala
@@ -1,15 +1,16 @@
 package io.joern.joerncli
 
-import better.files.File
 import io.joern.joerncli.JoernExport.Representation
 import io.shiftleft.codepropertygraph.generated.Cpg
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
+import java.nio.file.Paths
+
 class JoernExportTests extends AnyWordSpec with Matchers with AbstractJoernCliTest {
 
   "export to graphson, for example code 'testcode/free'" should withTestCpg(
-    File(getClass.getClassLoader.getResource("testcode/free"))
+    Paths.get(getClass.getClassLoader.getResource("testcode/free").toURI)
   ) { case (cpg: Cpg, _) =>
     "split output by method" in {
       val tempDir = os.temp.dir(prefix = "joern-export-test")

--- a/joern-cli/src/test/scala/io/joern/joerncli/RunScriptTests.scala
+++ b/joern-cli/src/test/scala/io/joern/joerncli/RunScriptTests.scala
@@ -1,12 +1,15 @@
 package io.joern.joerncli
 
-import better.files._
-import java.nio.file.Paths
+import better.files.File
+import java.nio.file.{Files, Path, Paths}
 import io.joern.console.Config
 import io.joern.joerncli.console.ReplBridge
+import io.joern.x2cpg.utils.FileUtil
 import io.shiftleft.utils.ProjectRoot
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.jdk.CollectionConverters.*
 
 class RunScriptTests extends AnyWordSpec with Matchers {
   import RunScriptTests._
@@ -30,54 +33,61 @@ class RunScriptTests extends AnyWordSpec with Matchers {
     }
 
     "execute a simple script" in new Fixture {
-      def test(scriptFile: File, outputFile: File) = {
-        val escScriptPath = outputFile.pathAsString.replace("\\", "\\\\")
-        scriptFile.write(s"""
+      def test(scriptFile: Path, outputFile: Path) = {
+        val escScriptPath = outputFile.toString.replace("\\", "\\\\")
+        Files.writeString(
+          scriptFile,
+          s"""
         |val fw = new java.io.FileWriter("$escScriptPath", true)
         |fw.write("michael was here")
-        |fw.close() 
-        """.stripMargin)
+        |fw.close()
+        """.stripMargin
+        )
 
-        ReplBridge.main(Array("--script", scriptFile.pathAsString))
+        ReplBridge.main(Array("--script", scriptFile.toString))
 
         withClue(s"$outputFile content: ") {
-          outputFile.lines.head shouldBe "michael was here"
+          Files.readAllLines(outputFile).asScala.head shouldBe "michael was here"
         }
       }
     }
 
     "pass parameters to script" in new Fixture {
-      def test(scriptFile: File, outputFile: File) = {
-        scriptFile.write(s"""
+      def test(scriptFile: Path, outputFile: Path) = {
+        Files.writeString(
+          scriptFile,
+          s"""
           |@main def foo(outFile: String, magicNumber: Int) = {
           |  val fw = new java.io.FileWriter(outFile, true)
           |  fw.write(magicNumber.toString)
           |  fw.close() 
           |}
-          """.stripMargin)
+          """.stripMargin
+        )
 
         ReplBridge.main(
           Array(
             "--script",
-            scriptFile.pathAsString,
+            scriptFile.toString,
             "--param",
-            s"outFile=${outputFile.pathAsString}",
+            s"outFile=${outputFile.toString}",
             "--param",
             "magicNumber=42"
           )
         )
 
         withClue(s"$outputFile content: ") {
-          outputFile.lines.head shouldBe "42"
+          Files.readAllLines(outputFile).asScala.head shouldBe "42"
         }
       }
     }
 
     "script with multiple @main methods" in new Fixture {
-      def test(scriptFile: File, outputFile: File) = {
-        val escScriptPath = outputFile.pathAsString.replace("\\", "\\\\")
-
-        scriptFile.write(s"""
+      def test(scriptFile: Path, outputFile: Path) = {
+        val escScriptPath = outputFile.toString.replace("\\", "\\\\")
+        Files.writeString(
+          scriptFile,
+          s"""
           |@main def foo() = {
           |  val fw = new java.io.FileWriter("$escScriptPath", true)
           |  fw.write("foo was called")
@@ -88,51 +98,56 @@ class RunScriptTests extends AnyWordSpec with Matchers {
           |  fw.write("bar was called")
           |  fw.close() 
           |}
-          """.stripMargin)
+          """.stripMargin
+        )
 
-        ReplBridge.main(Array("--script", scriptFile.pathAsString, "--command", "bar"))
+        ReplBridge.main(Array("--script", scriptFile.toString, "--command", "bar"))
 
         withClue(s"$outputFile content: ") {
-          outputFile.lines.head shouldBe "bar was called"
+          Files.readAllLines(outputFile).asScala.head shouldBe "bar was called"
         }
       }
     }
 
     "use additional import script: //> using file directive" in new Fixture {
-      def test(scriptFile: File, outputFile: File) = {
-        val escScriptPath        = outputFile.pathAsString.replace("\\", "\\\\")
+      def test(scriptFile: Path, outputFile: Path) = {
+        val escScriptPath        = outputFile.toString.replace("\\", "\\\\")
         val additionalImportFile = Paths.get("joern-cli/src/test/resources/additional-import.sc").toAbsolutePath
-
-        scriptFile.write(s"""
+        Files.writeString(
+          scriptFile,
+          s"""
           |//> using file $additionalImportFile
           |val fw = new java.io.FileWriter("$escScriptPath", true)
           |fw.write(sayHello("michael")) //function defined in additionalImportFile
           |fw.close() 
-          """.stripMargin)
+          """.stripMargin
+        )
 
-        ReplBridge.main(Array("--script", scriptFile.pathAsString))
+        ReplBridge.main(Array("--script", scriptFile.toString))
 
         withClue(s"$outputFile content: ") {
-          outputFile.lines.head shouldBe "hello, michael"
+          Files.readAllLines(outputFile).asScala.head shouldBe "hello, michael"
         }
       }
     }
 
     "use additional import script: --import parameter" in new Fixture {
-      def test(scriptFile: File, outputFile: File) = {
-        val escScriptPath        = outputFile.pathAsString.replace("\\", "\\\\")
+      def test(scriptFile: Path, outputFile: Path) = {
+        val escScriptPath        = outputFile.toString.replace("\\", "\\\\")
         val additionalImportFile = Paths.get("joern-cli/src/test/resources/additional-import.sc").toAbsolutePath
-
-        scriptFile.write(s"""
+        Files.writeString(
+          scriptFile,
+          s"""
           |val fw = new java.io.FileWriter("$escScriptPath", true)
           |fw.write(sayHello("michael")) //function defined in additionalImportFile
           |fw.close() 
-          """.stripMargin)
+          """.stripMargin
+        )
 
-        ReplBridge.main(Array("--script", scriptFile.pathAsString, "--import", additionalImportFile.toString))
+        ReplBridge.main(Array("--script", scriptFile.toString, "--import", additionalImportFile.toString))
 
         withClue(s"$outputFile content: ") {
-          outputFile.lines.head shouldBe "hello, michael"
+          Files.readAllLines(outputFile).asScala.head shouldBe "hello, michael"
         }
       }
     }
@@ -165,10 +180,20 @@ object RunScriptTests {
   }
 
   trait Fixture {
-    def test(scriptFile: File, outputFile: File): Unit
-    for {
-      scriptFile <- File.temporaryFile()
-      outputFile <- File.temporaryFile()
-    } test(scriptFile, outputFile)
+    def test(scriptFile: Path, outputFile: Path): Unit
+
+    def withTemporaryFiles[T](f: (Path, Path) => T): T = {
+      val scriptFile = FileUtil.newTemporaryFile()
+      val outputFile = FileUtil.newTemporaryFile()
+
+      try {
+        f(scriptFile, outputFile)
+      } finally {
+        FileUtil.delete(scriptFile)
+        FileUtil.delete(outputFile)
+      }
+    }
+
+    withTemporaryFiles(test)
   }
 }

--- a/joern-cli/src/test/scala/io/joern/joerncli/RunScriptTests.scala
+++ b/joern-cli/src/test/scala/io/joern/joerncli/RunScriptTests.scala
@@ -3,7 +3,7 @@ package io.joern.joerncli
 import java.nio.file.{Files, Path, Paths}
 import io.joern.console.Config
 import io.joern.joerncli.console.ReplBridge
-import io.joern.x2cpg.utils.FileUtil
+import io.shiftleft.semanticcpg.utils.FileUtil
 import io.shiftleft.utils.ProjectRoot
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/joern-cli/src/test/scala/io/joern/joerncli/RunScriptTests.scala
+++ b/joern-cli/src/test/scala/io/joern/joerncli/RunScriptTests.scala
@@ -1,6 +1,5 @@
 package io.joern.joerncli
 
-import better.files.File
 import java.nio.file.{Files, Path, Paths}
 import io.joern.console.Config
 import io.joern.joerncli.console.ReplBridge

--- a/querydb/src/main/scala/io/joern/dumpq/Main.scala
+++ b/querydb/src/main/scala/io/joern/dumpq/Main.scala
@@ -6,6 +6,8 @@ import io.joern.dataflowengineoss.semanticsloader.NoSemantics
 import org.json4s.{Formats, NoTypeHints}
 import org.json4s.native.Serialization
 
+import java.nio.file.{Files, Paths}
+
 object Main {
 
   def main(args: Array[String]) = {
@@ -19,9 +21,7 @@ object Main {
     val queryDb = new QueryDatabase(new JoernDefaultArgumentProvider(0))
     // TODO allow specifying file from the outside and make this portable
     val outFileName = "/tmp/querydb.json"
-    better.files
-      .File(outFileName)
-      .write(Serialization.write(queryDb.allQueries))
+    Files.writeString(Paths.get(outFileName), Serialization.write(queryDb.allQueries))
     println(s"Queries written to: $outFileName")
   }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/SourceHighlighter.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/SourceHighlighter.scala
@@ -1,9 +1,10 @@
 package io.shiftleft.semanticcpg.codedumper
 
-import better.files.File
 import io.shiftleft.codepropertygraph.generated.Languages
-import io.shiftleft.semanticcpg.utils.ExternalCommand
+import io.shiftleft.semanticcpg.utils.{ExternalCommand, FileUtil}
 import org.slf4j.{Logger, LoggerFactory}
+
+import java.nio.file.Files
 
 /** language must be one of io.shiftleft.codepropertygraph.generated.Languages TODO: generate enums instead of Strings
   * for the languages
@@ -21,11 +22,11 @@ object SourceHighlighter {
       case other => throw new RuntimeException(s"Attempting to call highlighter on unsupported language: $other")
     }
 
-    val tmpSrcFile = File.newTemporaryFile("dump")
-    tmpSrcFile.writeText(source.code)
+    val tmpSrcFile = FileUtil.newTemporaryFile("dump")
+    Files.writeString(tmpSrcFile, source.code)
     try {
       val highlightedCode = ExternalCommand
-        .run(Seq("source-highlight-esc.sh", tmpSrcFile.path.toString, langFlag))
+        .run(Seq("source-highlight-esc.sh", tmpSrcFile.toString, langFlag))
         .stdOut
         .mkString("\n")
       Some(highlightedCode)
@@ -34,7 +35,7 @@ object SourceHighlighter {
         logger.info("syntax highlighting not working. Is `source-highlight` installed?", exception)
         Some(source.code)
     } finally {
-      tmpSrcFile.delete()
+      FileUtil.delete(tmpSrcFile)
     }
   }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/dotextension/Shared.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/dotextension/Shared.scala
@@ -1,8 +1,9 @@
 package io.shiftleft.semanticcpg.language.dotextension
 
-import better.files.File
-import io.shiftleft.semanticcpg.utils.ExternalCommand
+import io.shiftleft.semanticcpg.utils.{ExternalCommand, FileUtil}
+import io.shiftleft.semanticcpg.utils.FileUtil.*
 
+import java.nio.file.{Files, Path}
 import scala.util.{Failure, Success, Try}
 
 trait ImageViewer {
@@ -13,19 +14,19 @@ object Shared {
 
   def plotAndDisplay(dotStrings: List[String], viewer: ImageViewer): Unit = {
     dotStrings.foreach { dotString =>
-      File.usingTemporaryFile("semanticcpg") { dotFile =>
-        File.usingTemporaryFile("semanticcpg") { svgFile =>
-          dotFile.write(dotString)
-          createSvgFile(dotFile, svgFile).toOption.foreach(_ => viewer.view(svgFile.path.toAbsolutePath.toString))
+      FileUtil.usingTemporaryFile("semanticcpg") { dotFile =>
+        FileUtil.usingTemporaryFile("semanticcpg") { svgFile =>
+          Files.writeString(dotFile, dotString)
+          createSvgFile(dotFile, svgFile).toOption.foreach(_ => viewer.view(svgFile.absolutePathAsString))
         }
       }
     }
   }
 
-  private def createSvgFile(in: File, out: File): Try[String] = {
+  private def createSvgFile(in: Path, out: Path): Try[String] = {
     Try {
       ExternalCommand
-        .run(Seq("dot", "-Tsvg", in.path.toAbsolutePath.toString, "-o", out.path.toAbsolutePath.toString))
+        .run(Seq("dot", "-Tsvg", in.absolutePathAsString, "-o", out.absolutePathAsString))
         .stdOut
         .mkString("\n")
     } match {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/LiteralMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/LiteralMethods.scala
@@ -5,6 +5,14 @@ import io.shiftleft.semanticcpg.NodeExtension
 import io.shiftleft.semanticcpg.language.*
 
 class LiteralMethods(val literal: Literal) extends AnyVal with NodeExtension with HasLocation {
+  def value(typeFullName: String): String = {
+    if (literal.typeFullName == typeFullName) {
+      return "asd"
+    }
+
+    return ""
+  }
+
   override def location: NewLocation = {
     LocationCreator(literal, literal.code, literal.label, literal.lineNumber, literal.method)
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/FileUtil.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/FileUtil.scala
@@ -1,18 +1,9 @@
-package io.joern.x2cpg.utils
+package io.shiftleft.semanticcpg.utils
 
-import java.io.{BufferedOutputStream, FileNotFoundException, IOException, InputStream, OutputStream}
-import java.nio.file.{
-  FileAlreadyExistsException,
-  Files,
-  LinkOption,
-  NoSuchFileException,
-  Path,
-  Paths,
-  SimpleFileVisitor,
-  StandardCopyOption
-}
-import java.nio.file.attribute.BasicFileAttributes
+import java.io.*
 import java.nio.charset.Charset
+import java.nio.file.attribute.BasicFileAttributes
+import java.nio.file.*
 import java.util.zip.{ZipEntry, ZipFile}
 import scala.annotation.tailrec
 import scala.jdk.CollectionConverters.*

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/FileUtil.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/FileUtil.scala
@@ -108,7 +108,7 @@ object FileUtil {
     def absolutePathAsString: String = p.toAbsolutePath.toString
 
     def /(child: String): Path = {
-      p.resolve(child).toAbsolutePath.normalize()
+      p.resolve(child)
     }
 
     def copyToDirectory(destination: Path): Unit = {


### PR DESCRIPTION
* Replaced all instances of `better.files.File` with `java.nio.file.Path` equivalent
* Created helper methods in `FileUtil` where required

Note: We are still allowing `better.files` to be used in the `build.sbt` files, as we don't have access to any of the functions in `FileUtil`.