### PR TITLE
[c2cpg] Make bindings also unique to the PolicyLinker

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/FullNameUniquenessPass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/FullNameUniquenessPass.scala
@@ -71,6 +71,7 @@ class FullNameUniquenessPass(cpg: Cpg) extends CpgPass(cpg) {
         if (method.isStatic.nonEmpty) {
           val callCandidates = callsAffected.filter(_.file.exists(_.name == method.filename))
           callCandidates.foreach { call =>
+            dstGraph.setNodeProperty(call, Call.PropertyNames.Name, s"${call.name}$suffix")
             dstGraph.setNodeProperty(call, Call.PropertyNames.MethodFullName, newFullName)
           }
         }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/FullNameUniquenessPass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/FullNameUniquenessPass.scala
@@ -52,17 +52,19 @@ class FullNameUniquenessPass(cpg: Cpg) extends CpgPass(cpg) {
         cpg.call.methodFullNameExact(fullName).filterNot(_.file.exists(_.name == sortedMethods.head.filename)).l
       lazy val bindingsAffected = cpg.binding.methodFullNameExact(fullName).l
       sortedMethods.tail.zipWithIndex.foreach { case (method, index) =>
+        val suffix      = s"${Defines.DuplicateSuffix}$index"
         val signature   = method.signature
         val isCFunction = !fullName.endsWith(s":$signature")
         val newFullName = if (isCFunction) {
-          s"$fullName${Defines.DuplicateSuffix}$index"
+          s"$fullName$suffix"
         } else {
           val fullNameWithoutSignature = fullName.stripSuffix(s":$signature")
-          s"$fullNameWithoutSignature${Defines.DuplicateSuffix}$index:$signature"
+          s"$fullNameWithoutSignature$suffix:$signature"
         }
         dstGraph.setNodeProperty(method, Method.PropertyNames.FullName, newFullName)
         // fixup bindings
         bindingsAffected.filter(_.refOut.contains(method)).foreach { binding =>
+          dstGraph.setNodeProperty(binding, Binding.PropertyNames.Name, s"${binding.name}$suffix")
           dstGraph.setNodeProperty(binding, Binding.PropertyNames.MethodFullName, newFullName)
         }
         // fixup calls to static methods in the same compilation unit via the naive namespace-by-filename approach
@@ -127,7 +129,8 @@ class FullNameUniquenessPass(cpg: Cpg) extends CpgPass(cpg) {
       logDuplicates(nodesList, fullName)
       val sortedNodes = sortNodesByLocation(nodesList)
       sortedNodes.tail.zipWithIndex.foreach { case (node, index) =>
-        val newFullName = s"${node.fullName}${Defines.DuplicateSuffix}$index"
+        val suffix      = s"${Defines.DuplicateSuffix}$index"
+        val newFullName = s"${node.fullName}$suffix"
         dstGraph.setNodeProperty(node, fullNameProperty, newFullName)
       }
     }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/FullNameUniquenessPassTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/FullNameUniquenessPassTests.scala
@@ -132,7 +132,7 @@ class FullNameUniquenessPassTests extends C2CpgSuite {
         "f in main.c -> CALL -> f in main.c",
         "m in main.c -> CALL -> m in main.c",
         "sf in a.c -> CALL -> sf in a.c",
-        "sf in main.c -> CALL -> sf<duplicate>0 in main.c" // fixed call here
+        "sf<duplicate>0 in main.c -> CALL -> sf<duplicate>0 in main.c" // fixed call here
       )
     }
   }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/FullNameUniquenessPassTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/FullNameUniquenessPassTests.scala
@@ -4,9 +4,9 @@ import io.joern.c2cpg.testfixtures.C2CpgSuite
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 
-class MethodFullNameUniquenessPassTests extends C2CpgSuite {
+class FullNameUniquenessPassTests extends C2CpgSuite {
 
-  "the MethodUniquenessPass" should {
+  "the FullNameUniquenessPass" should {
     "create truly unique method fullnames for multiple C functions" in {
       val cpg = code(
         """
@@ -32,6 +32,31 @@ class MethodFullNameUniquenessPassTests extends C2CpgSuite {
         "foo",
         "foo<duplicate>0",
         "main"
+      )
+    }
+
+    "create truly unique method fullnames and bindings for templated C++ functions" in {
+      val cpg = code(
+        """
+          |class Foo {
+          |  public:
+          |    template<typename Bar, Kind k>
+          |    bool foo(Bar x) { return true; }
+          |
+          |    template<typename Bar>
+          |    bool foo(Bar x) { return false; }
+          |}
+          |""".stripMargin,
+        "main.cpp"
+      )
+      cpg.method.fullName.size shouldBe cpg.method.fullName.toSet.size
+      cpg.method.nameNot(NamespaceTraversal.globalNamespaceName).fullName.sorted.l shouldBe List(
+        "Foo.foo:bool(Bar)",
+        "Foo.foo<duplicate>0:bool(Bar)"
+      )
+      cpg.binding.l.map(b => (b.methodFullName, b.name, b.signature)) shouldBe List(
+        ("Foo.foo:bool(Bar)", "foo", "bool(Bar)"),
+        ("Foo.foo<duplicate>0:bool(Bar)", "foo<duplicate>0", "bool(Bar)")
       )
     }
 


### PR DESCRIPTION
The PolicyLinker compares them  by name + signature so adjusting the fullname was not enough. We set the name now also. That should not break things as the REFed  method stays the same (REF edge is already there).