### PR TITLE
Switch to lazy/less storage `.loc` and `Loc` over `.location` and `{New}Location`

### DIFF
--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/LocQueryTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/LocQueryTests.scala
@@ -1,0 +1,96 @@
+package io.joern.c2cpg.querying
+
+import io.joern.c2cpg.testfixtures.C2CpgSuite
+import io.shiftleft.semanticcpg.language.*
+
+class LocQueryTests extends C2CpgSuite {
+
+  private implicit val finder: NodeExtensionFinder = DefaultNodeExtensionFinder
+
+  private val cpg = code("""
+   |int my_func(int param1) {
+   |   int x = foo(param1);
+   |}""".stripMargin)
+
+  "should return loc for method" in {
+    val locs = cpg.method.name("my_func").loc.l
+    locs.size shouldBe 1
+
+    val loc = locs.head
+    loc.methodFullName shouldBe "my_func"
+    loc.methodShortName shouldBe "my_func"
+    loc.symbol shouldBe "my_func"
+    loc.lineNumber shouldBe Option(2)
+    loc.filename should endWith(".c")
+    loc.nodeLabel shouldBe "METHOD"
+  }
+
+  "should return loc for parameter" in {
+    val locs = cpg.parameter.name("param1").loc.l
+    locs.size shouldBe 1
+
+    val loc = locs.head
+    loc.methodFullName shouldBe "my_func"
+    loc.methodShortName shouldBe "my_func"
+    loc.symbol shouldBe "param1"
+    loc.lineNumber shouldBe Option(2)
+    loc.filename should endWith(".c")
+    loc.nodeLabel shouldBe "METHOD_PARAMETER_IN"
+
+  }
+
+  "should return loc for return parameter" in {
+    val locs = cpg.method.name("my_func").methodReturn.loc.l
+    locs.size shouldBe 1
+
+    val loc = locs.head
+    loc.methodFullName shouldBe "my_func"
+    loc.methodShortName shouldBe "my_func"
+    loc.symbol shouldBe "$ret"
+    loc.lineNumber shouldBe Option(2)
+    loc.filename should endWith(".c")
+    loc.nodeLabel shouldBe "METHOD_RETURN"
+
+  }
+
+  "should return loc for call" in {
+    val locs = cpg.call.name("foo").loc.l
+    locs.size shouldBe 1
+
+    val loc = locs.head
+    loc.methodFullName shouldBe "my_func"
+    loc.methodShortName shouldBe "my_func"
+    loc.symbol shouldBe "foo(param1)"
+    loc.lineNumber shouldBe Option(3)
+    loc.filename should endWith(".c")
+    loc.nodeLabel shouldBe "CALL"
+
+  }
+
+  "should return loc for identifier" in {
+    val locs = cpg.identifier.name("x").loc.l
+    locs.size shouldBe 1
+
+    val loc = locs.head
+    loc.methodFullName shouldBe "my_func"
+    loc.methodShortName shouldBe "my_func"
+    loc.symbol shouldBe "x"
+    loc.lineNumber shouldBe Option(3)
+    loc.filename should endWith(".c")
+    loc.nodeLabel shouldBe "IDENTIFIER"
+  }
+
+  "should return loc for local" in {
+    val locs = cpg.local.name("x").loc.l
+    locs.size shouldBe 1
+
+    val loc = locs.head
+    loc.methodFullName shouldBe "my_func"
+    loc.methodShortName shouldBe "my_func"
+    loc.symbol shouldBe "x"
+    loc.lineNumber shouldBe Option(3)
+    loc.filename should endWith(".c")
+    loc.nodeLabel shouldBe "LOCAL"
+  }
+
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/HasLocation.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/HasLocation.scala
@@ -2,6 +2,11 @@ package io.shiftleft.semanticcpg.language
 
 import io.shiftleft.codepropertygraph.generated.nodes.NewLocation
 
+@deprecated("Prefer HasLoc to HasLocation: Location and NewLocation are deprecated.")
 trait HasLocation extends Any {
   def location: NewLocation
+}
+
+trait HasLoc extends Any {
+  def loc: Loc
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Loc.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Loc.scala
@@ -1,0 +1,66 @@
+package io.shiftleft.semanticcpg.language
+
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.*
+
+import scala.annotation.tailrec
+
+class Loc(val node: StoredNode) {
+  def symbol: String = {
+    node match {
+      case call: Call                   => call.code
+      case method: Method               => method.name
+      case inParam: MethodParameterIn   => inParam.name
+      case ident: Identifier            => ident.name
+      case lit: Literal                 => lit.code
+      case local: Local                 => local.name
+      case outParam: MethodParameterOut => outParam.name
+      case methodRef: MethodRef         => methodRef.code
+      case methodReturn: MethodReturn   => "$ret"
+      case _                            => defaultString
+    }
+  }
+
+  def nodeLabel: String = node.label
+
+  def lineNumber: Option[Int] = node match {
+    case astNode: AstNode => astNode.lineNumber
+    case cfgNode: CfgNode => cfgNode.lineNumber
+  }
+
+  def methodFullName: String = method.fullName
+
+  def methodShortName: String = method.name
+
+  def packageName: String = namespaceOption.getOrElse(defaultString)
+
+  def className: String = typeOption.map(_.fullName).getOrElse(defaultString)
+
+  def classShortName: String = typeOption.map(_.name).getOrElse(defaultString)
+
+  def filename: String = if (method.filename.isEmpty) "N/A" else method.filename
+
+  private val defaultString = "<empty>";
+
+  private lazy val typeOption = findAncestor[TypeDecl](method)
+
+  private lazy val namespaceOption = for {
+    tpe            <- typeOption
+    namespaceBlock <- tpe.namespaceBlock
+    namespace      <- namespaceBlock._namespaceViaRefOut.nextOption()
+  } yield namespace.name
+
+  private lazy val method: Method = node match {
+    case cfgNode: CfgNode => cfgNode.method
+    case local: Local     => local.method.head
+  }
+
+  @tailrec
+  private def findAncestor[TargetNodeType <: StoredNode](node: StoredNode): Option[TargetNodeType] = {
+    node._astIn.iterator.nextOption() match {
+      case Some(head) if head.isInstanceOf[TargetNodeType] => Some(head.asInstanceOf[TargetNodeType])
+      case Some(head)                                      => findAncestor[TargetNodeType](head)
+      case None                                            => None
+    }
+  }
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/LocationCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/LocationCreator.scala
@@ -8,6 +8,7 @@ import scala.annotation.tailrec
 
 /* TODO MP: this should be part of the normal steps, rather than matching on the type at runtime
  * all (and only) steps extending DataFlowObject should/must have `newSink`, `newSource` and `newLocation` */
+@deprecated("Prefer the .loc node step which lazily computes location information.")
 object LocationCreator {
 
   private val logger: Logger = LoggerFactory.getLogger(getClass)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeSteps.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeSteps.scala
@@ -44,8 +44,12 @@ class NodeSteps[NodeType <: StoredNode](val traversal: Iterator[NodeType]) exten
       |on the user's side.
       |"""
   )
+  @deprecated("Prefer the .loc node step which lazily computes location information")
   def location(implicit finder: NodeExtensionFinder): Iterator[NewLocation] =
     traversal.map(_.location)
+
+  def loc(implicit finder: NodeExtensionFinder): Iterator[Loc] =
+    traversal.map(Loc(_))
 
   @Doc(
     info = "Display code (with syntax highlighting)",

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CallMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CallMethods.scala
@@ -5,7 +5,7 @@ import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.semanticcpg.NodeExtension
 import io.shiftleft.semanticcpg.language.*
 
-class CallMethods(val node: Call) extends AnyVal with NodeExtension with HasLocation {
+class CallMethods(val node: Call) extends AnyVal with NodeExtension with HasLocation with HasLoc {
 
   def isStatic: Boolean =
     node.dispatchType == DispatchTypes.STATIC_DISPATCH
@@ -42,6 +42,9 @@ class CallMethods(val node: Call) extends AnyVal with NodeExtension with HasLoca
     node.astChildren.isBlock.maxByOption(_.order).iterator.expressionDown
   }
 
+  @deprecated("Prefer .loc to .location")
   override def location: NewLocation =
     LocationCreator(node, node.code, node.label, node.lineNumber, node.method)
+
+  override def loc: Loc = Loc(node)
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/IdentifierMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/IdentifierMethods.scala
@@ -4,9 +4,14 @@ import io.shiftleft.codepropertygraph.generated.nodes.{Declaration, Identifier, 
 import io.shiftleft.semanticcpg.NodeExtension
 import io.shiftleft.semanticcpg.language.*
 
-class IdentifierMethods(val identifier: Identifier) extends AnyVal with NodeExtension with HasLocation {
+class IdentifierMethods(val identifier: Identifier) extends AnyVal with NodeExtension with HasLocation with HasLoc {
+  @deprecated("Prefer .loc to .location")
   override def location: NewLocation = {
     LocationCreator(identifier, identifier.name, identifier.label, identifier.lineNumber, identifier.method)
+  }
+
+  override def loc: Loc = {
+    Loc(identifier)
   }
 
   def isModuleVariable: Boolean = identifier.refOut.collectAll[Declaration].method.isModule.nonEmpty

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/LiteralMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/LiteralMethods.scala
@@ -11,7 +11,7 @@ import org.slf4j.{Logger, LoggerFactory}
 
 import scala.collection.immutable.HashMap
 
-class LiteralMethods(val literal: Literal) extends AnyVal with NodeExtension with HasLocation {
+class LiteralMethods(val literal: Literal) extends AnyVal with NodeExtension with HasLocation with HasLoc {
   def strippedCode: String = {
     val language         = Cpg(literal.graph).metaData.language.head
     val stringDelimiters = delimiters(language)
@@ -28,9 +28,14 @@ class LiteralMethods(val literal: Literal) extends AnyVal with NodeExtension wit
       .getOrElse(literal.code)
   }
 
+  @deprecated("Prefer .loc to .location")
   override def location: NewLocation = {
     LocationCreator(literal, literal.code, literal.label, literal.lineNumber, literal.method)
 
+  }
+
+  override def loc: Loc = {
+    Loc(literal)
   }
 }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/LocalMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/LocalMethods.scala
@@ -4,9 +4,14 @@ import io.shiftleft.codepropertygraph.generated.nodes.{Local, Method, NewLocatio
 import io.shiftleft.semanticcpg.NodeExtension
 import io.shiftleft.semanticcpg.language.*
 
-class LocalMethods(val local: Local) extends AnyVal with NodeExtension with HasLocation {
+class LocalMethods(val local: Local) extends AnyVal with NodeExtension with HasLocation with HasLoc {
+  @deprecated("Prefer .loc to .location")
   override def location: NewLocation = {
     LocationCreator(local, local.name, local.label, local.lineNumber, method.head)
+  }
+
+  override def loc: Loc = {
+    Loc(local)
   }
 
   /** The method hosting this local variable

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
@@ -4,7 +4,7 @@ import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.NodeExtension
 import io.shiftleft.semanticcpg.language.*
 
-class MethodMethods(val method: Method) extends AnyVal with NodeExtension with HasLocation {
+class MethodMethods(val method: Method) extends AnyVal with NodeExtension with HasLocation with HasLoc {
 
   /** Traverse to annotations of method
     */
@@ -68,8 +68,13 @@ class MethodMethods(val method: Method) extends AnyVal with NodeExtension with H
   def body: Block =
     method.block
 
+  @deprecated("Prefer .loc to .location")
   override def location: NewLocation = {
     LocationCreator(method, method.name, method.label, method.lineNumber, method)
+  }
+
+  override def loc: Loc = {
+    Loc(method)
   }
 
   def content: Option[String] = {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodParameterInMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodParameterInMethods.scala
@@ -4,8 +4,17 @@ import io.shiftleft.codepropertygraph.generated.nodes.{MethodParameterIn, NewLoc
 import io.shiftleft.semanticcpg.NodeExtension
 import io.shiftleft.semanticcpg.language.*
 
-class MethodParameterInMethods(val paramIn: MethodParameterIn) extends AnyVal with NodeExtension with HasLocation {
+class MethodParameterInMethods(val paramIn: MethodParameterIn)
+    extends AnyVal
+    with NodeExtension
+    with HasLocation
+    with HasLoc {
+  @deprecated("Prefer .loc to .location")
   override def location: NewLocation = {
     LocationCreator(paramIn, paramIn.name, paramIn.label, paramIn.lineNumber, paramIn.method)
+  }
+
+  override def loc: Loc = {
+    Loc(paramIn)
   }
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodParameterOutMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodParameterOutMethods.scala
@@ -4,8 +4,17 @@ import io.shiftleft.codepropertygraph.generated.nodes.{MethodParameterOut, NewLo
 import io.shiftleft.semanticcpg.NodeExtension
 import io.shiftleft.semanticcpg.language.*
 
-class MethodParameterOutMethods(val paramOut: MethodParameterOut) extends AnyVal with NodeExtension with HasLocation {
+class MethodParameterOutMethods(val paramOut: MethodParameterOut)
+    extends AnyVal
+    with NodeExtension
+    with HasLocation
+    with HasLoc {
+  @deprecated("Prefer .loc to .location")
   override def location: NewLocation = {
     LocationCreator(paramOut, paramOut.name, paramOut.label, paramOut.lineNumber, paramOut.method)
+  }
+
+  override def loc: Loc = {
+    Loc(paramOut)
   }
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodRefMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodRefMethods.scala
@@ -4,7 +4,8 @@ import io.shiftleft.codepropertygraph.generated.nodes.{MethodRef, NewLocation}
 import io.shiftleft.semanticcpg.NodeExtension
 import io.shiftleft.semanticcpg.language.*
 
-class MethodRefMethods(val methodRef: MethodRef) extends AnyVal with NodeExtension with HasLocation {
+class MethodRefMethods(val methodRef: MethodRef) extends AnyVal with NodeExtension with HasLocation with HasLoc {
+  @deprecated("Prefer .loc to .location")
   override def location: NewLocation = {
     LocationCreator(
       methodRef,
@@ -13,5 +14,9 @@ class MethodRefMethods(val methodRef: MethodRef) extends AnyVal with NodeExtensi
       methodRef.lineNumber,
       methodRef._methodViaContainsIn.next()
     )
+  }
+
+  override def loc: Loc = {
+    Loc(methodRef)
   }
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodReturnMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodReturnMethods.scala
@@ -4,9 +4,14 @@ import io.shiftleft.codepropertygraph.generated.nodes.{Call, MethodReturn, NewLo
 import io.shiftleft.semanticcpg.NodeExtension
 import io.shiftleft.semanticcpg.language.*
 
-class MethodReturnMethods(val node: MethodReturn) extends AnyVal with NodeExtension with HasLocation {
+class MethodReturnMethods(val node: MethodReturn) extends AnyVal with NodeExtension with HasLocation with HasLoc {
+  @deprecated("Prefer .loc to .location")
   override def location: NewLocation = {
     LocationCreator(node, "$ret", node.label, node.lineNumber, node.method)
+  }
+
+  override def loc: Loc = {
+    Loc(node)
   }
 
   def returnUser(implicit callResolver: ICallResolver): Iterator[Call] = {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/NodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/NodeMethods.scala
@@ -6,10 +6,17 @@ import io.shiftleft.semanticcpg.language.*
 
 class NodeMethods(val node: AbstractNode) extends AnyVal with NodeExtension {
 
+  @deprecated("Prefer the .loc node step which lazily computes location information.")
   def location(implicit finder: NodeExtensionFinder): NewLocation =
     node match {
       case storedNode: StoredNode => LocationCreator(storedNode)
       case _                      => LocationCreator.emptyLocation("", None)
     }
+
+  def loc: Loc = {
+    node match {
+      case storedNode: StoredNode => Loc(storedNode)
+    }
+  }
 
 }


### PR DESCRIPTION
- Adds `Loc` class as replacement for `LocationCreator` and the `location` node step. `Loc` is a replacement that is meant to compute and store less up-front compared to `LocationCreator` and `location`. IIUC, scala lazy values also take up space, so I eyeballed the operations that might take more steps to compute and made those lazy and those that are just lookups on the underlying node and made these methods.
- Adds a duplicate of one of the `c2cpg` test files to use `Loc` rather than replacing the other tests for now
- Add deprecation warnings to the previous location code