### PR TITLE
[c2cpg] Speed up parsing

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/Main.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/Main.scala
@@ -16,7 +16,6 @@ final case class Config(
   printIfDefsOnly: Boolean = false,
   includePathsAutoDiscovery: Boolean = false,
   skipFunctionBodies: Boolean = false,
-  noImageLocations: Boolean = false,
   withPreprocessedFiles: Boolean = false,
   compilationDatabase: Option[String] = None
 ) extends X2CpgConfig[Config] {
@@ -50,10 +49,6 @@ final case class Config(
 
   def withSkipFunctionBodies(value: Boolean): Config = {
     this.copy(skipFunctionBodies = value).withInheritedFields(this)
-  }
-
-  def withNoImageLocations(value: Boolean): Config = {
-    this.copy(noImageLocations = value).withInheritedFields(this)
   }
 
   def withPreprocessedFiles(value: Boolean): Config = {
@@ -99,10 +94,8 @@ private object Frontend {
         .text("instructs the parser to skip function and method bodies.")
         .action((_, c) => c.withSkipFunctionBodies(true)),
       opt[Unit]("no-image-locations")
-        .text("""performance optimization, allows the parser not to create image-locations.
-            | An image location explains how a name made it into the translation unit.
-            | E.g., via macro expansion or preprocessor.""".stripMargin)
-        .action((_, c) => c.withNoImageLocations(true)),
+        // deprecated, won't be removed for now to avoid breaking existing scripts
+        .hidden(),
       opt[Unit]("with-preprocessed-files")
         .text("includes *.i files and gives them priority over their unprocessed origin source files.")
         .action((_, c) => c.withPreprocessedFiles(true)),

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreator.scala
@@ -75,7 +75,7 @@ class AstCreator(
   /** Creates an AST of all declarations found in the translation unit - wrapped in a fake method.
     */
   private def astInFakeMethod(fullName: String, path: String, iASTTranslationUnit: IASTTranslationUnit): Ast = {
-    val includeInactive = config.compilationDatabase.nonEmpty || config.defines.nonEmpty
+    val includeInactive = config.compilationDatabase.isEmpty && config.defines.isEmpty
     val allDecls        = iASTTranslationUnit.getDeclarations(includeInactive).toList.filterNot(isIncludedNode)
     val name            = NamespaceTraversal.globalNamespaceName
 
@@ -91,7 +91,6 @@ class AstCreator(
     scope.pushNewMethodScope(fakeGlobalMethod.fullName, fakeGlobalMethod.name, blockNode_, None)
     val declsAsts = allDecls.flatMap(astsForDeclaration)
     setArgumentIndices(declsAsts)
-    scope.popScope()
 
     val methodReturn = methodReturnNode(iASTTranslationUnit, Defines.Any)
     Ast(fakeGlobalTypeDecl).withChild(

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreator.scala
@@ -23,8 +23,7 @@ class AstCreator(
   val cdtAst: IASTTranslationUnit,
   val headerFileFinder: HeaderFileFinder,
   val file2OffsetTable: ConcurrentHashMap[String, Array[Int]]
-)(implicit withSchemaValidation: ValidationMode)
-    extends AstCreatorBase(filename)
+) extends AstCreatorBase(filename)(config.schemaValidation)
     with AstForTypesCreator
     with AstForFunctionsCreator
     with AstForPrimitivesCreator
@@ -36,6 +35,8 @@ class AstCreator(
     with FullNameProvider
     with MacroHandler
     with X2CpgAstNodeBuilder[IASTNode, AstCreator] {
+
+  protected implicit val schemaValidation: ValidationMode = config.schemaValidation
 
   protected val logger: Logger = LoggerFactory.getLogger(classOf[AstCreator])
 
@@ -115,17 +116,17 @@ class AstCreator(
     }
   }
 
-  protected def columnEnd(node: IASTNode): Option[Int] = {
-    nodeOffsets(node).map { case (_, endOffset) =>
-      offsetToColumn(node, endOffset - 1)
-    }
-  }
-
   private def nodeOffsets(node: IASTNode): Option[(Int, Int)] = {
     for {
       startOffset <- nullSafeFileLocation(node).map(l => l.getNodeOffset)
       endOffset   <- nullSafeFileLocation(node).map(l => l.getNodeOffset + l.getNodeLength)
     } yield (startOffset, endOffset)
+  }
+
+  protected def columnEnd(node: IASTNode): Option[Int] = {
+    nodeOffsets(node).map { case (_, endOffset) =>
+      offsetToColumn(node, endOffset - 1)
+    }
   }
 
   override protected def offset(node: IASTNode): Option[(Int, Int)] = {

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreator.scala
@@ -75,8 +75,9 @@ class AstCreator(
   /** Creates an AST of all declarations found in the translation unit - wrapped in a fake method.
     */
   private def astInFakeMethod(fullName: String, path: String, iASTTranslationUnit: IASTTranslationUnit): Ast = {
-    val allDecls = iASTTranslationUnit.getDeclarations.toList.filterNot(isIncludedNode)
-    val name     = NamespaceTraversal.globalNamespaceName
+    val includeInactive = config.compilationDatabase.nonEmpty || config.defines.nonEmpty
+    val allDecls        = iASTTranslationUnit.getDeclarations(includeInactive).toList.filterNot(isIncludedNode)
+    val name            = NamespaceTraversal.globalNamespaceName
 
     val fakeGlobalTypeDecl =
       typeDeclNode(iASTTranslationUnit, name, fullName, filename, name, NodeTypes.NAMESPACE_BLOCK, fullName)

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
@@ -2,7 +2,6 @@ package io.joern.c2cpg.astcreation
 
 import io.joern.x2cpg.Ast
 import io.joern.x2cpg.SourceFiles
-import io.joern.x2cpg.ValidationMode
 import io.joern.x2cpg.utils.IntervalKeyPool
 import io.joern.x2cpg.utils.NodeBuilders
 import io.joern.x2cpg.utils.NodeBuilders.newDependencyNode

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
@@ -12,7 +12,6 @@ import io.shiftleft.codepropertygraph.generated.nodes.NewNode
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.NewIdentifier
 import io.shiftleft.codepropertygraph.generated.nodes.NewLocal
-import io.shiftleft.utils.IOUtils
 import org.apache.commons.lang3.StringUtils
 import org.eclipse.cdt.core.dom.ast.*
 import org.eclipse.cdt.core.dom.ast.c.ICASTArrayDesignator
@@ -36,13 +35,11 @@ import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPFunction
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPVariable
 import org.eclipse.cdt.internal.core.model.ASTStringUtil
 
-import java.nio.file.Path
-import java.nio.file.Paths
 import scala.annotation.nowarn
 import scala.collection.mutable
 import scala.util.Try
 
-trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
+trait AstCreatorHelper { this: AstCreator =>
 
   private val nameKeyPool = new IntervalKeyPool(first = 0, last = Long.MaxValue)
 
@@ -131,16 +128,11 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
 
   private def fileOffsetTable(node: IASTNode): Array[Int] = {
     val path = SourceFiles.toAbsolutePath(fileName(node), config.inputPath)
-    file2OffsetTable.computeIfAbsent(path, _ => genFileOffsetTable(Paths.get(path)))
+    file2OffsetTable.computeIfAbsent(path, _ => genFileOffsetTable())
   }
 
-  private def genFileOffsetTable(absolutePath: Path): Array[Int] = {
-    IOUtils
-      .readLinesInFile(absolutePath)
-      .mkString("\n")
-      .toCharArray
-      .zipWithIndex
-      .collect { case ('\n', idx) => idx + 1 }
+  private def genFileOffsetTable(): Array[Int] = {
+    cdtAst.getRawSignature.linesWithSeparators.mkString.toCharArray.zipWithIndex.collect { case ('\n', idx) => idx + 1 }
   }
 
   protected def fileName(node: IASTNode): String = {

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForExpressionsCreator.scala
@@ -21,7 +21,7 @@ import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTFoldExpression
 
 import scala.util.Try
 
-trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
+trait AstForExpressionsCreator { this: AstCreator =>
 
   private val OperatorMap: Map[Int, String] = Map(
     IASTBinaryExpression.op_multiply         -> Operators.multiplication,

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForExpressionsCreator.scala
@@ -1,7 +1,6 @@
 package io.joern.c2cpg.astcreation
 
 import io.joern.x2cpg.Ast
-import io.joern.x2cpg.ValidationMode
 import io.joern.x2cpg.Defines as X2CpgDefines
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, Operators}
 import org.apache.commons.lang3.StringUtils

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForFunctionsCreator.scala
@@ -1,7 +1,6 @@
 package io.joern.c2cpg.astcreation
 
 import io.joern.x2cpg.Ast
-import io.joern.x2cpg.ValidationMode
 import io.joern.x2cpg.datastructures.Stack.*
 import io.joern.x2cpg.utils.NodeBuilders.newModifierNode
 import io.shiftleft.codepropertygraph.generated.EvaluationStrategies

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForFunctionsCreator.scala
@@ -32,7 +32,7 @@ import org.eclipse.cdt.internal.core.model.ASTStringUtil
 import scala.annotation.tailrec
 import scala.util.Try
 
-trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
+trait AstForFunctionsCreator { this: AstCreator =>
 
   final protected def parameters(functionNode: IASTNode): Seq[IASTNode] = functionNode match {
     case arr: IASTArrayDeclarator       => parameters(arr.getNestedDeclarator)

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForInitializersCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForInitializersCreator.scala
@@ -11,7 +11,7 @@ import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTDesignatedInitializer
 import org.eclipse.cdt.internal.core.dom.parser.c.CASTArrayRangeDesignator
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTArrayRangeDesignator
 
-trait AstForInitializersCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
+trait AstForInitializersCreator { this: AstCreator =>
 
   protected def astForInitializerList(l: IASTInitializerList): Ast = {
     val MAX_INITIALIZERS = 1000

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForInitializersCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForInitializersCreator.scala
@@ -1,7 +1,6 @@
 package io.joern.c2cpg.astcreation
 
 import io.joern.x2cpg.Ast
-import io.joern.x2cpg.ValidationMode
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.codepropertygraph.generated.Operators
 import org.eclipse.cdt.core.dom.ast.*

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForPrimitivesCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForPrimitivesCreator.scala
@@ -23,7 +23,7 @@ import org.eclipse.cdt.internal.core.model.ASTStringUtil
 
 import scala.util.Try
 
-trait AstForPrimitivesCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
+trait AstForPrimitivesCreator { this: AstCreator =>
 
   protected def astForComment(comment: IASTComment): Ast =
     Ast(newCommentNode(comment, code(comment), fileName(comment)))

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForPrimitivesCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForPrimitivesCreator.scala
@@ -1,7 +1,6 @@
 package io.joern.c2cpg.astcreation
 
 import io.joern.x2cpg.Ast
-import io.joern.x2cpg.ValidationMode
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.NewMethod

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForStatementsCreator.scala
@@ -23,7 +23,7 @@ import org.eclipse.cdt.internal.core.model.ASTStringUtil
 import java.nio.file.Paths
 import scala.collection.mutable
 
-trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
+trait AstForStatementsCreator { this: AstCreator =>
 
   protected def astForBlockStatement(blockStmt: IASTCompoundStatement, blockNode: NewBlock, order: Int = -1): Ast = {
     val codeString  = code(blockStmt)

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForStatementsCreator.scala
@@ -2,7 +2,6 @@ package io.joern.c2cpg.astcreation
 
 import io.joern.c2cpg.parser.CdtParser
 import io.joern.x2cpg.Ast
-import io.joern.x2cpg.ValidationMode
 import io.shiftleft.codepropertygraph.generated.ControlStructureTypes
 import io.shiftleft.codepropertygraph.generated.nodes.AstNodeNew
 import io.shiftleft.codepropertygraph.generated.nodes.ExpressionNew

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForTypesCreator.scala
@@ -11,7 +11,7 @@ import io.joern.x2cpg.datastructures.Stack.*
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import org.apache.commons.lang3.StringUtils
 
-trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
+trait AstForTypesCreator { this: AstCreator =>
 
   protected def astForDecltypeSpecifier(decl: ICPPASTDecltypeSpecifier): Ast = {
     val op       = Defines.OperatorTypeOf

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForTypesCreator.scala
@@ -2,7 +2,7 @@ package io.joern.c2cpg.astcreation
 
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
-import io.joern.x2cpg.{Ast, ValidationMode}
+import io.joern.x2cpg.Ast
 import org.eclipse.cdt.core.dom.ast.*
 import org.eclipse.cdt.core.dom.ast.cpp.*
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTAliasDeclaration

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroHandler.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroHandler.scala
@@ -20,7 +20,7 @@ import org.eclipse.cdt.internal.core.model.ASTStringUtil
 import scala.annotation.nowarn
 import scala.collection.mutable
 
-trait MacroHandler(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
+trait MacroHandler { this: AstCreator =>
 
   private val nodeOffsetMacroPairs: mutable.Stack[(Int, IASTPreprocessorMacroDefinition)] = {
     mutable.Stack.from(

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CdtParser.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CdtParser.scala
@@ -56,11 +56,12 @@ class CdtParser(
   private val log            = new DefaultLogService
 
   private var opts: Int =
-    ILanguage.OPTION_PARSE_INACTIVE_CODE |  // enables parsing of code behind disabled preprocessor defines
-      ILanguage.OPTION_NO_IMAGE_LOCATIONS | // performance optimization, allows the parser not to create image-locations
+    ILanguage.OPTION_NO_IMAGE_LOCATIONS | // performance optimization, allows the parser not to create image-locations
       ILanguage.OPTION_SKIP_TRIVIAL_EXPRESSIONS_IN_AGGREGATE_INITIALIZERS // performance optimization, skips trivial expressions in aggregate initializers
-    // instructs the parser to skip function and method bodies
+  // instructs the parser to skip function and method bodies
   if (config.skipFunctionBodies) opts |= ILanguage.OPTION_SKIP_FUNCTION_BODIES
+  // enables parsing of code behind disabled preprocessor defines
+  if (config.compilationDatabase.isEmpty && config.defines.isEmpty) opts |= ILanguage.OPTION_PARSE_INACTIVE_CODE
 
   def preprocessorStatements(file: Path): Iterable[IASTPreprocessorStatement] = {
     parse(file).map(t => preprocessorStatements(t)).getOrElse(Iterable.empty)

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CdtParser.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CdtParser.scala
@@ -3,6 +3,7 @@ package io.joern.c2cpg.parser
 import better.files.File
 import io.joern.c2cpg.Config
 import io.joern.c2cpg.parser.JSONCompilationDatabaseParser.CommandObject
+import io.joern.x2cpg.SourceFiles
 import io.shiftleft.utils.IOUtils
 import org.eclipse.cdt.core.dom.ast.IASTPreprocessorStatement
 import org.eclipse.cdt.core.dom.ast.IASTTranslationUnit
@@ -34,8 +35,7 @@ object CdtParser {
 
   private case class ParseResult(
     translationUnit: Option[IASTTranslationUnit],
-    preprocessorErrorCount: Int = 0,
-    problems: Int = 0,
+    relativeFilePath: Option[String] = None,
     failure: Option[Throwable] = None
   )
 
@@ -55,12 +55,12 @@ class CdtParser(
   private val includePaths   = parserConfig.userIncludePaths
   private val log            = new DefaultLogService
 
-  // enables parsing of code behind disabled preprocessor defines:
-  private var opts: Int = ILanguage.OPTION_PARSE_INACTIVE_CODE
-  // instructs the parser to skip function and method bodies
+  private var opts: Int =
+    ILanguage.OPTION_PARSE_INACTIVE_CODE |  // enables parsing of code behind disabled preprocessor defines
+      ILanguage.OPTION_NO_IMAGE_LOCATIONS | // performance optimization, allows the parser not to create image-locations
+      ILanguage.OPTION_SKIP_TRIVIAL_EXPRESSIONS_IN_AGGREGATE_INITIALIZERS // performance optimization, skips trivial expressions in aggregate initializers
+    // instructs the parser to skip function and method bodies
   if (config.skipFunctionBodies) opts |= ILanguage.OPTION_SKIP_FUNCTION_BODIES
-  // performance optimization, allows the parser not to create image-locations
-  if (config.noImageLocations) opts |= ILanguage.OPTION_NO_IMAGE_LOCATIONS
 
   def preprocessorStatements(file: Path): Iterable[IASTPreprocessorStatement] = {
     parse(file).map(t => preprocessorStatements(t)).getOrElse(Iterable.empty)
@@ -69,12 +69,12 @@ class CdtParser(
   def parse(file: Path): Option[IASTTranslationUnit] = {
     val parseResult = parseInternal(file)
     parseResult match {
-      case ParseResult(Some(t), c, p, _) =>
-        logger.info(s"Parsed '${t.getFilePath}' ($c preprocessor error(s), $p problems)")
+      case ParseResult(Some(t), Some(relativeFilePath), _) =>
+        logger.info(s"Parsed '$relativeFilePath'")
         Option(t)
-      case ParseResult(_, _, _, maybeThrowable) =>
+      case ParseResult(_, maybeRelativePath, maybeThrowable) =>
         logger.warn(
-          s"Failed to parse '$file': ${maybeThrowable.map(extractParseException).getOrElse("Unknown parse error!")}"
+          s"Failed to parse '${maybeRelativePath.getOrElse(file.toString)}': ${maybeThrowable.map(extractParseException).getOrElse("Unknown parse error!")}"
         )
         None
     }
@@ -83,6 +83,7 @@ class CdtParser(
   private def parseInternal(file: File): ParseResult = {
     if (file.isRegularFile) { // handling potentially broken symlinks
       try {
+        val relativeFilePath    = SourceFiles.toRelativePath(file.pathAsString, config.inputPath)
         val fileContent         = readFileAsFileContent(file.path)
         val fileContentProvider = new CustomFileContentProvider(headerFileFinder)
         val lang                = createParseLanguage(file.path, fileContent.toString)
@@ -91,11 +92,7 @@ class CdtParser(
         val problems        = CPPVisitor.getProblems(translationUnit)
         if (parserConfig.logProblems) logProblems(problems.toList)
         if (parserConfig.logPreprocessor) logPreprocessorStatements(translationUnit)
-        ParseResult(
-          Option(translationUnit),
-          preprocessorErrorCount = translationUnit.getPreprocessorProblemsCount,
-          problems = problems.length
-        )
+        ParseResult(Option(translationUnit), Some(relativeFilePath))
       } catch {
         case u: UnsupportedClassVersionError =>
           logger.error("c2cpg requires at least JRE-17 to run. Please check your Java Runtime Environment!", u)
@@ -146,7 +143,8 @@ class CdtParser(
   def parse(code: String, inFile: Path): Option[IASTTranslationUnit] = {
     Try(parseInternal(code, inFile)) match {
       case Failure(exception) =>
-        logger.warn(s"Failed to parse '$code' in file '$inFile': ${extractParseException(exception)}")
+        val relativePath = SourceFiles.toRelativePath(inFile.toString, config.inputPath)
+        logger.warn(s"Failed to parse '$code' in file '$relativePath': ${extractParseException(exception)}")
         None
       case Success(translationUnit) =>
         Some(translationUnit)

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/Report.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/Report.scala
@@ -14,7 +14,7 @@ object Report {
 
   private case class ReportEntry(loc: Int, parsed: Boolean, cpgGen: Boolean, duration: Long) {
     def toSeq: Seq[String] = {
-      val lines     = loc.toString
+      val lines     = if (loc == -1) "-" else loc.toString
       val dur       = if (duration == 0) "-" else TimeUtils.pretty(duration)
       val wasParsed = if (parsed) "yes" else "no"
       val gotCpg    = if (cpgGen) "yes" else "no"


### PR DESCRIPTION
This speeds up parsing quite a lot.

(OPTION_NO_IMAGE_LOCATIONS, OPTION_SKIP_TRIVIAL_EXPRESSIONS_IN_AGGREGATE_INITIALIZERS)

E.g., this shaves off ~16% on polarphp (39sec -> 33sec) total runtime.

Also cleaned up the logs:
- do not log preprocessorErrorCount and parse problem numbers. These numbers might be nice for small code snippets but do not mean anything on real projects when they go to >100 or the like.
- only log relative paths (easier to read logs)