### PR TITLE
[javasrc2cpg] Lower some unnecessary error logs to warn/debug

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForLambdasCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForLambdasCreator.scala
@@ -369,7 +369,7 @@ private[expressions] trait AstForLambdasCreator { this: AstCreator =>
     }
 
     if (paramTypesList.sizeIs != lambdaParameters.size) {
-      logger.error(s"Found different number lambda params and param types for $expr. Some parameters will be missing.")
+      logger.debug(s"Found different number lambda params and param types for $expr. Some parameters will be missing.")
     }
 
     val parameterNodes = lambdaParameters

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForForLoopsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForForLoopsCreator.scala
@@ -233,7 +233,7 @@ trait AstForForLoopsCreator { this: AstCreator =>
 
     val iterableAst = astsForExpression(iterableExpression, expectedType = expectedType) match {
       case Nil =>
-        logger.error(s"Could not create AST for iterable expr $iterableExpression: $filename:l$lineNo")
+        logger.warn(s"Could not create AST for iterable expr $iterableExpression: $filename:l$lineNo")
         Ast()
       case iterableAstHead :: Nil => iterableAstHead
       case iterableAsts =>
@@ -340,7 +340,7 @@ trait AstForForLoopsCreator { this: AstCreator =>
     // Create item local
     val maybeVariable = stmt.getVariable.getVariables.asScala.toList match {
       case Nil =>
-        logger.error(s"ForEach statement has empty variable list: $filename$lineNo")
+        logger.warn(s"ForEach statement has empty variable list: $filename$lineNo")
         None
       case variable :: Nil => Some(variable)
       case variable :: _ =>

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/jartypereader/descriptorparser/DescriptorParser.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/jartypereader/descriptorparser/DescriptorParser.scala
@@ -27,11 +27,11 @@ object DescriptorParser extends TypeParser {
       case Success(signature, _) => signature
 
       case Failure(err, _) =>
-        logger.error(s"parseClassSignature failed with $err")
+        logger.warn(s"parseClassSignature failed with $err")
         throw new IllegalArgumentException(s"FAILURE: Parsing invalid signature descriptor $descriptor")
 
       case Error(err, _) =>
-        logger.error(s"parseClassSignature raised error $err")
+        logger.warn(s"parseClassSignature raised error $err")
         throw new IllegalArgumentException(s"ERROR: Parsing invalid signature descriptor $descriptor")
     }
   }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/jartypereader/descriptorparser/TypeParser.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/jartypereader/descriptorparser/TypeParser.scala
@@ -33,7 +33,7 @@ trait TypeParser extends TokenParser {
       case Some("+") ~ typeSignature => BoundWildcard(BoundAbove, typeSignature)
 
       case Some(symbol) ~ typeSignature =>
-        logger.error(s"Invalid wildcard indicator `$symbol`. Treating as unbound wildcard")
+        logger.debug(s"Invalid wildcard indicator `$symbol`. Treating as unbound wildcard")
         UnboundWildcard
 
       case None ~ typeSignature => SimpleTypeArgument(typeSignature)


### PR DESCRIPTION
javasrc2cpg has some error-level logs left over from before a general logging level lowering a while ago. None of these should be logged at an error level, so this PR sets more appropriate levels.

These error logs may also be causing "language failure" messages to appear in the SL UI, but that's just a hunch.