### PR TITLE
[c2cpg] Remove ScopeElementIterator

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
@@ -224,19 +224,19 @@ trait AstCreatorHelper { this: AstCreator =>
     val capturedLocals      = mutable.HashMap.empty[String, NewNode]
 
     resolvedReferenceIt.foreach { case C2CpgScope.ResolvedReference(variableNodeId, origin) =>
-      var currentScope           = origin.stack
+      var maybeScopeElement      = origin.stack
       var currentReference       = origin.referenceNode
       var nextReference: NewNode = null
       var done                   = false
       while (!done) {
         val localOrCapturedLocalNodeOption =
-          if (currentScope.get.nameToVariableNode.contains(origin.variableName)) {
+          if (maybeScopeElement.get.nameToVariableNode.contains(origin.variableName)) {
             done = true
             Option(variableNodeId)
           } else {
-            currentScope.flatMap {
+            maybeScopeElement.flatMap {
               case methodScope: C2CpgScope.MethodScopeElement if methodScope.needsEnclosingScope =>
-                currentScope = Option(C2CpgScope.getEnclosingMethodScopeElement(currentScope))
+                maybeScopeElement = Option(scope.getEnclosingMethodScopeElement(maybeScopeElement))
                 None
               case methodScope: C2CpgScope.MethodScopeElement =>
                 val methodScopeNode          = methodScope.scopeNode
@@ -268,7 +268,7 @@ trait AstCreatorHelper { this: AstCreator =>
           diffGraph.addEdge(currentReference, localOrCapturedLocalNode, EdgeTypes.REF)
           currentReference = nextReference
         }
-        currentScope = currentScope.get.surroundingScope
+        maybeScopeElement = maybeScopeElement.get.surroundingScope
       }
     }
   }


### PR DESCRIPTION
- Simplifies variable lookup using a recursive approach instead of iteration
- Improves variable resolution with cleaner stack-based navigation