### PR TITLE
[c#] fix .code property

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 csharpsrc2cpg {
-    dotnetastgen_version: "0.39.0"
+    dotnetastgen_version: "0.42.0"
 }

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstCreatorHelper.scala
@@ -2,7 +2,7 @@ package io.joern.csharpsrc2cpg.astcreation
 
 import io.joern.csharpsrc2cpg.parser.DotNetJsonAst.*
 import io.joern.csharpsrc2cpg.parser.{DotNetJsonAst, DotNetNodeInfo, ParserKeys}
-import io.joern.csharpsrc2cpg.utils.Utils.{withoutSignature}
+import io.joern.csharpsrc2cpg.utils.Utils.withoutSignature
 import io.joern.csharpsrc2cpg.{CSharpDefines, Constants, astcreation}
 import io.joern.x2cpg.utils.IntervalKeyPool
 import io.joern.x2cpg.{Ast, Defines, ValidationMode}
@@ -208,12 +208,8 @@ object AstCreatorHelper {
     val lnEnd    = metaData(ParserKeys.LineEnd).numOpt.map(_.toInt)
     val cnEnd    = metaData(ParserKeys.ColumnEnd).numOpt.map(_.toInt)
     val node     = nodeType(metaData, relativeFileName)
-    val c = node.toString match
-      case "Attribute" =>
-        metaData(ParserKeys.Code).strOpt.map(x => x.takeWhile(x => x != '\n')).getOrElse("<empty>").strip()
-      case _ =>
-        metaData(ParserKeys.Code).strOpt.map(x => x.takeWhile(x => x != '\n' && x != '{')).getOrElse("<empty>").strip()
-    DotNetNodeInfo(node, json, c, ln, cn, lnEnd, cnEnd)
+    val code     = metaData(ParserKeys.Code).strOpt.getOrElse("<empty>").strip()
+    DotNetNodeInfo(node, json, code, ln, cn, lnEnd, cnEnd)
   }
 
   private def nodeType(node: Value, relativeFileName: Option[String] = None): DotNetParserNode =

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/CallTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/CallTests.scala
@@ -196,4 +196,49 @@ class CallTests extends CSharpCode2CpgFixture {
     }
   }
 
+  "call expression statements with surrounding comments" should {
+    val cpg = code("""
+        |/* Hey! */
+        |System.Console.WriteLine("Foo");
+        |// Hey2!
+        |System.Console.WriteLine("Bar");
+        |System.Console.WriteLine(0);
+        |// Hey3!
+        |
+        |System.Console.WriteLine(1); // Hey4!
+        |""".stripMargin)
+
+    "have correct code for call with block comment above it" in {
+      cpg.call.nameExact("WriteLine").code.headOption shouldBe Some("System.Console.WriteLine(\"Foo\")")
+    }
+
+    "have correct code for call with line comment above it" in {
+      cpg.literal("\"Bar\"").inCall.nameExact("WriteLine").code.headOption shouldBe Some(
+        "System.Console.WriteLine(\"Bar\")"
+      )
+    }
+
+    "have correct code for call with line comment below it" in {
+      cpg.literal("0").inCall.nameExact("WriteLine").code.headOption shouldBe Some("System.Console.WriteLine(0)")
+    }
+
+    "have correct code for call with line comment immediately after it (same-line)" in {
+      cpg.literal("1").inCall.nameExact("WriteLine").code.headOption shouldBe Some("System.Console.WriteLine(1)")
+    }
+  }
+
+  "call expression split into multiple statements" should {
+    val cpg = code("""
+        |System.
+        |  Code.
+        |    WriteLine("Foo");
+        |""".stripMargin)
+
+    "have correct code" in {
+      cpg.call.nameExact("WriteLine").code.headOption shouldBe Some("""System.
+        |  Code.
+        |    WriteLine("Foo")""".stripMargin)
+    }
+  }
+
 }

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/MethodTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/MethodTests.scala
@@ -16,8 +16,11 @@ class MethodTests extends CSharpCode2CpgFixture {
       x.fullName shouldBe "HelloWorld.Program.Main:System.Void(System.String[])"
       x.signature shouldBe "System.Void(System.String[])"
       x.filename shouldBe "Program.cs"
-      x.code shouldBe "static void Main(string[] args)"
-
+      x.code shouldBe
+        """static void Main(string[] args)
+          |    {
+          |      Console.WriteLine("Hello, world!");
+          |    }""".stripMargin
       x.typeDecl match
         case Some(typeDecl) => typeDecl.name shouldBe "Program"
         case None           => fail("No TYPE_DECL parent found!")

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/NamespaceTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/NamespaceTests.scala
@@ -11,7 +11,17 @@ class NamespaceTests extends CSharpCode2CpgFixture {
 
     "create a namespace block node" in {
       val helloWorld = cpg.namespaceBlock.nameExact("HelloWorld").head
-      helloWorld.code shouldBe "namespace HelloWorld"
+      helloWorld.code shouldBe """namespace HelloWorld
+                                 |{
+                                 |  class Program
+                                 |  {
+                                 |    static void Main(string[] args)
+                                 |    {
+                                 |      Console.WriteLine("Hello, world!");
+                                 |    }
+                                 |  }
+                                 |
+                                 |}""".stripMargin
       helloWorld.filename shouldBe "Program.cs"
       helloWorld.lineNumber shouldBe Some(2)
       helloWorld.columnNumber shouldBe Some(1)
@@ -26,7 +36,17 @@ class NamespaceTests extends CSharpCode2CpgFixture {
 
     "create a namespace block node" in {
       val helloWorld = cpg.namespaceBlock.nameExact("World").head
-      helloWorld.code shouldBe "namespace Hello.World"
+      helloWorld.code shouldBe """namespace Hello.World
+                                 |{
+                                 |  class Program
+                                 |  {
+                                 |    static void Main(string[] args)
+                                 |    {
+                                 |      Console.WriteLine("Hello, world!");
+                                 |    }
+                                 |  }
+                                 |
+                                 |}""".stripMargin
       helloWorld.filename shouldBe "Program.cs"
       helloWorld.fullName shouldBe "Hello.World"
     }

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/TypeDeclTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/TypeDeclTests.scala
@@ -1,11 +1,11 @@
 package io.joern.csharpsrc2cpg.querying.ast
 
-import io.joern.csharpsrc2cpg.testfixtures.CSharpCode2CpgFixture
-import io.shiftleft.semanticcpg.language.*
-import io.shiftleft.codepropertygraph.generated.ModifierTypes
 import io.joern.csharpsrc2cpg.astcreation.BuiltinTypes
 import io.joern.csharpsrc2cpg.astcreation.BuiltinTypes.DotNetTypeMap
+import io.joern.csharpsrc2cpg.testfixtures.CSharpCode2CpgFixture
 import io.joern.x2cpg.Defines
+import io.shiftleft.codepropertygraph.generated.ModifierTypes
+import io.shiftleft.semanticcpg.language.*
 
 class TypeDeclTests extends CSharpCode2CpgFixture {
 
@@ -14,7 +14,7 @@ class TypeDeclTests extends CSharpCode2CpgFixture {
 
     "generate a type declaration with the correct properties" in {
       val x = cpg.typeDecl.nameExact("Container").head
-      x.code shouldBe "public class Container"
+      x.code shouldBe "public class Container {  }"
       x.fullName shouldBe "Container"
       x.filename shouldBe "Container.cs"
       x.aliasTypeFullName shouldBe None
@@ -39,7 +39,7 @@ class TypeDeclTests extends CSharpCode2CpgFixture {
 
     "generate a type declaration with the correct properties" in {
       val x = cpg.typeDecl.nameExact("SampleClass").head
-      x.code shouldBe "private class SampleClass"
+      x.code shouldBe "private class SampleClass { }"
       x.fullName shouldBe "SampleNamespace.SampleClass"
       x.filename shouldBe "SampleClass.cs"
       x.aliasTypeFullName shouldBe None
@@ -258,7 +258,11 @@ class TypeDeclTests extends CSharpCode2CpgFixture {
       inside(cpg.typeDecl.name("ISampleInterface").headOption) {
         case Some(typeDecl) =>
           typeDecl.fullName shouldBe "Foo.ISampleInterface"
-          typeDecl.code shouldBe "interface ISampleInterface"
+          typeDecl.code shouldBe
+            """interface ISampleInterface
+              | {
+              |     void SampleMethod();
+              | }""".stripMargin
         case None => fail("No interface type declaration node found!")
       }
     }


### PR DESCRIPTION
* Resumes #5314, by upgrading DotNetAstGen to 0.42.0
* Fixes the `.code` property for `CALL` nodes
* No more edge cases in AstCreatorHelper -- doesn't seem to break any test. This effectively shifts the responsibility of formatting a resulting node's `.code` to their respective `astForXXX` methods.