### PR TITLE
Update obsolete dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,21 +1,18 @@
-FROM centos:centos7.9.2009
+FROM almalinux:latest
 
-# install git git-lfs
-RUN yum -y install zlib zlib-devel curl perl-ExtUtils-CBuilder perl-ExtUtils-MakeMaker gcc curl-devel expect make wget gettext zip unzip \
-    && yum -y remove git \
-    && yum -y install git
+RUN yum install wget unzip git -y
 
-# install jdk11 sbt
+# install jdk21 sbt
 RUN mkdir -p /data/App \
     && cd /data/App \
-    && wget https://github.com/sbt/sbt/releases/download/v1.6.1/sbt-1.6.1.zip \
+    && wget https://github.com/sbt/sbt/releases/download/v1.10.11/sbt-1.10.11.zip \
     && unzip *.zip \
     && rm *.zip \
-    && mv sbt/ sbt-1.6.1/ \
-    && wget https://download.java.net/java/GA/jdk11/13/GPL/openjdk-11.0.1_linux-x64_bin.tar.gz \
+    && mv sbt/ sbt-1.10.11/ \
+    && wget https://download.java.net/java/21/archive/jdk-21.0.7_linux-x64_bin.tar.gz \
     && tar zxvf *.tar.gz \
     && rm *.tar.gz
 
 ENV LANG=en_US.UTF-8 \
-    JAVA_HOME=/data/App/jdk-11.0.1 \
-    PATH=/data/App/sbt-1.6.1/bin:/data/App/jdk-11.0.1/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    JAVA_HOME=/data/App/jdk-21.0.7 \
+    PATH=/data/App/sbt-1.10.11/bin:/data/App/jdk-21.0.7/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,15 @@
 {
 	"name": "dev environment",
 	"dockerFile": "Dockerfile",
-	"extensions": [
-		"vscjava.vscode-java-pack",
-		"scala-lang.scala",
-		"scalameta.metals",
-		"scala-lang.scala-snippets",
-		"VisualStudioExptTeam.vscodeintellicode"
-	]
+	"customizations": {
+	  "vscode": {
+		"extensions": [
+		  "vscjava.vscode-java-pack",
+		  "scala-lang.scala",
+		  "scalameta.metals",
+		  "scala-lang.scala-snippets",
+		  "VisualStudioExptTeam.vscodeintellicode"
+		]
+	  }
+	}
 }

--- a/README.md
+++ b/README.md
@@ -111,11 +111,11 @@ Thank you for taking time to contribute to Joern! Here are a few guidelines to e
 #### VSCode
 - Install VSCode and Docker
 - Install the plugin `ms-vscode-remote.remote-containers`
-- Open Joern project folder in [VSCode](https://docs.microsoft.com/en-us/azure-sphere/app-development/container-build-vscode#build-and-debug-the-project)
-  Visual Studio Code detects the new files and opens a message box saying: `Folder contains a Dev Container configuration file. Reopen to folder to develop in a container.`
-- Select the `Reopen in Container` button to reopen the folder in the container created by the `.devcontainer/Dockerfile` file
-- Switch to `scalameta.metals` sidebar in VSCode, and select `import build` in `BUILD COMMANDS`
-- After `import build` succeeds, you are ready to start writing code for Joern
+- Open Joern project folder in VSCode
+  - [Option 1](https://docs.microsoft.com/en-us/azure-sphere/app-development/container-build-vscode#build-and-debug-the-project): Visual Studio Code detects the new files and opens a message box saying: `Folder contains a Dev Container configuration file. Reopen to folder to develop in a container.`. Select the `Reopen in Container` button to reopen the folder in the container created by the `.devcontainer/Dockerfile` file.
+  - Option 2: press `Ctrl + Shift + P` then select `Dev Containers: Reopen in Container`
+- Press `Ctrl + Shift + P` then select `Metals: Import build`
+- After `Metals: Import build` succeeds, you are ready to start writing code for Joern
 
 ## QueryDB (queries plugin)
 Quick way to develop and test QueryDB:


### PR DESCRIPTION
Fixes #5451:
- changed base image from CentOS to AlmaLinux
- updated JDK to version 21

Additional changes:
- removed unnecessary packages installed by `yum`
- updated `sbt` to version 1.10
- updated `devcontainer.json` (this new structure is expected by the current version of VS Code)
- updated the readme