### PR TITLE
[ghidra2cpg] Fix function signature mismatch

### DIFF
--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/utils/Utils.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/utils/Utils.scala
@@ -66,6 +66,7 @@ object Utils {
   }
   def createMethodNode(decompiler: Decompiler, function: Function, fileName: String): NewMethod = {
     val code       = decompiler.toDecompiledFunction(function).map(_.getC).getOrElse("")
+    val signature  = decompiler.toDecompiledFunction(function).map(_.getSignature).getOrElse("")
     val isExternal = Option(function.getThunkedFunction(true)).map(_.isExternal).getOrElse(function.isExternal)
     val lineNumberEnd = Option(function.getReturn)
       .flatMap(x => Option(x.getMinAddress))
@@ -78,7 +79,7 @@ object Utils {
       .name(function.getName)
       .fullName(function.getName)
       .isExternal(isExternal)
-      .signature(function.getSignature(true).toString)
+      .signature(signature)
       .lineNumber(function.getEntryPoint.getOffsetAsBigInteger.intValue())
       .columnNumber(-1)
       .lineNumberEnd(lineNumberEnd)


### PR DESCRIPTION
Fixes #5473

The reason for the mismatch is that previously different APIs have been used.

Before:

```scala
joern> cpg.method("vuln").l
val res1: List[io.shiftleft.codepropertygraph.generated.nodes.Method] = List(
  Method(
    astParentFullName = "/home/gemesa/git-repos/tmp/vuln:<global>",
    astParentType = "NAMESPACE_BLOCK",
    code = """
int vuln(void)

{
  int iVar1;
  char acStack_8 [8];
  
  printf("Enter some text: ");
  __isoc23_scanf(&DAT_004007f8,acStack_8);
  iVar1 = puts(acStack_8);
  return iVar1;
}

""",
    columnNumber = Some(value = -1),
    columnNumberEnd = None,
    filename = "/home/gemesa/git-repos/tmp/vuln",
    fullName = "vuln",
    genericSignature = "<empty>",
    hash = None,
    isExternal = false,
    lineNumber = Some(value = 4196196),
    lineNumberEnd = Some(value = -1),
    name = "vuln",
    offset = None,
    offsetEnd = None,
    order = 0,
    signature = "undefined vuln(void)"
  )
)
                                                                                                                      
joern>
```

After:

```scala
joern> cpg.method("vuln").l
val res1: List[io.shiftleft.codepropertygraph.generated.nodes.Method] = List(
  Method(
    astParentFullName = "/home/gemesa/git-repos/tmp/vuln:<global>",
    astParentType = "NAMESPACE_BLOCK",
    code = """
int vuln(void)

{
  int iVar1;
  char acStack_8 [8];
  
  printf("Enter some text: ");
  __isoc23_scanf(&DAT_004007f8,acStack_8);
  iVar1 = puts(acStack_8);
  return iVar1;
}

""",
    columnNumber = Some(value = -1),
    columnNumberEnd = None,
    filename = "/home/gemesa/git-repos/tmp/vuln",
    fullName = "vuln",
    genericSignature = "<empty>",
    hash = None,
    isExternal = false,
    lineNumber = Some(value = 4196196),
    lineNumberEnd = Some(value = -1),
    name = "vuln",
    offset = None,
    offsetEnd = None,
    order = 0,
    signature = "int vuln(void);"
  )
)
                                                                                                                      
joern>
```