### PR TITLE
[x2cpg] frontend server mode: add a timeout option to shutdown automatically 

### DIFF
--- a/joern-cli/frontends/c2cpg/c2cpg.sh
+++ b/joern-cli/frontends/c2cpg/c2cpg.sh
@@ -4,4 +4,4 @@ SCRIPT_ABS_PATH=$(readlink -f "$0")
 SCRIPT_ABS_DIR=$(dirname $SCRIPT_ABS_PATH)
 LOG4J2_CONFIG="${SCRIPT_ABS_DIR}/src/main/resources/log4j2.xml"
 
-"${SCRIPT_ABS_DIR}/target/universal/stage/bin/c2cpg.sh" -Dlog4j2.formatMsgNoLookups=true -Dlog4j.configurationFile="${LOG4J2_CONFIG}" "$@"
+exec "${SCRIPT_ABS_DIR}/target/universal/stage/bin/c2cpg.sh" -Dlog4j2.formatMsgNoLookups=true -Dlog4j.configurationFile="${LOG4J2_CONFIG}" "$@"

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/Main.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/Main.scala
@@ -120,7 +120,7 @@ object Main extends X2CpgMain(cmdLineParser, new C2Cpg()) with FrontendHTTPServe
 
   override def run(config: Config, c2cpg: C2Cpg): Unit = {
     config match {
-      case c if c.serverMode      => startup()
+      case c if c.serverMode      => startup(); config.serverTimeoutSeconds.foreach(serveUntilTimeout)
       case c if c.printIfDefsOnly => c2cpg.printIfDefsOnly(config)
       case _                      => c2cpg.run(config)
     }

--- a/joern-cli/frontends/c2cpg/src/universal/bin/c2cpg.sh
+++ b/joern-cli/frontends/c2cpg/src/universal/bin/c2cpg.sh
@@ -14,4 +14,4 @@ if [ ! -f "$SCRIPT" ]; then
     exit 1
 fi
 
-$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -Dlog4j.configurationFile="$SCRIPT_ABS_DIR"/conf/log4j2.xml "$@"
+exec $SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -Dlog4j.configurationFile="$SCRIPT_ABS_DIR"/conf/log4j2.xml "$@"

--- a/joern-cli/frontends/csharpsrc2cpg/csharpsrc2cpg.sh
+++ b/joern-cli/frontends/csharpsrc2cpg/csharpsrc2cpg.sh
@@ -4,4 +4,4 @@ SCRIPT_ABS_PATH=$(readlink -f "$0")
 SCRIPT_ABS_DIR=$(dirname $SCRIPT_ABS_PATH)
 LOG4J2_CONFIG="${SCRIPT_ABS_DIR}/src/main/resources/log4j2.xml"
 
-"${SCRIPT_ABS_DIR}/target/universal/stage/bin/csharpsrc2cpg.sh" -Dlog4j2.formatMsgNoLookups=true -Dlog4j.configurationFile="${LOG4J2_CONFIG}" "$@"
+exec "${SCRIPT_ABS_DIR}/target/universal/stage/bin/csharpsrc2cpg.sh" -Dlog4j2.formatMsgNoLookups=true -Dlog4j.configurationFile="${LOG4J2_CONFIG}" "$@"

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/Main.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/Main.scala
@@ -65,7 +65,7 @@ object Main extends X2CpgMain(cmdLineParser, new CSharpSrc2Cpg()) with FrontendH
   override protected def newDefaultConfig(): Config = Config()
 
   def run(config: Config, csharpsrc2cpg: CSharpSrc2Cpg): Unit = {
-    if (config.serverMode) { startup() }
+    if (config.serverMode) { startup(); config.serverTimeoutSeconds.foreach(serveUntilTimeout) }
     else {
       val absPath = Paths.get(config.inputPath).toAbsolutePath.toString
       if (Environment.pathExists(absPath)) {

--- a/joern-cli/frontends/csharpsrc2cpg/src/universal/bin/csharpsrc2cpg.sh
+++ b/joern-cli/frontends/csharpsrc2cpg/src/universal/bin/csharpsrc2cpg.sh
@@ -14,4 +14,4 @@ if [ ! -f "$SCRIPT" ]; then
     exit 1
 fi
 
-$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -Dlog4j.configurationFile="$SCRIPT_ABS_DIR"/conf/log4j2.xml "$@"
+exec $SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -Dlog4j.configurationFile="$SCRIPT_ABS_DIR"/conf/log4j2.xml "$@"

--- a/joern-cli/frontends/ghidra2cpg/ghidra2cpg.sh
+++ b/joern-cli/frontends/ghidra2cpg/ghidra2cpg.sh
@@ -3,4 +3,4 @@
 SCRIPT_ABS_PATH=$(readlink -f "$0")
 SCRIPT_ABS_DIR=$(dirname $SCRIPT_ABS_PATH)
 
-$SCRIPT_ABS_DIR/target/universal/stage/bin/ghidra2cpg.sh $@
+exec $SCRIPT_ABS_DIR/target/universal/stage/bin/ghidra2cpg.sh $@

--- a/joern-cli/frontends/ghidra2cpg/src/universal/bin/ghidra2cpg.sh
+++ b/joern-cli/frontends/ghidra2cpg/src/universal/bin/ghidra2cpg.sh
@@ -14,4 +14,4 @@ if [ ! -f "$SCRIPT" ]; then
     exit 1
 fi
 
-$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -Dlog4j.configurationFile="$SCRIPT_ABS_DIR"/conf/log4j2.xml "$@"
+exec $SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -Dlog4j.configurationFile="$SCRIPT_ABS_DIR"/conf/log4j2.xml "$@"

--- a/joern-cli/frontends/gosrc2cpg/gosrc2cpg.sh
+++ b/joern-cli/frontends/gosrc2cpg/gosrc2cpg.sh
@@ -4,4 +4,4 @@ SCRIPT_ABS_PATH=$(readlink -f "$0")
 SCRIPT_ABS_DIR=$(dirname $SCRIPT_ABS_PATH)
 LOG4J2_CONFIG="${SCRIPT_ABS_DIR}/src/main/resources/log4j2.xml"
 
-"${SCRIPT_ABS_DIR}/target/universal/stage/bin/gosrc2cpg" -Dlog4j2.formatMsgNoLookups=true -Dlog4j.configurationFile="${LOG4J2_CONFIG}" "$@"
+exec "${SCRIPT_ABS_DIR}/target/universal/stage/bin/gosrc2cpg" -Dlog4j2.formatMsgNoLookups=true -Dlog4j.configurationFile="${LOG4J2_CONFIG}" "$@"

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/Main.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/Main.scala
@@ -48,7 +48,7 @@ object Main extends X2CpgMain(cmdLineParser, new GoSrc2Cpg()) with FrontendHTTPS
   override protected def newDefaultConfig(): Config = Config()
 
   def run(config: Config, gosrc2cpg: GoSrc2Cpg): Unit = {
-    if (config.serverMode) { startup() }
+    if (config.serverMode) { startup(); config.serverTimeoutSeconds.foreach(serveUntilTimeout) }
     else {
       val absPath = Paths.get(config.inputPath).toAbsolutePath.toString
       gosrc2cpg.run(config.withInputPath(absPath))

--- a/joern-cli/frontends/javasrc2cpg/javasrc2cpg.sh
+++ b/joern-cli/frontends/javasrc2cpg/javasrc2cpg.sh
@@ -4,4 +4,4 @@ SCRIPT_ABS_PATH=$(readlink -f "$0")
 SCRIPT_ABS_DIR=$(dirname $SCRIPT_ABS_PATH)
 LOG4J2_CONFIG="${SCRIPT_ABS_DIR}/src/main/resources/log4j2.xml"
 
-"${SCRIPT_ABS_DIR}/target/universal/stage/bin/javasrc2cpg.sh" -Dlog4j2.formatMsgNoLookups=true -Dlog4j.configurationFile="${LOG4J2_CONFIG}" "$@"
+exec "${SCRIPT_ABS_DIR}/target/universal/stage/bin/javasrc2cpg.sh" -Dlog4j2.formatMsgNoLookups=true -Dlog4j.configurationFile="${LOG4J2_CONFIG}" "$@"

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
@@ -164,7 +164,7 @@ object Main extends X2CpgMain(cmdLineParser, new JavaSrc2Cpg()) with FrontendHTT
 
   def run(config: Config, javasrc2Cpg: JavaSrc2Cpg): Unit = {
     config match {
-      case c if c.serverMode         => startup()
+      case c if c.serverMode         => startup(); c.serverTimeoutSeconds.foreach(serveUntilTimeout)
       case c if c.showEnv            => JavaSrc2Cpg.showEnv()
       case c if c.dumpJavaparserAsts => JavaParserAstPrinter.printJpAsts(c)
       case _                         => javasrc2Cpg.run(config)

--- a/joern-cli/frontends/javasrc2cpg/src/universal/bin/javasrc2cpg.sh
+++ b/joern-cli/frontends/javasrc2cpg/src/universal/bin/javasrc2cpg.sh
@@ -14,4 +14,4 @@ if [ ! -f "$SCRIPT" ]; then
     exit 1
 fi
 
-$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -Dlog4j.configurationFile="$SCRIPT_ABS_DIR"/conf/log4j2.xml "$@"
+exec $SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -Dlog4j.configurationFile="$SCRIPT_ABS_DIR"/conf/log4j2.xml "$@"

--- a/joern-cli/frontends/jimple2cpg/jimple2cpg.sh
+++ b/joern-cli/frontends/jimple2cpg/jimple2cpg.sh
@@ -3,4 +3,4 @@
 SCRIPT_ABS_PATH=$(readlink -f "$0")
 SCRIPT_ABS_DIR=$(dirname $SCRIPT_ABS_PATH)
 
-$SCRIPT_ABS_DIR/target/universal/stage/bin/jimple2cpg.sh $@
+exec $SCRIPT_ABS_DIR/target/universal/stage/bin/jimple2cpg.sh $@

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Main.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Main.scala
@@ -84,7 +84,7 @@ object Main extends X2CpgMain(cmdLineParser, new Jimple2Cpg()) with FrontendHTTP
   override protected val executor: ExecutorService = FrontendHTTPServer.singleThreadExecutor()
 
   def run(config: Config, jimple2Cpg: Jimple2Cpg): Unit = {
-    if (config.serverMode) { startup() }
+    if (config.serverMode) { startup(); config.serverTimeoutSeconds.foreach(serveUntilTimeout) }
     else { jimple2Cpg.run(config) }
   }
 }

--- a/joern-cli/frontends/jimple2cpg/src/universal/bin/jimple2cpg.sh
+++ b/joern-cli/frontends/jimple2cpg/src/universal/bin/jimple2cpg.sh
@@ -14,4 +14,4 @@ if [ ! -f "$SCRIPT" ]; then
     exit 1
 fi
 
-$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -Dlog4j.configurationFile="$SCRIPT_ABS_DIR"/conf/log4j2.xml "$@"
+exec $SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -Dlog4j.configurationFile="$SCRIPT_ABS_DIR"/conf/log4j2.xml "$@"

--- a/joern-cli/frontends/jssrc2cpg/jssrc2cpg.sh
+++ b/joern-cli/frontends/jssrc2cpg/jssrc2cpg.sh
@@ -4,4 +4,4 @@ SCRIPT_ABS_PATH=$(readlink -f "$0")
 SCRIPT_ABS_DIR=$(dirname $SCRIPT_ABS_PATH)
 LOG4J2_CONFIG="${SCRIPT_ABS_DIR}/src/main/resources/log4j2.xml"
 
-"${SCRIPT_ABS_DIR}/target/universal/stage/bin/jssrc2cpg.sh" -Dlog4j2.formatMsgNoLookups=true -Dlog4j.configurationFile="${LOG4J2_CONFIG}" "$@"
+exec "${SCRIPT_ABS_DIR}/target/universal/stage/bin/jssrc2cpg.sh" -Dlog4j2.formatMsgNoLookups=true -Dlog4j.configurationFile="${LOG4J2_CONFIG}" "$@"

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/Main.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/Main.scala
@@ -40,7 +40,7 @@ object Main extends X2CpgMain(cmdLineParser, new JsSrc2Cpg()) with FrontendHTTPS
   override protected def newDefaultConfig(): Config = Config()
 
   def run(config: Config, jssrc2cpg: JsSrc2Cpg): Unit = {
-    if (config.serverMode) { startup() }
+    if (config.serverMode) { startup(); config.serverTimeoutSeconds.foreach(serveUntilTimeout) }
     else {
       val absPath = Paths.get(config.inputPath).toAbsolutePath.toString
       if (Environment.pathExists(absPath)) {

--- a/joern-cli/frontends/jssrc2cpg/src/universal/bin/jssrc2cpg.sh
+++ b/joern-cli/frontends/jssrc2cpg/src/universal/bin/jssrc2cpg.sh
@@ -14,4 +14,4 @@ if [ ! -f "$SCRIPT" ]; then
     exit 1
 fi
 
-$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -Dlog4j.configurationFile="$SCRIPT_ABS_DIR"/conf/log4j2.xml "$@"
+exec $SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -Dlog4j.configurationFile="$SCRIPT_ABS_DIR"/conf/log4j2.xml "$@"

--- a/joern-cli/frontends/kotlin2cpg/kotlin2cpg.sh
+++ b/joern-cli/frontends/kotlin2cpg/kotlin2cpg.sh
@@ -4,5 +4,5 @@ readonly SCRIPT_DIR=$(dirname "$(realpath "$0")")
 readonly BIN="${SCRIPT_DIR}/target/universal/stage/bin/kotlin2cpg"
 readonly LOG4J2_CONFIG="${SCRIPT_DIR}/src/main/resources/log4j2.xml"
 
-"${BIN}" -Dlog4j2.formatMsgNoLookups=true -Dlog4j.configurationFile="${LOG4J2_CONFIG}" \
+exec "${BIN}" -Dlog4j2.formatMsgNoLookups=true -Dlog4j.configurationFile="${LOG4J2_CONFIG}" \
   "$@"

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Main.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Main.scala
@@ -102,7 +102,7 @@ object Main extends X2CpgMain(cmdLineParser, new Kotlin2Cpg()) with FrontendHTTP
   override protected def newDefaultConfig(): Config = Config()
 
   def run(config: Config, kotlin2cpg: Kotlin2Cpg): Unit = {
-    if (config.serverMode) { startup() }
+    if (config.serverMode) { startup(); config.serverTimeoutSeconds.foreach(serveUntilTimeout) }
     else { kotlin2cpg.run(config) }
   }
 }

--- a/joern-cli/frontends/php2cpg/php2cpg.sh
+++ b/joern-cli/frontends/php2cpg/php2cpg.sh
@@ -4,4 +4,4 @@ SCRIPT_ABS_PATH=$(readlink -f "$0")
 SCRIPT_ABS_DIR=$(dirname $SCRIPT_ABS_PATH)
 LOG4J2_CONFIG="${SCRIPT_ABS_DIR}/src/main/resources/log4j2.xml"
 
-"${SCRIPT_ABS_DIR}/target/universal/stage/bin/php2cpg.sh" -Dlog4j2.formatMsgNoLookups=true -Dlog4j.configurationFile="${LOG4J2_CONFIG}" "$@"
+exec "${SCRIPT_ABS_DIR}/target/universal/stage/bin/php2cpg.sh" -Dlog4j2.formatMsgNoLookups=true -Dlog4j.configurationFile="${LOG4J2_CONFIG}" "$@"

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Main.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Main.scala
@@ -57,7 +57,7 @@ object Main extends X2CpgMain(cmdLineParser, new Php2Cpg()) with FrontendHTTPSer
   override protected def newDefaultConfig(): Config = Config()
 
   def run(config: Config, php2Cpg: Php2Cpg): Unit = {
-    if (config.serverMode) { startup() }
+    if (config.serverMode) { startup(); config.serverTimeoutSeconds.foreach(serveUntilTimeout) }
     else { php2Cpg.run(config) }
   }
 }

--- a/joern-cli/frontends/php2cpg/src/universal/bin/php2cpg.sh
+++ b/joern-cli/frontends/php2cpg/src/universal/bin/php2cpg.sh
@@ -14,4 +14,4 @@ if [ ! -f "$SCRIPT" ]; then
     exit 1
 fi
 
-$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -Dlog4j.configurationFile="$SCRIPT_ABS_DIR"/conf/log4j2.xml "$@"
+exec $SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -Dlog4j.configurationFile="$SCRIPT_ABS_DIR"/conf/log4j2.xml "$@"

--- a/joern-cli/frontends/pysrc2cpg/pysrc2cpg.sh
+++ b/joern-cli/frontends/pysrc2cpg/pysrc2cpg.sh
@@ -6,5 +6,5 @@ readonly SCRIPT_DIR=$(dirname "$(realpath "$0")")
 readonly BIN="${SCRIPT_DIR}/target/universal/stage/bin/pysrc2cpg"
 readonly LOG4J2_CONFIG="${SCRIPT_DIR}/src/main/resources/log4j2.xml"
 
-"${BIN}" -Dlog4j2.formatMsgNoLookups=true -Dlog4j.configurationFile="${LOG4J2_CONFIG}" \
+exec "${BIN}" -Dlog4j2.formatMsgNoLookups=true -Dlog4j.configurationFile="${LOG4J2_CONFIG}" \
   "$@"

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/Main.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/Main.scala
@@ -46,7 +46,7 @@ object NewMain
   override protected def newDefaultConfig(): Py2CpgOnFileSystemConfig = Py2CpgOnFileSystemConfig()
 
   def run(config: Py2CpgOnFileSystemConfig, frontend: Py2CpgOnFileSystem): Unit = {
-    if (config.serverMode) { startup() }
+    if (config.serverMode) { startup(); config.serverTimeoutSeconds.foreach(serveUntilTimeout) }
     else { frontend.run(config) }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/rubysrc2cpg.sh
+++ b/joern-cli/frontends/rubysrc2cpg/rubysrc2cpg.sh
@@ -4,4 +4,4 @@ SCRIPT_ABS_PATH=$(readlink -f "$0")
 SCRIPT_ABS_DIR=$(dirname $SCRIPT_ABS_PATH)
 LOG4J2_CONFIG="${SCRIPT_ABS_DIR}/src/main/resources/log4j2.xml"
 
-"${SCRIPT_ABS_DIR}/target/universal/stage/bin/rubysrc2cpg" -Dlog4j2.formatMsgNoLookups=true -Dlog4j.configurationFile="${LOG4J2_CONFIG}" "$@"
+exec "${SCRIPT_ABS_DIR}/target/universal/stage/bin/rubysrc2cpg" -Dlog4j2.formatMsgNoLookups=true -Dlog4j.configurationFile="${LOG4J2_CONFIG}" "$@"

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/Main.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/Main.scala
@@ -59,7 +59,7 @@ object Main extends X2CpgMain(cmdLineParser, new RubySrc2Cpg()) with FrontendHTT
   override protected def newDefaultConfig(): Config = Config()
 
   def run(config: Config, rubySrc2Cpg: RubySrc2Cpg): Unit = {
-    if (config.serverMode) { startup() }
+    if (config.serverMode) { startup(); config.serverTimeoutSeconds.foreach(serveUntilTimeout) }
     else { rubySrc2Cpg.run(config) }
   }
 }

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/Main.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/Main.scala
@@ -40,7 +40,7 @@ object Main extends X2CpgMain(cmdLineParser, new SwiftSrc2Cpg()) with FrontendHT
   override protected def newDefaultConfig(): Config = Config()
 
   def run(config: Config, swiftsrc2cpg: SwiftSrc2Cpg): Unit = {
-    if (config.serverMode) { startup() }
+    if (config.serverMode) { startup(); config.serverTimeoutSeconds.foreach(serveUntilTimeout) }
     else {
       val absPath = Paths.get(config.inputPath).toAbsolutePath.toString
       if (Environment.pathExists(absPath)) {

--- a/joern-cli/frontends/swiftsrc2cpg/src/universal/bin/swiftsrc2cpg.sh
+++ b/joern-cli/frontends/swiftsrc2cpg/src/universal/bin/swiftsrc2cpg.sh
@@ -14,4 +14,4 @@ if [ ! -f "$SCRIPT" ]; then
     exit 1
 fi
 
-$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -Dlog4j.configurationFile="$SCRIPT_ABS_DIR"/conf/log4j2.xml "$@"
+exec $SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -Dlog4j.configurationFile="$SCRIPT_ABS_DIR"/conf/log4j2.xml "$@"

--- a/joern-cli/frontends/swiftsrc2cpg/swiftsrc2cpg.sh
+++ b/joern-cli/frontends/swiftsrc2cpg/swiftsrc2cpg.sh
@@ -4,4 +4,4 @@ SCRIPT_ABS_PATH=$(readlink -f "$0")
 SCRIPT_ABS_DIR=$(dirname $SCRIPT_ABS_PATH)
 LOG4J2_CONFIG="${SCRIPT_ABS_DIR}/src/main/resources/log4j2.xml"
 
-"${SCRIPT_ABS_DIR}/target/universal/stage/bin/swiftsrc2cpg" -Dlog4j2.formatMsgNoLookups=true -Dlog4j.configurationFile="${LOG4J2_CONFIG}" "$@"
+exec "${SCRIPT_ABS_DIR}/target/universal/stage/bin/swiftsrc2cpg" -Dlog4j2.formatMsgNoLookups=true -Dlog4j.configurationFile="${LOG4J2_CONFIG}" "$@"

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
@@ -20,9 +20,10 @@ object X2CpgConfig {
 }
 
 trait X2CpgConfig[R <: X2CpgConfig[R]] {
-  var inputPath: String   = X2CpgConfig.defaultInputPath
-  var outputPath: String  = X2CpgConfig.defaultOutputPath
-  var serverMode: Boolean = false
+  var inputPath: String                  = X2CpgConfig.defaultInputPath
+  var outputPath: String                 = X2CpgConfig.defaultOutputPath
+  var serverMode: Boolean                = false
+  var serverTimeoutSeconds: Option[Long] = None
 
   def withInputPath(inputPath: String): R = {
     this.inputPath = Paths.get(inputPath).toAbsolutePath.normalize().toString
@@ -37,6 +38,11 @@ trait X2CpgConfig[R <: X2CpgConfig[R]] {
   def withServerMode(x: Boolean): R = {
     this.serverMode = x
     this.asInstanceOf[R]
+  }
+
+  def withServerTimeoutSeconds(x: Long): this.type = {
+    this.serverTimeoutSeconds = Some(x)
+    this
   }
 
   var defaultIgnoredFilesRegex: Seq[Regex] = Seq.empty
@@ -314,6 +320,10 @@ object X2Cpg {
         .action((_, c) => c.withServerMode(true))
         .hidden()
         .text("runs this frontend in server mode (disabled by default)"),
+      opt[Long]("server-timeout-minutes")
+        .action((secs, c) => c.withServerTimeoutSeconds(secs * 60))
+        .hidden()
+        .text("timeout after which the server should terminate (use with --server)"),
       opt[Unit]("disable-file-content")
         .action((_, c) => c.withDisableFileContent(true))
         .hidden()

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
@@ -88,6 +88,7 @@ trait X2CpgConfig[R <: X2CpgConfig[R]] {
     this.inputPath = config.inputPath
     this.outputPath = config.outputPath
     this.serverMode = config.serverMode
+    this.serverTimeoutSeconds = config.serverTimeoutSeconds
     this.defaultIgnoredFilesRegex = config.defaultIgnoredFilesRegex
     this.ignoredFilesRegex = config.ignoredFilesRegex
     this.ignoredFiles = config.ignoredFiles

--- a/joern-cli/src/universal/c2cpg.sh
+++ b/joern-cli/src/universal/c2cpg.sh
@@ -14,4 +14,4 @@ if [ ! -f "$SCRIPT" ]; then
     exit 1
 fi
 
-$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -Dlog4j.configurationFile="$SCRIPT_ABS_DIR"/conf/log4j2.xml "$@"
+exec $SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -Dlog4j.configurationFile="$SCRIPT_ABS_DIR"/conf/log4j2.xml "$@"

--- a/joern-cli/src/universal/jssrc2cpg.sh
+++ b/joern-cli/src/universal/jssrc2cpg.sh
@@ -14,4 +14,4 @@ if [ ! -f "$SCRIPT" ]; then
     exit 1
 fi
 
-$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -Dlog4j.configurationFile="$SCRIPT_ABS_DIR"/conf/log4j2.xml "$@"
+exec $SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -Dlog4j.configurationFile="$SCRIPT_ABS_DIR"/conf/log4j2.xml "$@"

--- a/joern-cli/src/universal/swiftsrc2cpg.sh
+++ b/joern-cli/src/universal/swiftsrc2cpg.sh
@@ -14,4 +14,4 @@ if [ ! -f "$SCRIPT" ]; then
     exit 1
 fi
 
-$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -Dlog4j.configurationFile="$SCRIPT_ABS_DIR"/conf/log4j2.xml "$@"
+exec $SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -Dlog4j.configurationFile="$SCRIPT_ABS_DIR"/conf/log4j2.xml "$@"


### PR DESCRIPTION
I noticed that over time I was accumulating quite a few frontend servers running in the background on my machine. This should stop that (once the code science test suite makes use of the timeout option added here).

- adds a `--server-timeout-minutes=` option, where the server is shut down after disuse
- all the frontend wrapper shell scripts use `exec` now to start the actual frontend, so that anything starting the frontend has an easier time killing the frontend (and not just the shell wrapping the frontend)
- some small simplifications in server code: the shutdown hook is removed, since process exit would stop the server any way. And we let the OS chose the random port for us now.