### PR TITLE
[ruby] Add Support for ERB files

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/resources/application.conf
@@ -1,4 +1,4 @@
 rubysrc2cpg {
-    ruby_ast_gen_version: "0.37.0"
+    ruby_ast_gen_version: "0.39.0"
     joern_type_stubs_version: "0.6.0"
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/resources/application.conf
@@ -1,4 +1,4 @@
 rubysrc2cpg {
-    ruby_ast_gen_version: "0.33.0"
+    ruby_ast_gen_version: "0.37.0"
     joern_type_stubs_version: "0.6.0"
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -83,7 +83,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
   protected def astForNilBlock: Ast = blockAst(NewBlock(), List(astForNilLiteral))
 
   protected def astForDynamicLiteral(node: DynamicLiteral): Ast = {
-    val fmtValueAsts = node.expressions.map {
+    val fmtValueAsts = node.expressions.collect {
       case stmtList: StatementList if stmtList.size == 1 =>
         val expressionAst = astForExpression(stmtList.statements.head)
         val call = callNode(
@@ -101,7 +101,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
           s"Interpolations containing multiple statements are not supported yet: ${stmtList.text} ($relativeFileName), skipping"
         )
         astForUnknown(stmtList)
-      case node =>
+      case node if (!isLineFeed(node.text)) =>
         val call = callNode(
           node = node,
           code = node.text,
@@ -1087,4 +1087,6 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
   private def getUnaryOperatorName(op: String): Option[String] = UnaryOperatorNames.get(op)
 
   private def getAssignmentOperatorName(op: String): Option[String] = AssignmentOperatorNames.get(op)
+
+  private def isLineFeed(text: String): Boolean = text == "\n" || text == "\r" || text == "\r\n"
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/ConfigFileCreationPass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/ConfigFileCreationPass.scala
@@ -27,8 +27,6 @@ class ConfigFileCreationPass(cpg: Cpg) extends XConfigFileCreationPass(cpg) {
     extensionFilter(".yaml"),
     extensionFilter(".yml"),
     // XML files
-    extensionFilter(".xml"),
-    // ERB files
-    extensionFilter(".erb")
+    extensionFilter(".xml")
   )
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/ConfigFileCreationPass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/ConfigFileCreationPass.scala
@@ -27,6 +27,8 @@ class ConfigFileCreationPass(cpg: Cpg) extends XConfigFileCreationPass(cpg) {
     extensionFilter(".yaml"),
     extensionFilter(".yml"),
     // XML files
-    extensionFilter(".xml")
+    extensionFilter(".xml"),
+    // HTML.ERB files
+    pathEndFilter(".html.erb")
   )
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
@@ -55,6 +55,8 @@ object Defines {
     val splat             = "<operator>.splat"
     val regexpMatch       = "=~"
     val regexpNotMatch    = "!~"
+    val templateOutRaw    = "<operator>.templateOutRaw"
+    val templateOutEscape = "<operator>.templateOutEscape"
 
     val regexMethods = Set("match") // TODO: Figure out how to model these, "sub", "gsub")
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ConfigFileCreationPassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ConfigFileCreationPassTests.scala
@@ -45,4 +45,18 @@ class ConfigFileCreationPassTests extends RubyCode2CpgFixture {
     config.content should include("<p>bar<p>")
   }
 
+  "html erb files should be included" in {
+    val cpg = code(
+      """
+        |<foo>
+        | <p><%= ENV['SOME_VAR'] %></p>
+        |</foo>
+        |""".stripMargin,
+      "config.html.erb"
+    )
+
+    val config = cpg.configFile.name("config.html.erb").head
+    config.content should include("<p><%= ENV['SOME_VAR'] %></p>")
+  }
+
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ConfigFileCreationPassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/ConfigFileCreationPassTests.scala
@@ -45,16 +45,4 @@ class ConfigFileCreationPassTests extends RubyCode2CpgFixture {
     config.content should include("<p>bar<p>")
   }
 
-  "erb files should be included" in {
-    val cpg = code(
-      """
-        |<%= 1 + 2 %>
-        |""".stripMargin,
-      "foo.erb"
-    )
-
-    val config = cpg.configFile.name("foo.erb").head
-    config.content should include("1 + 2")
-  }
-
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ErbTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ErbTests.scala
@@ -1,0 +1,196 @@
+package io.joern.rubysrc2cpg.querying
+
+import io.joern.x2cpg.Defines
+import io.joern.x2cpg.frontendspecific.rubysrc2cpg.Constants
+import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
+import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, Operators}
+import io.shiftleft.codepropertygraph.generated.nodes.{Block, Call, FieldIdentifier, Identifier, Literal}
+import io.shiftleft.semanticcpg.language.*
+
+class ErbTests extends RubyCode2CpgFixture {
+  "Complete ERB processing" should {
+    val cpg = code(
+      """
+        |app_name: <%= ENV['APP_NAME'] %>
+        |version: <%= ENV['APP_VERSION'] %>
+        |
+        |database:
+        |  host: <%= ENV['DB_HOST'] %>
+        |  port: <%= ENV['DB_PORT'] %>
+        |
+        |<% if ENV['USE_REDIS'] == 'true' %>
+        |redis:
+        |  host: <%= ENV['REDIS_HOST'] %>
+        |  port: <%= ENV['REDIS_PORT'] %>
+        |<% end %>
+        |""".stripMargin,
+      "test.erb"
+    )
+
+    "Contain a call to <operator>.conditional" in {
+      inside(cpg.call.name(Operators.conditional).l) {
+        case _ :: Nil =>
+        // Do nothing - contains call to operator.conditional
+        case _ => fail("AST Should contain one if statement")
+      }
+    }
+
+    "Contain a call to fmtString in the true branch of the <operator>.conditional" in {
+      inside(cpg.call.name(Operators.conditional).argument.l) {
+        case (condition: Call) :: (trueBranch: Block) :: _ :: Nil =>
+          condition.code shouldBe "ENV['USE_REDIS'] == 'true'"
+          condition.methodFullName shouldBe Operators.equals
+
+          inside(trueBranch.astChildren.isCall.l) {
+            case fmtStringCall :: Nil =>
+              fmtStringCall.methodFullName shouldBe Operators.formatString
+              fmtStringCall.argument.l.size shouldBe 4
+              val List(fmtVal1: Call, fmtVal2: Call, fmtVal3: Call, fmtVal4: Call) =
+                fmtStringCall.argument.l: @unchecked
+
+              fmtVal1.methodFullName shouldBe Operators.formattedValue
+              fmtVal1.code shouldBe
+                """redis:
+                  |  host: """.stripMargin
+
+              fmtVal2.methodFullName shouldBe Operators.formattedValue
+              fmtVal2.code shouldBe "#{ENV['REDIS_HOST']}"
+
+              fmtVal3.methodFullName shouldBe Operators.formattedValue
+              fmtVal3.code shouldBe "  port: "
+
+              fmtVal4.methodFullName shouldBe Operators.formattedValue
+              fmtVal4.code shouldBe "#{ENV['REDIS_PORT']}"
+            case xs => fail(s"Expected one call to fmtString, got [${xs.mkString(",")}]")
+          }
+        case xs => fail(s"Expected three arguments, got ${xs.size}: [${xs.mkString(",")}] instead")
+      }
+    }
+
+    "Contains calls to formattedValue" in {
+      cpg.call.name(Operators.formattedValue).l.size shouldBe 14
+    }
+  }
+
+  "ERB With If-Elsif contains IF-Struct" in {
+    val cpg = code(
+      """
+        |app_name: <%= ENV['APP_NAME'] %>
+        |version: <%= ENV['APP_VERSION'] %>
+        |
+        |database:
+        |  host: <%= ENV['DB_HOST'] %>
+        |  port: <%= ENV['DB_PORT'] %>
+        |
+        |<% if ENV['USE_REDIS'] == 'true' %>
+        |redis:
+        |  host: <%= ENV['REDIS_HOST'] %>
+        |  port: <%= ENV['REDIS_PORT'] %>
+        |<% elsif ENV['USE_RABBITMQ'] == 'true' %>
+        |rabbitmq:
+        |  host: <%= ENV['RABBITMQ_HOST'] %>
+        |  port: <%= ENV['RABBITMQ_PORT'] %>
+        |<% end %>
+        |""".stripMargin,
+      "test.erb"
+    )
+
+    inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).l) {
+      case ifStruct :: _ :: Nil =>
+        inside(ifStruct.condition.l) {
+          case (cond: Call) :: Nil =>
+            cond.methodFullName shouldBe Operators.equals
+            val List(lhs: Call, rhs: Literal) = cond.argument.l: @unchecked
+            lhs.methodFullName shouldBe Operators.indexAccess
+            rhs.code shouldBe "'true'"
+          case xs => fail(s"Expected one condition, got [${xs.code.mkString(",")}]")
+        }
+
+        inside(ifStruct.whenTrue.isBlock.astChildren.isCall.l) {
+          case fmtStringCall :: Nil =>
+            fmtStringCall.methodFullName shouldBe Operators.formatString
+            fmtStringCall.argument.l.size shouldBe 4
+            val List(fmtVal1: Call, fmtVal2: Call, fmtVal3: Call, fmtVal4: Call) = fmtStringCall.argument.l: @unchecked
+
+            fmtVal1.methodFullName shouldBe Operators.formattedValue
+            fmtVal1.code shouldBe
+              """redis:
+                |  host: """.stripMargin
+
+            fmtVal2.methodFullName shouldBe Operators.formattedValue
+            fmtVal2.code shouldBe "#{ENV['REDIS_HOST']}"
+
+            fmtVal3.methodFullName shouldBe Operators.formattedValue
+            fmtVal3.code shouldBe """  port: """
+
+            fmtVal4.methodFullName shouldBe Operators.formattedValue
+            fmtVal4.code shouldBe "#{ENV['REDIS_PORT']}"
+
+          case xs => fail(s"Expected one body for true branch, got [${xs.code.mkString(",")}]")
+        }
+
+        inside(ifStruct.whenFalse.isBlock.astChildren.isControlStructure.l) {
+          case elsifStruct :: Nil =>
+            inside(elsifStruct.condition.l) {
+              case (cond: Call) :: Nil =>
+                cond.methodFullName shouldBe Operators.equals
+                val List(lhs: Call, rhs: Literal) = cond.argument.l: @unchecked
+                lhs.methodFullName shouldBe Operators.indexAccess
+                rhs.code shouldBe "'true'"
+              case xs => fail(s"Expected one condition, got [${xs.code.mkString(",")}]")
+            }
+
+            inside(elsifStruct.whenTrue.isBlock.astChildren.isCall.l) {
+              case fmtStringCall :: Nil =>
+                fmtStringCall.methodFullName shouldBe Operators.formatString
+                fmtStringCall.argument.l.size shouldBe 4
+                val List(fmtVal1: Call, fmtVal2: Call, fmtVal3: Call, fmtVal4: Call) =
+                  fmtStringCall.argument.l: @unchecked
+
+                fmtVal1.methodFullName shouldBe Operators.formattedValue
+                fmtVal1.code shouldBe
+                  """rabbitmq:
+                    |  host: """.stripMargin
+
+                fmtVal2.methodFullName shouldBe Operators.formattedValue
+                fmtVal2.code shouldBe "#{ENV['RABBITMQ_HOST']}"
+
+                fmtVal3.methodFullName shouldBe Operators.formattedValue
+                fmtVal3.code shouldBe "  port: "
+
+                fmtVal4.methodFullName shouldBe Operators.formattedValue
+                fmtVal4.code shouldBe "#{ENV['RABBITMQ_PORT']}"
+              case xs => fail(s"Expected one body with call for true branch, got [${xs.code.mkString(",")}]")
+            }
+          case _ => fail(s"Expected one IF struct in false branch")
+        }
+
+      case xs => fail(s"Expected two IF Structures, got [${xs.code.mkString(",")}]")
+    }
+  }
+
+  "Invalid ERB processing" in {
+    val cpg = code(
+      """
+        |app_name: <%= ENV['APP_NAME'] %>
+        |version: <%= ENV['APP_VERSION'] %>
+        |
+        |database:
+        |  host: <%= ENV['DB_HOST'] %>
+        |  port: <%= ENV['DB_PORT'] %>
+        |
+        |<% if ENV['USE_REDIS'] == 'true' %>
+        |redis:
+        |  host: <%= ENV['REDIS_HOST'] %>
+        |  port: <%= ENV['REDIS_PORT'] %>
+        |""".stripMargin,
+      "test.erb"
+    )
+
+    inside(cpg.method.name(Constants.Main).body.astChildren.isCall.l) {
+      case fmtString :: Nil =>
+        fmtString.methodFullName shouldBe Operators.formatString
+      case xs => fail(s"Expected one call to fmtString, got [${xs.code.mkString(",")}]")
+    }
+  }
+}

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/LiteralTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/LiteralTests.scala
@@ -189,9 +189,7 @@ class LiteralTests extends RubyCode2CpgFixture {
         |>
         |""".stripMargin)
 
-    val List(firstLine, xyz, one23) = cpg.literal.l
-    firstLine.code.trim shouldBe ""
-    firstLine.lineNumber shouldBe Some(2)
+    val List(xyz, one23) = cpg.literal.l
     xyz.code.trim shouldBe "xyz"
     xyz.lineNumber shouldBe Some(3)
     xyz.typeFullName shouldBe RubyDefines.prefixAsCoreType("String")


### PR DESCRIPTION
* Added support for basic ERB files
* Added `templateOutRaw` (`<%== %>`) and `templateOutEscape` (`<%= %>`) operator calls
* Added return for the generated fmtString from the ERB processing
* Added `.html.erb` files as config files