### PR TITLE
Add `.strippedCode` step for String literals

### DIFF
--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/AstQueryTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/AstQueryTests.scala
@@ -192,4 +192,31 @@ class AstQueryTests extends C2CpgSuite {
     }
   }
 
+  "inner text in string literals" in {
+    val cpg = code("""
+        |void foo() {
+        | char a[] = "abc";
+        | char b[] = "\"abc";
+        | char c[] = "abc\"";
+        | char d[] = 'abc';
+        | char e[] = '\'abc';
+        | char f[] = 'abc\'';
+        | char g[] = '"abc"';
+        | char h[] = "'abc'";
+        | char i[] = "'abc\"";
+        |}
+        |""".stripMargin)
+
+    cpg.literal.innerText.l shouldBe List(
+      Some("abc"),
+      Some("\\\"abc"),
+      Some("abc\\\""),
+      Some("abc"),
+      Some("\\'abc"),
+      Some("abc\\'"),
+      Some("\"abc\""),
+      Some("'abc'"),
+      Some("'abc\\\"")
+    )
+  }
 }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/AstQueryTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/AstQueryTests.scala
@@ -207,7 +207,7 @@ class AstQueryTests extends C2CpgSuite {
         |}
         |""".stripMargin)
 
-    cpg.literal.innerText.l shouldBe List(
+    cpg.literal.strippedCode.l shouldBe List(
       Some("abc"),
       Some("\\\"abc"),
       Some("abc\\\""),

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/AstQueryTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/AstQueryTests.scala
@@ -208,15 +208,15 @@ class AstQueryTests extends C2CpgSuite {
         |""".stripMargin)
 
     cpg.literal.strippedCode.l shouldBe List(
-      Some("abc"),
-      Some("\\\"abc"),
-      Some("abc\\\""),
-      Some("abc"),
-      Some("\\'abc"),
-      Some("abc\\'"),
-      Some("\"abc\""),
-      Some("'abc'"),
-      Some("'abc\\\"")
+      "abc",
+      "\\\"abc",
+      "abc\\\"",
+      "abc",
+      "\\'abc",
+      "abc\\'",
+      "\"abc\"",
+      "'abc'",
+      "'abc\\\""
     )
   }
 }

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/LiteralTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/LiteralTests.scala
@@ -13,7 +13,7 @@ class LiteralTests extends CSharpCode2CpgFixture {
         |var e = "a\"b\"c";
         |""".stripMargin))
 
-    cpg.literal.innerText.l shouldBe List(
+    cpg.literal.strippedCode.l shouldBe List(
       Some("abc"),
       Some("\\\"abc"),
       Some("abc\\\""),

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/LiteralTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/LiteralTests.scala
@@ -13,12 +13,6 @@ class LiteralTests extends CSharpCode2CpgFixture {
         |var e = "a\"b\"c";
         |""".stripMargin))
 
-    cpg.literal.strippedCode.l shouldBe List(
-      Some("abc"),
-      Some("\\\"abc"),
-      Some("abc\\\""),
-      Some("\\\"abc\\\""),
-      Some("a\\\"b\\\"c")
-    )
+    cpg.literal.strippedCode.l shouldBe List("abc", "\\\"abc", "abc\\\"", "\\\"abc\\\"", "a\\\"b\\\"c")
   }
 }

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/LiteralTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/LiteralTests.scala
@@ -1,0 +1,24 @@
+package io.joern.csharpsrc2cpg.querying.ast
+
+import io.joern.csharpsrc2cpg.testfixtures.CSharpCode2CpgFixture
+import io.shiftleft.semanticcpg.language.*
+
+class LiteralTests extends CSharpCode2CpgFixture {
+  "inner text in string literals" in {
+    val cpg = code(basicBoilerplate("""
+        |var a = "abc";
+        |var b = "\"abc";
+        |var c = "abc\"";
+        |var d = "\"abc\"";
+        |var e = "a\"b\"c";
+        |""".stripMargin))
+
+    cpg.literal.innerText.l shouldBe List(
+      Some("abc"),
+      Some("\\\"abc"),
+      Some("abc\\\""),
+      Some("\\\"abc\\\""),
+      Some("a\\\"b\\\"c")
+    )
+  }
+}

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/LiteralCpgTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/LiteralCpgTests.scala
@@ -54,7 +54,7 @@ class LiteralCpgTests extends GoCodeToCpgSuite {
          |}
          |""".stripMargin)
 
-    cpg.literal.strippedCode.l shouldBe List(Some("abc"), Some("\\\"abc"), Some("abc\\\""), Some("abc"))
+    cpg.literal.strippedCode.l shouldBe List("abc", "\\\"abc", "abc\\\"", "abc")
 
   }
 }

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/LiteralCpgTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/LiteralCpgTests.scala
@@ -54,7 +54,7 @@ class LiteralCpgTests extends GoCodeToCpgSuite {
          |}
          |""".stripMargin)
 
-    cpg.literal.innerText.l shouldBe List(Some("abc"), Some("\\\"abc"), Some("abc\\\""), Some("abc"))
+    cpg.literal.strippedCode.l shouldBe List(Some("abc"), Some("\\\"abc"), Some("abc\\\""), Some("abc"))
 
   }
 }

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/LiteralCpgTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/LiteralCpgTests.scala
@@ -42,4 +42,19 @@ class LiteralCpgTests extends GoCodeToCpgSuite {
     literalNode.code.size shouldBe 1000
     literalNode.code.endsWith("...") shouldBe true
   }
+
+  "inner text for string literals" in {
+    val cpg = code("""
+         |package main
+         |func foo() {
+         |  a := "abc"
+         |  b := "\"abc"
+         |  c := "abc\""
+         |  d := `abc`
+         |}
+         |""".stripMargin)
+
+    cpg.literal.innerText.l shouldBe List(Some("abc"), Some("\\\"abc"), Some("abc\\\""), Some("abc"))
+
+  }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
@@ -53,7 +53,7 @@ class AstCreationPass(config: Config, cpg: Cpg, sourcesOverride: Option[List[Str
     sourceParser.parseAnalysisFile(filename, !config.disableFileContent) match {
       case Some(compilationUnit, fileContent) =>
         symbolSolver.inject(compilationUnit)
-        val contentToUse = if (!config.disableFileContent) fileContent else None
+        val contentToUse = if (!config.disableFileContent) fileContent.map(_.replaceAll("\r\n", "\n")) else None
 
         diffGraph.absorb(
           new AstCreator(

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LiteralTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LiteralTests.scala
@@ -78,7 +78,7 @@ class LiteralTests extends JavaSrcCode2CpgFixture {
          |}
          |""".stripMargin)
 
-    cpg.literal.innerText.l shouldBe List(
+    cpg.literal.strippedCode.l shouldBe List(
       Some("abc"),
       Some("\\\"abc"),
       Some("abc\\\""),

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LiteralTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LiteralTests.scala
@@ -79,13 +79,13 @@ class LiteralTests extends JavaSrcCode2CpgFixture {
          |""".stripMargin)
 
     cpg.literal.strippedCode.l shouldBe List(
-      Some("abc"),
-      Some("\\\"abc"),
-      Some("abc\\\""),
-      Some("""
+      "abc",
+      "\\\"abc",
+      "abc\\\"",
+      """
           |    abc
           |    def
-          |    """.stripMargin)
+          |    """.stripMargin
     )
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LiteralTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LiteralTests.scala
@@ -63,4 +63,29 @@ class LiteralTests extends JavaSrcCode2CpgFixture {
       }
     }
   }
+
+  "inner text in literal strings" in {
+    val tripQuote = "\"\"\""
+    val cpg = code(s"""
+         |class Foo {
+         | String a = "abc";
+         | String b = "\\\"abc";
+         | String c = "abc\\\"";
+         | String d = ${tripQuote}
+         |abc
+         |def
+         |${tripQuote};
+         |}
+         |""".stripMargin)
+
+    cpg.literal.innerText.l shouldBe List(
+      Some("abc"),
+      Some("\\\"abc"),
+      Some("abc\\\""),
+      Some("""
+          |    abc
+          |    def
+          |    """.stripMargin)
+    )
+  }
 }

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/LiteralTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/LiteralTests.scala
@@ -18,6 +18,6 @@ class LiteralTests extends JimpleCode2CpgFixture {
          |}
          |""".stripMargin)
 
-    cpg.literal.strippedCode.l shouldBe List(Some("abc"), Some("\\\"abc"), Some("abc\\\""), Some("abc\\ndef\\n"))
+    cpg.literal.strippedCode.l shouldBe List("abc", "\\\"abc", "abc\\\"", "abc\\ndef\\n")
   }
 }

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/LiteralTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/LiteralTests.scala
@@ -1,0 +1,23 @@
+package io.joern.jimple2cpg.querying
+
+import io.joern.jimple2cpg.testfixtures.JimpleCode2CpgFixture
+import io.shiftleft.semanticcpg.language.*
+
+class LiteralTests extends JimpleCode2CpgFixture {
+  "inner text in literal strings" in {
+    val tripQuote = "\"\"\""
+    val cpg = code(s"""
+         |class Foo {
+         | String a = "abc";
+         | String b = "\\\"abc";
+         | String c = "abc\\\"";
+         | String d = ${tripQuote}
+         |abc
+         |def
+         |${tripQuote};
+         |}
+         |""".stripMargin)
+
+    cpg.literal.innerText.l shouldBe List(Some("abc"), Some("\\\"abc"), Some("abc\\\""), Some("abc\\ndef\\n"))
+  }
+}

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/LiteralTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/LiteralTests.scala
@@ -18,6 +18,6 @@ class LiteralTests extends JimpleCode2CpgFixture {
          |}
          |""".stripMargin)
 
-    cpg.literal.innerText.l shouldBe List(Some("abc"), Some("\\\"abc"), Some("abc\\\""), Some("abc\\ndef\\n"))
+    cpg.literal.strippedCode.l shouldBe List(Some("abc"), Some("\\\"abc"), Some("abc\\\""), Some("abc\\ndef\\n"))
   }
 }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/SimpleAstCreationPassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/SimpleAstCreationPassTests.scala
@@ -105,7 +105,7 @@ class SimpleAstCreationPassTests extends AstJsSrc2CpgSuite {
           |`
           |""".stripMargin)
 
-      cpg.literal.innerText.l shouldBe List(
+      cpg.literal.strippedCode.l shouldBe List(
         Some("abc"),
         Some("\"abc"),
         Some("abc\""),

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/SimpleAstCreationPassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/SimpleAstCreationPassTests.scala
@@ -89,6 +89,38 @@ class SimpleAstCreationPassTests extends AstJsSrc2CpgSuite {
       z.typeFullName shouldBe Defines.Boolean
     }
 
+    "have correct inner text for string literals" in {
+      val cpg = code("""
+          |let a = "abc";
+          |let b = "\"abc";
+          |let c = "abc\"";
+          |let d = 'abc';
+          |let e = '\'abc';
+          |let f = 'abc\'';
+          |let g = "'abc'";
+          |let h = '"abc"';
+          |let i = '\'abc\'';
+          |let j = `abc
+          |def
+          |`
+          |""".stripMargin)
+
+      cpg.literal.innerText.l shouldBe List(
+        Some("abc"),
+        Some("\"abc"),
+        Some("abc\""),
+        Some("abc"),
+        Some("'abc"),
+        Some("abc'"),
+        Some("'abc'"),
+        Some("\"abc\""),
+        Some("'abc'"),
+        Some("""abc
+            |def
+            |""".stripMargin)
+      )
+    }
+
     "have correct structure for multiple declarators in one place" in {
       val cpg                                         = code("let x = 1, y = 2, z = 3;")
       val List(xAssignment, yAssignment, zAssignment) = cpg.call.l.sortBy(_.code)

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/SimpleAstCreationPassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/SimpleAstCreationPassTests.scala
@@ -106,18 +106,18 @@ class SimpleAstCreationPassTests extends AstJsSrc2CpgSuite {
           |""".stripMargin)
 
       cpg.literal.strippedCode.l shouldBe List(
-        Some("abc"),
-        Some("\"abc"),
-        Some("abc\""),
-        Some("abc"),
-        Some("'abc"),
-        Some("abc'"),
-        Some("'abc'"),
-        Some("\"abc\""),
-        Some("'abc'"),
-        Some("""abc
+        "abc",
+        "\"abc",
+        "abc\"",
+        "abc",
+        "'abc",
+        "abc'",
+        "'abc'",
+        "\"abc\"",
+        "'abc'",
+        """abc
             |def
-            |""".stripMargin)
+            |""".stripMargin
       )
     }
 

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/testfixtures/AstJsSrc2CpgFrontend.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/testfixtures/AstJsSrc2CpgFrontend.scala
@@ -1,12 +1,12 @@
 package io.joern.jssrc2cpg.testfixtures
 
 import io.joern.jssrc2cpg.Config
-import io.joern.jssrc2cpg.passes.AstCreationPass
-import io.joern.jssrc2cpg.passes.JavaScriptTypeNodePass
+import io.joern.jssrc2cpg.passes.{AstCreationPass, JavaScriptMetaDataPass, JavaScriptTypeNodePass}
 import io.joern.jssrc2cpg.utils.AstGenRunner
 import io.joern.x2cpg.testfixtures.LanguageFrontend
 import io.joern.x2cpg.ValidationMode
 import io.joern.x2cpg.X2Cpg.newEmptyCpg
+import io.joern.x2cpg.utils.HashUtil
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.semanticcpg.utils.FileUtil
 
@@ -22,6 +22,10 @@ trait AstJsSrc2CpgFrontend extends LanguageFrontend {
       .fold(Config())(_.asInstanceOf[Config])
       .withInputPath(pathAsString)
       .withOutputPath(pathAsString)
+    val hash = HashUtil.sha256(pathAsString)
+
+    new JavaScriptMetaDataPass(cpg, hash, pathAsString).createAndApply()
+
     val astGenResult    = new AstGenRunner(config).execute(Paths.get(pathAsString))
     val astCreationPass = new AstCreationPass(cpg, astGenResult, config)(ValidationMode.Enabled)
     astCreationPass.createAndApply()

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LiteralTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LiteralTests.scala
@@ -77,13 +77,13 @@ class LiteralTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
          |""".stripMargin)
 
     cpg.literal.strippedCode.l shouldBe List(
-      Some("abc"),
-      Some("\\\"abc"),
-      Some("abc\\\""),
-      Some("""
+      "abc",
+      "\\\"abc",
+      "abc\\\"",
+      """
           |abc
           |def
-          |""".stripMargin)
+          |""".stripMargin
     )
   }
 }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LiteralTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LiteralTests.scala
@@ -61,4 +61,29 @@ class LiteralTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
       cpg.literal("0b010101").typeFullName.head shouldBe "int"
     }
   }
+
+  "inner text in literal strings" in {
+    val tripQuote = "\"\"\""
+    val cpg = code(s"""
+         |class Foo {
+         | val a: String = "abc";
+         | val b: String = "\\\"abc";
+         | val c: String = "abc\\\"";
+         | val d: String = ${tripQuote}
+         |abc
+         |def
+         |${tripQuote};
+         |}
+         |""".stripMargin)
+
+    cpg.literal.innerText.l shouldBe List(
+      Some("abc"),
+      Some("\\\"abc"),
+      Some("abc\\\""),
+      Some("""
+          |abc
+          |def
+          |""".stripMargin)
+    )
+  }
 }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LiteralTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LiteralTests.scala
@@ -76,7 +76,7 @@ class LiteralTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
          |}
          |""".stripMargin)
 
-    cpg.literal.innerText.l shouldBe List(
+    cpg.literal.strippedCode.l shouldBe List(
       Some("abc"),
       Some("\\\"abc"),
       Some("abc\\\""),

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/ScalarTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/ScalarTests.scala
@@ -110,7 +110,7 @@ class ScalarTests extends PhpCode2CpgFixture {
         |$i = "'abc'"
         |""".stripMargin)
 
-    cpg.literal.innerText.l shouldBe List(
+    cpg.literal.strippedCode.l shouldBe List(
       Some("abc"),
       Some("\\\"abc"),
       Some("abc\\\""),

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/ScalarTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/ScalarTests.scala
@@ -96,4 +96,30 @@ class ScalarTests extends PhpCode2CpgFixture {
       nullLiteral.typeFullName shouldBe "null"
     }
   }
+
+  "inner text in string literals" in {
+    val cpg = code("""<?php
+        |$a = "abc"
+        |$b = "\"abc"
+        |$c = "abc\""
+        |$d = 'abc'
+        |$e = '\'abc'
+        |$f = 'abc\''
+        |$g = '\'abc\''
+        |$h = '"abc"'
+        |$i = "'abc'"
+        |""".stripMargin)
+
+    cpg.literal.innerText.l shouldBe List(
+      Some("abc"),
+      Some("\\\"abc"),
+      Some("abc\\\""),
+      Some("abc"),
+      Some("\\'abc"),
+      Some("abc\\'"),
+      Some("\\'abc\\'"),
+      Some("\\\"abc\\\""),
+      Some("\\'abc\\'")
+    )
+  }
 }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/ScalarTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/ScalarTests.scala
@@ -111,15 +111,15 @@ class ScalarTests extends PhpCode2CpgFixture {
         |""".stripMargin)
 
     cpg.literal.strippedCode.l shouldBe List(
-      Some("abc"),
-      Some("\\\"abc"),
-      Some("abc\\\""),
-      Some("abc"),
-      Some("\\'abc"),
-      Some("abc\\'"),
-      Some("\\'abc\\'"),
-      Some("\\\"abc\\\""),
-      Some("\\'abc\\'")
+      "abc",
+      "\\\"abc",
+      "abc\\\"",
+      "abc",
+      "\\'abc",
+      "abc\\'",
+      "\\'abc\\'",
+      "\\\"abc\\\"",
+      "\\'abc\\'"
     )
   }
 }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/StrLiteralCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/StrLiteralCpgTests.scala
@@ -36,7 +36,7 @@ class StrLiteralCpgTests extends AnyFreeSpec with Matchers {
         |'''
         |""".stripMargin)
 
-    cpg2.literal.innerText.l shouldBe List(
+    cpg2.literal.strippedCode.l shouldBe List(
       Some("abc"),
       Some("\\\"abc"),
       Some("abc\\\""),

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/StrLiteralCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/StrLiteralCpgTests.scala
@@ -37,20 +37,20 @@ class StrLiteralCpgTests extends AnyFreeSpec with Matchers {
         |""".stripMargin)
 
     cpg2.literal.strippedCode.l shouldBe List(
-      Some("abc"),
-      Some("\\\"abc"),
-      Some("abc\\\""),
-      Some("abc"),
-      Some("\\'abc"),
-      Some("abc\\'"),
-      Some("""
+      "abc",
+      "\\\"abc",
+      "abc\\\"",
+      "abc",
+      "\\'abc",
+      "abc\\'",
+      """
           |abc
           |def
-          |""".stripMargin),
-      Some("""
+          |""".stripMargin,
+      """
           |abc
           |def
-          |""".stripMargin)
+          |""".stripMargin
     )
   }
 }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/StrLiteralCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/StrLiteralCpgTests.scala
@@ -17,4 +17,40 @@ class StrLiteralCpgTests extends AnyFreeSpec with Matchers {
     literal.lineNumber shouldBe Some(1)
     literal.columnNumber shouldBe Some(1)
   }
+
+  "inner text in string literal" in {
+    val cpg2 = Py2CpgTestContext.buildCpg(s"""
+        |a = "abc"
+        |b = "\\\"abc"
+        |c = "abc\\\""
+        |d = 'abc'
+        |e = '\\'abc'
+        |f = 'abc\\''
+        |g = \"\"\"
+        |abc
+        |def
+        |\"\"\"
+        |h = '''
+        |abc
+        |def
+        |'''
+        |""".stripMargin)
+
+    cpg2.literal.innerText.l shouldBe List(
+      Some("abc"),
+      Some("\\\"abc"),
+      Some("abc\\\""),
+      Some("abc"),
+      Some("\\'abc"),
+      Some("abc\\'"),
+      Some("""
+          |abc
+          |def
+          |""".stripMargin),
+      Some("""
+          |abc
+          |def
+          |""".stripMargin)
+    )
+  }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/LiteralTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/LiteralTests.scala
@@ -285,13 +285,6 @@ class LiteralTests extends RubyCode2CpgFixture {
         |"\"a'"
         |""".stripMargin)
 
-    cpg.literal.strippedCode.l shouldBe List(
-      Some("abc"),
-      Some("abc"),
-      Some("\\\"a"),
-      Some("'a'"),
-      Some("\"a\""),
-      Some("\\\"a'")
-    )
+    cpg.literal.strippedCode.l shouldBe List("abc", "abc", "\\\"a", "'a'", "\"a\"", "\\\"a'")
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/LiteralTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/LiteralTests.scala
@@ -275,4 +275,23 @@ class LiteralTests extends RubyCode2CpgFixture {
     }
   }
 
+  "inner text" in {
+    val cpg = code("""
+        |"abc"
+        |'abc'
+        |"\"a"
+        |"'a'"
+        |'"a"'
+        |"\"a'"
+        |""".stripMargin)
+
+    cpg.literal.innerText.l shouldBe List(
+      Some("abc"),
+      Some("abc"),
+      Some("\\\"a"),
+      Some("'a'"),
+      Some("\"a\""),
+      Some("\\\"a'")
+    )
+  }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/LiteralTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/LiteralTests.scala
@@ -285,7 +285,7 @@ class LiteralTests extends RubyCode2CpgFixture {
         |"\"a'"
         |""".stripMargin)
 
-    cpg.literal.innerText.l shouldBe List(
+    cpg.literal.strippedCode.l shouldBe List(
       Some("abc"),
       Some("abc"),
       Some("\\\"a"),

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/ExpressionTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/ExpressionTests.scala
@@ -440,7 +440,7 @@ class ExpressionTests extends AstSwiftSrc2CpgSuite {
            |}
            |""".stripMargin)
 
-      cpg.literal.innerText.l shouldBe List(
+      cpg.literal.strippedCode.l shouldBe List(
         Some("abc"),
         Some("\\\"abc"),
         Some("abc\\\""),

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/ExpressionTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/ExpressionTests.scala
@@ -426,6 +426,28 @@ class ExpressionTests extends AstSwiftSrc2CpgSuite {
       ???
     }
 
+    "inner text in literal strings" in {
+      val tripQuote = "\"\"\""
+      val cpg = code(s"""
+           |class Foo {
+           | var a = "abc";
+           | var b = "\\\"abc";
+           | var c = "abc\\\"";
+           | var d = ${tripQuote}
+           |abc
+           |def
+           |${tripQuote};
+           |}
+           |""".stripMargin)
+
+      cpg.literal.innerText.l shouldBe List(
+        Some("abc"),
+        Some("\\\"abc"),
+        Some("abc\\\""),
+        Some("abc"), // Multiline strings are split into single strings in Swift
+        Some("def")
+      )
+    }
   }
 
 }

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/ExpressionTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/ExpressionTests.scala
@@ -441,11 +441,11 @@ class ExpressionTests extends AstSwiftSrc2CpgSuite {
            |""".stripMargin)
 
       cpg.literal.strippedCode.l shouldBe List(
-        Some("abc"),
-        Some("\\\"abc"),
-        Some("abc\\\""),
-        Some("abc"), // Multiline strings are split into single strings in Swift
-        Some("def")
+        "abc",
+        "\\\"abc",
+        "abc\\\"",
+        "abc", // Multiline strings are split into single strings in Swift
+        "def"
       )
     }
   }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/LiteralMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/LiteralMethods.scala
@@ -13,8 +13,14 @@ import scala.collection.immutable.HashMap
 
 class LiteralMethods(val literal: Literal) extends AnyVal with NodeExtension with HasLocation {
   def strippedCode: String = {
-    val language         = Cpg(literal.graph).metaData.language.head
-    val stringDelimiters = delimiters(language)
+    val stringDelimiters = Cpg(literal.graph).metaData.language.headOption match {
+      case Some(language) => delimiters(language)
+      case None =>
+        logger.warn("Language not found for literal")
+        "\"" :: Nil
+    }
+
+    val code = literal.code
 
     stringDelimiters
       .filter(literal.code.startsWith(_))

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/LiteralMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/LiteralMethods.scala
@@ -13,14 +13,10 @@ import scala.collection.immutable.HashMap
 
 class LiteralMethods(val literal: Literal) extends AnyVal with NodeExtension with HasLocation {
   def strippedCode: String = {
-    val stringDelimiter = Cpg(literal.graph).metaData.language.headOption match {
-      case Some(language) => delimiters(language)
-      case _ =>
-        logger.warn("Language must be defined for literal")
-        return literal.code
-    }
+    val language         = Cpg(literal.graph).metaData.language.head
+    val stringDelimiters = delimiters(language)
 
-    stringDelimiter
+    stringDelimiters
       .filter(literal.code.startsWith(_))
       .map(delimiter =>
         val delimiterLength = delimiter.length

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/LiteralMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/LiteralMethods.scala
@@ -25,11 +25,8 @@ class LiteralMethods(val literal: Literal) extends AnyVal with NodeExtension wit
     stringDelimiters
       .filter(literal.code.startsWith(_))
       .map(delimiter =>
-        val delimiterLength = delimiter.length
-        val start =
-          if (delimiter == "\"\"\"" || delimiter == "'''") then literal.code.indexOf(delimiter) + delimiterLength
-          else literal.code.indexOf(delimiter) + delimiterLength
-        val end = literal.code.lastIndexOf(delimiter)
+        val start = literal.code.indexOf(delimiter) + delimiter.length
+        val end   = literal.code.lastIndexOf(delimiter)
 
         literal.code.substring(start, end)
       )

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/LiteralMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/LiteralMethods.scala
@@ -12,7 +12,14 @@ class LiteralMethods(val literal: Literal) extends AnyVal with NodeExtension wit
   def innerText: Option[String] = {
     delimiters(literal)
       .filter(literal.code.startsWith(_))
-      .map(StringUtils.strip(literal.code, _))
+      .map(delimiter =>
+        val start =
+          if (delimiter == "\"\"\"" || delimiter == "'''") then literal.code.indexOf(delimiter) + 3
+          else literal.code.indexOf(delimiter) + 1
+        val end = literal.code.lastIndexOf(delimiter)
+
+        literal.code.substring(start, end)
+      )
       .headOption
   }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/LiteralMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/LiteralMethods.scala
@@ -13,14 +13,8 @@ import scala.collection.immutable.HashMap
 
 class LiteralMethods(val literal: Literal) extends AnyVal with NodeExtension with HasLocation {
   def strippedCode: String = {
-    val stringDelimiters = Cpg(literal.graph).metaData.language.headOption match {
-      case Some(language) => delimiters(language)
-      case None =>
-        logger.warn("Language not found for literal")
-        "\"" :: Nil
-    }
-
-    val code = literal.code
+    val language         = Cpg(literal.graph).metaData.language.head
+    val stringDelimiters = delimiters(language)
 
     stringDelimiters
       .filter(literal.code.startsWith(_))

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/LiteralMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/LiteralMethods.scala
@@ -25,7 +25,10 @@ class LiteralMethods(val literal: Literal) extends AnyVal with NodeExtension wit
           else literal.code.indexOf(delimiter) + 1
         val end = literal.code.lastIndexOf(delimiter)
 
-        literal.code.substring(start, end)
+        /* Windows uses `\r\n` for new line characters, but this can cause issues on different operating systems. So
+        we replace all `\r\n` to have consistency across all OS
+         */
+        literal.code.substring(start, end).replaceAll("\r\n", "\n")
       )
       .headOption
   }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/LiteralMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/LiteralMethods.scala
@@ -5,43 +5,40 @@ import io.shiftleft.codepropertygraph.generated.Languages
 import io.shiftleft.codepropertygraph.generated.nodes.{Literal, NewLocation}
 import io.shiftleft.semanticcpg.NodeExtension
 import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.language.nodemethods.LiteralMethods.delimiters
+import org.apache.commons.lang3.StringUtils
 
 class LiteralMethods(val literal: Literal) extends AnyVal with NodeExtension with HasLocation {
   def innerText: Option[String] = {
-    val delimiters = Cpg(literal.graph).metaData.language.headOption match {
-      case Some(Languages.JAVASRC | Languages.JAVA | Languages.KOTLIN | Languages.SWIFTSRC) =>
-        "\"\"\"" :: "\"" :: Nil
-      case Some(Languages.C | Languages.NEWC | Languages.PHP) =>
-        "\"" :: "'" :: Nil
-      case Some(Languages.JAVASCRIPT | Languages.JSSRC) =>
-        "\"" :: "'" :: "`" :: Nil
-      case Some(Languages.GOLANG) =>
-        "\"" :: "`" :: Nil
-      case Some(Languages.CSHARP | Languages.CSHARPSRC) =>
-        "\"" :: Nil
-      case Some(Languages.RUBYSRC) =>
-        "\"" :: "'" :: Nil
-      case Some(Languages.PYTHON | Languages.PYTHONSRC) =>
-        "\"\"\"" :: "'''" :: "\"" :: "'" :: Nil
-      case _ =>
-        "\"" :: Nil
-    }
-
-    delimiters
+    delimiters(literal)
       .filter(literal.code.startsWith(_))
-      .map { delimiter =>
-        val start =
-          if (delimiter == "\"\"\"" || delimiter == "'''") then literal.code.indexOf(delimiter) + 3
-          else literal.code.indexOf(delimiter) + 1
-        val end = literal.code.lastIndexOf(delimiter)
-
-        literal.code.substring(start, end)
-      }
+      .map(StringUtils.strip(literal.code, _))
       .headOption
   }
 
   override def location: NewLocation = {
     LocationCreator(literal, literal.code, literal.label, literal.lineNumber, literal.method)
 
+  }
+}
+
+object LiteralMethods {
+  def delimiters(literal: Literal): List[String] = Cpg(literal.graph).metaData.language.headOption match {
+    case Some(Languages.JAVASRC | Languages.JAVA | Languages.KOTLIN | Languages.SWIFTSRC) =>
+      "\"\"\"" :: "\"" :: Nil
+    case Some(Languages.C | Languages.NEWC | Languages.PHP) =>
+      "\"" :: "'" :: Nil
+    case Some(Languages.JAVASCRIPT | Languages.JSSRC) =>
+      "\"" :: "'" :: "`" :: Nil
+    case Some(Languages.GOLANG) =>
+      "\"" :: "`" :: Nil
+    case Some(Languages.CSHARP | Languages.CSHARPSRC) =>
+      "\"" :: Nil
+    case Some(Languages.RUBYSRC) =>
+      "\"" :: "'" :: Nil
+    case Some(Languages.PYTHON | Languages.PYTHONSRC) =>
+      "\"\"\"" :: "'''" :: "\"" :: "'" :: Nil
+    case _ =>
+      "\"" :: Nil
   }
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/LiteralMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/LiteralMethods.scala
@@ -1,16 +1,43 @@
 package io.shiftleft.semanticcpg.language.nodemethods
 
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.Languages
 import io.shiftleft.codepropertygraph.generated.nodes.{Literal, NewLocation}
 import io.shiftleft.semanticcpg.NodeExtension
 import io.shiftleft.semanticcpg.language.*
 
 class LiteralMethods(val literal: Literal) extends AnyVal with NodeExtension with HasLocation {
-  def value(typeFullName: String): String = {
-    if (literal.typeFullName == typeFullName) {
-      return "asd"
+  def innerText: Option[String] = {
+    val delimiters = Cpg(literal.graph).metaData.language.headOption match {
+      case Some(Languages.JAVASRC | Languages.JAVA | Languages.KOTLIN | Languages.SWIFTSRC) =>
+        "\"\"\"" :: "\"" :: Nil
+      case Some(Languages.C | Languages.NEWC | Languages.PHP) =>
+        "\"" :: "'" :: Nil
+      case Some(Languages.JAVASCRIPT | Languages.JSSRC) =>
+        "\"" :: "'" :: "`" :: Nil
+      case Some(Languages.GOLANG) =>
+        "\"" :: "`" :: Nil
+      case Some(Languages.CSHARP | Languages.CSHARPSRC) =>
+        "\"" :: Nil
+      case Some(Languages.RUBYSRC) =>
+        "\"" :: "'" :: Nil
+      case Some(Languages.PYTHON | Languages.PYTHONSRC) =>
+        "\"\"\"" :: "'''" :: "\"" :: "'" :: Nil
+      case _ =>
+        "\"" :: Nil
     }
 
-    return ""
+    delimiters
+      .filter(literal.code.startsWith(_))
+      .map { delimiter =>
+        val start =
+          if (delimiter == "\"\"\"" || delimiter == "'''") then literal.code.indexOf(delimiter) + 3
+          else literal.code.indexOf(delimiter) + 1
+        val end = literal.code.lastIndexOf(delimiter)
+
+        literal.code.substring(start, end)
+      }
+      .headOption
   }
 
   override def location: NewLocation = {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -96,9 +96,10 @@ package object language
   ): AnnotationParameterAssignTraversal =
     new AnnotationParameterAssignTraversal(a.iterator)
 
-  implicit def toMember(traversal: IterableOnce[Member]): MemberTraversal = new MemberTraversal(traversal.iterator)
-  implicit def toLocal(traversal: IterableOnce[Local]): LocalTraversal    = new LocalTraversal(traversal.iterator)
-  implicit def toMethod(traversal: IterableOnce[Method]): OriginalMethod  = new OriginalMethod(traversal.iterator)
+  implicit def toMember(traversal: IterableOnce[Member]): MemberTraversal    = new MemberTraversal(traversal.iterator)
+  implicit def toLocal(traversal: IterableOnce[Local]): LocalTraversal       = new LocalTraversal(traversal.iterator)
+  implicit def toMethod(traversal: IterableOnce[Method]): OriginalMethod     = new OriginalMethod(traversal.iterator)
+  implicit def toLiteral(traversal: IterableOnce[Literal]): LiteralTraversal = new LiteralTraversal(traversal.iterator)
 
   implicit def singleToMethodParameterInTrav[A <: MethodParameterIn](a: A): MethodParameterTraversal =
     new MethodParameterTraversal(Iterator.single(a))

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/LiteralTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/LiteralTraversal.scala
@@ -4,6 +4,6 @@ import io.shiftleft.codepropertygraph.generated.nodes.Literal
 import io.shiftleft.semanticcpg.language.toLiteralMethods
 
 class LiteralTraversal(val traversal: Iterator[Literal]) extends AnyVal {
-  def strippedCode: Iterator[Option[String]] =
+  def strippedCode: Iterator[String] =
     traversal.map(_.strippedCode)
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/LiteralTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/LiteralTraversal.scala
@@ -4,6 +4,6 @@ import io.shiftleft.codepropertygraph.generated.nodes.Literal
 import io.shiftleft.semanticcpg.language.toLiteralMethods
 
 class LiteralTraversal(val traversal: Iterator[Literal]) extends AnyVal {
-  def innerText: Iterator[Option[String]] =
-    traversal.map(_.innerText)
+  def strippedCode: Iterator[Option[String]] =
+    traversal.map(_.strippedCode)
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/LiteralTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/LiteralTraversal.scala
@@ -1,0 +1,9 @@
+package io.shiftleft.semanticcpg.language.types.structure
+
+import io.shiftleft.codepropertygraph.generated.nodes.Literal
+import io.shiftleft.semanticcpg.language.toLiteralMethods
+
+class LiteralTraversal(val traversal: Iterator[Literal]) extends AnyVal {
+  def innerText: Iterator[Option[String]] =
+    traversal.map(_.innerText)
+}


### PR DESCRIPTION
* Added a new `.innerText` step for String literals to get the value inside the quotes
* Returns `Some(string)` if the literal is a `string` and has surrounding quotes (language specific), otherwise returns `None`
* Only works on `LITERAL` nodes, not on interpolated strings that are transformed into calls in the AST.