### PR TITLE
[PHP] Add query to detect magic hash

### DIFF
--- a/querydb/src/main/scala/io/joern/scanners/Crew.scala
+++ b/querydb/src/main/scala/io/joern/scanners/Crew.scala
@@ -10,5 +10,6 @@ object Crew {
   val dave     = "@DavidBakerEffendi"
   val SJ1iu    = "@piggyctf"
   val yichao   = "@yichaoxu"
+  val penghui  = "@peng-hui"
 
 }

--- a/querydb/src/main/scala/io/joern/scanners/QueryTags.scala
+++ b/querydb/src/main/scala/io/joern/scanners/QueryTags.scala
@@ -24,5 +24,6 @@ object QueryTags {
   val pathTraversal          = "path-traversal"
   val cryptography           = "cryptography"
   val remoteCodeExecution    = "remote-code-execution"
+  val magicHash              = "magic-hash"
 
 }

--- a/querydb/src/main/scala/io/joern/scanners/php/MagicHash.scala
+++ b/querydb/src/main/scala/io/joern/scanners/php/MagicHash.scala
@@ -39,9 +39,9 @@ object MagicHash extends QueryBundle {
           ) ++
           cpg.call.name("(?i)(md5|md5_file|sha1|sha1_file)")
 
-        def sink = cpg.call.name(Operators.equals, Operators.notEquals)
+        def sink = cpg.call.name(Operators.equals, Operators.notEquals).argument
 
-        sink.reachableBy(hash).reachableBy(source).l.iterator
+        sink.reachableBy(hash).argument(2).reachableBy(source)
       }),
       tags = List(QueryTags.magicHash, QueryTags.default)
     )

--- a/querydb/src/main/scala/io/joern/scanners/php/MagicHash.scala
+++ b/querydb/src/main/scala/io/joern/scanners/php/MagicHash.scala
@@ -1,0 +1,48 @@
+package io.joern.scanners.php
+
+import io.joern.console.*
+import io.joern.dataflowengineoss.language.*
+import io.joern.dataflowengineoss.queryengine.EngineContext
+import io.joern.macros.QueryMacros.*
+import io.joern.scanners.*
+import io.shiftleft.codepropertygraph.generated.Operators
+import io.shiftleft.semanticcpg.language.*
+
+object MagicHash extends QueryBundle {
+
+  implicit val resolver: ICallResolver = NoResolve
+
+  @q
+  def magicHash()(implicit context: EngineContext): Query =
+    Query.make(
+      name = "magic-hash",
+      author = Crew.penghui,
+      title = "Magic Hash: A parameter is used to compute a hash and then loosely compared (`==`) with another value.",
+      description = """
+          |An attacker controlled parameter is used in a hash related func call and then loosely compared with another value. This is also known as type juggling.
+          |
+          |This could potentially lead to bypass of the checks, resulting in authentication bypass, etc.
+          |""".stripMargin,
+      score = 5,
+      withStrRep({ cpg =>
+        // $_REQUEST["foo"], $_GET["foo"], $_POST["foo"]
+        // are identifier (at the moment)
+        def source = cpg.call.name(Operators.assignment).argument.code(".*_(REQUEST|GET|POST).*")
+
+        // according to real-world cases listed in https://github.com/spaze/hashes
+        def hash = cpg.call
+          .name("(?i)hash")
+          .where(
+            _.argument(1).isLiteral.code(
+              "\"(?i)(md2|md4|md5|sha1|sha224|sha256|ripemd128|ripemd160|tiger128,3|tiger128,4|tiger160,3|tiger160,4|tiger192,3|haval128,3|haval160,3|haval128,4|haval160,4|haval128,5|haval160,5|adler32|crc32|crc32b|crc32c|fnv132|fnv1a32|fnv164|fnv1a64|joaat|murmur3a|murmur3c|murmur3f|xxh32|xxh64|xxh128)\""
+            )
+          ) ++
+          cpg.call.name("(?i)(md5|md5_file|sha1|sha1_file)")
+
+        def sink = cpg.call.name(Operators.equals, Operators.notEquals)
+
+        sink.reachableBy(hash).reachableBy(source).l.iterator
+      }),
+      tags = List(QueryTags.magicHash, QueryTags.default)
+    )
+}

--- a/querydb/src/test/scala/io/joern/scanners/php/MagicHashTests.scala
+++ b/querydb/src/test/scala/io/joern/scanners/php/MagicHashTests.scala
@@ -1,0 +1,35 @@
+package io.joern.scanners.php
+import io.joern.suites.PHPQueryTestSuite
+import io.joern.console.Query
+import io.joern.console.scan.QueryWrapper
+
+class MagicHashTests extends PHPQueryTestSuite(MagicHash) {
+
+  "The `magic-hash` query" when {
+    "detects Magic Hash in loose comparison " in {
+      val cpg = code("""<?php
+          |$input = $_GET["password"];
+          |$hash = hash('md5', $input);
+          |if ($hash == "0e1234") {
+          |};
+          |""".stripMargin)
+      val query   = queryBundle.magicHash()
+      val results = this.findMatchingCalls(cpg, query)
+      results shouldBe List("$_GET[\"password\"]")
+    }
+  }
+
+  "The `magic-hash` query" when {
+    "detects (case insensitive) Magic Hash in loose comparison " in {
+      val cpg = code("""<?php
+          |$input = $_GET["password"];
+          |$hash = hAsh('mD5', $input);
+          |if ($hash == "0e1234") {
+          |};
+          |""".stripMargin)
+      val query   = queryBundle.magicHash()
+      val results = this.findMatchingCalls(cpg, query)
+      results shouldBe List("$_GET[\"password\"]")
+    }
+  }
+}


### PR DESCRIPTION
Magic hash exploits the type juggling in PHP, for example, the following conditional statement would be evaluated as true. 
```php
<php
if(md5("240610708")== md5("QLTHNDT"))
    echo "good";
```
This is because 
- `md5("240610708")= "0e462097431906509019562988736854"`
-  `md5("QLTHNDT")="0e405967825401955372549139051580"`
- Both form the scientific notation of 0*10^xxx, then 0;

This PR query identifies flows from 1. source -> hash functions, and 2. hash functions -> loose comparison.
