### PR TITLE
[c2cpg] Fixed empty filenames and AST names

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
@@ -24,6 +24,7 @@ import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTArrayRangeDesignator
 import org.eclipse.cdt.internal.core.dom.parser.cpp.ICPPEvaluation
 
 import scala.collection.mutable
+import scala.util.Success
 import scala.util.Try
 
 trait AstCreatorHelper { this: AstCreator =>
@@ -98,7 +99,10 @@ trait AstCreatorHelper { this: AstCreator =>
   }
 
   protected def fileName(node: IASTNode): String = {
-    val path = Try(node.getContainingFilename).getOrElse(filename)
+    val path = Try(node.getContainingFilename) match {
+      case Success(value) if value.nonEmpty => value
+      case _                                => filename
+    }
     SourceFiles.toRelativePath(path, config.inputPath)
   }
 
@@ -118,7 +122,7 @@ trait AstCreatorHelper { this: AstCreator =>
 
   protected def safeGetEvaluation(expr: ICPPASTExpression): Option[ICPPEvaluation] = {
     // In case of unresolved includes etc. this may fail throwing an unrecoverable exception
-    Try(expr.getEvaluation).toOption
+    Try(expr.getEvaluation).toOption.filter(_ != null)
   }
 
   protected def safeGetBinding(idExpression: IASTIdExpression): Option[IBinding] = {
@@ -130,7 +134,7 @@ trait AstCreatorHelper { this: AstCreator =>
 
   protected def safeGetBinding(name: IASTName): Option[IBinding] = {
     // In case of unresolved includes etc. this may fail throwing an unrecoverable exception
-    Try(name.resolveBinding()).toOption
+    Try(name.resolveBinding()).toOption.filter(_ != null)
   }
 
   protected def safeGetBinding(spec: IASTNamedTypeSpecifier): Option[IBinding] = {

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForStatementsCreator.scala
@@ -21,7 +21,6 @@ import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTSimpleDeclaration
 import org.eclipse.cdt.internal.core.model.ASTStringUtil
 
 import java.nio.file.Paths
-import scala.collection.mutable
 
 trait AstForStatementsCreator { this: AstCreator =>
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/C2CpgScope.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/C2CpgScope.scala
@@ -11,7 +11,7 @@ import scala.collection.mutable
 
 object C2CpgScope {
 
-  sealed trait ScopeElement(scopeNode: NewNode) {
+  sealed trait ScopeElement {
     val surroundingScope: Option[ScopeElement]
     val nameToVariableNode: mutable.Map[String, (NewNode, String, String)] = mutable.HashMap.empty
 
@@ -40,14 +40,13 @@ object C2CpgScope {
     capturingRefId: Option[NewNode],
     scopeNode: NewNode,
     surroundingScope: Option[ScopeElement]
-  ) extends ScopeElement(scopeNode) {
+  ) extends ScopeElement {
     def needsEnclosingScope: Boolean = {
       scopeNode.isInstanceOf[NewTypeDecl] || scopeNode.isInstanceOf[NewNamespaceBlock]
     }
   }
 
-  private case class BlockScopeElement(scopeNode: NewNode, surroundingScope: Option[ScopeElement])
-      extends ScopeElement(scopeNode)
+  private case class BlockScopeElement(scopeNode: NewNode, surroundingScope: Option[ScopeElement]) extends ScopeElement
 
 }
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/FullNameProvider.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/FullNameProvider.scala
@@ -109,7 +109,6 @@ trait FullNameProvider { this: AstCreator =>
     val name = node match {
       case n: IASTName                    => shortNameForIASTName(n)
       case d: IASTDeclarator              => shortNameForIASTDeclarator(d)
-      case f: ICPPASTFunctionDefinition   => shortNameForICPPASTFunctionDefinition(f)
       case f: IASTFunctionDefinition      => shortNameForIASTFunctionDefinition(f)
       case d: CPPASTIdExpression          => shortNameForCPPASTIdExpression(d)
       case u: IASTUnaryExpression         => shortName(u.getOperand)
@@ -235,22 +234,11 @@ trait FullNameProvider { this: AstCreator =>
 
   private def shortNameForIASTDeclarator(declarator: IASTDeclarator): String = {
     safeGetBinding(declarator.getName).map(_.getName).getOrElse {
-      if (ASTStringUtil.getSimpleName(declarator.getName).isEmpty && declarator.getNestedDeclarator != null) {
-        shortName(declarator.getNestedDeclarator)
-      } else {
-        ASTStringUtil.getSimpleName(declarator.getName)
-      }
-    }
-  }
-
-  private def shortNameForICPPASTFunctionDefinition(definition: ICPPASTFunctionDefinition): String = {
-    if (
-      ASTStringUtil.getSimpleName(definition.getDeclarator.getName).isEmpty
-      && definition.getDeclarator.getNestedDeclarator != null
-    ) {
-      shortName(definition.getDeclarator.getNestedDeclarator)
-    } else {
-      shortName(definition.getDeclarator.getName)
+      if (
+        (declarator.getName == null || ASTStringUtil.getSimpleName(declarator.getName).isEmpty)
+        && declarator.getNestedDeclarator != null
+      ) { shortName(declarator.getNestedDeclarator) }
+      else { ASTStringUtil.getSimpleName(declarator.getName) }
     }
   }
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroHandler.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroHandler.scala
@@ -1,7 +1,6 @@
 package io.joern.c2cpg.astcreation
 
 import io.joern.x2cpg.Ast
-import io.joern.x2cpg.ValidationMode
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.codepropertygraph.generated.nodes.AstNodeNew
 import io.shiftleft.codepropertygraph.generated.nodes.ExpressionNew


### PR DESCRIPTION
Missing includes / header files may lead to AST names being null (Java `null`) and filenames being empty (empty string `""`).

Discoverd during testing on https://github.com/openssl/openssl