### PR TITLE
[c2cpg] Do not query parse problems all the time

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/ParseProblemsLogger.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/ParseProblemsLogger.scala
@@ -1,6 +1,8 @@
 package io.joern.c2cpg.parser
 
 import org.eclipse.cdt.core.dom.ast.IASTProblem
+import org.eclipse.cdt.core.dom.ast.IASTTranslationUnit
+import org.eclipse.cdt.internal.core.dom.parser.cpp.semantics.CPPVisitor
 import org.slf4j.LoggerFactory
 
 trait ParseProblemsLogger {
@@ -9,8 +11,8 @@ trait ParseProblemsLogger {
 
   private val logger = LoggerFactory.getLogger(classOf[ParseProblemsLogger])
 
-  protected def logProblems(problems: List[IASTProblem]): Unit = {
-    problems.foreach(logProblemNode)
+  protected def logProblems(translationUnit: IASTTranslationUnit): Unit = {
+    CPPVisitor.getProblems(translationUnit).foreach(logProblemNode)
   }
 
   private def logProblemNode(node: IASTProblem): Unit = {


### PR DESCRIPTION
This is a rather small performance boost but notable for larger projects. We only need to retrieve all parse problem if they actually should be logged.