### PR TITLE
[swiftsrc2cpg] Bring in encoding fix

### DIFF
--- a/joern-cli/frontends/swiftsrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 swiftsrc2cpg {
-    astgen_version: "0.2.4"
+    astgen_version: "0.2.5"
 }

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/Main.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/Main.scala
@@ -1,9 +1,11 @@
 package io.joern.swiftsrc2cpg
 
 import io.joern.swiftsrc2cpg.Frontend.*
-import io.joern.x2cpg.passes.frontend.{TypeRecoveryParserConfig, XTypeRecovery, XTypeRecoveryConfig}
+import io.joern.x2cpg.X2CpgConfig
+import io.joern.x2cpg.X2CpgMain
+import io.joern.x2cpg.passes.frontend.TypeRecoveryParserConfig
+import io.joern.x2cpg.passes.frontend.XTypeRecoveryConfig
 import io.joern.x2cpg.utils.Environment
-import io.joern.x2cpg.{X2CpgConfig, X2CpgMain}
 import io.joern.x2cpg.utils.server.FrontendHTTPServer
 import scopt.OParser
 

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/parser/SwiftJsonParser.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/parser/SwiftJsonParser.scala
@@ -16,7 +16,7 @@ object SwiftJsonParser {
     val json              = ujson.read(jsonContent)
     val filename          = json("relativeFilePath").str
     val fullPath          = Paths.get(json("fullFilePath").str)
-    val sourceFileContent = IOUtils.readEntireFile(fullPath)
+    val sourceFileContent = json("content").str
     val ast               = SwiftNodeSyntax.createSwiftNode(json)
     ParseResult(filename, fullPath.toString, ast, sourceFileContent)
   }

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/io/ProjectParseTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/io/ProjectParseTests.scala
@@ -1,0 +1,77 @@
+package io.joern.swiftsrc2cpg.io
+
+import io.joern.swiftsrc2cpg.testfixtures.SwiftSrc2CpgSuite
+import io.joern.swiftsrc2cpg.Config
+import io.joern.swiftsrc2cpg.passes.AstCreationPass
+import io.joern.swiftsrc2cpg.utils.AstGenRunner
+import io.joern.x2cpg.ValidationMode
+import io.joern.x2cpg.X2Cpg.newEmptyCpg
+import io.shiftleft.semanticcpg.utils.FileUtil.*
+import io.shiftleft.codepropertygraph.generated.Cpg
+import io.shiftleft.codepropertygraph.generated.Operators
+import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.utils.FileUtil
+import org.scalatest.BeforeAndAfterAll
+
+import java.nio.file.{Files, Path}
+
+class ProjectParseTests extends SwiftSrc2CpgSuite with BeforeAndAfterAll {
+
+  private implicit val schemaValidationMode: ValidationMode = ValidationMode.Enabled
+
+  private val projectWithUtf8: Path = {
+    val dir  = Files.createTempDirectory("swiftsrc2cpgTestsUtf8")
+    val file = dir / "utf8.swift"
+    file.createWithParentsIfNotExists(createParents = true)
+    val content = """
+      |import Foundation
+      |
+      |// 🚀
+      |// 😼
+      |// ❌
+      |// 1️⃣ Some comment ...
+      |func main() {
+      |  print("6️⃣ Something: \(foo?.bar ?? 0)")  // 💥 May crash
+      |  print("✅ Done!")
+      |}
+      |""".stripMargin
+    Files.writeString(file, content)
+    dir
+  }
+
+  override def afterAll(): Unit = {
+    FileUtil.delete(projectWithUtf8, swallowIoExceptions = true)
+  }
+
+  private object ProjectParseTestsFixture {
+    def apply(projectDir: Path)(f: Cpg => Unit): Unit = {
+      FileUtil.usingTemporaryDirectory("swiftsrc2cpgTests") { tmpDir =>
+        val cpg = newEmptyCpg()
+        val config = Config()
+          .withInputPath(projectDir.toString)
+          .withOutputPath(tmpDir.toString)
+          .withDisableFileContent(false)
+        val astGenResult = new AstGenRunner(config).execute(tmpDir)
+        new AstCreationPass(cpg, astGenResult, config).createAndApply()
+        f(cpg)
+      }
+    }
+  }
+
+  "Parsing a project" should {
+
+    "handle utf8 correctly" in ProjectParseTestsFixture(projectWithUtf8) { cpg =>
+      val List(op) = cpg.call.nameExact(Operators.elvis).l
+      op.offset shouldBe Some(99)
+      op.offsetEnd shouldBe Some(112)
+      cpg.method.nameExact("main").content.head.linesIterator.map(_.trim).toSeq shouldBe Seq(
+        "func main() {",
+        "print(\"6?? Something: \\(foo?.bar ?? 0)\")  // ? May crash",
+        "print(\"? Done!\")",
+        "}"
+      )
+    }
+
+  }
+
+}


### PR DESCRIPTION
Swifts representation of characters beyond 127 differ from what the JVM does. E.g.,  ️⃣  is `\ufe0f\u20e3` in Swift but `\ufe0f\u20e3\u0020` in Scala. SwiftAstGen now encodes all of them before parsing and passes that as content to swiftsrc2cpg. Hence, all offsets are the same.