### PR TITLE
temporarily set read timeout to an extremely high value (12 hours)...

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,6 +100,7 @@ Global / onChangedBuildSource := ReloadOnSourceChanges
 // publishing info for sonatype / maven central
 ThisBuild / publishTo              := sonatypePublishToBundle.value
 ThisBuild / sonatypeCredentialHost := xerial.sbt.Sonatype.sonatypeCentralHost
+sonatypeTimeoutMillis  := 43200000 // temporarily set read timeout to an extremely high value (12 hours), mostly to see if this has any effect at all...
 
 ThisBuild / scmInfo  := Some(ScmInfo(url("https://github.com/joernio/joern"), "scm:git@github.com:joernio/joern.git"))
 ThisBuild / homepage := Some(url("https://joern.io/"))


### PR DESCRIPTION
... mostly to see if this has any effect at all.
We keep running into read timeouts at the final step (validating the
release), but the timeouts don't quite make sense...

see e.g. https://github.com/joernio/joern/actions/runs/13967737826/job/39101942676

```
2025-03-20 11:38:44.040Z  info [SonatypeCentralClient] Uploading bundle /home/runner/work/joern/joern/target/sonatype-staging/4.0.299-bundle/bundle.zip to Sonatype Central  - (SonatypeCentralClient.scala:72)
  +4 seconds:
2025-03-20 11:38:47.814Z  info [SonatypeCentralService] Checking if deployment succeeded for deployment id: 583c03d8-b0cb-431f-b3d5-a7990a1e435d...  - (SonatypeCentralService.scala:27)
  +16mins
           11:54:06.356 [main] ERROR sttp.client4.logging.slf4j.Slf4jLoggingBackend - Exception when sending request: POST https://central.sonatype.com/api/v1/publisher/status?id=583c03d8-b0cb-431f-b3d5-a7990a1e435d, took: 5.085s
sttp.client4.SttpClientException$TimeoutException: Exception when sending request: POST https://central.sonatype.com/api/v1/publisher/status?id=583c03d8-b0cb-431f-b3d5-a7990a1e435d
	at sttp.client4.SttpClientExceptionExtensions.defaultExceptionToSttpClientException(SttpClientExceptionExtensions.scala:21) ~[?:?]
```