### PR TITLE
[x2cpg] Fix crash when GradleDependencies fetches aar without jar

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/GradleDependencies.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/GradleDependencies.scala
@@ -186,7 +186,7 @@ object GradleDependencies {
     val newPath           = aar.toString.replaceFirst(aarFileExtension + "$", "jar")
     val aarUnzipDirSuffix = ".unzipped"
     val outDir            = Paths.get(aar.toString + aarUnzipDirSuffix)
-    aar.unzipTo(outDir, _.getName == jarInsideAarFileName)
+    aar.unzipTo(outDir)
     val outFile = Paths.get(newPath)
     val classesJarEntries =
       Files
@@ -197,7 +197,7 @@ object GradleDependencies {
         .filter(_.fileName == jarInsideAarFileName)
         .toList
     if (classesJarEntries.size != 1) {
-      logger.warn(s"Found aar file without `classes.jar` inside at path $aar")
+      logger.debug(s"Found aar file without `classes.jar` inside at path $aar")
       FileUtil.delete(outDir)
       None
     } else {


### PR DESCRIPTION
The zip filter would filter out and not extract an `aar` not containing a `jar`. `Files.walk(outDir)` would then throw an exception since `outdir` doesn't exist. By removing the filter, the `aar` will always be extracted, preventing the crash. I think this is fine since the `if` statement below filters out these results afterwards regardless.