### PR TITLE
[ghidra2cpg] Add support for loading Ghidra projects

### DIFF
--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/Ghidra2Cpg.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/Ghidra2Cpg.scala
@@ -43,11 +43,24 @@ class Ghidra2Cpg extends X2CpgFrontend[Config] {
         var project: GhidraProject = null;
 
         try {
-          // The 'true' parameter indicates this is a temporary project
-          project =
-            GhidraProject.createProject(tempWorkingDir.absolutePathAsString, CommandLineConfig.projectName, true)
-          program = project.importProgram(inputFile)
-          addProgramToCpg(program, inputFile.getCanonicalPath, cpg)
+          // .gpr is the extension of Ghidra projects
+          if (inputFile.getName().endsWith(".gpr")) {
+            project = GhidraProject.openProject(inputFile.getParent(), inputFile.getName())
+            if (!project.getRootFolder().isEmpty()) {
+              // In the current implementation we use the first domain file
+              // It is the user's responsibility to provide a Ghidra project with one domain file
+              val domainFile = project.getRootFolder().getFiles().head
+              // This is a project path, which is OS-indepenent and always uses the forward-slash notation
+              program = project.openProgram("/", domainFile.getName(), true)
+              addProgramToCpg(program, inputFile.getCanonicalPath, cpg)
+            }
+          } else {
+            // The 'true' parameter indicates this is a temporary project
+            project =
+              GhidraProject.createProject(tempWorkingDir.absolutePathAsString, CommandLineConfig.projectName, true)
+            program = project.importProgram(inputFile)
+            addProgramToCpg(program, inputFile.getCanonicalPath, cpg)
+          }
         } catch {
           case e: Exception =>
             e.printStackTrace()


### PR DESCRIPTION
Fixes #2534 

Added support for loading existing Ghidra projects. The linked issue describes why this is a useful feature. If the input file is a non-empty Ghidra project (.gpr), we load the first program (domain file) from it and create the CPG.

Test binary:

[hello-arm64.zip](https://github.com/user-attachments/files/20016584/hello-arm64.zip)

**Edit:**
Note: First I tried to upload the .gpr file but turns out Ghidra projects can not be easily shared in the .gpr + .rep format because such a project is locked to a username (to the user who created it). For testing, a project has to be manually created in Ghidra and the test binary (after unzip) has to be manually imported and auto-analyzed. Then you need to save the project and Ghidra **needs to be closed completely**. Otherwise it will lock the project via a lockfile and `joern-parse` will fail.

Test run:

```
$ joern-parse ~/hello-arm64.gpr --language GHIDRA
Parsing code at: /home/gemesa/hello-arm64.gpr - language: `GHIDRA`
[+] Running language frontend
=======================================================================================================
Invoking CPG generator in a separate process. Note that the new process will consume additional memory.
If you are importing a large codebase (and/or running into memory issues), please try the following:
1) exit joern
2) invoke the frontend: /home/gemesa/git-repos/joern/joern-cli/target/universal/stage/ghidra2cpg -J-Xmx3472m /home/gemesa/hello-arm64.gpr --output cpg.bin
3) start joern, import the cpg: `importCpg("path/to/cpg")`
=======================================================================================================

[+] Applying default overlays
Successfully wrote graph to: /home/gemesa/git-repos/tmp/cpg.bin
To load the graph, type `joern /home/gemesa/git-repos/tmp/cpg.bin`
                                                                                                                      
$ joern /home/gemesa/git-repos/tmp/cpg.bin
Creating project `cpg.bin` for CPG at `/home/gemesa/git-repos/tmp/cpg.bin`
Project with name cpg.bin already exists - overwriting
Creating working copy of CPG to be safe
Loading base CPG from: /home/gemesa/git-repos/tmp/workspace/cpg.bin/cpg.bin.tmp
Overlay dataflowOss already exists - skipping
The graph has been modified. You may want to use the `save` command to persist changes to disk.  All changes will also be saved collectively on exit

     ██╗ ██████╗ ███████╗██████╗ ███╗   ██╗
     ██║██╔═══██╗██╔════╝██╔══██╗████╗  ██║
     ██║██║   ██║█████╗  ██████╔╝██╔██╗ ██║
██   ██║██║   ██║██╔══╝  ██╔══██╗██║╚██╗██║
╚█████╔╝╚██████╔╝███████╗██║  ██║██║ ╚████║
 ╚════╝  ╚═════╝ ╚══════╝╚═╝  ╚═╝╚═╝  ╚═══╝
Version: 0.0.0+3813-9478888c
Type `help` to begin
      
                                                                                                                      
joern> cpg.method("main").code.l
val res1: List[String] = List(
  """
/* WARNING: Unknown calling convention -- yet parameter storage is locked */

int main(void)

{
  puts("hello world");
  return 0;
}

"""
)
                                                                                                                      
joern>
```