### PR TITLE
Deprecate newFieldIdentifierNode and remove uses

### DIFF
--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForTypeDeclCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForTypeDeclCreator.scala
@@ -3,7 +3,6 @@ import io.joern.gosrc2cpg.datastructures.LambdaTypeInfo
 import io.joern.gosrc2cpg.parser.ParserAst.*
 import io.joern.gosrc2cpg.parser.{ParserKeys, ParserNodeInfo}
 import io.joern.x2cpg
-import io.joern.x2cpg.utils.NodeBuilders.newFieldIdentifierNode
 import io.joern.x2cpg.{Ast, ValidationMode, Defines as XDefines}
 import io.shiftleft.codepropertygraph.generated.Operators
 import ujson.Value
@@ -91,8 +90,6 @@ trait AstForTypeDeclCreator(implicit withSchemaValidation: ValidationMode) { thi
     val fieldIdentifier                     = info.json(ParserKeys.Sel)(ParserKeys.Name).str
     val callNode =
       operatorCallNode(info, info.code, Operators.fieldAccess, Some(fieldTypeFullName))
-    Seq(
-      callAst(callNode, identifierAsts ++ Seq(Ast(newFieldIdentifierNode(fieldIdentifier, line(info), column(info)))))
-    )
+    Seq(callAst(callNode, identifierAsts ++ Seq(Ast(fieldIdentifierNode(info, fieldIdentifier, fieldIdentifier)))))
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForForLoopsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForForLoopsCreator.scala
@@ -11,7 +11,7 @@ import io.joern.javasrc2cpg.util.NameConstants
 import io.joern.javasrc2cpg.util.Util.composeMethodFullName
 import io.joern.x2cpg.{Ast, Defines}
 import io.joern.x2cpg.utils.IntervalKeyPool
-import io.joern.x2cpg.utils.NodeBuilders.{newFieldIdentifierNode, newIdentifierNode}
+import io.joern.x2cpg.utils.NodeBuilders.newIdentifierNode
 import io.shiftleft.codepropertygraph.generated.nodes.Call.PropertyDefaults
 import io.shiftleft.codepropertygraph.generated.nodes.{
   NewBlock,
@@ -300,19 +300,19 @@ trait AstForForLoopsCreator { this: AstCreator =>
 
     val compareNode = operatorCallNode(
       stmt,
-      code = s"$idxName < ${iterableSource.name}.length",
+      code = s"$idxName < ${iterableSource.name}.${NameConstants.Length}",
       Operators.lessThan,
       typeFullName = Some(TypeConstants.Boolean)
     )
     val comparisonIdxIdentifier = newIdentifierNode(idxName, idxLocal.typeFullName)
     val comparisonFieldAccess = operatorCallNode(
       stmt,
-      code = s"${iterableSource.name}.length",
+      code = s"${iterableSource.name}.${NameConstants.Length}",
       Operators.fieldAccess,
       typeFullName = Some(TypeConstants.Int)
     )
     val fieldAccessIdentifier = newIdentifierNode(iterableSource.name, iterableSource.typeFullName.getOrElse("ANY"))
-    val fieldAccessFieldIdentifier = newFieldIdentifierNode("length", line(stmt))
+    val fieldAccessFieldIdentifier = fieldIdentifierNode(stmt, NameConstants.Length, NameConstants.Length)
     val fieldAccessArgs            = List(fieldAccessIdentifier, fieldAccessFieldIdentifier).map(Ast(_))
     val fieldAccessAst             = callAst(comparisonFieldAccess, fieldAccessArgs)
     val compareArgs                = List(Ast(comparisonIdxIdentifier), fieldAccessAst)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/NameConstants.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/NameConstants.scala
@@ -9,4 +9,5 @@ object NameConstants {
   val NextCallName: String       = "next"
   val IteratorCallName: String   = "iterator"
   val HasNextCallName: String    = "hasNext"
+  val Length: String             = "length"
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/NodeBuilders.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/NodeBuilders.scala
@@ -104,6 +104,10 @@ object NodeBuilders {
       .dependencyGroupId(groupId)
       .version(version)
 
+  @deprecated(
+    "Deprecated in favour of the corresponding method io.joern.x2cpg.AstNodeBuilder and will be removed in a future version",
+    "4.0.285"
+  )
   def newFieldIdentifierNode(name: String, line: Option[Int] = None, column: Option[Int] = None): NewFieldIdentifier = {
     NewFieldIdentifier()
       .canonicalName(name)


### PR DESCRIPTION
There's still one use left in x2cpg in the same `fieldAccessAst` method mentioned in the `newOperatorCall` PR