### PR TITLE
[php] Pre-Parsing Directly on `PhpNode` objects

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
@@ -61,6 +61,10 @@ class Php2Cpg extends X2CpgFrontend[Config] {
           new DependencySymbolsPass(cpg, dependencyDir).createAndApply()
         }
         parser.foreach { parser =>
+          // The following block parses the code twice, once to summarize all symbols across various namespaces, and
+          // twice to build the AST. This helps resolve symbols during the latter parse. Compared to parsing once, and
+          // holding the AST in-memory, it was decided that parsing did not incur a significant speed impact, and lower
+          // memory was prioritized.
           var buffer = Option.empty[Seq[SymbolSummary]]
           new SymbolSummaryPass(config, cpg, parser, summary => buffer = Option(summary)).createAndApply()
           new AstCreationPass(config, cpg, parser, buffer.getOrElse(Nil)).createAndApply()

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
@@ -61,10 +61,9 @@ class Php2Cpg extends X2CpgFrontend[Config] {
           new DependencySymbolsPass(cpg, dependencyDir).createAndApply()
         }
         parser.foreach { parser =>
-          val summary = new java.util.concurrent.ConcurrentLinkedQueue[SymbolSummary]()
-          new SymbolSummaryPass(config, cpg, parser, summary.add).createAndApply()
-          val dedupSummary = SymbolSummaryPass.deduplicateSummary(summary.asScala.toSeq)
-          new AstCreationPass(config, cpg, parser, dedupSummary).createAndApply()
+          var buffer = Option.empty[Seq[SymbolSummary]]
+          new SymbolSummaryPass(config, cpg, parser, summary => buffer = Option(summary)).createAndApply()
+          new AstCreationPass(config, cpg, parser, buffer.getOrElse(Nil)).createAndApply()
         }
         new AstParentInfoPass(cpg).createAndApply()
         new AnyTypePass(cpg).createAndApply()

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
@@ -63,13 +63,8 @@ class Php2Cpg extends X2CpgFrontend[Config] {
         parser.foreach { parser =>
           val summary = new java.util.concurrent.ConcurrentLinkedQueue[SymbolSummary]()
           new SymbolSummaryPass(config, cpg, parser, summary.add).createAndApply()
-          val reducedSummary = summary.asScala.foldLeft(Seq.empty[SymbolSummary])((acc, next) =>
-            acc match {
-              case Nil          => next :: Nil
-              case head :: tail => head + next ++ tail
-            }
-          )
-          new AstCreationPass(config, cpg, parser, reducedSummary).createAndApply()
+          val dedupSummary = SymbolSummaryPass.deduplicateSummary(summary.asScala.toSeq)
+          new AstCreationPass(config, cpg, parser, dedupSummary).createAndApply()
         }
         new AstParentInfoPass(cpg).createAndApply()
         new AnyTypePass(cpg).createAndApply()

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/PhpParser.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/PhpParser.scala
@@ -12,6 +12,8 @@ import scala.collection.mutable
 import scala.io.Source
 import scala.util.{Failure, Success, Try}
 
+private[php2cpg] case class PhpParseResult(fileName: String, parseResult: Option[PhpFile], infoLines: String)
+
 class PhpParser private (phpParserPath: String, phpIniPath: String, disableFileContent: Boolean) {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
@@ -21,7 +23,7 @@ class PhpParser private (phpParserPath: String, phpIniPath: String, disableFileC
     Seq("php", "--php-ini", phpIniPath, phpParserPath) ++ phpParserCommands ++ filenames
   }
 
-  def parseFiles(inputPaths: collection.Seq[String]): collection.Seq[(String, Option[PhpFile], String)] = {
+  def parseFiles(inputPaths: collection.Seq[String]): collection.Seq[PhpParseResult] = {
     // We need to keep a map between the input path and its canonical representation in
     // order to map back the canonical file name we get from the php parser.
     // Otherwise later on file name/path processing might get confused because the returned
@@ -43,7 +45,7 @@ class PhpParser private (phpParserPath: String, phpIniPath: String, disableFileC
           (filename, jsonToPhpFile(jsonObjectOption, filename), infoLines)
         }
         val withRemappedFileName = asPhpFile.map { case (filename, phpFileOption, infoLines) =>
-          (canonicalToInputPath.apply(filename), phpFileOption, infoLines)
+          PhpParseResult(canonicalToInputPath.apply(filename), phpFileOption, infoLines)
         }
         withRemappedFileName
       case ExternalCommand.ExternalCommandResult(exitCode, _, _) =>

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/AstCreationPass.scala
@@ -2,63 +2,28 @@ package io.joern.php2cpg.passes
 
 import io.joern.php2cpg.Config
 import io.joern.php2cpg.astcreation.AstCreator
-import io.joern.php2cpg.parser.PhpParser
-import io.joern.x2cpg.{SourceFiles, ValidationMode}
+import io.joern.php2cpg.parser.{Domain, PhpParser}
+import io.joern.php2cpg.passes.SymbolSummaryPass.SymbolSummary
+import io.joern.x2cpg.ValidationMode
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.passes.ForkJoinParallelCpgPass
 import io.shiftleft.semanticcpg.utils.FileUtil.*
-import org.slf4j.LoggerFactory
 
 import java.nio.file.Paths
 
-class AstCreationPass(config: Config, cpg: Cpg, parser: PhpParser)(implicit withSchemaValidation: ValidationMode)
-    extends ForkJoinParallelCpgPass[Array[String]](cpg) {
+class AstCreationPass(config: Config, cpg: Cpg, parser: PhpParser, summary: Seq[SymbolSummary])
+    extends ForkJoinParallelCpgPass[Array[String]](cpg)
+    with AstParsingPass(config, parser) {
 
-  private val logger = LoggerFactory.getLogger(this.getClass)
-
-  val PhpSourceFileExtensions: Set[String] = Set(".php")
-
-  override def generateParts(): Array[Array[String]] = {
-    val sourceFiles = SourceFiles
-      .determine(
-        config.inputPath,
-        PhpSourceFileExtensions,
-        ignoredFilesRegex = Option(config.ignoredFilesRegex),
-        ignoredFilesPath = Option(config.ignoredFiles)
-      )
-      .toArray
-
-    // We need to feed the php parser big groups of file in order
-    // to speed up the parsing. Apparently it is some sort of slow
-    // startup phase which makes single file processing prohibitively
-    // slow.
-    // On the other hand we need to be careful to not choose too big
-    // chunks because:
-    //   1. The argument length to the php executable has system
-    //      dependent limits
-    //   2. We want to make use of multiple CPU cores for the rest
-    //      of the CPG creation.
-    //
-    val parts = sourceFiles.grouped(20).toArray
-    parts
-  }
-
-  override def runOnPart(diffGraph: DiffGraphBuilder, filenames: Array[String]): Unit = {
-    parser.parseFiles(filenames).foreach { case (filename, parseResult, infoLines) =>
-      parseResult match {
-        case Some(parseResult) =>
-          val relativeFilename = if (filename == config.inputPath) {
-            Paths.get(filename).fileName
-          } else {
-            Paths.get(config.inputPath).relativize(Paths.get(filename)).toString
-          }
-          diffGraph.absorb(
-            new AstCreator(relativeFilename, filename, parseResult, config.disableFileContent)(config.schemaValidation)
-              .createAst()
-          )
-        case None =>
-          logger.warn(s"Could not parse file $filename. Results will be missing!")
-      }
+  override protected def processPart(builder: DiffGraphBuilder, fileName: String, result: Domain.PhpFile): Unit = {
+    val relativeFilename = if (fileName == config.inputPath) {
+      Paths.get(fileName).fileName
+    } else {
+      Paths.get(config.inputPath).relativize(Paths.get(fileName)).toString
     }
+    builder.absorb(
+      new AstCreator(relativeFilename, fileName, result, config.disableFileContent)(config.schemaValidation)
+        .createAst()
+    )
   }
 }

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/AstParsingPass.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/AstParsingPass.scala
@@ -1,0 +1,54 @@
+package io.joern.php2cpg.passes
+
+import io.joern.php2cpg.Config
+import io.joern.php2cpg.parser.{Domain, PhpParseResult, PhpParser}
+import io.joern.x2cpg.SourceFiles
+import io.shiftleft.passes.ForkJoinParallelCpgPass
+import org.slf4j.{Logger, LoggerFactory}
+
+import java.nio.file.Paths
+
+private[php2cpg] type BatchOfPhpScripts = Array[String]
+
+trait AstParsingPass(config: Config, parser: PhpParser) { this: ForkJoinParallelCpgPass[BatchOfPhpScripts] =>
+
+  protected val logger: Logger = LoggerFactory.getLogger(this.getClass)
+
+  private val PhpSourceFileExtensions: Set[String] = Set(".php")
+
+  override def generateParts(): Array[BatchOfPhpScripts] = {
+    val sourceFiles = SourceFiles
+      .determine(
+        config.inputPath,
+        PhpSourceFileExtensions,
+        ignoredFilesRegex = Option(config.ignoredFilesRegex),
+        ignoredFilesPath = Option(config.ignoredFiles)
+      )
+      .toArray
+    // We need to feed the php parser big groups of file in order
+    // to speed up the parsing. Apparently it is some sort of slow
+    // startup phase which makes single file processing prohibitively
+    // slow.
+    // On the other hand we need to be careful to not choose too big
+    // chunks because:
+    //   1. The argument length to the php executable has system
+    //      dependent limits
+    //   2. We want to make use of multiple CPU cores for the rest
+    //      of the CPG creation.
+    //
+    val parts = sourceFiles.grouped(20).toArray
+    parts
+  }
+
+  override def runOnPart(builder: DiffGraphBuilder, part: BatchOfPhpScripts): Unit = {
+    parser.parseFiles(part).foreach {
+      case PhpParseResult(fileName, Some(result), _) => processPart(builder, fileName, result)
+      case PhpParseResult(fileName, None, _) =>
+        logger.warn(s"Could not parse file $fileName. Results will be missing!")
+        None
+    }
+  }
+
+  protected def processPart(builder: DiffGraphBuilder, fileName: String, result: Domain.PhpFile): Unit
+
+}

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/SymbolSummaryPass.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/SymbolSummaryPass.scala
@@ -1,0 +1,130 @@
+package io.joern.php2cpg.passes
+
+import io.joern.php2cpg.Config
+import io.joern.php2cpg.parser.Domain.*
+import io.joern.php2cpg.parser.{Domain, PhpParser}
+import io.joern.php2cpg.passes.SymbolSummaryPass.PhpNamespace
+import io.joern.x2cpg.passes.frontend.MetaDataPass
+import io.shiftleft.codepropertygraph.generated.Cpg
+import io.shiftleft.passes.ForkJoinParallelCpgPass
+
+/** Gathers all the symbols from types and methods one can import from each PHP script and namespace.
+  *
+  * @param captureResult
+  *   when a task has finished summarizing a file, this method captures the result. This is not thread safe.
+  */
+class SymbolSummaryPass(config: Config, cpg: Cpg, parser: PhpParser, captureResult: PhpNamespace => Unit)
+    extends ForkJoinParallelCpgPass[BatchOfPhpScripts](cpg)
+    with AstParsingPass(config, parser) {
+
+  import io.joern.php2cpg.passes.SymbolSummaryPass.*
+
+  override def processPart(builder: DiffGraphBuilder, fileName: String, result: Domain.PhpFile): Unit = {
+    val fullName = MetaDataPass.getGlobalNamespaceBlockFullName(None)
+    val children = result.children.flatMap {
+      case namespace: PhpNamespaceStmt if namespace.name.isEmpty => namespace.stmts.flatMap(visit)
+      case stmt                                                  => visit(stmt).toList
+    }
+    captureResult(PhpNamespace(fullName, children))
+  }
+
+  private def visit(node: PhpNode): Seq[SymbolSummary] = {
+    node match {
+      case stmt: PhpNamespaceStmt                                  => visitNamespaceStmt(stmt)
+      case method: PhpMethodDecl                                   => visitMethodDecl(method)
+      case classLike: PhpClassLikeStmt if classLike.name.isDefined => visitClassDecl(classLike)
+      case cs: PhpConstStmt                                        => cs.consts.map(c => PhpMember(c.name.name))
+      case cp: PhpPropertyStmt                                     => cp.variables.map(c => PhpMember(c.name.name))
+      case _                                                       => Nil
+    }
+  }
+
+  private def visitNamespaceStmt(stmt: PhpNamespaceStmt): Seq[SymbolSummary] = {
+    val children = stmt.stmts.flatMap(visit)
+    stmt.name match {
+      case None       => children
+      case Some(name) => PhpNamespace(name.name, children) :: Nil
+    }
+  }
+
+  private def visitMethodDecl(method: PhpMethodDecl): Seq[SymbolSummary] = {
+    val name = method.name.name
+    PhpFunction(name) :: Nil
+  }
+
+  private def visitClassDecl(classLike: PhpClassLikeStmt): Seq[SymbolSummary] = {
+    val name        = classLike.name.map(_.name).get
+    val constructor = if !classLike.hasConstructor then Nil else PhpFunction(Domain.ConstructorMethodName) :: Nil
+    val children    = constructor ++ classLike.stmts.flatMap(visit)
+    PhpClass(name, children) :: Nil
+  }
+
+}
+
+object SymbolSummaryPass {
+
+  sealed trait SymbolSummary {
+
+    /** Combines two symbol summary objects at the same namespace/AST level.
+      * @param o
+      *   the object to combine with.
+      * @return
+      *   two separate objects if they cannot be combined, or a single combined object if otherwise.
+      */
+    def +(o: SymbolSummary): Seq[SymbolSummary]
+  }
+
+  sealed trait HasChildren { this: SymbolSummary =>
+
+    def children: Seq[SymbolSummary]
+
+    protected def combineChildren(o: SymbolSummary & HasChildren): Seq[SymbolSummary] = {
+      (this.children ++ o.children).foldLeft(Seq.empty[SymbolSummary])((acc, next) =>
+        acc match {
+          case Nil          => next :: Nil
+          case head :: tail => head + next ++ tail
+        }
+      )
+    }
+
+  }
+
+  case class PhpNamespace(name: String, children: Seq[SymbolSummary]) extends SymbolSummary with HasChildren {
+    override def +(o: SymbolSummary): Seq[SymbolSummary] = {
+      o match {
+        case n: PhpNamespace if n.name == this.name =>
+          PhpNamespace(name, combineChildren(n)) :: Nil
+        case _ => this :: o :: Nil
+      }
+    }
+  }
+
+  case class PhpFunction(name: String) extends SymbolSummary {
+    override def +(o: SymbolSummary): Seq[SymbolSummary] = {
+      o match {
+        case f: PhpFunction if f.name == this.name => this :: Nil
+        case _                                     => this :: o :: Nil
+      }
+    }
+  }
+
+  case class PhpClass(name: String, children: Seq[SymbolSummary]) extends SymbolSummary with HasChildren {
+    override def +(o: SymbolSummary): Seq[SymbolSummary] = {
+      o match {
+        case c: PhpClass if c.name == this.name =>
+          PhpClass(name, combineChildren(c)) :: Nil
+        case _ => this :: o :: Nil
+      }
+    }
+  }
+
+  case class PhpMember(name: String) extends SymbolSummary {
+    override def +(o: SymbolSummary): Seq[SymbolSummary] = {
+      o match {
+        case f: PhpMember if f.name == this.name => this :: Nil
+        case _                                   => this :: o :: Nil
+      }
+    }
+  }
+
+}

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/passes/PhpSymbolSummaryPassTest.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/passes/PhpSymbolSummaryPassTest.scala
@@ -1,12 +1,11 @@
 package io.joern.php2cpg.passes
 
+import io.joern.php2cpg.Config
 import io.joern.php2cpg.parser.{Domain, PhpParser}
 import io.joern.php2cpg.passes.SymbolSummaryPass.*
-import io.joern.php2cpg.{Config, Php2Cpg}
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 import io.shiftleft.semanticcpg.utils.FileUtil
-import org.scalatest.Assertion
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -21,7 +20,7 @@ class PhpSymbolSummaryPassTest extends AnyWordSpec with Matchers {
     assertAgainstTempFile(
       """<?php
         |function foo($a, string $b): int {}
-        |""".stripMargin,
+        |""".stripMargin :: Nil,
       { case PhpNamespace(name, (fooMethod: PhpFunction) :: Nil) :: Nil =>
         name shouldBe NamespaceTraversal.globalNamespaceName
         fooMethod.name shouldBe "foo"
@@ -37,7 +36,7 @@ class PhpSymbolSummaryPassTest extends AnyWordSpec with Matchers {
         |    return 0;
         |  }
         |}
-        |""".stripMargin,
+        |""".stripMargin :: Nil,
       {
         case PhpNamespace(
               name,
@@ -57,7 +56,7 @@ class PhpSymbolSummaryPassTest extends AnyWordSpec with Matchers {
         |class Foo {
         |  const B = "B";
         |}
-        |""".stripMargin,
+        |""".stripMargin :: Nil,
       {
         case PhpNamespace(
               name,
@@ -71,6 +70,52 @@ class PhpSymbolSummaryPassTest extends AnyWordSpec with Matchers {
     )
   }
 
+  "pre-parsing a file with a nested namespace declaration should be summarized accordingly" in {
+    assertAgainstTempFile(
+      """<?php
+        |namespace Foo\Bar;
+        |class Baz {}
+        |""".stripMargin :: Nil,
+      {
+        case PhpNamespace(
+              globalName,
+              PhpNamespace(fooName, PhpNamespace(barName, PhpClass(bazName, _) :: Nil) :: Nil) :: Nil
+            ) :: Nil =>
+          globalName shouldBe NamespaceTraversal.globalNamespaceName
+          fooName shouldBe "Foo"
+          barName shouldBe "Bar"
+          bazName shouldBe "Baz"
+      }
+    )
+  }
+
+  "pre-parsing a file with a duplicate namespace declaration should be summarized and deduplicated accordingly" in {
+    assertAgainstTempFile(
+      """<?php
+        |namespace Foo\Bar;
+        |class Baz {}
+        |""".stripMargin ::
+        """<?php
+        |namespace Foo\Bar;
+        |class Faz {}
+        |""".stripMargin :: Nil,
+      {
+        case PhpNamespace(
+              globalName,
+              PhpNamespace(
+                fooName,
+                PhpNamespace(barName, PhpClass(bazName, _) :: PhpClass(fazName, _) :: Nil) :: Nil
+              ) :: Nil
+            ) :: Nil =>
+          globalName shouldBe NamespaceTraversal.globalNamespaceName
+          fooName shouldBe "Foo"
+          barName shouldBe "Bar"
+          bazName shouldBe "Baz"
+          fazName shouldBe "Faz"
+      }
+    )
+  }
+
 }
 
 object PhpSymbolSummaryPassTest {
@@ -79,17 +124,19 @@ object PhpSymbolSummaryPassTest {
 
   case class ConfigAndParser(config: Config, parser: PhpParser)
 
-  def assertAgainstTempFile(code: String, assertion: Seq[SymbolSummary] => Unit): Unit = {
+  def assertAgainstTempFile(code: Seq[String], assertion: Seq[SymbolSummary] => Unit): Unit = {
     FileUtil.usingTemporaryDirectory("php-test") { tmpDirPath =>
-      val tmpFilePath = tmpDirPath / "Test.php"
-      Files.createFile(tmpFilePath)
-      FileUtil.writeBytes(tmpFilePath, code.getBytes)
-      val config = Config().withInputPath(tmpFilePath.toString)
+      code.zipWithIndex.map { (content, idx) =>
+        val tmpFilePath = tmpDirPath / s"Test$idx.php"
+        Files.createFile(tmpFilePath)
+        FileUtil.writeBytes(tmpFilePath, content.getBytes)
+      }
+      val config = Config().withInputPath(tmpDirPath.toString)
       PhpParser.getParser(config) match {
         case Some(parser) =>
           val buffer = mutable.Buffer.empty[SymbolSummary]
           new SymbolSummaryPass(config, Cpg.empty, parser, buffer.append).createAndApply()
-          assertion(buffer.toSeq)
+          assertion(SymbolSummaryPass.deduplicateSummary(buffer.toSeq))
         case None => Matchers.fail(s"Unable to create a PHP parser! See logs for details.")
       }
     }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/passes/PhpSymbolSummaryPassTest.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/passes/PhpSymbolSummaryPassTest.scala
@@ -1,0 +1,98 @@
+package io.joern.php2cpg.passes
+
+import io.joern.php2cpg.parser.{Domain, PhpParser}
+import io.joern.php2cpg.passes.SymbolSummaryPass.*
+import io.joern.php2cpg.{Config, Php2Cpg}
+import io.shiftleft.codepropertygraph.generated.Cpg
+import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
+import io.shiftleft.semanticcpg.utils.FileUtil
+import org.scalatest.Assertion
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.nio.file.Files
+import scala.collection.mutable
+
+class PhpSymbolSummaryPassTest extends AnyWordSpec with Matchers {
+
+  import PhpSymbolSummaryPassTest.*
+
+  "pre-parsing a file with a top-level function should provide a summary of that function" in {
+    assertAgainstTempFile(
+      """<?php
+        |function foo($a, string $b): int {}
+        |""".stripMargin,
+      { case PhpNamespace(name, (fooMethod: PhpFunction) :: Nil) :: Nil =>
+        name shouldBe NamespaceTraversal.globalNamespaceName
+        fooMethod.name shouldBe "foo"
+      }
+    )
+  }
+
+  "pre-parsing a file with a top-level class with a nested function should provide a summary of that class" in {
+    assertAgainstTempFile(
+      """<?php
+        |class Foo {
+        |  final public function foo(int $x): int {
+        |    return 0;
+        |  }
+        |}
+        |""".stripMargin,
+      {
+        case PhpNamespace(
+              name,
+              PhpClass(className, (constr: PhpFunction) :: (fooMethod: PhpFunction) :: Nil) :: Nil
+            ) :: Nil =>
+          name shouldBe NamespaceTraversal.globalNamespaceName
+          className shouldBe "Foo"
+          constr.name shouldBe Domain.ConstructorMethodName
+          fooMethod.name shouldBe "foo"
+      }
+    )
+  }
+
+  "pre-parsing a file with a top-level class with a nested constant should provide a summary of that class" in {
+    assertAgainstTempFile(
+      """<?php
+        |class Foo {
+        |  const B = "B";
+        |}
+        |""".stripMargin,
+      {
+        case PhpNamespace(
+              name,
+              PhpClass(className, (constr: PhpFunction) :: (bConst: PhpMember) :: Nil) :: Nil
+            ) :: Nil =>
+          name shouldBe NamespaceTraversal.globalNamespaceName
+          className shouldBe "Foo"
+          constr.name shouldBe Domain.ConstructorMethodName
+          bConst.name shouldBe "B"
+      }
+    )
+  }
+
+}
+
+object PhpSymbolSummaryPassTest {
+
+  import FileUtil.PathExt
+
+  case class ConfigAndParser(config: Config, parser: PhpParser)
+
+  def assertAgainstTempFile(code: String, assertion: Seq[SymbolSummary] => Unit): Unit = {
+    FileUtil.usingTemporaryDirectory("php-test") { tmpDirPath =>
+      val tmpFilePath = tmpDirPath / "Test.php"
+      Files.createFile(tmpFilePath)
+      FileUtil.writeBytes(tmpFilePath, code.getBytes)
+      val config = Config().withInputPath(tmpFilePath.toString)
+      PhpParser.getParser(config) match {
+        case Some(parser) =>
+          val buffer = mutable.Buffer.empty[SymbolSummary]
+          new SymbolSummaryPass(config, Cpg.empty, parser, buffer.append).createAndApply()
+          assertion(buffer.toSeq)
+        case None => Matchers.fail(s"Unable to create a PHP parser! See logs for details.")
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Implemented a leaner version of https://github.com/joernio/joern/pull/5467 by operating directly on `PhpNode`s and parsing code twice to keep memory low. Handles namespace collisions gracefully.