### PR TITLE
Make AstNodeBuilder available to AstCreatorBase and deprecate newMethodReturn

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreator.scala
@@ -23,7 +23,7 @@ class AstCreator(
   val cdtAst: IASTTranslationUnit,
   val headerFileFinder: HeaderFileFinder,
   val file2OffsetTable: ConcurrentHashMap[String, Array[Int]]
-) extends AstCreatorBase(filename)(config.schemaValidation)
+) extends AstCreatorBase[IASTNode, AstCreator](filename)(config.schemaValidation)
     with AstForTypesCreator
     with AstForFunctionsCreator
     with AstForPrimitivesCreator
@@ -33,8 +33,7 @@ class AstCreator(
     with AstNodeBuilder
     with AstCreatorHelper
     with FullNameProvider
-    with MacroHandler
-    with X2CpgAstNodeBuilder[IASTNode, AstCreator] {
+    with MacroHandler {
 
   protected implicit val schemaValidation: ValidationMode = config.schemaValidation
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
@@ -1,7 +1,6 @@
 package io.joern.c2cpg.astcreation
 
-import io.joern.x2cpg.Ast
-import io.joern.x2cpg.SourceFiles
+import io.joern.x2cpg.{Ast, AstNodeBuilder, SourceFiles}
 import io.joern.x2cpg.utils.IntervalKeyPool
 import io.joern.x2cpg.utils.NodeBuilders
 import io.joern.x2cpg.utils.NodeBuilders.newDependencyNode
@@ -434,7 +433,7 @@ trait AstCreatorHelper { this: AstCreator =>
     variableName: String,
     tpe: String
   ): NewLocal = {
-    val local = localNodeWithExplicitPositionInfo(variableName, variableName, tpe).order(0)
+    val local = AstNodeBuilder.localNodeWithExplicitPositionInfo(variableName, variableName, tpe).order(0)
     diffGraph.addEdge(methodScopeNodeId, local, EdgeTypes.AST)
     local
   }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForTypesCreator.scala
@@ -306,8 +306,6 @@ trait AstForTypesCreator { this: AstCreator =>
       astForDeclarator(typeSpecifier.getParent.asInstanceOf[IASTSimpleDeclaration], d, i)
     }
 
-    val lineNumber                       = line(typeSpecifier)
-    val columnNumber                     = column(typeSpecifier)
     val TypeFullNameInfo(name, fullName) = typeFullNameInfo(typeSpecifier)
     val codeString                       = code(typeSpecifier)
     val nameAlias                        = decls.headOption.map(d => registerType(shortName(d))).filter(_.nonEmpty)
@@ -339,13 +337,12 @@ trait AstForTypesCreator { this: AstCreator =>
       Ast(typeDecl).withChildren(member) +: declAsts
     } else {
       val init = staticInitMethodAst(
+        typeSpecifier,
         calls,
         s"$fullName.${io.joern.x2cpg.Defines.StaticInitMethodName}",
         None,
         Defines.Any,
-        Some(filename),
-        lineNumber,
-        columnNumber
+        Some(filename)
       )
       Ast(typeDecl).withChildren(member).withChild(init) +: declAsts
     }
@@ -412,8 +409,6 @@ trait AstForTypesCreator { this: AstCreator =>
       astForDeclarator(typeSpecifier.getParent.asInstanceOf[IASTSimpleDeclaration], d, i)
     }
 
-    val lineNumber                       = line(typeSpecifier)
-    val columnNumber                     = column(typeSpecifier)
     val TypeFullNameInfo(name, fullName) = typeFullNameInfo(typeSpecifier)
     val nameAlias                        = decls.headOption.map(d => registerType(shortName(d))).filter(_.nonEmpty)
     val alias                            = filterNameAlias(nameAlias, None, fullName)
@@ -449,13 +444,12 @@ trait AstForTypesCreator { this: AstCreator =>
       Ast(typeDecl).withChildren(member) +: declAsts
     } else {
       val init = staticInitMethodAst(
+        typeSpecifier,
         calls,
         s"$deAliasedFullName:${io.joern.x2cpg.Defines.StaticInitMethodName}",
         None,
         Defines.Any,
-        Some(filename),
-        lineNumber,
-        columnNumber
+        Some(filename)
       )
       Ast(typeDecl).withChildren(member).withChild(init) +: declAsts
     }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/TypeDeclNodePass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/TypeDeclNodePass.scala
@@ -53,7 +53,7 @@ class TypeDeclNodePass(cpg: Cpg, config: Config) extends CpgPass(cpg) {
         .astParentType(NodeTypes.NAMESPACE_BLOCK)
         .astParentFullName(fullName)
     val blockNode    = NewBlock().typeFullName(Defines.Any)
-    val methodReturn = AstNodeBuilder.methodReturnNodeWithExplicitPositionInfo(Defines.Any, line = None, column = None)
+    val methodReturn = AstNodeBuilder.methodReturnNodeWithExplicitPositionInfo(Defines.Any, lineNumber = Option(1))
     Ast(includesFile).withChild(
       Ast(namespaceBlock)
         .withChild(Ast(fakeGlobalIncludesMethod).withChild(Ast(blockNode)).withChild(Ast(methodReturn)))

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/TypeDeclNodePass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/TypeDeclNodePass.scala
@@ -1,5 +1,6 @@
 package io.joern.c2cpg.passes
 
+import io.joern.x2cpg.AstNodeBuilder
 import io.joern.c2cpg.astcreation.Defines
 import io.joern.c2cpg.Config
 import io.shiftleft.codepropertygraph.generated.Cpg
@@ -10,7 +11,6 @@ import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 import io.shiftleft.semanticcpg.language.*
 import io.joern.x2cpg.passes.frontend.MetaDataPass
 import io.joern.x2cpg.{Ast, ValidationMode}
-import io.joern.x2cpg.utils.NodeBuilders.newMethodReturnNode
 
 class TypeDeclNodePass(cpg: Cpg, config: Config) extends CpgPass(cpg) {
 
@@ -53,7 +53,7 @@ class TypeDeclNodePass(cpg: Cpg, config: Config) extends CpgPass(cpg) {
         .astParentType(NodeTypes.NAMESPACE_BLOCK)
         .astParentFullName(fullName)
     val blockNode    = NewBlock().typeFullName(Defines.Any)
-    val methodReturn = newMethodReturnNode(Defines.Any, line = None, column = None)
+    val methodReturn = AstNodeBuilder.methodReturnNodeWithExplicitPositionInfo(Defines.Any, line = None, column = None)
     Ast(includesFile).withChild(
       Ast(namespaceBlock)
         .withChild(Ast(fakeGlobalIncludesMethod).withChild(Ast(blockNode)).withChild(Ast(methodReturn)))

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreator.scala
@@ -5,7 +5,7 @@ import io.joern.csharpsrc2cpg.datastructures.{CSharpProgramSummary, CSharpScope,
 import io.joern.csharpsrc2cpg.parser.DotNetJsonAst.*
 import io.joern.csharpsrc2cpg.parser.{DotNetNodeInfo, ParserKeys}
 import io.joern.csharpsrc2cpg.utils.Utils.*
-import io.joern.x2cpg.astgen.{AstGenNodeBuilder, ParserResult}
+import io.joern.x2cpg.astgen.{AstGenNodeBuilder, BaseNodeInfo, ParserResult}
 import io.joern.x2cpg.utils.NodeBuilders.newModifierNode
 import io.joern.x2cpg.{Ast, AstCreatorBase, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.{DiffGraphBuilder, ModifierTypes, NodeTypes}
@@ -29,7 +29,7 @@ class AstCreator(
   val parserResult: ParserResult,
   val programSummary: CSharpProgramSummary = CSharpProgramSummary()
 )(implicit withSchemaValidation: ValidationMode)
-    extends AstCreatorBase(relativeFileName)
+    extends AstCreatorBase[BaseNodeInfo[?], AstCreator](relativeFileName)
     with AstCreatorHelper
     with AstForDeclarationsCreator
     with AstForPrimitivesCreator

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstCreator.scala
@@ -4,7 +4,7 @@ import io.joern.gosrc2cpg.datastructures.GoGlobal
 import io.joern.gosrc2cpg.model.GoModHelper
 import io.joern.gosrc2cpg.parser.ParserAst.*
 import io.joern.gosrc2cpg.parser.{GoAstJsonParser, ParserKeys, ParserNodeInfo}
-import io.joern.x2cpg.astgen.AstGenNodeBuilder
+import io.joern.x2cpg.astgen.{AstGenNodeBuilder, BaseNodeInfo}
 import io.joern.x2cpg.datastructures.Scope
 import io.joern.x2cpg.datastructures.Stack.*
 import io.joern.x2cpg.utils.NodeBuilders.newModifierNode
@@ -24,7 +24,7 @@ class AstCreator(
   val goMod: GoModHelper,
   val goGlobal: GoGlobal
 )(implicit withSchemaValidation: ValidationMode)
-    extends AstCreatorBase(relPathFileName)
+    extends AstCreatorBase[BaseNodeInfo[?], AstCreator](relPathFileName)
     with AstCreatorHelper
     with AstForGenDeclarationCreator
     with AstForExpressionCreator

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForPackageConstructorCreator.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/AstForPackageConstructorCreator.scala
@@ -3,7 +3,7 @@ package io.joern.gosrc2cpg.astcreation
 import io.joern.gosrc2cpg.datastructures.PackageMemberAst
 import io.joern.gosrc2cpg.parser.ParserAst.Unknown
 import io.joern.gosrc2cpg.parser.ParserNodeInfo
-import io.joern.x2cpg.astgen.AstGenNodeBuilder
+import io.joern.x2cpg.astgen.{AstGenNodeBuilder, BaseNodeInfo}
 import io.joern.x2cpg.{Ast, AstCreatorBase, ValidationMode, Defines as XDefines}
 import io.shiftleft.codepropertygraph.generated.NodeTypes
 import org.apache.commons.lang3.StringUtils
@@ -14,7 +14,7 @@ import scala.collection.immutable.Set
 
 class AstForPackageConstructorCreator(val pacakgePath: String, statements: Set[PackageMemberAst])(implicit
   withSchemaValidation: ValidationMode
-) extends AstCreatorBase(pacakgePath)
+) extends AstCreatorBase[BaseNodeInfo[?], AstForPackageConstructorCreator](pacakgePath)
     with AstGenNodeBuilder[AstForPackageConstructorCreator] {
 
   override def createAst(): DiffGraphBuilder = {

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
@@ -94,8 +94,7 @@ class AstCreator(
   protected val keepTypeArguments: Boolean,
   val loggedExceptionCounts: scala.collection.concurrent.Map[Class[?], Int]
 )(implicit val withSchemaValidation: ValidationMode, val disableTypeFallback: Boolean)
-    extends AstCreatorBase(filename)
-    with AstNodeBuilder[Node, AstCreator]
+    extends AstCreatorBase[Node, AstCreator](filename)
     with AstForDeclarationsCreator
     with AstForExpressionsCreator
     with AstForStatementsCreator {

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForTypeDeclsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForTypeDeclsCreator.scala
@@ -384,7 +384,7 @@ private[declarations] trait AstForTypeDeclsCreator { this: AstCreator =>
     val (staticFields, instanceFields) = fields.partition(_.isStatic)
     val staticFieldInitializers        = getStaticFieldInitializers(staticFields)
 
-    val clinitAst = clinitAstFromStaticInits(staticFieldInitializers)
+    val clinitAst = clinitAstFromStaticInits(originNode, staticFieldInitializers)
 
     val membersAstPairs: List[(Node, List[Ast])] = members.map { member =>
       val memberAsts = member match {

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForLambdasCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForLambdasCreator.scala
@@ -93,7 +93,7 @@ private[expressions] trait AstForLambdasCreator { this: AstCreator =>
       .collect { case identifier: NewIdentifier => identifier }
       .filter { identifier => lambdaParameterNamesToNodes.contains(identifier.name) }
 
-    val returnNode = newMethodReturnNode(returnType.getOrElse(defaultTypeFallback()), None, line(expr), column(expr))
+    val returnNode      = methodReturnNode(expr, returnType.getOrElse(defaultTypeFallback()))
     val virtualModifier = Some(newModifierNode(ModifierTypes.VIRTUAL))
     val staticModifier  = Option.when(thisParam.isEmpty)(newModifierNode(ModifierTypes.STATIC))
     val privateModifier = Some(newModifierNode(ModifierTypes.PRIVATE))

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/astcreation/AstCreator.scala
@@ -26,11 +26,10 @@ class AstCreator(
   global: Global,
   fileContent: Option[String] = None
 )(implicit withSchemaValidation: ValidationMode)
-    extends AstCreatorBase(filename)
+    extends AstCreatorBase[Host, AstCreator](filename)
     with AstForDeclarationsCreator
     with AstForStatementsCreator
-    with AstForExpressionsCreator
-    with AstNodeBuilder[Host, AstCreator] {
+    with AstForExpressionsCreator {
 
   private val logger = LoggerFactory.getLogger(getClass)
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreator.scala
@@ -9,11 +9,9 @@ import io.joern.jssrc2cpg.parser.BabelNodeInfo
 import io.joern.x2cpg.Ast
 import io.joern.x2cpg.AstCreatorBase
 import io.joern.x2cpg.ValidationMode
-import io.joern.x2cpg.AstNodeBuilder as X2CpgAstNodeBuilder
 import io.joern.x2cpg.datastructures.Global
 import io.joern.x2cpg.datastructures.Stack.*
 import io.joern.x2cpg.frontendspecific.jssrc2cpg.Defines
-import io.joern.x2cpg.utils.NodeBuilders.newMethodReturnNode
 import io.joern.x2cpg.utils.NodeBuilders.newModifierNode
 import io.shiftleft.codepropertygraph.generated.EvaluationStrategies
 import io.shiftleft.codepropertygraph.generated.ModifierTypes
@@ -32,7 +30,7 @@ import scala.collection.mutable
 
 class AstCreator(val config: Config, val global: Global, val parserResult: ParseResult)(implicit
   withSchemaValidation: ValidationMode
-) extends AstCreatorBase(parserResult.filename)
+) extends AstCreatorBase[BabelNodeInfo, AstCreator](parserResult.filename)
     with AstForExpressionsCreator
     with AstForPrimitivesCreator
     with AstForTypesCreator
@@ -42,8 +40,7 @@ class AstCreator(val config: Config, val global: Global, val parserResult: Parse
     with AstForTemplateDomCreator
     with AstNodeBuilder
     with TypeHelper
-    with AstCreatorHelper
-    with X2CpgAstNodeBuilder[BabelNodeInfo, AstCreator] {
+    with AstCreatorHelper {
 
   protected val logger: Logger = LoggerFactory.getLogger(classOf[AstCreator])
 
@@ -107,7 +104,7 @@ class AstCreator(val config: Config, val global: Global, val parserResult: Parse
     val methodChildren = astsForFile(astNodeInfo)
     setArgumentIndices(methodChildren)
 
-    val methodReturn = newMethodReturnNode(Defines.Any, line = None, column = None)
+    val methodReturn = methodReturnNode(astNodeInfo, Defines.Any)
 
     localAstParentStack.pop()
     scope.popScope()

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreatorHelper.scala
@@ -6,13 +6,13 @@ import io.joern.jssrc2cpg.parser.BabelNodeInfo
 import io.joern.x2cpg.frontendspecific.jssrc2cpg.Defines
 import io.joern.x2cpg.utils.IntervalKeyPool
 import io.joern.x2cpg.utils.NodeBuilders.newClosureBindingNode
-import io.joern.x2cpg.{Ast, ValidationMode}
+import io.joern.x2cpg.{Ast, AstNodeBuilder, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, EvaluationStrategies}
 import io.shiftleft.codepropertygraph.generated.nodes.File.PropertyDefaults
 import ujson.Value
 
-import scala.collection.{mutable, SortedMap}
+import scala.collection.{SortedMap, mutable}
 import scala.util.{Success, Try}
 
 trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
@@ -261,12 +261,14 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
                 capturedLocals.updateWith(closureBindingIdProperty) {
                   case None =>
                     val methodScopeNode = methodScope.scopeNode
-                    val localNode_ = localNodeWithExplicitPositionInfo(
-                      origin.variableName,
-                      origin.variableName,
-                      Defines.Any,
-                      Option(closureBindingIdProperty)
-                    ).order(0)
+                    val localNode_ = AstNodeBuilder
+                      .localNodeWithExplicitPositionInfo(
+                        origin.variableName,
+                        origin.variableName,
+                        Defines.Any,
+                        Option(closureBindingIdProperty)
+                      )
+                      .order(0)
                     diffGraph.addEdge(methodScopeNode, localNode_, EdgeTypes.AST)
                     val closureBindingNode = newClosureBindingNode(
                       closureBindingIdProperty,
@@ -302,7 +304,7 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
     methodScopeNodeId: NewNode,
     variableName: String
   ): (NewNode, ScopeType) = {
-    val local = localNodeWithExplicitPositionInfo(variableName, variableName, Defines.Any).order(0)
+    val local = AstNodeBuilder.localNodeWithExplicitPositionInfo(variableName, variableName, Defines.Any).order(0)
     diffGraph.addEdge(methodScopeNodeId, local, EdgeTypes.AST)
     (local, MethodScope)
   }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
@@ -266,7 +266,13 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
       Ast.storeInDiffGraph(Ast(typeDeclNode_).withChildren(member), diffGraph)
     } else {
       val init =
-        staticInitMethodAst(calls, s"$typeFullName:${io.joern.x2cpg.Defines.StaticInitMethodName}", None, Defines.Any)
+        staticInitMethodAst(
+          tsEnum,
+          calls,
+          s"$typeFullName:${io.joern.x2cpg.Defines.StaticInitMethodName}",
+          None,
+          Defines.Any
+        )
       Ast.storeInDiffGraph(Ast(typeDeclNode_).withChildren(member).withChild(init), diffGraph)
     }
 
@@ -379,6 +385,7 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
 
     if (staticMemberInitCalls.nonEmpty || staticInitBlockAsts.nonEmpty) {
       val init = staticInitMethodAst(
+        clazz,
         staticMemberInitCalls ++ staticInitBlockAsts,
         s"$typeFullName:${io.joern.x2cpg.Defines.StaticInitMethodName}",
         None,

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstNodeBuilder.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstNodeBuilder.scala
@@ -4,7 +4,6 @@ import io.joern.jssrc2cpg.parser.BabelNodeInfo
 import io.joern.x2cpg
 import io.joern.x2cpg.{Ast, ValidationMode}
 import io.joern.x2cpg.frontendspecific.jssrc2cpg.Defines
-import io.joern.x2cpg.utils.NodeBuilders.newMethodReturnNode
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators, PropertyNames}
 
@@ -13,7 +12,7 @@ trait AstNodeBuilder(implicit withSchemaValidation: ValidationMode) { this: AstC
     val tpe           = typeFor(func)
     val possibleTypes = Seq(tpe)
     val typeFullName  = if (Defines.isBuiltinType(tpe)) tpe else Defines.Any
-    newMethodReturnNode(typeFullName, line = func.lineNumber, column = func.columnNumber).possibleTypes(possibleTypes)
+    methodReturnNode(func, typeFullName).possibleTypes(possibleTypes)
   }
 
   protected def setOrderExplicitly(ast: Ast, order: Int): Unit = {

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstCreator.scala
@@ -8,14 +8,12 @@ import io.joern.kotlin2cpg.types.TypeConstants
 import io.joern.kotlin2cpg.types.TypeInfoProvider
 import io.joern.x2cpg.Ast
 import io.joern.x2cpg.AstCreatorBase
-import io.joern.x2cpg.AstNodeBuilder
 import io.joern.x2cpg.Defines
 import io.joern.x2cpg.ValidationMode
 import io.joern.x2cpg.datastructures.Global
 import io.joern.x2cpg.datastructures.Stack.*
 import io.joern.x2cpg.utils.IntervalKeyPool
 import io.joern.x2cpg.utils.NodeBuilders
-import io.joern.x2cpg.utils.NodeBuilders.newMethodReturnNode
 import io.shiftleft.codepropertygraph.generated.*
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.DiffGraphBuilder
@@ -46,13 +44,12 @@ object AstCreator {
 
 class AstCreator(fileWithMeta: KtFileWithMeta, bindingContext: BindingContext, global: Global)(implicit
   withSchemaValidation: ValidationMode
-) extends AstCreatorBase(fileWithMeta.filename)
+) extends AstCreatorBase[PsiElement, AstCreator](fileWithMeta.filename)
     with AstForDeclarationsCreator
     with AstForPrimitivesCreator
     with AstForFunctionsCreator
     with AstForStatementsCreator
-    with AstForExpressionsCreator
-    with AstNodeBuilder[PsiElement, AstCreator] {
+    with AstForExpressionsCreator {
 
   import AstCreator.BindingInfo
   import AstCreator.ClosureBindingDef
@@ -373,7 +370,7 @@ class AstCreator(fileWithMeta: KtFileWithMeta, bindingContext: BindingContext, g
     scope.pushNewScope(fakeGlobalMethod)
 
     val blockNode_   = blockNode(ktFile, "<empty>", registerType(TypeConstants.Any))
-    val methodReturn = newMethodReturnNode(TypeConstants.Any, None, None, None)
+    val methodReturn = methodReturnNode(ktFile, TypeConstants.Any)
 
     val declarationsAsts = ktFile.getDeclarations.asScala.flatMap(astsForDeclaration)
     val fileNode         = NewFile().name(fileWithMeta.relativizedPath)

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForDeclarationsCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForDeclarationsCreator.scala
@@ -10,7 +10,6 @@ import io.joern.x2cpg.Defines
 import io.joern.x2cpg.ValidationMode
 import io.joern.x2cpg.utils.NodeBuilders
 import io.joern.x2cpg.utils.NodeBuilders.newBindingNode
-import io.joern.x2cpg.utils.NodeBuilders.newMethodReturnNode
 import io.joern.x2cpg.utils.NodeBuilders.newModifierNode
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes, ModifierTypes, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.NewBlock
@@ -140,12 +139,7 @@ trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) {
     val anonymousInitExpressions = ktClass.getAnonymousInitializers.asScala
     val anonymousInitAsts        = anonymousInitExpressions.flatMap(astsForExpression(_, None))
 
-    val constructorMethodReturn = newMethodReturnNode(
-      TypeConstants.Void,
-      None,
-      line(ktClass.getPrimaryConstructor),
-      column(ktClass.getPrimaryConstructor)
-    )
+    val constructorMethodReturn = methodReturnNode(ktClass.getPrimaryConstructor, TypeConstants.Void)
     val constructorAst = methodAst(
       primaryCtorMethodNode,
       constructorParamsAsts,
@@ -461,7 +455,7 @@ trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) {
         methodNode(valueParam, componentName, fullName, signature, relativizedPath),
         Seq(Ast(thisParam)),
         methodBlockAst,
-        newMethodReturnNode(typeFullName, None, None, None)
+        methodReturnNode(valueParam, typeFullName)
       )
     }
   }
@@ -505,7 +499,7 @@ trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) {
       scope.popScope()
 
       val ctorMethodReturnNode =
-        newMethodReturnNode(TypeConstants.Void, None, line(ctor), column(ctor))
+        methodReturnNode(ctor, TypeConstants.Void)
 
       // TODO: see if necessary to take the other asts for the ctorMethodBlock
       methodAst(

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForFunctionsCreator.scala
@@ -9,7 +9,6 @@ import io.joern.x2cpg.datastructures.Stack.StackWrapper
 import io.joern.x2cpg.utils.NodeBuilders
 import io.joern.x2cpg.utils.NodeBuilders.newBindingNode
 import io.joern.x2cpg.utils.NodeBuilders.newClosureBindingNode
-import io.joern.x2cpg.utils.NodeBuilders.newMethodReturnNode
 import io.joern.x2cpg.utils.NodeBuilders.newModifierNode
 import io.shiftleft.codepropertygraph.generated.EvaluationStrategies
 import io.shiftleft.codepropertygraph.generated.ModifierTypes
@@ -152,7 +151,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) {
     val otherBodyAsts     = bodyAsts.drop(1)
     val explicitTypeName  = Option(ktFn.getTypeReference).map(_.getText).getOrElse(TypeConstants.Any)
     val typeFullName      = registerType(nameRenderer.typeFullName(funcDesc.getReturnType).getOrElse(explicitTypeName))
-    val _methodReturnNode = newMethodReturnNode(typeFullName, None, line(ktFn), column(ktFn))
+    val _methodReturnNode = methodReturnNode(ktFn, typeFullName)
 
     val visibilityModifierType =
       modifierTypeForVisibility(funcDesc.getVisibility)
@@ -343,7 +342,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) {
       lambdaMethodNode,
       parametersAsts,
       bodyAst,
-      newMethodReturnNode(returnTypeFullName, None, line(fn), column(fn)),
+      methodReturnNode(fn, returnTypeFullName),
       NodeBuilders.newModifierNode(ModifierTypes.VIRTUAL) :: NodeBuilders.newModifierNode(ModifierTypes.LAMBDA) :: Nil
     )
 
@@ -480,7 +479,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) {
       lambdaMethodNode,
       paramAsts.toSeq,
       bodyAst,
-      newMethodReturnNode(returnTypeFullName, None, line(expr), column(expr)),
+      methodReturnNode(expr, returnTypeFullName),
       newModifierNode(ModifierTypes.VIRTUAL) :: newModifierNode(ModifierTypes.LAMBDA) :: Nil
     )
 

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/dataflow/DestructuringTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/dataflow/DestructuringTests.scala
@@ -36,7 +36,6 @@ class DestructuringTests extends KotlinCode2CpgFixture(withOssDataflow = true) {
             ("tmp_1.component1()", Some(6)),
             ("component1(this)", None),
             ("RET", Some(4)),
-            ("RET", None),
             ("tmp_1.component1()", Some(6)),
             ("name = tmp_1.component1()", Some(6)),
             ("println(name)", Some(7))
@@ -64,7 +63,6 @@ class DestructuringTests extends KotlinCode2CpgFixture(withOssDataflow = true) {
             ("tmp_1.component2()", Some(6)),
             ("component2(this)", None),
             ("RET", Some(4)),
-            ("RET", None),
             ("tmp_1.component2()", Some(6)),
             ("id = tmp_1.component2()", Some(6)),
             ("println(id)", Some(8))

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/NodeBuilder.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/NodeBuilder.scala
@@ -183,13 +183,13 @@ class NodeBuilder(diffGraph: DiffGraphBuilder) {
     dynamicTypeHintFullName: Option[String],
     lineAndColumn: LineAndColumn
   ): nodes.NewMethodReturn = {
-    val methodReturnNode = NodeBuilders
-      .newMethodReturnNode(
-        staticTypeHint.getOrElse(Constants.ANY),
-        dynamicTypeHintFullName,
-        Some(lineAndColumn.line),
-        Some(lineAndColumn.column)
-      )
+    val methodReturnNode = nodes
+      .NewMethodReturn()
+      .typeFullName(staticTypeHint.getOrElse(Constants.ANY))
+      .dynamicTypeHintFullName(dynamicTypeHintFullName)
+      .lineNumber(lineAndColumn.line)
+      .columnNumber(lineAndColumn.column)
+      .code("RET")
       .evaluationStrategy(EvaluationStrategies.BY_SHARING)
 
     addNodeToDiff(methodReturnNode)

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
@@ -4,7 +4,7 @@ import PythonAstVisitor.{logger, metaClassSuffix, noLineAndColumn}
 import io.joern.pysrc2cpg.memop.*
 import io.joern.x2cpg.frontendspecific.pysrc2cpg.Constants.builtinPrefix
 import io.joern.pythonparser.ast
-import io.joern.pythonparser.ast.{Arguments, iexpr, istmt}
+import io.joern.pythonparser.ast.{Arguments, iast, iexpr, istmt}
 import io.joern.x2cpg.frontendspecific.pysrc2cpg.Constants
 import io.joern.x2cpg.{AstCreatorBase, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.*
@@ -32,7 +32,7 @@ class PythonAstVisitor(
   version: PythonVersion,
   enableFileContent: Boolean
 )(implicit withSchemaValidation: ValidationMode)
-    extends AstCreatorBase(relFileName)
+    extends AstCreatorBase[ast.iast, PythonAstVisitor](relFileName)
     with PythonAstVisitorHelpers {
 
   private val redefintionSuffix = "$redefinition"
@@ -2159,6 +2159,12 @@ class PythonAstVisitor(
       relFileName + ":" + name
     }
   }
+
+  override protected def line(node: iast): Option[Int]         = None
+  override protected def column(node: iast): Option[Int]       = None
+  override protected def lineEnd(node: iast): Option[Int]      = None
+  override protected def columnEnd(element: iast): Option[Int] = None
+  override protected def code(node: iast): String              = node.toString
 }
 
 object PythonAstVisitor {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -21,15 +21,14 @@ class AstCreator(
   val fileContent: String = "",
   val rootNode: StatementList
 )(implicit withSchemaValidation: ValidationMode)
-    extends AstCreatorBase(fileName)
+    extends AstCreatorBase[RubyExpression, AstCreator](fileName)
     with AstCreatorHelper
     with AstForStatementsCreator
     with AstForExpressionsCreator
     with AstForControlStructuresCreator
     with AstForFunctionsCreator
     with AstForTypesCreator
-    with AstSummaryVisitor
-    with AstNodeBuilder[RubyExpression, AstCreator] {
+    with AstSummaryVisitor {
 
   val tmpGen: FreshNameGenerator[String]                      = FreshNameGenerator(i => s"<tmp-$i>")
   val procParamGen: FreshNameGenerator[Left[String, Nothing]] = FreshNameGenerator(i => Left(s"<proc-param-$i>"))

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstCreator.scala
@@ -5,7 +5,6 @@ import io.joern.swiftsrc2cpg.datastructures.Scope
 import io.joern.swiftsrc2cpg.parser.SwiftJsonParser.ParseResult
 import io.joern.swiftsrc2cpg.parser.SwiftNodeSyntax.*
 import io.joern.x2cpg.datastructures.Stack.*
-import io.joern.x2cpg.utils.NodeBuilders.newMethodReturnNode
 import io.joern.x2cpg.{Ast, AstCreatorBase, ValidationMode, AstNodeBuilder as X2CpgAstNodeBuilder}
 import io.joern.x2cpg.datastructures.Global
 import io.joern.x2cpg.frontendspecific.swiftsrc2cpg.Defines
@@ -27,7 +26,7 @@ import scala.collection.mutable
 
 class AstCreator(val config: Config, val global: Global, val parserResult: ParseResult)(implicit
   withSchemaValidation: ValidationMode
-) extends AstCreatorBase(parserResult.filename)
+) extends AstCreatorBase[SwiftNode, AstCreator](parserResult.filename)
     with AstForSwiftTokenCreator
     with AstForSyntaxCreator
     with AstForExprSyntaxCreator
@@ -37,8 +36,7 @@ class AstCreator(val config: Config, val global: Global, val parserResult: Parse
     with AstForStmtSyntaxCreator
     with AstForSyntaxCollectionCreator
     with AstCreatorHelper
-    with AstNodeBuilder
-    with X2CpgAstNodeBuilder[SwiftNode, AstCreator] {
+    with AstNodeBuilder {
 
   protected val logger: Logger = LoggerFactory.getLogger(classOf[AstCreator])
 
@@ -84,7 +82,7 @@ class AstCreator(val config: Config, val global: Global, val parserResult: Parse
     methodAstParentStack.push(fakeGlobalMethod)
     scope.pushNewMethodScope(fullName, name, fakeGlobalMethod, None)
     val sourceFileAst = astForNode(ast)
-    val methodReturn  = newMethodReturnNode(Defines.Any, None, line(ast), column(ast))
+    val methodReturn  = methodReturnNode(ast, Defines.Any)
     val modifiers = Seq(newModifierNode(ModifierTypes.VIRTUAL).order(0), newModifierNode(ModifierTypes.MODULE).order(1))
     Ast(fakeGlobalTypeDecl).withChild(
       methodAst(fakeGlobalMethod, Seq.empty, sourceFileAst, methodReturn, modifiers = modifiers)

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstCreatorHelper.scala
@@ -11,8 +11,8 @@ import io.joern.swiftsrc2cpg.parser.SwiftNodeSyntax.InitializerDeclSyntax
 import io.joern.swiftsrc2cpg.parser.SwiftNodeSyntax.SwiftNode
 import io.joern.x2cpg.frontendspecific.swiftsrc2cpg.Defines
 import io.joern.x2cpg.utils.IntervalKeyPool
-import io.joern.x2cpg.{Ast, ValidationMode}
-import io.joern.x2cpg.utils.NodeBuilders.{newClosureBindingNode}
+import io.joern.x2cpg.{Ast, AstNodeBuilder, ValidationMode}
+import io.joern.x2cpg.utils.NodeBuilders.newClosureBindingNode
 import io.shiftleft.codepropertygraph.generated.nodes.NewNode
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, EvaluationStrategies}
 import io.shiftleft.codepropertygraph.generated.nodes.NewNamespaceBlock
@@ -178,12 +178,14 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
                 capturedLocals.updateWith(closureBindingIdProperty) {
                   case None =>
                     val methodScopeNode = methodScope.scopeNode
-                    val localNode_ = localNodeWithExplicitPositionInfo(
-                      origin.variableName,
-                      origin.variableName,
-                      Defines.Any,
-                      Option(closureBindingIdProperty)
-                    ).order(0)
+                    val localNode_ = AstNodeBuilder
+                      .localNodeWithExplicitPositionInfo(
+                        origin.variableName,
+                        origin.variableName,
+                        Defines.Any,
+                        Option(closureBindingIdProperty)
+                      )
+                      .order(0)
                     diffGraph.addEdge(methodScopeNode, localNode_, EdgeTypes.AST)
                     val closureBindingNode = newClosureBindingNode(
                       closureBindingIdProperty,
@@ -220,7 +222,7 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
     methodScopeNodeId: NewNode,
     variableName: String
   ): (NewNode, ScopeType) = {
-    val local = localNodeWithExplicitPositionInfo(variableName, variableName, Defines.Any).order(0)
+    val local = AstNodeBuilder.localNodeWithExplicitPositionInfo(variableName, variableName, Defines.Any).order(0)
     diffGraph.addEdge(methodScopeNodeId, local, EdgeTypes.AST)
     (local, MethodScope)
   }

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForDeclSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForDeclSyntaxCreator.scala
@@ -164,13 +164,7 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     val modifiers   = Seq(NewModifier().modifierType(ModifierTypes.CONSTRUCTOR))
 
     methodAstParentStack.push(methodNode_)
-    val methodReturnNode =
-      newMethodReturnNode(
-        typeDeclNode.fullName,
-        dynamicTypeHintFullName = None,
-        line = line(node),
-        column = column(node)
-      )
+    val methodReturnNode_ = methodReturnNode(node, typeDeclNode.fullName)
 
     methodAstParentStack.pop()
 
@@ -178,11 +172,11 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
       createFunctionTypeAndTypeDeclAst(node, methodNode_, constructorName, methodFullName)
 
     val (mAst, bAst) = if (methodBlockContent.isEmpty) {
-      (methodStubAst(methodNode_, Seq.empty, methodReturnNode, modifiers), Ast())
+      (methodStubAst(methodNode_, Seq.empty, methodReturnNode_, modifiers), Ast())
     } else {
       setArgumentIndices(methodBlockContent)
       val bodyAst = blockAst(NewBlock(), methodBlockContent)
-      (methodAstWithAnnotations(methodNode_, Seq.empty, bodyAst, methodReturnNode, modifiers), bodyAst)
+      (methodAstWithAnnotations(methodNode_, Seq.empty, bodyAst, methodReturnNode_, modifiers), bodyAst)
     }
 
     Ast.storeInDiffGraph(mAst, diffGraph)
@@ -382,6 +376,7 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
 
     if (staticMemberInitCalls.nonEmpty) {
       val init = staticInitMethodAstAndBlock(
+        node,
         staticMemberInitCalls,
         s"$typeFullName:${io.joern.x2cpg.Defines.StaticInitMethodName}",
         None,
@@ -530,6 +525,7 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
 
     if (staticMemberInitCalls.nonEmpty) {
       val init = staticInitMethodAstAndBlock(
+        node,
         staticMemberInitCalls,
         s"$typeFullName:${io.joern.x2cpg.Defines.StaticInitMethodName}",
         None,
@@ -739,8 +735,7 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
         List.empty[Ast]
     }
 
-    val methodReturnNode =
-      newMethodReturnNode(returnType, dynamicTypeHintFullName = None, line = line(node), column = column(node))
+    val methodReturnNode_ = methodReturnNode(node, returnType)
 
     val bodyAsts = methodBlockContent ++ bodyStmtAsts
     setArgumentIndices(bodyAsts)
@@ -750,7 +745,7 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
         methodNode_,
         parameterAsts,
         blockAst_,
-        methodReturnNode,
+        methodReturnNode_,
         modifiers = modifiers,
         annotations = attributes
       )

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstNodeBuilder.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstNodeBuilder.scala
@@ -5,7 +5,6 @@ import io.joern.x2cpg
 import io.joern.x2cpg.Ast
 import io.joern.x2cpg.ValidationMode
 import io.joern.x2cpg.frontendspecific.swiftsrc2cpg.Defines
-import io.joern.x2cpg.utils.NodeBuilders.newMethodReturnNode
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.codepropertygraph.generated.ModifierTypes
@@ -242,19 +241,18 @@ trait AstNodeBuilder(implicit withSchemaValidation: ValidationMode) { this: AstC
   }
 
   def staticInitMethodAstAndBlock(
+    node: SwiftNode,
     initAsts: List[Ast],
     fullName: String,
     signature: Option[String],
     returnType: String,
-    fileName: Option[String] = None,
-    lineNumber: Option[Int] = None,
-    columnNumber: Option[Int] = None
+    fileName: Option[String] = None
   ): AstAndMethod = {
     val methodNode = NewMethod()
       .name(io.joern.x2cpg.Defines.StaticInitMethodName)
       .fullName(fullName)
-      .lineNumber(lineNumber)
-      .columnNumber(columnNumber)
+      .lineNumber(line(node))
+      .columnNumber(column(node))
     if (signature.isDefined) {
       methodNode.signature(signature.get)
     }
@@ -263,7 +261,7 @@ trait AstNodeBuilder(implicit withSchemaValidation: ValidationMode) { this: AstC
     }
     val staticModifier = NewModifier().modifierType(ModifierTypes.STATIC)
     val body           = blockAst(NewBlock(), initAsts)
-    val methodReturn   = newMethodReturnNode(returnType, None, None, None)
+    val methodReturn   = methodReturnNode(node, returnType)
     AstAndMethod(methodAst(methodNode, Nil, body, methodReturn, List(staticModifier)), methodNode, body)
   }
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstNodeBuilder.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstNodeBuilder.scala
@@ -1,6 +1,5 @@
 package io.joern.x2cpg
 
-import io.joern.x2cpg.utils.NodeBuilders.newMethodReturnNode
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EvaluationStrategies}
 import io.shiftleft.codepropertygraph.generated.nodes.Block.PropertyDefaults as BlockDefaults
 import io.shiftleft.codepropertygraph.generated.nodes.{
@@ -382,8 +381,18 @@ trait AstNodeBuilder[Node, NodeProcessor] { this: NodeProcessor =>
     node_
   }
 
-  protected def methodReturnNode(node: Node, typeFullName: String): NewMethodReturn = {
-    newMethodReturnNode(typeFullName, None, line(node), column(node))
+  protected def methodReturnNode(
+    node: Node,
+    typeFullName: String,
+    dynamicTypeHintFullName: Option[String] = None
+  ): NewMethodReturn = {
+    NewMethodReturn()
+      .typeFullName(typeFullName)
+      .dynamicTypeHintFullName(dynamicTypeHintFullName)
+      .code("RET")
+      .evaluationStrategy(EvaluationStrategies.BY_VALUE)
+      .lineNumber(line(node))
+      .columnNumber(column(node))
   }
 
   protected def jumpTargetNode(

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstNodeBuilder.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstNodeBuilder.scala
@@ -1,5 +1,6 @@
 package io.joern.x2cpg
 
+import io.joern.x2cpg.AstNodeBuilder.methodReturnNodeWithExplicitPositionInfo
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EvaluationStrategies}
 import io.shiftleft.codepropertygraph.generated.nodes.Block.PropertyDefaults as BlockDefaults
 import io.shiftleft.codepropertygraph.generated.nodes.{
@@ -289,7 +290,7 @@ trait AstNodeBuilder[Node, NodeProcessor] { this: NodeProcessor =>
   ): NewLocal = {
     val (nodeOffset, nodeOffsetEnd) =
       offset(node).map((offset, offsetEnd) => (Option(offset), Option(offsetEnd))).getOrElse((None, None))
-    localNodeWithExplicitPositionInfo(
+    AstNodeBuilder.localNodeWithExplicitPositionInfo(
       name,
       code,
       typeFullName,
@@ -300,33 +301,6 @@ trait AstNodeBuilder[Node, NodeProcessor] { this: NodeProcessor =>
       nodeOffset,
       nodeOffsetEnd
     )
-  }
-
-  /** It is useful (perhaps necessary) to be able to create locals without an "origin node" in some cases, so allow that
-    * but make it clear that positional information (line/col number and offsets) must be specified explicitly.
-    */
-  protected def localNodeWithExplicitPositionInfo(
-    name: String,
-    code: String,
-    typeFullName: String,
-    closureBindingId: Option[String] = None,
-    genericSignature: Option[String] = None,
-    lineNumber: Option[Int] = None,
-    columnNumber: Option[Int] = None,
-    offset: Option[Int] = None,
-    offsetEnd: Option[Int] = None
-  ): NewLocal = {
-    val node_ = NewLocal()
-      .name(name)
-      .code(code)
-      .typeFullName(typeFullName)
-      .closureBindingId(closureBindingId)
-      .lineNumber(lineNumber)
-      .columnNumber(columnNumber)
-      .offset(offset)
-      .offsetEnd(offsetEnd)
-    genericSignature.foreach(node_.genericSignature(_))
-    node_
   }
 
   protected def identifierNode(
@@ -386,13 +360,8 @@ trait AstNodeBuilder[Node, NodeProcessor] { this: NodeProcessor =>
     typeFullName: String,
     dynamicTypeHintFullName: Option[String] = None
   ): NewMethodReturn = {
-    NewMethodReturn()
-      .typeFullName(typeFullName)
-      .dynamicTypeHintFullName(dynamicTypeHintFullName)
-      .code("RET")
-      .evaluationStrategy(EvaluationStrategies.BY_VALUE)
-      .lineNumber(line(node))
-      .columnNumber(column(node))
+    // TODO: Add offsets
+    methodReturnNodeWithExplicitPositionInfo(typeFullName, dynamicTypeHintFullName, line(node), column(node))
   }
 
   protected def jumpTargetNode(
@@ -407,5 +376,55 @@ trait AstNodeBuilder[Node, NodeProcessor] { this: NodeProcessor =>
       .code(code)
       .lineNumber(line(node))
       .columnNumber(column(node))
+  }
+}
+
+/** It is sometimes necessary to create nodes without an origin node to use as a reference for positional information
+  * (for example in passes after AST creation). These methods provide a way to do that, but the AstNodeBuilder trait
+  * methods are STRONGLY preferred and should be used instead of these static methods whenever possible.
+  */
+object AstNodeBuilder {
+
+  private[joern] def localNodeWithExplicitPositionInfo(
+    name: String,
+    code: String,
+    typeFullName: String,
+    closureBindingId: Option[String] = None,
+    genericSignature: Option[String] = None,
+    lineNumber: Option[Int] = None,
+    columnNumber: Option[Int] = None,
+    offset: Option[Int] = None,
+    offsetEnd: Option[Int] = None
+  ): NewLocal = {
+    val node_ = NewLocal()
+      .name(name)
+      .code(code)
+      .typeFullName(typeFullName)
+      .closureBindingId(closureBindingId)
+      .lineNumber(lineNumber)
+      .columnNumber(columnNumber)
+      .offset(offset)
+      .offsetEnd(offsetEnd)
+    genericSignature.foreach(node_.genericSignature(_))
+    node_
+  }
+
+  private[joern] def methodReturnNodeWithExplicitPositionInfo(
+    typeFullName: String,
+    dynamicTypeHintFullName: Option[String] = None,
+    lineNumber: Option[Int] = None,
+    columnNumber: Option[Int] = None,
+    offset: Option[Int] = None,
+    offsetEnd: Option[Int] = None
+  ): NewMethodReturn = {
+    NewMethodReturn()
+      .typeFullName(typeFullName)
+      .dynamicTypeHintFullName(dynamicTypeHintFullName)
+      .code("RET")
+      .evaluationStrategy(EvaluationStrategies.BY_VALUE)
+      .lineNumber(lineNumber)
+      .columnNumber(columnNumber)
+      .offset(offset)
+      .offsetEnd(offsetEnd)
   }
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/NodeBuilders.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/NodeBuilders.scala
@@ -187,8 +187,10 @@ object NodeBuilders {
       .order(0)
   }
 
-  /** Create a method return node
-    */
+  @deprecated(
+    "Deprecated in favour of the corresponding method io.joern.x2cpg.AstNodeBuilder and will be removed in a future version",
+    "4.0.286"
+  )
   def newMethodReturnNode(
     typeFullName: String,
     dynamicTypeHintFullName: Option[String] = None,


### PR DESCRIPTION
This PR touches a bunch of files since I needed to make `AstCreatorBase` extend `AstNodeBuilder` to be able to use the `methodReturnNode` method.

There is still one use of the deprecated method in `c2cpg.passes.TypeDeclNodePass`. The pattern we're following here doesn't work for non-ASTCreator passes, so some sort of static node builder method may be required, potentially in a companion object for `AstNodeBuilder`. I'm open to other suggestions for how we could handle this case though.