### PR TITLE
[swiftsrc2cpg] Bump swiftastgen version

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,8 +29,9 @@ jobs:
         if: matrix.os == 'windows-latest'
         uses: SwiftyLab/setup-swift@latest
         with:
+          check-latest: true
           development: true
-          swift-version: "5.10"
+          swift-version: "6.1"
       - name: Delete `.rustup` directory
         run: rm -rf /home/runner/.rustup # to save disk space
         if: runner.os == 'Linux'

--- a/joern-cli/frontends/swiftsrc2cpg/build.sbt
+++ b/joern-cli/frontends/swiftsrc2cpg/build.sbt
@@ -6,9 +6,9 @@ import scala.util.Try
 name := "swiftsrc2cpg"
 
 dependsOn(
-  Projects.dataflowengineoss  % "compile->compile;test->test",
-  Projects.x2cpg              % "compile->compile;test->test",
-  Projects.linterRules % ScalafixConfig
+  Projects.dataflowengineoss % "compile->compile;test->test",
+  Projects.x2cpg             % "compile->compile;test->test",
+  Projects.linterRules       % ScalafixConfig
 )
 
 lazy val appProperties = settingKey[Config]("App Properties")
@@ -34,9 +34,10 @@ Test / fork := false
 
 enablePlugins(JavaAppPackaging, LauncherJarPlugin)
 
-lazy val AstgenWin   = "SwiftAstGen-win.exe"
-lazy val AstgenLinux = "SwiftAstGen-linux"
-lazy val AstgenMac   = "SwiftAstGen-mac"
+lazy val AstgenWin      = "SwiftAstGen-win.exe"
+lazy val AstgenLinux    = "SwiftAstGen-linux"
+lazy val AstgenLinuxArm = "SwiftAstGen-linux-arm64"
+lazy val AstgenMac      = "SwiftAstGen-mac"
 
 lazy val astGenDlUrl = settingKey[String]("astgen download url")
 astGenDlUrl := s"https://github.com/joernio/swiftastgen/releases/download/v${astGenVersion.value}/"
@@ -53,13 +54,16 @@ astGenBinaryNames := {
   if (hasCompatibleAstGenVersion(astGenVersion.value)) {
     Seq.empty
   } else if (sys.props.get("ALL_PLATFORMS").contains("TRUE")) {
-    Seq(AstgenWin, AstgenLinux, AstgenMac)
+    Seq(AstgenWin, AstgenLinux, AstgenLinuxArm, AstgenMac)
   } else {
     Environment.operatingSystem match {
       case Environment.OperatingSystemType.Windows =>
         Seq(AstgenWin)
       case Environment.OperatingSystemType.Linux =>
-        Seq(AstgenLinux)
+        Environment.architecture match {
+          case Environment.ArchitectureType.X86   => Seq(AstgenLinux)
+          case Environment.ArchitectureType.ARMv8 => Seq(AstgenLinuxArm)
+        }
       case Environment.OperatingSystemType.Mac =>
         Seq(AstgenMac)
       case Environment.OperatingSystemType.Unknown =>

--- a/joern-cli/frontends/swiftsrc2cpg/build.sbt
+++ b/joern-cli/frontends/swiftsrc2cpg/build.sbt
@@ -67,7 +67,7 @@ astGenBinaryNames := {
       case Environment.OperatingSystemType.Mac =>
         Seq(AstgenMac)
       case Environment.OperatingSystemType.Unknown =>
-        Seq(AstgenWin, AstgenLinux, AstgenMac)
+        Seq(AstgenWin, AstgenLinux, AstgenLinuxArm, AstgenMac)
     }
   }
 }

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 swiftsrc2cpg {
-    astgen_version: "0.2.7"
+    astgen_version: "0.2.8"
 }

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 swiftsrc2cpg {
-    astgen_version: "0.2.5"
+    astgen_version: "0.2.6"
 }

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 swiftsrc2cpg {
-    astgen_version: "0.2.6"
+    astgen_version: "0.2.7"
 }

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/utils/AstGenRunner.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/utils/AstGenRunner.scala
@@ -39,8 +39,12 @@ object AstGenRunner {
 
   lazy private val executableName = Environment.operatingSystem match {
     case Environment.OperatingSystemType.Windows => "SwiftAstGen-win.exe"
-    case Environment.OperatingSystemType.Linux   => "SwiftAstGen-linux"
-    case Environment.OperatingSystemType.Mac     => "SwiftAstGen-mac"
+    case Environment.OperatingSystemType.Linux =>
+      Environment.architecture match {
+        case Environment.ArchitectureType.X86   => "SwiftAstGen-linux"
+        case Environment.ArchitectureType.ARMv8 => "SwiftAstGen-linux-arm64"
+      }
+    case Environment.OperatingSystemType.Mac => "SwiftAstGen-mac"
     case Environment.OperatingSystemType.Unknown =>
       logger.warn("Could not detect OS version! Defaulting to 'Linux'.")
       "SwiftAstGen-linux"


### PR DESCRIPTION
Brings in the new musl based swiftastgen Linux binary (no glibc version dependency anymore)