### PR TITLE
Deprecate newAnnotationLiteral node

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForTypeDeclsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForTypeDeclsCreator.scala
@@ -639,19 +639,19 @@ private[declarations] trait AstForTypeDeclsCreator { this: AstCreator =>
   }
 
   private def astForAnnotationLiteralExpr(literalExpr: LiteralExpr): Ast = {
-    val valueNode =
+    val name =
       literalExpr match {
-        case literal: StringLiteralExpr    => newAnnotationLiteralNode(literal.getValue)
-        case literal: IntegerLiteralExpr   => newAnnotationLiteralNode(literal.getValue)
-        case literal: BooleanLiteralExpr   => newAnnotationLiteralNode(java.lang.Boolean.toString(literal.getValue))
-        case literal: CharLiteralExpr      => newAnnotationLiteralNode(literal.getValue)
-        case literal: DoubleLiteralExpr    => newAnnotationLiteralNode(literal.getValue)
-        case literal: LongLiteralExpr      => newAnnotationLiteralNode(literal.getValue)
-        case _: NullLiteralExpr            => newAnnotationLiteralNode("null")
-        case literal: TextBlockLiteralExpr => newAnnotationLiteralNode(literal.getValue)
+        case literal: StringLiteralExpr    => literal.getValue
+        case literal: IntegerLiteralExpr   => literal.getValue
+        case literal: BooleanLiteralExpr   => java.lang.Boolean.toString(literal.getValue)
+        case literal: CharLiteralExpr      => literal.getValue
+        case literal: DoubleLiteralExpr    => literal.getValue
+        case literal: LongLiteralExpr      => literal.getValue
+        case _: NullLiteralExpr            => "null"
+        case literal: TextBlockLiteralExpr => literal.getValue
       }
 
-    Ast(valueNode)
+    Ast(annotationLiteralNode(literalExpr, name))
   }
 
   private def modifiersForTypeDecl(typ: TypeDeclaration[?], isInterface: Boolean): List[NewModifier] = {

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstNodeBuilder.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstNodeBuilder.scala
@@ -1,9 +1,12 @@
 package io.joern.x2cpg
 
 import io.joern.x2cpg.utils.NodeBuilders.{newMethodReturnNode, newOperatorCallNode}
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EvaluationStrategies}
 import io.shiftleft.codepropertygraph.generated.nodes.Block.PropertyDefaults as BlockDefaults
 import io.shiftleft.codepropertygraph.generated.nodes.{
   NewAnnotation,
+  NewAnnotationLiteral,
+  NewBinding,
   NewBlock,
   NewCall,
   NewControlStructure,
@@ -18,6 +21,8 @@ import io.shiftleft.codepropertygraph.generated.nodes.{
   NewMethodParameterIn,
   NewMethodRef,
   NewMethodReturn,
+  NewModifier,
+  NewNamespaceBlock,
   NewReturn,
   NewTypeDecl,
   NewTypeRef,
@@ -58,6 +63,14 @@ trait AstNodeBuilder[Node, NodeProcessor] { this: NodeProcessor =>
       .code(code)
       .name(name)
       .fullName(fullName)
+      .lineNumber(line(node))
+      .columnNumber(column(node))
+  }
+
+  protected def annotationLiteralNode(node: Node, name: String): NewAnnotationLiteral = {
+    NewAnnotationLiteral()
+      .name(name)
+      .code(name)
       .lineNumber(line(node))
       .columnNumber(column(node))
   }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/NodeBuilders.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/NodeBuilders.scala
@@ -32,6 +32,10 @@ object NodeBuilders {
     s"$typeDeclPrefix$name:$signature"
   }
 
+  @deprecated(
+    "Deprecated in favour of the corresponding method io.joern.x2cpg.AstNodeBuilder and will be removed in a future version",
+    "4.0.280"
+  )
   def newAnnotationLiteralNode(name: String): NewAnnotationLiteral =
     NewAnnotationLiteral()
       .name(name)


### PR DESCRIPTION
This is the first in a series of PRs which will deprecate the node builder methods in `NodeBuliders.scala` in favour of the `AstNodeBuilder` methods which follow the pattern of taking an origin node and calculating line/column numbers and offsets from that. 

I think that breaking these PRs up by method will probably be the easiest to review, but am happy to do it by frontend instead if that's better.