### PR TITLE
factor out 'release-github' as a separate build.

### DIFF
--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -36,9 +36,6 @@ jobs:
           ./schema-extender/test.sh
           cd -
       - run: sha512sum target/joern-cli.zip > target/joern-cli.zip.sha512
-      - name: Export ENV vars
-        run:
-          echo "LATEST_TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
       - run: sbt "querydb/runMain io.joern.dumpq.Main"
       - name: Create Release
         id: create_release
@@ -46,8 +43,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ env.LATEST_TAG }}
-          release_name: ${{ env.LATEST_TAG }}
+          tag_name: ${{ github.ref_name }}
+          release_name: ${{ github.ref_name }}
           draft: false
           prerelease: false
       - name: Upload joern-install.sh

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Delete `.cargo` directory # to save disk space
         run: rm -rf /home/runner/.cargo
         if: runner.os == 'Linux'
+      - run: sbt createDistribution
       - run: |
           cd joern-cli/target/universal/stage
           ./schema-extender/test.sh

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -1,0 +1,97 @@
+name: release to github
+on:
+  push:
+    tags:
+      - "v*.*.*"
+jobs:
+  release-github:
+    if: github.repository_owner == 'joernio'
+    concurrency: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: sbt
+      - uses: sbt/setup-sbt@v1
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+      - name: Install Bundler
+        run: gem install bundler -v 2.4.22
+      - name: Delete `.rustup` directory
+        run: rm -rf /home/runner/.rustup # to save disk space
+        if: runner.os == 'Linux'
+      - name: Delete `.cargo` directory # to save disk space
+        run: rm -rf /home/runner/.cargo
+        if: runner.os == 'Linux'
+      - run: |
+          cd joern-cli/target/universal/stage
+          ./schema-extender/test.sh
+          cd -
+      - run: sha512sum target/joern-cli.zip > target/joern-cli.zip.sha512
+      - name: Export ENV vars
+        run:
+          echo "LATEST_TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
+      - run: sbt "querydb/runMain io.joern.dumpq.Main"
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.LATEST_TAG }}
+          release_name: ${{ env.LATEST_TAG }}
+          draft: false
+          prerelease: false
+      - name: Upload joern-install.sh
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./joern-install.sh
+          asset_name: joern-install.sh
+          asset_content_type: text/plain
+      - name: Upload joern-cli.zip
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: target/joern-cli.zip
+          asset_name: joern-cli.zip
+          asset_content_type: application/zip
+      - name: Upload joern-cli.zip.sha512
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: target/joern-cli.zip.sha512
+          asset_name: joern-cli.zip.sha512
+          asset_content_type: text/plain
+      - name: Upload querydb.zip
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: querydb/target/querydb.zip
+          asset_name: querydb.zip
+          asset_content_type: application/zip
+      - name: Upload querydb.json
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: /tmp/querydb.json
+          asset_name: querydb.json
+          asset_content_type: application/json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: release
 on:
   schedule:
-    - cron: "0 7 * * *" # run once daily
+    - cron: "0 7 * * *" # run once daily - will not create a new release if the current HEAD already has a version tag
   workflow_dispatch:    # allow to manually trigger this workflow
 jobs:
   release:
@@ -45,63 +45,3 @@ jobs:
         env:
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-      - run: sha512sum target/joern-cli.zip > target/joern-cli.zip.sha512
-      - name: Export ENV vars
-        run:
-          echo "LATEST_TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
-      - run: sbt "querydb/runMain io.joern.dumpq.Main"
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ env.LATEST_TAG }}
-          release_name: ${{ env.LATEST_TAG }}
-          draft: false
-          prerelease: false
-      - name: Upload joern-install.sh
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./joern-install.sh
-          asset_name: joern-install.sh
-          asset_content_type: text/plain
-      - name: Upload joern-cli.zip
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: target/joern-cli.zip
-          asset_name: joern-cli.zip
-          asset_content_type: application/zip
-      - name: Upload joern-cli.zip.sha512
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: target/joern-cli.zip.sha512
-          asset_name: joern-cli.zip.sha512
-          asset_content_type: text/plain
-      - name: Upload querydb.zip
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: querydb/target/querydb.zip
-          asset_name: querydb.zip
-          asset_content_type: application/zip
-      - name: Upload querydb.json
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: /tmp/querydb.json
-          asset_name: querydb.json
-          asset_content_type: application/json


### PR DESCRIPTION
Required because we no longer create a release if there's no changes - see
the currently release build.

Triggered by version tags, which are set by the regular release build.

Also: use the tag from gh actions env