### PR TITLE
[ghidra2cpg] Simplify checking of external functions

### DIFF
--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/PCodePass.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/PCodePass.scala
@@ -117,8 +117,8 @@ class PCodePass(currentProgram: Program, fileName: String, functions: List[Funct
   override def runOnPart(diffGraphBuilder: DiffGraphBuilder, function: Function): Unit = {
     val localDiffGraph = Cpg.newDiffGraphBuilder
     // we need it just once with default settings
-    val blockNode  = nodes.NewBlock().code("").order(0)
-    val methodNode = createMethodNode(decompiler, function, fileName, checkIfExternal(currentProgram, function.getName))
+    val blockNode    = nodes.NewBlock().code("").order(0)
+    val methodNode   = createMethodNode(decompiler, function, fileName)
     val methodReturn = createReturnNode()
 
     localDiffGraph.addNode(methodNode)

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/arm/ArmFunctionPass.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/arm/ArmFunctionPass.scala
@@ -4,7 +4,7 @@ import ghidra.program.model.listing.{Function, Program}
 import io.joern.ghidra2cpg.utils.Decompiler
 import io.joern.ghidra2cpg.passes.FunctionPass
 import io.joern.ghidra2cpg.processors.ArmProcessor
-import io.joern.ghidra2cpg.utils.Utils.{checkIfExternal, createMethodNode, createReturnNode}
+import io.joern.ghidra2cpg.utils.Utils.{createMethodNode, createReturnNode}
 import io.shiftleft.codepropertygraph.generated.nodes.NewBlock
 import io.shiftleft.codepropertygraph.generated.{Cpg, EdgeTypes, nodes}
 
@@ -22,7 +22,7 @@ class ArmFunctionPass(
     val blockNode: NewBlock = nodes.NewBlock().code("").order(0)
     try {
       val methodNode =
-        createMethodNode(decompiler, function, filename, checkIfExternal(currentProgram, function.getName))
+        createMethodNode(decompiler, function, filename)
       val methodReturn = createReturnNode()
       localDiffGraph.addNode(methodNode)
       localDiffGraph.addNode(blockNode)

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/mips/MipsFunctionPass.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/mips/MipsFunctionPass.scala
@@ -261,8 +261,8 @@ class MipsFunctionPass(
     val localDiffGraph = Cpg.newDiffGraphBuilder
     // we need it just once with default settings
     val blockNode: NewBlock = nodes.NewBlock().code("").order(0)
-    val methodNode = createMethodNode(decompiler, function, filename, checkIfExternal(currentProgram, function.getName))
-    val methodReturn = createReturnNode()
+    val methodNode          = createMethodNode(decompiler, function, filename)
+    val methodReturn        = createReturnNode()
     localDiffGraph.addNode(methodNode)
     localDiffGraph.addNode(blockNode)
     localDiffGraph.addEdge(methodNode, blockNode, EdgeTypes.AST)

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/x86/X86FunctionPass.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/x86/X86FunctionPass.scala
@@ -50,7 +50,7 @@ class X86FunctionPass(
     // we need it just once with default settings
     val blockNode: NewBlock = nodes.NewBlock().code("").order(0)
     val methodNode =
-      createMethodNode(decompiler, function, filename, checkIfExternal(currentProgram, function.getName))
+      createMethodNode(decompiler, function, filename)
     val localGraphBuilder = Cpg.newDiffGraphBuilder
     val methodReturn      = createReturnNode()
     localGraphBuilder.addNode(methodNode)

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/utils/Utils.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/utils/Utils.scala
@@ -64,8 +64,9 @@ object Utils {
   def createReturnNode(): NewMethodReturn = {
     NewMethodReturn().order(1)
   }
-  def createMethodNode(decompiler: Decompiler, function: Function, fileName: String, isExternal: Boolean): NewMethod = {
-    val code = decompiler.toDecompiledFunction(function).map(_.getC).getOrElse("")
+  def createMethodNode(decompiler: Decompiler, function: Function, fileName: String): NewMethod = {
+    val code       = decompiler.toDecompiledFunction(function).map(_.getC).getOrElse("")
+    val isExternal = Option(function.getThunkedFunction(true)).map(_.isExternal).getOrElse(function.isExternal)
     val lineNumberEnd = Option(function.getReturn)
       .flatMap(x => Option(x.getMinAddress))
       .flatMap(x => Option(x.getOffsetAsBigInteger))
@@ -85,13 +86,6 @@ object Utils {
       .filename(fileName)
       .astParentType(NodeTypes.NAMESPACE_BLOCK)
       .astParentFullName(s"$fileName:<global>")
-  }
-  def checkIfExternal(currentProgram: Program, functionName: String): Boolean = {
-    currentProgram.getFunctionManager.getExternalFunctions
-      .iterator()
-      .asScala
-      .map(_.getName)
-      .contains(functionName)
   }
   def getInstructions(program: Program, function: Function): Seq[Instruction] =
     program.getListing.getInstructions(function.getBody, true).iterator().asScala.toList


### PR DESCRIPTION
Currently [`getExternalFunctions`](https://ghidra.re/ghidra_docs/api/ghidra/program/model/listing/FunctionManager.html#getExternalFunctions()) is used to determine if a function is external. The problem with this approach is that the code needs to iterate over this list each time it wants to decide if a function is external or not. `Function`s already have this information and it can be obtained using [`getThunkedFunction`](https://ghidra.re/ghidra_docs/api/ghidra/program/model/listing/Function.html#getThunkedFunction(boolean)) together with [`isExternal`](https://ghidra.re/ghidra_docs/api/ghidra/program/model/listing/Function.html#isExternal()) which is simpler and more efficient. Thunk functions are references to other functions (e.g. external ones), so first we need to follow the references until we find the thunked function (`getThunkedFunction` returns a `Function`). Then we can check if it is external or not. If `getThunkedFunction` returns null, then we tried to call it on a non-thunk function and this means we can just call `isExternal` on the original function.

Test file: 
[hello-arm64.zip](https://github.com/user-attachments/files/19873108/hello-arm64.zip)

```scala
joern> cpg.method.map(x=>s"""${x.name} - ${x.isExternal}""").l
val res1: List[String] = List(
  "_init - false",
  "FUN_004004f0 - false",
  "__libc_start_main - true",
  "__gmon_start__ - true",
  "abort - true",
  "puts - true",
  "_start - false",
  "_dl_relocate_static_pie - false",
  "call_weak_fn - false",
  "deregister_tm_clones - false",
  "register_tm_clones - false",
  "__do_global_dtors_aux - false",
  "frame_dummy - false",
  "main - false",
  "_fini - false",
  "__libc_start_main - true",
  "_ITM_deregisterTMCloneTable - true",
  "__gmon_start__ - true",
  "abort - true",
  "puts - true",
  "_ITM_registerTMCloneTable - true",
  "UNKNOWN - true",
  "<operator>.assignment - true",
  "<operator>.addressOf - true",
  "<operator>.incBy - true",
  "<operator>.goto - true",
  "<operator>.compare - true",
  "<operator>.subtraction - true",
  "<operator>.logicalShiftRight - true",
  "<operator>.arithmeticShiftRight - true"
)
```