### PR TITLE
ciRelease: skip if there's no changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
           cd joern-cli/target/universal/stage
           ./schema-extender/test.sh
           cd -
-      - run: sbt ciReleaseTagNextVersion ciReleaseSonatype createDistribution
+      - run: sbt ciReleaseSkipIfAlreadyReleased ciReleaseTagNextVersion ciReleaseSonatype createDistribution
         env:
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("com.simplytyped" % "sbt-antlr4"           % "0.8.3")
 addSbtPlugin("com.github.sbt"  % "sbt-native-packager"  % "1.10.4")
 addSbtPlugin("org.scalameta"   % "sbt-scalafmt"         % "2.5.2")
-addSbtPlugin("io.shiftleft"    % "sbt-ci-release-early" % "2.0.49")
+addSbtPlugin("io.shiftleft"    % "sbt-ci-release-early" % "2.1.1")
 addSbtPlugin("com.github.sbt"  % "sbt-dynver"           % "5.1.0")
 addSbtPlugin("ch.epfl.scala"   % "sbt-scalafix"         % "0.14.2")


### PR DESCRIPTION
originally suggested in https://github.com/joernio/joern/issues/3823,
I just added that functionality to sbt-ci-release-early

To prevent situations like this:
![image](https://github.com/user-attachments/assets/07e482a1-037f-4d8a-812a-d92128ff35f7)
