### PR TITLE
Add ref edge to this for explicit super receiver

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForSimpleExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForSimpleExpressionsCreator.scala
@@ -336,7 +336,10 @@ trait AstForSimpleExpressionsCreator { this: AstCreator =>
         .getOrElse(defaultTypeFallback())
 
     val identifier = identifierNode(superExpr, NameConstants.This, NameConstants.Super, typeFullName)
-    Ast(identifier)
+
+    val refsTo = scope.lookupVariable(NameConstants.This).variableNode.toList
+
+    Ast(identifier).withRefEdges(identifier, refsTo)
   }
 
   private[expressions] def astForThisExpr(expr: ThisExpr, expectedType: ExpectedType): Ast = {


### PR DESCRIPTION
Calls with an explicit `super` receiver, e.g. `super.foo()` were missing a `REF` edge to the `this` parameter of the method in which it is called. This PR fixes that.