### PR TITLE
[php] Pre-Parse and Summarize Symbols

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
@@ -1,23 +1,29 @@
 package io.joern.php2cpg
 
-import io.joern.php2cpg.parser.PhpParser
+import io.joern.php2cpg.astcreation.AstCreator
+import io.joern.php2cpg.datastructures.PhpProgramSummary
+import io.joern.php2cpg.parser.{PhpParseResult, PhpParser}
 import io.joern.php2cpg.passes.*
 import io.joern.php2cpg.utils.DependencyDownloader
 import io.joern.x2cpg.X2Cpg.withNewEmptyCpg
 import io.joern.x2cpg.passes.frontend.{MetaDataPass, TypeNodePass}
+import io.joern.x2cpg.utils.ConcurrentTaskUtil
 import io.shiftleft.semanticcpg.utils.ExternalCommand
 import io.joern.x2cpg.{SourceFiles, X2CpgFrontend}
 import io.shiftleft.codepropertygraph.generated.{Cpg, Languages}
+import io.shiftleft.semanticcpg.utils.FileUtil.PathExt
 import org.slf4j.LoggerFactory
 import versionsort.VersionHelper
 
+import java.nio.file.Paths
 import scala.collection.mutable
 import scala.util.matching.Regex
 import scala.util.{Failure, Success, Try}
 
 class Php2Cpg extends X2CpgFrontend[Config] {
 
-  private val logger = LoggerFactory.getLogger(this.getClass)
+  private val logger                               = LoggerFactory.getLogger(this.getClass)
+  private val PhpSourceFileExtensions: Set[String] = Set(".php")
 
   private def isPhpVersionSupported: Boolean = {
     val result = ExternalCommand.run(Seq("php", "--version"), Some(".")).toTry
@@ -58,7 +64,7 @@ class Php2Cpg extends X2CpgFrontend[Config] {
           // Parse dependencies and add high-level nodes to the CPG
           new DependencySymbolsPass(cpg, dependencyDir).createAndApply()
         }
-        new AstCreationPass(config, cpg, parser.get)(config.schemaValidation).createAndApply()
+        new AstCreationPass(cpg, parseFiles(config, parser)).createAndApply()
         new AstParentInfoPass(cpg).createAndApply()
         new AnyTypePass(cpg).createAndApply()
         TypeNodePass.withTypesFromCpg(cpg).createAndApply()
@@ -89,4 +95,67 @@ class Php2Cpg extends X2CpgFrontend[Config] {
       )
       .filter(_.endsWith("composer.json"))
   }
+
+  /** We need to feed the php parser big groups of file in order to speed up the parsing. Apparently it is some sort of
+    * slow startup phase which makes single file processing prohibitively slow. On the other hand we need to be careful
+    * to not choose too big chunks because:
+    *   1. The argument length to the php executable has system dependent limits 2. We want to make use of multiple CPU
+    *      cores for the rest of the CPG creation.
+    */
+  private def parseFiles(config: Config, maybeParser: Option[PhpParser]): List[AstCreator] = {
+
+    def parseResultToAstCreator(parseResult: PhpParseResult): Option[AstCreator] = {
+      parseResult match {
+        case PhpParseResult(fileName, Some(result), _) =>
+          val relativeFilename = if (fileName == config.inputPath) {
+            Paths.get(fileName).fileName
+          } else {
+            Paths.get(config.inputPath).relativize(Paths.get(fileName)).toString
+          }
+          Option(new AstCreator(relativeFilename, fileName, result, config.disableFileContent)(config.schemaValidation))
+        case PhpParseResult(fileName, None, _) =>
+          logger.warn(s"Could not parse file $fileName. Results will be missing!")
+          None
+      }
+    }
+
+    maybeParser match {
+      case None => List.empty
+      case Some(parser) =>
+        val sourceFiles = SourceFiles
+          .determine(
+            config.inputPath,
+            PhpSourceFileExtensions,
+            ignoredFilesRegex = Option(config.ignoredFilesRegex),
+            ignoredFilesPath = Option(config.ignoredFiles)
+          )
+          .toArray
+
+        // Parse files concurrently in batches, creating AST creators from them
+        val batchedParserTasks =
+          sourceFiles
+            .grouped(20)
+            .map(fileNames => () => parser.parseFiles(fileNames).flatMap(parseResultToAstCreator).toSeq)
+
+        val astCreators = ConcurrentTaskUtil
+          .runUsingThreadPool(batchedParserTasks.iterator)
+          .flatMap {
+            case Failure(exception)   => logger.warn(s"Unable to parse PHP file batch, skipping - ", exception); Nil
+            case Success(astCreators) => astCreators
+          }
+
+        // Pre-parse ASTs on a high level, not including method bodies, etc.
+        val internalProgramSummary = ConcurrentTaskUtil
+          .runUsingThreadPool(astCreators.map(x => () => x.summarize).iterator)
+          .flatMap {
+            case Failure(exception) => logger.warn(s"Unable to pre-parse PHP file, skipping - ", exception); None
+            case Success(summary)   => Option(summary)
+          }
+          .foldLeft(PhpProgramSummary())(_ ++= _)
+
+        // The result are AST creators with a reference to the program summary of all internal symbols (types/methods)
+        astCreators.map(_.withSummary(internalProgramSummary))
+    }
+  }
+
 }

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
@@ -102,7 +102,7 @@ class Php2Cpg extends X2CpgFrontend[Config] {
     *   1. The argument length to the php executable has system dependent limits 2. We want to make use of multiple CPU
     *      cores for the rest of the CPG creation.
     */
-  private def parseFiles(config: Config, maybeParser: Option[PhpParser]): List[AstCreator] = {
+  private[php2cpg] def parseFiles(config: Config, maybeParser: Option[PhpParser]): List[AstCreator] = {
 
     def parseResultToAstCreator(parseResult: PhpParseResult): Option[AstCreator] = {
       parseResult match {

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
@@ -18,7 +18,7 @@ class AstCreator(
   val fileName: String,
   protected val phpAst: PhpFile,
   protected val disableFileContent: Boolean,
-  protected val programSummary: PhpProgramSummary = PhpProgramSummary(),
+  protected[php2cpg] val programSummary: PhpProgramSummary = PhpProgramSummary(),
   protected val parseLevel: AstParseLevel = AstParseLevel.FULL_AST
 )(implicit withSchemaValidation: ValidationMode)
     extends AstCreatorBase[PhpNode, AstCreator](relativeFileName)

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreatorHelper.scala
@@ -11,7 +11,7 @@ import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 
 import java.nio.charset.StandardCharsets
 
-trait AstCreatorHelper(disableFileContent: Boolean)(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
+trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
   protected val globalNamespace: NewNamespaceBlock = globalNamespaceBlock()
 

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForControlStructuresCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForControlStructuresCreator.scala
@@ -1,7 +1,7 @@
 package io.joern.php2cpg.astcreation
 
-import io.joern.php2cpg.utils.PhpScopeElement
 import io.joern.php2cpg.astcreation.AstCreator.TypeConstants
+import io.joern.php2cpg.datastructures.PhpScopeElement
 import io.joern.php2cpg.parser.Domain.*
 import io.joern.x2cpg.Defines.UnresolvedSignature
 import io.joern.x2cpg.utils.AstPropertiesUtil.RootProperties

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForDeclarationsCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForDeclarationsCreator.scala
@@ -1,9 +1,11 @@
 package io.joern.php2cpg.astcreation
 
-import io.joern.php2cpg.parser.Domain.{PhpDeclareItem, PhpDeclareStmt, PhpOperators}
-import io.joern.x2cpg.{Ast, Defines, ValidationMode}
+import io.joern.php2cpg.astcreation.AstCreator.{NameConstants, TypeConstants}
+import io.joern.php2cpg.parser.Domain.*
 import io.joern.x2cpg.utils.AstPropertiesUtil.RootProperties
+import io.joern.x2cpg.{Ast, Defines, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.Operators
+import io.shiftleft.codepropertygraph.generated.nodes.{NewImport, NewNamespaceBlock}
 
 trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
@@ -31,6 +33,104 @@ trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) {
 
     val declareAssignment = operatorCallNode(item, code, Operators.assignment, None)
     callAst(declareAssignment, Ast(key) :: value :: Nil)
+  }
+
+  protected def astForGlobalStmt(stmt: PhpGlobalStmt): Ast = {
+    // This isn't an accurater representation of what `global` does, but with things like `global $$x` being possible,
+    // it's very difficult to figure out correct scopes for global variables.
+
+    val varsAsts = stmt.vars.map(astForExpr)
+    val code     = s"${PhpOperators.global} ${varsAsts.map(_.rootCodeOrEmpty).mkString(", ")}"
+
+    val globalCallNode = operatorCallNode(stmt, code, PhpOperators.global, Some(TypeConstants.Void))
+
+    callAst(globalCallNode, varsAsts)
+  }
+
+  protected def astForNamespaceStmt(stmt: PhpNamespaceStmt): Ast = {
+    val name     = stmt.name.map(_.name).getOrElse(NameConstants.Unknown)
+    val fullName = s"$relativeFileName:$name"
+
+    val namespaceBlock = NewNamespaceBlock()
+      .name(name)
+      .fullName(fullName)
+
+    scope.pushNewScope(namespaceBlock)
+    val bodyStmts = astsForClassLikeBody(stmt, stmt.stmts, createDefaultConstructor = false)
+    scope.popScope()
+
+    Ast(namespaceBlock).withChildren(bodyStmts)
+  }
+
+  protected def astForUseStmt(stmt: PhpUseStmt): Ast = {
+    // TODO Use useType + scope to get better name info
+    val imports = stmt.uses.map(astForUseUse(_))
+    wrapMultipleInBlock(imports, line(stmt))
+  }
+
+  protected def astForGroupUseStmt(stmt: PhpGroupUseStmt): Ast = {
+    // TODO Use useType + scope to get better name info
+    val groupPrefix = s"${stmt.prefix.name}\\"
+    val imports     = stmt.uses.map(astForUseUse(_, groupPrefix))
+    wrapMultipleInBlock(imports, line(stmt))
+  }
+
+  protected def astForTraitUseStmt(stmt: PhpTraitUseStmt): Ast = {
+    // TODO Actually implement this
+    logger.debug(
+      s"Trait use statement encountered. This is not yet supported. Location: $relativeFileName:${line(stmt)}"
+    )
+    Ast(unknownNode(stmt, code(stmt)))
+  }
+
+  protected def astForUseUse(stmt: PhpUseUse, namePrefix: String = ""): Ast = {
+    val originalName = s"$namePrefix${stmt.originalName.name}"
+    val aliasCode    = stmt.alias.map(alias => s" as ${alias.name}").getOrElse("")
+    val typeCode = stmt.useType match {
+      case PhpUseType.Function => s"function "
+      case PhpUseType.Constant => s"const "
+      case _                   => ""
+    }
+    val code = s"use $typeCode$originalName$aliasCode"
+
+    val importNode = NewImport()
+      .importedEntity(originalName)
+      .importedAs(stmt.alias.map(_.name))
+      .isExplicit(true)
+      .code(code)
+
+    Ast(importNode)
+  }
+
+  protected def astsForStaticStmt(stmt: PhpStaticStmt): List[Ast] = {
+    stmt.vars.flatMap { staticVarDecl =>
+      staticVarDecl.variable match {
+        case PhpVariable(PhpNameExpr(name, _), _) =>
+          val maybeDefaultValueAst = staticVarDecl.defaultValue.map(astForExpr)
+
+          val code         = s"static $$$name"
+          val typeFullName = maybeDefaultValueAst.flatMap(_.rootType).getOrElse(Defines.Any)
+
+          val local = localNode(stmt, name, code, typeFullName)
+          scope.addToScope(local.name, local)
+
+          val assignmentAst = maybeDefaultValueAst.map { defaultValue =>
+            val variableNode = identifierNode(stmt, name, s"$$$name", typeFullName)
+            val variableAst  = Ast(variableNode).withRefEdge(variableNode, local)
+
+            val assignCode = s"$code = ${defaultValue.rootCodeOrEmpty}"
+            val assignNode = operatorCallNode(stmt, assignCode, Operators.assignment, None)
+
+            callAst(assignNode, variableAst :: defaultValue :: Nil)
+          }
+
+          Ast(local) :: assignmentAst.toList
+
+        case other =>
+          logger.warn(s"Unexpected static variable type $other in $relativeFileName")
+          Nil
+      }
+    }
   }
 
 }

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
@@ -867,4 +867,27 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
       .withChild(returnIdentifierAst)
   }
 
+  protected def astForEchoStmt(echoStmt: PhpEchoStmt): Ast = {
+    val args     = echoStmt.exprs.map(astForExpr)
+    val code     = s"echo ${args.map(_.rootCodeOrEmpty).mkString(",")}"
+    val callNode = operatorCallNode(echoStmt, code, "echo", None)
+    callAst(callNode, args)
+  }
+
+  protected def astForHaltCompilerStmt(stmt: PhpHaltCompilerStmt): Ast = {
+    val call =
+      operatorCallNode(stmt, s"${NameConstants.HaltCompiler}()", NameConstants.HaltCompiler, Some(TypeConstants.Void))
+
+    Ast(call)
+  }
+
+  protected def astForUnsetStmt(stmt: PhpUnsetStmt): Ast = {
+    val name = PhpOperators.unset
+    val args = stmt.vars.map(astForExpr)
+    val code = s"$name(${args.map(_.rootCodeOrEmpty).mkString(", ")})"
+    val callNode = operatorCallNode(stmt, code, name, Some(TypeConstants.Void))
+      .methodFullName(PhpOperators.unset)
+    callAst(callNode, args)
+  }
+
 }

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForFunctionsCreator.scala
@@ -12,75 +12,73 @@ import io.shiftleft.codepropertygraph.generated.{EdgeTypes, EvaluationStrategies
 
 trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
-  protected def astForClosureExpr(closureExpr: PhpClosureExpr): Ast = parseLevel match {
-    case SIGNATURES => Ast()
-    case FULL_AST =>
-      val methodName = scope.getScopedClosureName
-      val methodRef  = methodRefNode(closureExpr, methodName, methodName, Defines.Any)
+  protected def astForClosureExpr(closureExpr: PhpClosureExpr): Ast = {
+    val methodName = scope.getScopedClosureName
+    val methodRef  = methodRefNode(closureExpr, methodName, methodName, Defines.Any)
 
-      val localsForUses = closureExpr.uses.flatMap { closureUse =>
-        closureUse.variable match {
-          case PhpVariable(PhpNameExpr(name, _), _) =>
-            val typeFullName = scope
-              .lookupVariable(name)
-              .flatMap(_.properties.get(PropertyNames.TYPE_FULL_NAME).map(_.toString))
-              .getOrElse(Defines.Any)
-            val byRefPrefix = if (closureUse.byRef) "&" else ""
+    val localsForUses = closureExpr.uses.flatMap { closureUse =>
+      closureUse.variable match {
+        case PhpVariable(PhpNameExpr(name, _), _) =>
+          val typeFullName = scope
+            .lookupVariable(name)
+            .flatMap(_.properties.get(PropertyNames.TYPE_FULL_NAME).map(_.toString))
+            .getOrElse(Defines.Any)
+          val byRefPrefix = if (closureUse.byRef) "&" else ""
 
-            Some(localNode(closureExpr, name, s"$byRefPrefix$$$name", typeFullName))
+          Some(localNode(closureExpr, name, s"$byRefPrefix$$$name", typeFullName))
 
-          case other =>
-            logger.warn(s"Found incorrect closure use variable '$other' in $relativeFileName")
-            None
-        }
+        case other =>
+          logger.warn(s"Found incorrect closure use variable '$other' in $relativeFileName")
+          None
       }
+    }
 
-      // Add closure bindings to diffgraph
-      localsForUses.foreach { local =>
-        val closureBindingId = s"$relativeFileName:$methodName:${local.name}"
-        local.closureBindingId(closureBindingId)
-        scope.addToScope(local.name, local)
+    // Add closure bindings to diffgraph
+    localsForUses.foreach { local =>
+      val closureBindingId = s"$relativeFileName:$methodName:${local.name}"
+      local.closureBindingId(closureBindingId)
+      scope.addToScope(local.name, local)
 
-        val closureBindingNode = NewClosureBinding()
-          .closureBindingId(closureBindingId)
-          .closureOriginalName(local.name)
-          .evaluationStrategy(EvaluationStrategies.BY_SHARING)
+      val closureBindingNode = NewClosureBinding()
+        .closureBindingId(closureBindingId)
+        .closureOriginalName(local.name)
+        .evaluationStrategy(EvaluationStrategies.BY_SHARING)
 
-        // The ref edge to the captured local is added in the ClosureRefPass
-        diffGraph.addNode(closureBindingNode)
-        diffGraph.addEdge(methodRef, closureBindingNode, EdgeTypes.CAPTURE)
-      }
+      // The ref edge to the captured local is added in the ClosureRefPass
+      diffGraph.addNode(closureBindingNode)
+      diffGraph.addEdge(methodRef, closureBindingNode, EdgeTypes.CAPTURE)
+    }
 
-      // Create method for closure
-      val name = PhpNameExpr(methodName, closureExpr.attributes)
-      // TODO Check for static modifier
-      val modifiers = ModifierTypes.LAMBDA :: (if (closureExpr.isStatic) ModifierTypes.STATIC :: Nil else Nil)
-      val methodDecl = PhpMethodDecl(
-        name,
-        closureExpr.params,
-        modifiers,
-        closureExpr.returnType,
-        closureExpr.stmts,
-        closureExpr.returnByRef,
-        namespacedName = None,
-        isClassMethod = closureExpr.isStatic,
-        closureExpr.attributes,
-        List.empty[PhpAttributeGroup]
-      )
-      val methodAst = astForMethodDecl(methodDecl, localsForUses.map(Ast(_)), Option(methodName))
+    // Create method for closure
+    val name = PhpNameExpr(methodName, closureExpr.attributes)
+    // TODO Check for static modifier
+    val modifiers = ModifierTypes.LAMBDA :: (if (closureExpr.isStatic) ModifierTypes.STATIC :: Nil else Nil)
+    val methodDecl = PhpMethodDecl(
+      name,
+      closureExpr.params,
+      modifiers,
+      closureExpr.returnType,
+      closureExpr.stmts,
+      closureExpr.returnByRef,
+      namespacedName = None,
+      isClassMethod = closureExpr.isStatic,
+      closureExpr.attributes,
+      List.empty[PhpAttributeGroup]
+    )
+    val methodAst = astForMethodDecl(methodDecl, localsForUses.map(Ast(_)), Option(methodName))
 
-      val usesCode = localsForUses match {
-        case Nil    => ""
-        case locals => s" use(${locals.map(_.code).mkString(", ")})"
-      }
-      methodAst.root.collect { case method: NewMethod => method }.foreach { methodNode =>
-        methodNode.code(methodNode.code ++ usesCode)
-      }
+    val usesCode = localsForUses match {
+      case Nil    => ""
+      case locals => s" use(${locals.map(_.code).mkString(", ")})"
+    }
+    methodAst.root.collect { case method: NewMethod => method }.foreach { methodNode =>
+      methodNode.code(methodNode.code ++ usesCode)
+    }
 
-      // Add method to scope to be attached to typeDecl later
-      scope.addAnonymousMethod(methodAst)
+    // Add method to scope to be attached to typeDecl later
+    scope.addAnonymousMethod(methodAst)
 
-      Ast(methodRef)
+    Ast(methodRef)
   }
 
   protected def astForMethodDecl(
@@ -88,51 +86,53 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     bodyPrefixAsts: List[Ast] = Nil,
     fullNameOverride: Option[String] = None,
     isConstructor: Boolean = false
-  ): Ast = parseLevel match {
-    case SIGNATURES => Ast()
-    case FULL_AST =>
-      val isStatic = decl.modifiers.contains(ModifierTypes.STATIC)
-      val thisParam = if (decl.isClassMethod && !isStatic) {
-        Option(thisParamAstForMethod(decl))
-      } else {
-        None
-      }
+  ): Ast = {
+    val isStatic = decl.modifiers.contains(ModifierTypes.STATIC)
+    val thisParam = if (decl.isClassMethod && !isStatic) {
+      Option(thisParamAstForMethod(decl))
+    } else {
+      None
+    }
 
-      val methodName = decl.name.name
-      val fullName   = fullNameOverride.getOrElse(composeMethodFullName(methodName, isStatic))
+    val methodName = decl.name.name
+    val fullName   = fullNameOverride.getOrElse(composeMethodFullName(methodName, isStatic))
 
-      val signature = s"$UnresolvedSignature(${decl.params.size})"
+    val signature = s"$UnresolvedSignature(${decl.params.size})"
 
-      val parameters = thisParam.toList ++ decl.params.zipWithIndex.map { case (param, idx) =>
-        astForParam(param, idx + 1)
-      }
+    val parameters = thisParam.toList ++ decl.params.zipWithIndex.map { case (param, idx) =>
+      astForParam(param, idx + 1)
+    }
 
-      val constructorModifier   = Option.when(isConstructor)(ModifierTypes.CONSTRUCTOR)
-      val defaultAccessModifier = Option.unless(containsAccessModifier(decl.modifiers))(ModifierTypes.PUBLIC)
+    val constructorModifier   = Option.when(isConstructor)(ModifierTypes.CONSTRUCTOR)
+    val defaultAccessModifier = Option.unless(containsAccessModifier(decl.modifiers))(ModifierTypes.PUBLIC)
 
-      val allModifiers      = constructorModifier ++: defaultAccessModifier ++: decl.modifiers
-      val modifiers         = allModifiers.map(modifierNode(decl, _))
-      val excludedModifiers = Set(ModifierTypes.MODULE, ModifierTypes.LAMBDA)
-      val modifierString = decl.modifiers.filterNot(excludedModifiers.contains) match {
-        case Nil  => ""
-        case mods => s"${mods.mkString(" ")} "
-      }
-      val methodCode = s"${modifierString}function $methodName(${parameters.map(_.rootCodeOrEmpty).mkString(",")})"
+    val allModifiers      = constructorModifier ++: defaultAccessModifier ++: decl.modifiers
+    val modifiers         = allModifiers.map(modifierNode(decl, _))
+    val excludedModifiers = Set(ModifierTypes.MODULE, ModifierTypes.LAMBDA)
+    val modifierString = decl.modifiers.filterNot(excludedModifiers.contains) match {
+      case Nil  => ""
+      case mods => s"${mods.mkString(" ")} "
+    }
+    val methodCode = s"${modifierString}function $methodName(${parameters.map(_.rootCodeOrEmpty).mkString(",")})"
 
-      val method = methodNode(decl, methodName, methodCode, fullName, Some(signature), relativeFileName)
+    val method     = methodNode(decl, methodName, methodCode, fullName, Some(signature), relativeFileName)
+    val isTopLevel = scope.isTopLevel
 
-      scope.pushNewScope(method)
+    scope.pushNewScope(method)
 
-      val returnType = decl.returnType.map(_.name).getOrElse(Defines.Any)
+    val returnType = decl.returnType.map(_.name).getOrElse(Defines.Any)
 
-      val methodBodyStmts = bodyPrefixAsts ++ decl.stmts.flatMap(astsForStmt)
-      val methodReturn    = methodReturnNode(decl, returnType)
+    val methodBodyStmts = bodyPrefixAsts ++ decl.stmts.flatMap(astsForStmt)
+    val methodReturn    = methodReturnNode(decl, returnType)
 
-      val attributeAsts = decl.attributeGroups.flatMap(astForAttributeGroup)
-      val methodBody    = blockAst(blockNode(decl), methodBodyStmts)
+    val attributeAsts = decl.attributeGroups.flatMap(astForAttributeGroup)
+    val methodBody = parseLevel match {
+      case SIGNATURES if !isTopLevel => blockAst(blockNode(decl), Nil)
+      case _                         => blockAst(blockNode(decl), methodBodyStmts)
+    }
 
-      scope.popScope()
-      methodAstWithAnnotations(method, parameters, methodBody, methodReturn, modifiers, attributeAsts)
+    scope.popScope()
+    methodAstWithAnnotations(method, parameters, methodBody, methodReturn, modifiers, attributeAsts)
   }
 
   private def thisParamAstForMethod(originNode: PhpNode): Ast = {

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForFunctionsCreator.scala
@@ -4,6 +4,7 @@ import io.joern.php2cpg.astcreation.AstCreator.{NameConstants, TypeConstants}
 import io.joern.php2cpg.parser.Domain.*
 import io.joern.php2cpg.parser.Domain.PhpModifiers.containsAccessModifier
 import io.joern.x2cpg.Defines.UnresolvedSignature
+import io.joern.x2cpg.datastructures.AstParseLevel.{FULL_AST, SIGNATURES}
 import io.joern.x2cpg.utils.AstPropertiesUtil.RootProperties
 import io.joern.x2cpg.{Ast, Defines, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.nodes.*
@@ -11,73 +12,75 @@ import io.shiftleft.codepropertygraph.generated.{EdgeTypes, EvaluationStrategies
 
 trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
-  protected def astForClosureExpr(closureExpr: PhpClosureExpr): Ast = {
-    val methodName = scope.getScopedClosureName
-    val methodRef  = methodRefNode(closureExpr, methodName, methodName, Defines.Any)
+  protected def astForClosureExpr(closureExpr: PhpClosureExpr): Ast = parseLevel match {
+    case SIGNATURES => Ast()
+    case FULL_AST =>
+      val methodName = scope.getScopedClosureName
+      val methodRef  = methodRefNode(closureExpr, methodName, methodName, Defines.Any)
 
-    val localsForUses = closureExpr.uses.flatMap { closureUse =>
-      closureUse.variable match {
-        case PhpVariable(PhpNameExpr(name, _), _) =>
-          val typeFullName = scope
-            .lookupVariable(name)
-            .flatMap(_.properties.get(PropertyNames.TYPE_FULL_NAME).map(_.toString))
-            .getOrElse(Defines.Any)
-          val byRefPrefix = if (closureUse.byRef) "&" else ""
+      val localsForUses = closureExpr.uses.flatMap { closureUse =>
+        closureUse.variable match {
+          case PhpVariable(PhpNameExpr(name, _), _) =>
+            val typeFullName = scope
+              .lookupVariable(name)
+              .flatMap(_.properties.get(PropertyNames.TYPE_FULL_NAME).map(_.toString))
+              .getOrElse(Defines.Any)
+            val byRefPrefix = if (closureUse.byRef) "&" else ""
 
-          Some(localNode(closureExpr, name, s"$byRefPrefix$$$name", typeFullName))
+            Some(localNode(closureExpr, name, s"$byRefPrefix$$$name", typeFullName))
 
-        case other =>
-          logger.warn(s"Found incorrect closure use variable '$other' in $relativeFileName")
-          None
+          case other =>
+            logger.warn(s"Found incorrect closure use variable '$other' in $relativeFileName")
+            None
+        }
       }
-    }
 
-    // Add closure bindings to diffgraph
-    localsForUses.foreach { local =>
-      val closureBindingId = s"$relativeFileName:$methodName:${local.name}"
-      local.closureBindingId(closureBindingId)
-      scope.addToScope(local.name, local)
+      // Add closure bindings to diffgraph
+      localsForUses.foreach { local =>
+        val closureBindingId = s"$relativeFileName:$methodName:${local.name}"
+        local.closureBindingId(closureBindingId)
+        scope.addToScope(local.name, local)
 
-      val closureBindingNode = NewClosureBinding()
-        .closureBindingId(closureBindingId)
-        .closureOriginalName(local.name)
-        .evaluationStrategy(EvaluationStrategies.BY_SHARING)
+        val closureBindingNode = NewClosureBinding()
+          .closureBindingId(closureBindingId)
+          .closureOriginalName(local.name)
+          .evaluationStrategy(EvaluationStrategies.BY_SHARING)
 
-      // The ref edge to the captured local is added in the ClosureRefPass
-      diffGraph.addNode(closureBindingNode)
-      diffGraph.addEdge(methodRef, closureBindingNode, EdgeTypes.CAPTURE)
-    }
+        // The ref edge to the captured local is added in the ClosureRefPass
+        diffGraph.addNode(closureBindingNode)
+        diffGraph.addEdge(methodRef, closureBindingNode, EdgeTypes.CAPTURE)
+      }
 
-    // Create method for closure
-    val name = PhpNameExpr(methodName, closureExpr.attributes)
-    // TODO Check for static modifier
-    val modifiers = ModifierTypes.LAMBDA :: (if (closureExpr.isStatic) ModifierTypes.STATIC :: Nil else Nil)
-    val methodDecl = PhpMethodDecl(
-      name,
-      closureExpr.params,
-      modifiers,
-      closureExpr.returnType,
-      closureExpr.stmts,
-      closureExpr.returnByRef,
-      namespacedName = None,
-      isClassMethod = closureExpr.isStatic,
-      closureExpr.attributes,
-      List.empty[PhpAttributeGroup]
-    )
-    val methodAst = astForMethodDecl(methodDecl, localsForUses.map(Ast(_)), Option(methodName))
+      // Create method for closure
+      val name = PhpNameExpr(methodName, closureExpr.attributes)
+      // TODO Check for static modifier
+      val modifiers = ModifierTypes.LAMBDA :: (if (closureExpr.isStatic) ModifierTypes.STATIC :: Nil else Nil)
+      val methodDecl = PhpMethodDecl(
+        name,
+        closureExpr.params,
+        modifiers,
+        closureExpr.returnType,
+        closureExpr.stmts,
+        closureExpr.returnByRef,
+        namespacedName = None,
+        isClassMethod = closureExpr.isStatic,
+        closureExpr.attributes,
+        List.empty[PhpAttributeGroup]
+      )
+      val methodAst = astForMethodDecl(methodDecl, localsForUses.map(Ast(_)), Option(methodName))
 
-    val usesCode = localsForUses match {
-      case Nil    => ""
-      case locals => s" use(${locals.map(_.code).mkString(", ")})"
-    }
-    methodAst.root.collect { case method: NewMethod => method }.foreach { methodNode =>
-      methodNode.code(methodNode.code ++ usesCode)
-    }
+      val usesCode = localsForUses match {
+        case Nil    => ""
+        case locals => s" use(${locals.map(_.code).mkString(", ")})"
+      }
+      methodAst.root.collect { case method: NewMethod => method }.foreach { methodNode =>
+        methodNode.code(methodNode.code ++ usesCode)
+      }
 
-    // Add method to scope to be attached to typeDecl later
-    scope.addAnonymousMethod(methodAst)
+      // Add method to scope to be attached to typeDecl later
+      scope.addAnonymousMethod(methodAst)
 
-    Ast(methodRef)
+      Ast(methodRef)
   }
 
   protected def astForMethodDecl(
@@ -85,49 +88,51 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     bodyPrefixAsts: List[Ast] = Nil,
     fullNameOverride: Option[String] = None,
     isConstructor: Boolean = false
-  ): Ast = {
-    val isStatic = decl.modifiers.contains(ModifierTypes.STATIC)
-    val thisParam = if (decl.isClassMethod && !isStatic) {
-      Option(thisParamAstForMethod(decl))
-    } else {
-      None
-    }
+  ): Ast = parseLevel match {
+    case SIGNATURES => Ast()
+    case FULL_AST =>
+      val isStatic = decl.modifiers.contains(ModifierTypes.STATIC)
+      val thisParam = if (decl.isClassMethod && !isStatic) {
+        Option(thisParamAstForMethod(decl))
+      } else {
+        None
+      }
 
-    val methodName = decl.name.name
-    val fullName   = fullNameOverride.getOrElse(composeMethodFullName(methodName, isStatic))
+      val methodName = decl.name.name
+      val fullName   = fullNameOverride.getOrElse(composeMethodFullName(methodName, isStatic))
 
-    val signature = s"$UnresolvedSignature(${decl.params.size})"
+      val signature = s"$UnresolvedSignature(${decl.params.size})"
 
-    val parameters = thisParam.toList ++ decl.params.zipWithIndex.map { case (param, idx) =>
-      astForParam(param, idx + 1)
-    }
+      val parameters = thisParam.toList ++ decl.params.zipWithIndex.map { case (param, idx) =>
+        astForParam(param, idx + 1)
+      }
 
-    val constructorModifier   = Option.when(isConstructor)(ModifierTypes.CONSTRUCTOR)
-    val defaultAccessModifier = Option.unless(containsAccessModifier(decl.modifiers))(ModifierTypes.PUBLIC)
+      val constructorModifier   = Option.when(isConstructor)(ModifierTypes.CONSTRUCTOR)
+      val defaultAccessModifier = Option.unless(containsAccessModifier(decl.modifiers))(ModifierTypes.PUBLIC)
 
-    val allModifiers      = constructorModifier ++: defaultAccessModifier ++: decl.modifiers
-    val modifiers         = allModifiers.map(modifierNode(decl, _))
-    val excludedModifiers = Set(ModifierTypes.MODULE, ModifierTypes.LAMBDA)
-    val modifierString = decl.modifiers.filterNot(excludedModifiers.contains) match {
-      case Nil  => ""
-      case mods => s"${mods.mkString(" ")} "
-    }
-    val methodCode = s"${modifierString}function $methodName(${parameters.map(_.rootCodeOrEmpty).mkString(",")})"
+      val allModifiers      = constructorModifier ++: defaultAccessModifier ++: decl.modifiers
+      val modifiers         = allModifiers.map(modifierNode(decl, _))
+      val excludedModifiers = Set(ModifierTypes.MODULE, ModifierTypes.LAMBDA)
+      val modifierString = decl.modifiers.filterNot(excludedModifiers.contains) match {
+        case Nil  => ""
+        case mods => s"${mods.mkString(" ")} "
+      }
+      val methodCode = s"${modifierString}function $methodName(${parameters.map(_.rootCodeOrEmpty).mkString(",")})"
 
-    val method = methodNode(decl, methodName, methodCode, fullName, Some(signature), relativeFileName)
+      val method = methodNode(decl, methodName, methodCode, fullName, Some(signature), relativeFileName)
 
-    scope.pushNewScope(method)
+      scope.pushNewScope(method)
 
-    val returnType = decl.returnType.map(_.name).getOrElse(Defines.Any)
+      val returnType = decl.returnType.map(_.name).getOrElse(Defines.Any)
 
-    val methodBodyStmts = bodyPrefixAsts ++ decl.stmts.flatMap(astsForStmt)
-    val methodReturn    = methodReturnNode(decl, returnType)
+      val methodBodyStmts = bodyPrefixAsts ++ decl.stmts.flatMap(astsForStmt)
+      val methodReturn    = methodReturnNode(decl, returnType)
 
-    val attributeAsts = decl.attributeGroups.flatMap(astForAttributeGroup)
-    val methodBody    = blockAst(blockNode(decl), methodBodyStmts)
+      val attributeAsts = decl.attributeGroups.flatMap(astForAttributeGroup)
+      val methodBody    = blockAst(blockNode(decl), methodBodyStmts)
 
-    scope.popScope()
-    methodAstWithAnnotations(method, parameters, methodBody, methodReturn, modifiers, attributeAsts)
+      scope.popScope()
+      methodAstWithAnnotations(method, parameters, methodBody, methodReturn, modifiers, attributeAsts)
   }
 
   private def thisParamAstForMethod(originNode: PhpNode): Ast = {

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstSummaryVisitor.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstSummaryVisitor.scala
@@ -1,0 +1,79 @@
+package io.joern.php2cpg.astcreation
+
+import flatgraph.DiffGraphApplier
+import io.joern.php2cpg.datastructures.*
+import io.joern.x2cpg.datastructures.AstParseLevel
+import io.joern.x2cpg.datastructures.AstParseLevel.{FULL_AST, SIGNATURES}
+import io.joern.x2cpg.passes.base.AstLinkerPass
+import io.joern.x2cpg.{Ast, ValidationMode}
+import io.shiftleft.codepropertygraph.generated.nodes.Namespace
+import io.shiftleft.codepropertygraph.generated.{Cpg, nodes}
+import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
+
+import scala.collection.mutable
+import scala.util.Using
+
+trait AstSummaryVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
+
+  def summarize: PhpProgramSummary = this.parseLevel match {
+    case FULL_AST =>
+      AstCreator(relativeFileName, fileName, phpAst, disableFileContent, programSummary, SIGNATURES).summarize
+    case SIGNATURES =>
+      Using.resource(Cpg.empty) { cpg =>
+        // Build and store compilation unit AST
+        val ast = astForPhpFile(phpAst)
+        Ast.storeInDiffGraph(ast, diffGraph)
+        DiffGraphApplier.applyDiff(cpg.graph, diffGraph)
+
+        // Link basic AST elements
+        AstLinkerPass(cpg).createAndApply()
+        // Summarize findings
+        summarize(cpg)
+      }
+  }
+
+  def withSummary(newSummary: PhpProgramSummary): AstCreator = {
+    AstCreator(relativeFileName, fileName, phpAst, disableFileContent, newSummary, parseLevel)
+  }
+
+  private def summarize(cpg: Cpg): PhpProgramSummary = {
+
+    def toMethod(m: nodes.Method): PhpMethod = {
+      val definingTypeDeclFullName = m.definingTypeDecl.fullName.headOption
+
+      PhpMethod(
+        m.name,
+        m.parameter.map(x => x.name -> x.typeFullName).l,
+        m.methodReturn.typeFullName,
+        definingTypeDeclFullName
+      )
+    }
+
+    def toField(f: nodes.Member): PhpField = {
+      PhpField(f.name, f.typeFullName)
+    }
+
+    def toType(m: nodes.TypeDecl): PhpType = PhpType(m.fullName, m.method.map(toMethod).l, m.member.map(toField).l)
+
+    val namespaceToTypeMap = cpg.namespaceBlock.map { n =>
+      val phpTypes = n.astChildren.flatMap {
+        // We have TypeDecl(<global>)->Method(<global>)->/.../
+        case x: nodes.TypeDecl if x.name == NamespaceTraversal.globalNamespaceName =>
+          val classDecls = x.method.isModule.block.astChildren.collect { case classDecl: nodes.TypeDecl =>
+            toType(classDecl)
+          }.toList
+          val topLevelMethods = x.method.isModule.block.astChildren.collect { case functionDecl: nodes.Method =>
+            toMethod(functionDecl)
+          }.toList
+          val topLevelTypeDecl = PhpType(n.fullName, topLevelMethods, Nil)
+          topLevelTypeDecl :: classDecls
+        case x: nodes.Method => PhpType(n.fullName, toMethod(x) :: Nil, Nil) :: Nil
+        case _               => Nil
+      }.toSetMutable
+      n.fullName -> phpTypes
+    }.toSeq
+    PhpProgramSummary(mutable.Map(namespaceToTypeMap*))
+  }
+
+}

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/datastructures/PhpProgramSummary.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/datastructures/PhpProgramSummary.scala
@@ -1,0 +1,36 @@
+package io.joern.php2cpg.datastructures
+
+import io.joern.x2cpg.datastructures.{FieldLike, MethodLike, ProgramSummary, TypeLike}
+
+import scala.annotation.targetName
+import scala.collection.mutable
+
+type NamespaceToTypeMap = mutable.Map[String, mutable.Set[PhpType]]
+
+class PhpProgramSummary(
+  override val namespaceToType: NamespaceToTypeMap = mutable.Map.empty[String, mutable.Set[PhpType]]
+) extends ProgramSummary[PhpType, PhpMethod, PhpField] {
+
+  @targetName("appendAll")
+  def ++=(other: PhpProgramSummary): PhpProgramSummary =
+    PhpProgramSummary(ProgramSummary.merge(this.namespaceToType, other.namespaceToType))
+
+}
+
+case class PhpField(name: String, typeName: String) extends FieldLike
+
+case class PhpMethod(
+  name: String,
+  parameterTypes: List[(String, String)],
+  returnType: String,
+  baseTypeFullName: Option[String]
+) extends MethodLike
+
+case class PhpType(name: String, methods: List[PhpMethod], fields: List[PhpField])
+    extends TypeLike[PhpMethod, PhpField] {
+
+  @targetName("add")
+  override def +(o: TypeLike[PhpMethod, PhpField]): TypeLike[PhpMethod, PhpField] = {
+    this.copy(methods = mergeMethods(o), fields = mergeFields(o))
+  }
+}

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/datastructures/PhpScopeElement.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/datastructures/PhpScopeElement.scala
@@ -1,7 +1,7 @@
-package io.joern.php2cpg.utils
+package io.joern.php2cpg.datastructures
 
 import io.joern.php2cpg.parser.Domain.InstanceMethodDelimiter
-import io.shiftleft.codepropertygraph.generated.nodes.{NewBlock, NewMethod, NewNamespaceBlock, NewNode, NewTypeDecl}
+import io.shiftleft.codepropertygraph.generated.nodes.*
 
 class PhpScopeElement private (val node: NewNode, scopeName: String)(implicit nextClosureName: () => String) {
   private var tmpVarCounter   = 0

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/datastructures/Scope.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/datastructures/Scope.scala
@@ -1,10 +1,10 @@
-package io.joern.php2cpg.utils
+package io.joern.php2cpg.datastructures
 
 import io.joern.php2cpg.astcreation.AstCreator.NameConstants
 import io.joern.x2cpg.Ast
-import io.joern.x2cpg.datastructures.{ScopeElement, NamespaceLikeScope, Scope as X2CpgScope}
+import io.joern.x2cpg.datastructures.{NamespaceLikeScope, ScopeElement, Scope as X2CpgScope}
 import io.shiftleft.codepropertygraph.generated.NodeTypes
-import io.shiftleft.codepropertygraph.generated.nodes.{NewBlock, NewMethod, NewNamespaceBlock, NewNode, NewTypeDecl}
+import io.shiftleft.codepropertygraph.generated.nodes.*
 import org.slf4j.LoggerFactory
 
 import scala.collection.mutable

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/datastructures/Scope.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/datastructures/Scope.scala
@@ -5,6 +5,7 @@ import io.joern.x2cpg.Ast
 import io.joern.x2cpg.datastructures.{NamespaceLikeScope, ScopeElement, Scope as X2CpgScope}
 import io.shiftleft.codepropertygraph.generated.NodeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 import org.slf4j.LoggerFactory
 
 import scala.collection.mutable
@@ -69,6 +70,13 @@ class Scope(implicit nextClosureName: () => String) extends X2CpgScope[String, N
 
     scopeNode
   }
+
+  /** @return
+    *   true if the current scope is top-level, i.e., a direct child of the PHP script.
+    */
+  def isTopLevel: Boolean = stack.collectFirst { case ScopeElement(PhpScopeElement(x: NewTypeDecl), _) =>
+    x.name.endsWith(NamespaceTraversal.globalNamespaceName)
+  }.isDefined
 
   def getNewClassTmp: String = {
     stack.headOption match {

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/PhpParser.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/PhpParser.scala
@@ -12,6 +12,8 @@ import scala.collection.mutable
 import scala.io.Source
 import scala.util.{Failure, Success, Try}
 
+case class PhpParseResult(fileName: String, parseResult: Option[PhpFile], infoLines: String)
+
 class PhpParser private (phpParserPath: String, phpIniPath: String, disableFileContent: Boolean) {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
@@ -21,7 +23,7 @@ class PhpParser private (phpParserPath: String, phpIniPath: String, disableFileC
     Seq("php", "--php-ini", phpIniPath, phpParserPath) ++ phpParserCommands ++ filenames
   }
 
-  def parseFiles(inputPaths: collection.Seq[String]): collection.Seq[(String, Option[PhpFile], String)] = {
+  def parseFiles(inputPaths: collection.Seq[String]): collection.Seq[PhpParseResult] = {
     // We need to keep a map between the input path and its canonical representation in
     // order to map back the canonical file name we get from the php parser.
     // Otherwise later on file name/path processing might get confused because the returned
@@ -43,7 +45,7 @@ class PhpParser private (phpParserPath: String, phpIniPath: String, disableFileC
           (filename, jsonToPhpFile(jsonObjectOption, filename), infoLines)
         }
         val withRemappedFileName = asPhpFile.map { case (filename, phpFileOption, infoLines) =>
-          (canonicalToInputPath.apply(filename), phpFileOption, infoLines)
+          PhpParseResult(canonicalToInputPath.apply(filename), phpFileOption, infoLines)
         }
         withRemappedFileName
       case ExternalCommand.ExternalCommandResult(exitCode, _, _) =>

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/passes/PhpSummaryPassTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/passes/PhpSummaryPassTests.scala
@@ -1,0 +1,59 @@
+package io.joern.php2cpg.passes
+
+import io.joern.php2cpg.datastructures.{PhpMethod, PhpProgramSummary}
+import io.joern.php2cpg.parser.PhpParser
+import io.joern.php2cpg.{Config, Php2Cpg}
+import io.shiftleft.semanticcpg.utils.FileUtil
+import org.scalatest.Assertion
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.nio.file.Files
+
+class PhpSummaryPassTests extends AnyWordSpec with Matchers {
+
+  import PhpSummaryPassTests.*
+
+  "pre-parsing a file with a top-level function should provide a summary of that function" in {
+    assertAgainstTempFile(
+      """<?php
+        |function foo($a, $b): int {}
+        |""".stripMargin,
+      { programSummary =>
+        val summary = programSummary.namespaceToType
+        summary.size shouldBe 1
+        val globalType = summary("Test.php:<global>").head
+        globalType.name shouldBe "Test.php:<global>"
+        globalType.methods should contain(
+          PhpMethod("foo", List(("a", "ANY"), ("b", "ANY")), "int", Some("Test.php:<global>"))
+        )
+      }
+    )
+  }
+
+}
+
+object PhpSummaryPassTests {
+
+  import FileUtil.PathExt
+
+  case class ConfigAndParser(config: Config, parser: PhpParser)
+
+  def assertAgainstTempFile(code: String, assertion: PhpProgramSummary => Assertion): Unit = {
+    FileUtil.usingTemporaryDirectory("php-test") { tmpDirPath =>
+      val tmpFilePath = tmpDirPath / "Test.php"
+      Files.createFile(tmpFilePath)
+      FileUtil.writeBytes(tmpFilePath, code.getBytes)
+      val config = Config().withInputPath(tmpFilePath.toString)
+      PhpParser.getParser(config) match {
+        case Some(parser) =>
+          new Php2Cpg().parseFiles(config, Option(parser)).map(_.programSummary).headOption match {
+            case Some(summary) => assertion(summary)
+            case None          => Matchers.fail(s"Unable to obtain summary from given code! See logs for details.")
+          }
+        case None => Matchers.fail(s"Unable to create a PHP parser! See logs for details.")
+      }
+    }
+  }
+
+}

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/passes/PhpSummaryPassTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/passes/PhpSummaryPassTests.scala
@@ -1,6 +1,6 @@
 package io.joern.php2cpg.passes
 
-import io.joern.php2cpg.datastructures.{PhpMethod, PhpProgramSummary}
+import io.joern.php2cpg.datastructures.{PhpField, PhpMethod, PhpProgramSummary}
 import io.joern.php2cpg.parser.PhpParser
 import io.joern.php2cpg.{Config, Php2Cpg}
 import io.shiftleft.semanticcpg.utils.FileUtil
@@ -17,7 +17,7 @@ class PhpSummaryPassTests extends AnyWordSpec with Matchers {
   "pre-parsing a file with a top-level function should provide a summary of that function" in {
     assertAgainstTempFile(
       """<?php
-        |function foo($a, $b): int {}
+        |function foo($a, string $b): int {}
         |""".stripMargin,
       { programSummary =>
         val summary = programSummary.namespaceToType
@@ -25,8 +25,43 @@ class PhpSummaryPassTests extends AnyWordSpec with Matchers {
         val globalType = summary("Test.php:<global>").head
         globalType.name shouldBe "Test.php:<global>"
         globalType.methods should contain(
-          PhpMethod("foo", List(("a", "ANY"), ("b", "ANY")), "int", Some("Test.php:<global>"))
+          PhpMethod("foo", List(("a", "ANY"), ("b", "string")), "int", Some("Test.php:<global>"))
         )
+      }
+    )
+  }
+
+  "pre-parsing a file with a top-level class with a nested function should provide a summary of that class" in {
+    assertAgainstTempFile(
+      """<?php
+        |class Foo {
+        |  final public function foo(int $x): int {
+        |    return 0;
+        |  }
+        |}
+        |""".stripMargin,
+      { programSummary =>
+        val summary = programSummary.namespaceToType
+        summary.size shouldBe 1
+        val fooType = summary("Test.php:<global>").filter(_.name == "Foo").head
+        fooType.methods should contain(PhpMethod("foo", List(("this", "Foo"), ("x", "int")), "int", Some("Foo")))
+        fooType.methods should contain(PhpMethod("__construct", List(("this", "Foo")), "ANY", Some("Foo")))
+      }
+    )
+  }
+
+  "pre-parsing a file with a top-level class with a nested constant should provide a summary of that class" in {
+    assertAgainstTempFile(
+      """<?php
+        |class Foo {
+        |  const B = "B";
+        |}
+        |""".stripMargin,
+      { programSummary =>
+        val summary = programSummary.namespaceToType
+        summary.size shouldBe 1
+        val fooType = summary("Test.php:<global>").filter(_.name == "Foo").head
+        fooType.fields should contain(PhpField("B", "ANY"))
       }
     )
   }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/testfixtures/PhpCode2CpgFixture.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/testfixtures/PhpCode2CpgFixture.scala
@@ -1,7 +1,7 @@
 package io.joern.php2cpg.testfixtures
 
 import io.joern.dataflowengineoss.DefaultSemantics
-import io.joern.dataflowengineoss.semanticsloader.{FlowSemantic, Semantics}
+import io.joern.dataflowengineoss.semanticsloader.Semantics
 import io.joern.dataflowengineoss.testfixtures.{SemanticCpgTestFixture, SemanticTestCpg}
 import io.joern.php2cpg.{Config, Php2Cpg}
 import io.joern.x2cpg.frontendspecific.php2cpg

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreator.scala
@@ -4,7 +4,8 @@ import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.*
 import io.joern.rubysrc2cpg.datastructures.{BlockScope, NamespaceScope, RubyProgramSummary, RubyScope}
 import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.rubysrc2cpg.utils.FreshNameGenerator
-import io.joern.x2cpg.{Ast, AstCreatorBase, AstNodeBuilder, ValidationMode}
+import io.joern.x2cpg.datastructures.AstParseLevel
+import io.joern.x2cpg.{Ast, AstCreatorBase, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{DiffGraphBuilder, EvaluationStrategies, ModifierTypes}
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
@@ -132,17 +133,4 @@ class AstCreator(
       .getOrElse(Ast())
   }
 
-}
-
-/** Determines till what depth the AST creator will parse until.
-  */
-enum AstParseLevel {
-
-  /** This level will parse all types and methods signatures, but exclude method bodies.
-    */
-  case SIGNATURES
-
-  /** This level will parse the full AST.
-    */
-  case FULL_AST
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -15,6 +15,7 @@ import io.shiftleft.codepropertygraph.generated.{
   Operators
 }
 import io.joern.x2cpg.AstNodeBuilder.{bindingNode, closureBindingNode}
+import io.joern.x2cpg.datastructures.AstParseLevel
 
 import scala.collection.mutable
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
@@ -3,6 +3,7 @@ package io.joern.rubysrc2cpg.astcreation
 import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.{TypeDeclaration, *}
 import io.joern.rubysrc2cpg.datastructures.{BlockScope, MethodScope, ModuleScope, NamespaceScope, TypeScope}
 import io.joern.rubysrc2cpg.passes.Defines
+import io.joern.x2cpg.datastructures.AstParseLevel
 import io.joern.x2cpg.{Ast, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstSummaryVisitor.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstSummaryVisitor.scala
@@ -1,13 +1,11 @@
 package io.joern.rubysrc2cpg.astcreation
 
 import flatgraph.DiffGraphApplier
-import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.{RubyExpression, StatementList}
-import io.joern.rubysrc2cpg.datastructures.{RubyField, RubyMethod, RubyProgramSummary, RubyStubbedType, RubyType}
+import io.joern.rubysrc2cpg.datastructures.*
 import io.joern.rubysrc2cpg.passes.Defines
-import io.joern.x2cpg.layers.Base
-import io.joern.x2cpg.passes.base.{AstLinkerPass, FileCreationPass}
+import io.joern.x2cpg.datastructures.AstParseLevel
+import io.joern.x2cpg.passes.base.AstLinkerPass
 import io.joern.x2cpg.{Ast, ValidationMode}
-import io.shiftleft.codepropertygraph.cpgloading.CpgLoader
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{Local, Member, Method, TypeDecl}
 import io.shiftleft.semanticcpg.language.*


### PR DESCRIPTION
To resolve symbols and types that are brought into the current context via `use` functions, the approach of pre-parsing the AST for high-level symbols is implemented. A similar approach is used in Ruby, and this follows on that.

As this "summary" object is pretty similar to that in Ruby, we may want to unify these at some point with a "default" implementation of the summary objects to reduce the number of classes.