### PR TITLE
Deprecate newLocalNode method

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
@@ -433,7 +433,7 @@ trait AstCreatorHelper { this: AstCreator =>
     variableName: String,
     tpe: String
   ): NewLocal = {
-    val local = NodeBuilders.newLocalNode(variableName, tpe).order(0)
+    val local = localNodeWithExplicitPositionInfo(variableName, variableName, tpe).order(0)
     diffGraph.addEdge(methodScopeNodeId, local, EdgeTypes.AST)
     local
   }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreatorHelper.scala
@@ -5,7 +5,7 @@ import io.joern.jssrc2cpg.parser.BabelAst.*
 import io.joern.jssrc2cpg.parser.BabelNodeInfo
 import io.joern.x2cpg.frontendspecific.jssrc2cpg.Defines
 import io.joern.x2cpg.utils.IntervalKeyPool
-import io.joern.x2cpg.utils.NodeBuilders.{newClosureBindingNode, newLocalNode}
+import io.joern.x2cpg.utils.NodeBuilders.newClosureBindingNode
 import io.joern.x2cpg.{Ast, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, EvaluationStrategies}
@@ -261,9 +261,13 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
                 capturedLocals.updateWith(closureBindingIdProperty) {
                   case None =>
                     val methodScopeNode = methodScope.scopeNode
-                    val localNode =
-                      newLocalNode(origin.variableName, Defines.Any, Option(closureBindingIdProperty)).order(0)
-                    diffGraph.addEdge(methodScopeNode, localNode, EdgeTypes.AST)
+                    val localNode_ = localNodeWithExplicitPositionInfo(
+                      origin.variableName,
+                      origin.variableName,
+                      Defines.Any,
+                      Option(closureBindingIdProperty)
+                    ).order(0)
+                    diffGraph.addEdge(methodScopeNode, localNode_, EdgeTypes.AST)
                     val closureBindingNode = newClosureBindingNode(
                       closureBindingIdProperty,
                       origin.variableName,
@@ -273,7 +277,7 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
                       diffGraph.addEdge(ref, closureBindingNode, EdgeTypes.CAPTURE)
                     )
                     nextReference = closureBindingNode
-                    Option(localNode)
+                    Option(localNode_)
                   case someLocalNode =>
                     // When there is already a LOCAL representing the capturing, we do not
                     // need to process the surrounding scope element as this has already
@@ -298,7 +302,7 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
     methodScopeNodeId: NewNode,
     variableName: String
   ): (NewNode, ScopeType) = {
-    val local = newLocalNode(variableName, Defines.Any).order(0)
+    val local = localNodeWithExplicitPositionInfo(variableName, variableName, Defines.Any).order(0)
     diffGraph.addEdge(methodScopeNodeId, local, EdgeTypes.AST)
     (local, MethodScope)
   }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstNodeBuilder.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstNodeBuilder.scala
@@ -283,15 +283,46 @@ trait AstNodeBuilder[Node, NodeProcessor] { this: NodeProcessor =>
     closureBindingId: Option[String] = None,
     genericSignature: Option[String] = None
   ): NewLocal = {
-    val local = NewLocal()
+    val (nodeOffset, nodeOffsetEnd) =
+      offset(node).map((offset, offsetEnd) => (Option(offset), Option(offsetEnd))).getOrElse((None, None))
+    localNodeWithExplicitPositionInfo(
+      name,
+      code,
+      typeFullName,
+      closureBindingId,
+      genericSignature,
+      line(node),
+      column(node),
+      nodeOffset,
+      nodeOffsetEnd
+    )
+  }
+
+  /** It is useful (perhaps necessary) to be able to create locals without an "origin node" in some cases, so allow that
+    * but make it clear that positional information (line/col number and offsets) must be specified explicitly.
+    */
+  protected def localNodeWithExplicitPositionInfo(
+    name: String,
+    code: String,
+    typeFullName: String,
+    closureBindingId: Option[String] = None,
+    genericSignature: Option[String] = None,
+    lineNumber: Option[Int] = None,
+    columnNumber: Option[Int] = None,
+    offset: Option[Int] = None,
+    offsetEnd: Option[Int] = None
+  ): NewLocal = {
+    val node_ = NewLocal()
       .name(name)
       .code(code)
       .typeFullName(typeFullName)
       .closureBindingId(closureBindingId)
-      .lineNumber(line(node))
-      .columnNumber(column(node))
-    genericSignature.foreach(local.genericSignature(_))
-    local
+      .lineNumber(lineNumber)
+      .columnNumber(columnNumber)
+      .offset(offset)
+      .offsetEnd(offsetEnd)
+    genericSignature.foreach(node_.genericSignature(_))
+    node_
   }
 
   protected def identifierNode(

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/NodeBuilders.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/NodeBuilders.scala
@@ -48,6 +48,10 @@ object NodeBuilders {
       .signature(signature)
   }
 
+  @deprecated(
+    "Deprecated in favour of the corresponding method io.joern.x2cpg.AstNodeBuilder and will be removed in a future version",
+    "4.0.280"
+  )
   def newLocalNode(name: String, typeFullName: String, closureBindingId: Option[String] = None): NewLocal = {
     NewLocal()
       .code(name)


### PR DESCRIPTION
Ideally we wouldn't need the `localNodeWithExplicitPositionInfo` method at all, but I don't see an obvious way to avoid it in the `AstCreatorHelper` classes. @max-leuthaeuser you're more familiar with this part of code, so if you have any ideas please let me know. Otherwise I think keeping moving this local creation method into `AstNodeBuilders` and clearly distinguishing it from `localNode` by name is fine.