### PR TITLE
[PHP Case Sensitivity] PHP is case-insensitive for namespaces, function names, class names, and keywords, but case-sensitive for variable names.

### DIFF
--- a/querydb/src/main/scala/io/joern/scanners/php/PhpJoern.scala
+++ b/querydb/src/main/scala/io/joern/scanners/php/PhpJoern.scala
@@ -29,7 +29,9 @@ object PhpJoern extends QueryBundle {
         // are identifier (at the moment)
         def source = cpg.assignment.source.code(".*_(REQUEST|GET|POST).*")
         def sink =
-          cpg.call.name("(query|mysql_query|mysqli_query|mysqli_prepare|mysqli_execute|pg_query|pg_prepare)").argument
+          cpg.call
+            .name("(?i)(query|mysql_query|mysqli_query|mysqli_prepare|mysqli_execute|pg_query|pg_prepare)")
+            .argument
         sink.reachableBy(source)
       }),
       tags = List(QueryTags.sqlInjection, QueryTags.default)
@@ -51,7 +53,7 @@ object PhpJoern extends QueryBundle {
         // $_REQUEST["foo"], $_GET["foo"], $_POST["foo"]
         // are identifier (at the moment)
         def source = cpg.assignment.source.code(".*_(REQUEST|GET|POST).*")
-        def sink   = cpg.call.name("(system|exec|shell_exec|passthru|popen|proc_open|backticks)").argument
+        def sink   = cpg.call.name("(?i)(system|exec|shell_exec|passthru|popen|proc_open|backticks)").argument
 
         sink.reachableBy(source)
       }),
@@ -76,7 +78,7 @@ object PhpJoern extends QueryBundle {
         def source = cpg.assignment.source.code(".*_(REQUEST|GET|POST).*")
         def sink = cpg.call
           .name(
-            "(eval|assert|create_function|include|include_once|require|require_once|call_user_func|call_user_func_array)"
+            "(?i)(eval|assert|create_function|include|include_once|require|require_once|call_user_func|call_user_func_array)"
           )
           .argument
         sink.reachableBy(source)
@@ -102,7 +104,7 @@ object PhpJoern extends QueryBundle {
         def source = cpg.assignment.source.code(".*_(REQUEST|GET|POST).*")
         def sink = cpg.call
           .name(
-            "(file_get_contents|readfile|fgets|file|fopen|file_put_contents|fwrite|move_uploaded_file|unlink|rename|chmod|chown)"
+            "(?i)(file_get_contents|readfile|fgets|file|fopen|file_put_contents|fwrite|move_uploaded_file|unlink|rename|chmod|chown)"
           )
           .argument
         sink.reachableBy(source)
@@ -126,7 +128,7 @@ object PhpJoern extends QueryBundle {
         // $_REQUEST["foo"], $_GET["foo"], $_POST["foo"]
         // are identifier (at the moment)
         def source = cpg.assignment.source.code(".*_(REQUEST|GET|POST).*")
-        def sink   = cpg.call.name("(assert|echo|exit|print|printf|vprintf|print_r|var_dump)").argument
+        def sink   = cpg.call.name("(?i)(assert|echo|exit|print|printf|vprintf|print_r|var_dump)").argument
         sink.reachableBy(source)
       }),
       tags = List(QueryTags.xss, QueryTags.default)

--- a/querydb/src/main/scala/io/joern/scanners/php/SQLInjection.scala
+++ b/querydb/src/main/scala/io/joern/scanners/php/SQLInjection.scala
@@ -30,7 +30,7 @@ object SQLInjection extends QueryBundle {
         def source =
           cpg.call.name(Operators.assignment).argument.code(".*_(REQUEST|GET|POST).*")
 
-        def sink = cpg.call.name("query").filter(_.receiver.nonEmpty).argument
+        def sink = cpg.call.name("(?i)query").filter(_.receiver.nonEmpty).argument
 
         sink.reachableBy(source).l.iterator
       }),

--- a/querydb/src/main/scala/io/joern/scanners/php/ShellExec.scala
+++ b/querydb/src/main/scala/io/joern/scanners/php/ShellExec.scala
@@ -30,7 +30,7 @@ object ShellExec extends QueryBundle {
         def source =
           cpg.call.name(Operators.assignment).argument.code(".*_(REQUEST|GET|POST).*")
 
-        def sink = cpg.call.name("shell_exec").argument
+        def sink = cpg.call.name("(?i)shell_exec").argument
 
         sink.reachableBy(source).l.iterator
       }),


### PR DESCRIPTION
PHP APIs are case-insensitive, like `echo` is the same as `eCHo`. Add `(?i)` in the queries to realize this.