### PR TITLE
[kotlin2cpg] Another NPE fix

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForFunctionsCreator.scala
@@ -600,14 +600,24 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) {
     }
   }
 
+  private def safeFunctionDescriptorName(f: FunctionDescriptor): String = {
+    // if some type info fails, we may otherwise end up with some NPE at the getName call
+    scala.util.Try(f.getName.toString).toOption.getOrElse(Constants.UnknownLambdaBindingName)
+  }
+
+  private def safeFunctionDescriptorSignature(f: FunctionDescriptor): Option[String] = {
+    // if some type info fails, we may otherwise end up with some NPE in funcDescSignature
+    scala.util.Try(nameRenderer.funcDescSignature(f)).toOption.flatten
+  }
+
   private def createLambdaBindings(
     lambdaMethodNode: NewMethod,
     lambdaTypeDecl: NewTypeDecl,
     samInterface: Option[ClassDescriptor]
   ): Unit = {
     val samMethod          = samInterface.map(SamConversionResolverImplKt.getSingleAbstractMethodOrNull)
-    val samMethodName      = samMethod.map(_.getName.toString).getOrElse(Constants.UnknownLambdaBindingName)
-    val samMethodSignature = samMethod.flatMap(nameRenderer.funcDescSignature)
+    val samMethodName      = samMethod.map(safeFunctionDescriptorName).getOrElse(Constants.UnknownLambdaBindingName)
+    val samMethodSignature = samMethod.flatMap(safeFunctionDescriptorSignature)
 
     if (samMethodSignature.isDefined) {
       val interfaceLambdaBinding = bindingNode(samMethodName, samMethodSignature.get, lambdaMethodNode.fullName)

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForFunctionsCreator.scala
@@ -600,9 +600,9 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) {
     }
   }
 
-  private def safeFunctionDescriptorName(f: FunctionDescriptor): String = {
+  private def safeFunctionDescriptorName(f: FunctionDescriptor): Option[String] = {
     // if some type info fails, we may otherwise end up with some NPE at the getName call
-    scala.util.Try(f.getName.toString).toOption.getOrElse(Constants.UnknownLambdaBindingName)
+    scala.util.Try(f.getName.toString).toOption
   }
 
   private def safeFunctionDescriptorSignature(f: FunctionDescriptor): Option[String] = {
@@ -616,7 +616,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) {
     samInterface: Option[ClassDescriptor]
   ): Unit = {
     val samMethod          = samInterface.map(SamConversionResolverImplKt.getSingleAbstractMethodOrNull)
-    val samMethodName      = samMethod.map(safeFunctionDescriptorName).getOrElse(Constants.UnknownLambdaBindingName)
+    val samMethodName      = samMethod.flatMap(safeFunctionDescriptorName).getOrElse(Constants.UnknownLambdaBindingName)
     val samMethodSignature = samMethod.flatMap(safeFunctionDescriptorSignature)
 
     if (samMethodSignature.isDefined) {


### PR DESCRIPTION
Even so PR #5399 fixed the retrieval of a ClassDescriptor for a given function w.r.t. null safety we may still end up in a situation where the name or signature calculation throws a NPE in case of missing types.