### PR TITLE
Fix scaladoc warnings

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/datastructures/CSharpScope.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/datastructures/CSharpScope.scala
@@ -147,8 +147,8 @@ class CSharpScope(summary: CSharpProgramSummary)
     m.isStatic && m.name == name && m.parameterTypes.map(_._2).headOption.contains(thisType)
   }
 
-  /** Tries to find an extension method for [[baseTypeFullName]] with the given [[callName]] and [[argTypes]] in the
-    * types currently in scope.
+  /** Tries to find an extension method for `baseTypeFullName` with the given `callName` and `argTypes` in the types
+    * currently in scope.
     *
     * @param baseTypeFullName
     *   the extension method's `this` argument.

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/utils/Utils.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/utils/Utils.scala
@@ -30,7 +30,7 @@ object Utils {
     s"${sanitizedFileName}_Program"
   }
 
-  /** Strips the signature part from [[fullName]].
+  /** Strips the signature part from `fullName`.
     *
     * Useful when handling nested methods, as method full names include signatures. To avoid a nested method's full name
     * containing both its parent's signature and its own, we remove the parent's signature when entering its scope.

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/util/ProgramHandlingUtil.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/util/ProgramHandlingUtil.scala
@@ -240,7 +240,7 @@ object ProgramHandlingUtil {
 
     def packagePath: Option[String]
 
-    /** Copy the class file to its package path relative to [[destDir]]. This will overwrite a class file at the
+    /** Copy the class file to its package path relative to `destDir`. This will overwrite a class file at the
       * destination if it exists.
       *
       * @param destDir
@@ -302,8 +302,8 @@ object ProgramHandlingUtil {
 
   }
 
-  /** Find <pre>.class</pre> files, including those inside archives and copy them to their package path location
-    * relative to [[destDir]]
+  /** Find `.class` files, including those inside archives and copy them to their package path location relative to
+    * `destDir`.
     *
     * @param src
     *   The file/directory to search.

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/sarif/SarifConfig.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/sarif/SarifConfig.scala
@@ -25,8 +25,7 @@ import java.net.URI
   * @param resultConverter
   *   A transformer class to map from Finding nodes to a SARIF `Result`.
   * @param customSerializers
-  *   Additional JSON serializers for any additional properties for [[io.shiftleft.semanticcpg.sarif.Sarif]] derived
-  *   classes.
+  *   Additional JSON serializers for any additional properties for `Sarif` derived classes.
   */
 case class SarifConfig(
   toolName: String = "Joern",


### PR DESCRIPTION
We had some `Scala3doc: No DRI found for query ` warnings which are now fixed by providing the correct scaladoc. (see: https://github.com/scala/scala3/issues/14212)