### PR TITLE
[c2cpg] Remove global file offset table

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreator.scala
@@ -15,7 +15,6 @@ import org.eclipse.cdt.core.dom.ast.IASTTranslationUnit
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-import java.util.concurrent.ConcurrentHashMap
 import scala.collection.mutable
 
 /** Translates the Eclipse CDT AST into a CPG AST.
@@ -25,8 +24,7 @@ class AstCreator(
   val global: CGlobal,
   val config: Config,
   val cdtAst: IASTTranslationUnit,
-  val headerFileFinder: HeaderFileFinder,
-  val file2OffsetTable: ConcurrentHashMap[String, Array[Int]]
+  val headerFileFinder: HeaderFileFinder
 ) extends AstCreatorBase[IASTNode, AstCreator](filename)(config.schemaValidation)
     with AstForTypesCreator
     with AstForFunctionsCreator
@@ -113,7 +111,7 @@ class AstCreator(
 
   protected def column(node: IASTNode): Option[Int] = {
     nodeOffsets(node).map { case (startOffset, _) =>
-      offsetToColumn(node, startOffset)
+      offsetToColumn(startOffset)
     }
   }
 
@@ -126,7 +124,7 @@ class AstCreator(
 
   protected def columnEnd(node: IASTNode): Option[Int] = {
     nodeOffsets(node).map { case (_, endOffset) =>
-      offsetToColumn(node, endOffset - 1)
+      offsetToColumn(endOffset - 1)
     }
   }
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
@@ -21,7 +21,6 @@ import org.slf4j.LoggerFactory
 
 import java.nio.file.Path
 import java.nio.file.Paths
-import java.util.concurrent.ConcurrentHashMap
 import scala.collection.mutable
 import scala.util.Failure
 import scala.util.Success
@@ -38,12 +37,10 @@ class AstCreationPass(
 
   private val logger: Logger = LoggerFactory.getLogger(classOf[AstCreationPass])
 
-  private val headerFileFinder                                        = new HeaderFileFinder(config)
-  private val file2OffsetTable: ConcurrentHashMap[String, Array[Int]] = new ConcurrentHashMap()
-
   private val compilationDatabase: mutable.LinkedHashSet[CommandObject] =
     config.compilationDatabase.map(JSONCompilationDatabaseParser.parse).getOrElse(mutable.LinkedHashSet.empty)
 
+  private val headerFileFinder  = new HeaderFileFinder(config)
   private val parser: CdtParser = new CdtParser(config, headerFileFinder, compilationDatabase, global)
 
   override def generateParts(): Array[(Path, ILanguage)] = {
@@ -110,8 +107,7 @@ class AstCreationPass(
           val fileLOC = translationUnit.getRawSignature.linesIterator.size
           report.addReportInfo(relPath, fileLOC, parsed = true)
           Try {
-            val localDiff =
-              new AstCreator(relPath, global, config, translationUnit, headerFileFinder, file2OffsetTable).createAst()
+            val localDiff = new AstCreator(relPath, global, config, translationUnit, headerFileFinder).createAst()
             diffGraph.absorb(localDiff)
           } match {
             case Failure(exception) =>


### PR DESCRIPTION
We do not need a file offset table for a node which is not part of the current compilation unit anyway (stuff from included files is top-level only and already filtered).

This shaves off 6sec on my machine for polarphp (39sec -> 33sec).