### PR TITLE
Fix some issues in methodStubCreator

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForStatementsCreator.scala
@@ -373,7 +373,6 @@ trait AstForStatementsCreator { this: AstCreator =>
     val collection     = forStmt.getInitializerClause
     val collectionName = code(collection)
     val idType         = registerType(typeFor(forStmt.getDeclaration))
-    val collectionType = scope.lookupVariable(collectionName).map(_._2).getOrElse(registerType(typeFor(collection)))
 
     // iterator assignment:
     val iteratorName      = uniqueName("", "", "iterator")._1
@@ -394,7 +393,7 @@ trait AstForStatementsCreator { this: AstCreator =>
       )
 
     val iteratorCallBase = astForNode(collection)
-    val iteratorCallAst  = callAst(iteratorCall, base = Some(iteratorCallBase))
+    val iteratorCallAst  = createCallAst(iteratorCall, base = Some(iteratorCallBase), receiver = Some(iteratorCallBase))
 
     val iteratorAssignmentNode =
       callNode(
@@ -442,7 +441,8 @@ trait AstForStatementsCreator { this: AstCreator =>
     val hasNextReceiverNode = identifierNode(forStmt, iteratorName, iteratorName, Defines.Iterator)
     scope.addVariableReference(iteratorName, hasNextReceiverNode, Defines.Iterator, EvaluationStrategies.BY_REFERENCE)
 
-    val testAst = callAst(testCallNode, base = Option(Ast(hasNextReceiverNode)))
+    val testAst =
+      createCallAst(testCallNode, base = Some(Ast(hasNextReceiverNode)), receiver = Some(Ast(hasNextReceiverNode)))
 
     val whileLoopAst = Ast(whileLoopNode).withChild(testAst).withConditionEdge(whileLoopNode, testCallNode)
 
@@ -463,7 +463,8 @@ trait AstForStatementsCreator { this: AstCreator =>
     val nextReceiverNode = identifierNode(forStmt, iteratorName, iteratorName, Defines.Iterator)
     scope.addVariableReference(iteratorName, nextReceiverNode, Defines.Iterator, EvaluationStrategies.BY_REFERENCE)
 
-    val nextCallAst = callAst(nextCallNode, receiver = Option(Ast(nextReceiverNode)))
+    val nextCallAst =
+      createCallAst(nextCallNode, base = Some(Ast(nextReceiverNode)), receiver = Some(Ast(nextReceiverNode)))
 
     val loopVariableAssignmentNode = callNode(
       forStmt,

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/ForEachLoopTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/ForEachLoopTests.scala
@@ -106,7 +106,8 @@ class ForEachLoopTests extends AstC2CpgSuite(fileSuffix = FileDefaults.CppExt) {
 
     val List(iteratorCallReceiver) = iteratorAssignmentRhs.receiver.isIdentifier.l
     iteratorCallReceiver.name shouldBe "items"
-    iteratorCallReceiver.order shouldBe 1
+    iteratorCallReceiver.argumentIndex shouldBe 0
+    iteratorAssignmentRhs.argument(0) shouldBe iteratorCallReceiver
     iteratorCallReceiver.typeFullName shouldBe expectedCollectionType
 
     val List(varI) = node.astChildren.isIdentifier.nameExact("item").l

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/MethodStubCreator.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/MethodStubCreator.scala
@@ -1,7 +1,7 @@
 package io.joern.x2cpg.passes.base
 
 import io.joern.x2cpg.Defines
-import io.joern.x2cpg.passes.base.MethodStubCreator.createMethodStub
+import io.joern.x2cpg.passes.base.MethodStubCreator.{createMethodStub, logger}
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes, EvaluationStrategies, NodeTypes}
@@ -12,7 +12,15 @@ import io.shiftleft.codepropertygraph.generated.DiffGraphBuilder
 import scala.collection.mutable
 import scala.util.Try
 
-case class CallSummary(name: String, signature: String, fullName: String, dispatchType: String)
+case class CallSummary(
+  name: String,
+  signature: String,
+  fullName: String,
+  dispatchType: String,
+  minArg: Int,
+  maxArg: Int,
+  numArg: Int
+)
 
 /** This pass has no other pass as prerequisite.
   */
@@ -20,31 +28,70 @@ class MethodStubCreator(cpg: Cpg) extends CpgPass(cpg) {
 
   // Since the method fullNames for fuzzyc are not unique, we do not have
   // a 1to1 relation and may overwrite some values. This is ok for now.
-  private val methodFullNameToNode   = mutable.LinkedHashMap[String, Method]()
-  private val methodToParameterCount = mutable.LinkedHashMap[CallSummary, Int]()
+  private val methodToParameterCount = mutable.LinkedHashMap[String, mutable.LinkedHashSet[CallSummary]]()
 
   override def run(dstGraph: DiffGraphBuilder): Unit = {
-    for (method <- cpg.method) {
-      methodFullNameToNode.put(method.fullName, method)
-    }
-
-    for (call <- cpg.call if call.methodFullName != Defines.DynamicCallUnknownFullName) {
-      methodToParameterCount.put(
-        CallSummary(call.name, call.signature, call.methodFullName, call.dispatchType),
-        call.argument.size
-      )
-    }
 
     for (
-      (CallSummary(name, signature, fullName, dispatchType), parameterCount) <- methodToParameterCount
-      if !methodFullNameToNode.contains(fullName)
+      call <- cpg.call if call.methodFullName != Defines.DynamicCallUnknownFullName && cpg.method
+        .fullNameExact(call.methodFullName)
+        .isEmpty
     ) {
-      createMethodStub(name, fullName, signature, dispatchType, parameterCount, dstGraph)
+      methodToParameterCount
+        .getOrElseUpdate(call.methodFullName, mutable.LinkedHashSet.empty[CallSummary])
+        .add(
+          CallSummary(
+            call.name,
+            call.signature,
+            call.methodFullName,
+            call.dispatchType,
+            call.argument.argumentIndex.min,
+            call.argument.argumentIndex.max,
+            call.argument.size
+          )
+        )
+    }
+    for ((k, v) <- methodToParameterCount) {
+      var done = false
+      if (v.size == 1) {
+        val cs = v.head
+        if (cs.numArg == cs.maxArg - cs.minArg + 1 && (cs.minArg == 0 || cs.minArg == 1)) {
+          done = true
+          createMethodStub(
+            cs.name,
+            cs.fullName,
+            cs.signature,
+            cs.dispatchType,
+            cs.numArg,
+            dstGraph,
+            startWithInst = Some(cs.minArg == 0)
+          )
+        }
+      }
+      if (!done) {
+        // something is broken :(
+        logger.info(
+          s"Inconsistent/erroneous callInfo on calls to method fullname ${k} (we have ${v.size} many variants)"
+        )
+        // let's reconcile.
+        val cs     = v.head
+        val min    = Math.max(0, v.iterator.map(_.minArg).min)
+        val max    = v.iterator.map(_.maxArg).max
+        val numarg = if (min == 0) max + 1 else max
+        createMethodStub(
+          cs.name,
+          cs.fullName,
+          cs.signature,
+          cs.dispatchType,
+          numarg,
+          dstGraph,
+          startWithInst = Some(min == 0)
+        )
+      }
     }
   }
 
   override def finish(): Unit = {
-    methodFullNameToNode.clear()
     methodToParameterCount.clear()
     super.finish()
   }
@@ -52,6 +99,8 @@ class MethodStubCreator(cpg: Cpg) extends CpgPass(cpg) {
 }
 
 object MethodStubCreator {
+
+  private val logger = org.slf4j.LoggerFactory.getLogger(getClass)
 
   private def addLineNumberInfo(methodNode: NewMethod, fullName: String): NewMethod = {
     val s = fullName.split(":")
@@ -74,6 +123,7 @@ object MethodStubCreator {
     }
   }
 
+  // this method is hopelessly confused about the meaning of parameterCount, in the sense of whether INST is counted, and about index and order.
   def createMethodStub(
     name: String,
     fullName: String,
@@ -83,7 +133,8 @@ object MethodStubCreator {
     dstGraph: DiffGraphBuilder,
     isExternal: Boolean = true,
     astParentType: String = NodeTypes.NAMESPACE_BLOCK,
-    astParentFullName: String = "<global>"
+    astParentFullName: String = "<global>",
+    startWithInst: Option[Boolean] = None // None means: figure it out from STATIC_DISPATCH
   ): NewMethod = {
     val methodNode = NewMethod()
       .name(name)
@@ -98,23 +149,40 @@ object MethodStubCreator {
 
     dstGraph.addNode(methodNode)
 
-    val firstParameterOrder = dispatchType match {
-      case DispatchTypes.DYNAMIC_DISPATCH => 0
-      case _                              => 1
-    }
+    if (startWithInst.isEmpty) {
+      // this all looks wrong / legacy / confused, but don't touch it for now
+      val firstParameterOrder = dispatchType match {
+        case DispatchTypes.DYNAMIC_DISPATCH => 0
+        case _                              => 1
+      }
+      (firstParameterOrder to parameterCount).zipWithIndex.foreach { case (parameterOrder, index) =>
+        val nameAndCode = s"p$parameterOrder"
+        val param = NewMethodParameterIn()
+          .code(nameAndCode)
+          .order(parameterOrder)
+          .index(index + 1)
+          .name(nameAndCode)
+          .evaluationStrategy(EvaluationStrategies.BY_VALUE)
+          .typeFullName("ANY")
 
-    (firstParameterOrder to parameterCount).zipWithIndex.foreach { case (parameterOrder, index) =>
-      val nameAndCode = s"p$parameterOrder"
-      val param = NewMethodParameterIn()
-        .code(nameAndCode)
-        .order(parameterOrder)
-        .index(index + 1)
-        .name(nameAndCode)
-        .evaluationStrategy(EvaluationStrategies.BY_VALUE)
-        .typeFullName("ANY")
+        dstGraph.addNode(param)
+        dstGraph.addEdge(methodNode, param, EdgeTypes.AST)
+      }
+    } else {
+      val ran = if (startWithInst.get) Range(0, parameterCount) else Range(1, parameterCount + 1)
+      for (parameterOrder <- ran) {
+        val nameAndCode = s"p$parameterOrder"
+        val param = NewMethodParameterIn()
+          .code(nameAndCode)
+          .order(parameterOrder)
+          .index(parameterOrder)
+          .name(nameAndCode)
+          .evaluationStrategy(EvaluationStrategies.BY_VALUE)
+          .typeFullName("ANY")
 
-      dstGraph.addNode(param)
-      dstGraph.addEdge(methodNode, param, EdgeTypes.AST)
+        dstGraph.addNode(param)
+        dstGraph.addEdge(methodNode, param, EdgeTypes.AST)
+      }
     }
 
     val blockNode = NewBlock()


### PR DESCRIPTION
This:
1. Never causes fullname collisions during method stubbing
2. gets the arguments of stubbed methods correct
3. warns if there are mismatches

The main point is: In order to make anything work, each argument of a call to the method must have a matching parameter. Matching means: argumentIndex or argument equals index of parameter.

Unfortunately the old code looks hopelessly confused about all that, and it is used from other components. These components need to deconfuse themselves, and then we need to clean this up.