### PR TITLE
 DSL: make param <-> argument steps respect named arguments 

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskCreator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/TaskCreator.scala
@@ -78,12 +78,9 @@ class TaskCreator(context: EngineContext) {
     }
   }
 
-  private def paramToArgsOfCallers(param: MethodParameterIn): List[Expression] =
-    NoResolve
-      .getMethodCallsites(param.method)
-      .collectAll[Call]
-      .argument(param.index)
-      .l
+  private def paramToArgsOfCallers(param: MethodParameterIn): List[Expression] = {
+    param.argument(NoResolve).l
+  }
 
   /** Expand to receiver objects of calls that reference the method of the parameter, e.g., if `param` is a parameter of
     * `m`, return `foo` in `foo.bar(m)` TODO: I'm not sure whether `methodRef.methodFullNameExact(...)` uses an index.

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallTests.scala
@@ -299,8 +299,8 @@ class CallTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
     "should contain a CALL node with arguments that have the argument name set" in {
       val List(c) = cpg.call.code("Person.*").l
-      c.argument(1).argumentName shouldBe Some("lastName")
-      c.argument(2).argumentName shouldBe Some("firstName")
+      c.argumentsExact("lastName").size shouldBe 1
+      c.argumentsExact("firstName").size shouldBe 1
     }
   }
 
@@ -316,8 +316,8 @@ class CallTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
     "should contain a CALL node with arguments that have the argument name set" in {
       val List(c) = cpg.call.code("printNextLineRm.*").l
-      c.argument(1).argumentName shouldBe Some("line")
-      c.argument(2).argumentName shouldBe Some("file")
+      c.arguments("line").size shouldBe 1
+      c.arguments("file").size shouldBe 1
     }
   }
 

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallTests.scala
@@ -331,7 +331,7 @@ class CallTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
     "contain a CALL node with arguments that have the argument name set" in {
       val List(c) = cpg.call.name("copy").l
-      c.argument(1).argumentName shouldBe Some("second")
+      c.arguments("second").size shouldBe 1
     }
   }
 

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallTests.scala
@@ -299,8 +299,8 @@ class CallTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
     "should contain a CALL node with arguments that have the argument name set" in {
       val List(c) = cpg.call.code("Person.*").l
-      c.argumentsExact("lastName").size shouldBe 1
-      c.argumentsExact("firstName").size shouldBe 1
+      c.argumentsExact("lastName").code.sorted shouldBe Seq("y")
+      c.argumentsExact("firstName").code.sorted shouldBe Seq("x")
     }
   }
 
@@ -316,8 +316,8 @@ class CallTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
     "should contain a CALL node with arguments that have the argument name set" in {
       val List(c) = cpg.call.code("printNextLineRm.*").l
-      c.arguments("line").size shouldBe 1
-      c.arguments("file").size shouldBe 1
+      c.arguments("line").code.sorted shouldBe Seq(""""MD_Update(&m,buf,j);"""")
+      c.arguments("file").code.sorted shouldBe Seq(""""rand_lcl.h"""")
     }
   }
 
@@ -331,7 +331,7 @@ class CallTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
     "contain a CALL node with arguments that have the argument name set" in {
       val List(c) = cpg.call.name("copy").l
-      c.arguments("second").size shouldBe 1
+      c.arguments("second").code.sorted shouldBe Seq("3")
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/MethodTests.scala
@@ -56,8 +56,8 @@ class MethodTests extends RubyCode2CpgFixture(withPostProcessing = true, withDat
     sink.reachableByFlows(source).l.size shouldBe 2
   }
 
-  // Works in deprecated
-  "Data flow through blockExprAssocTypeArguments" in {
+  // variadic named parameters can't be expressed in the schema
+  "Data flow through blockExprAssocTypeArguments" ignore {
     val cpg = code("""
                      |def foo(*args)
                      |puts args

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/dataflow/DataFlowTests.scala
@@ -45,7 +45,7 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
     "find flows to arguments of `free`" in {
       implicit val callResolver: NoResolve.type = NoResolve
       val source                                = cpg.identifier
-      val sink                                  = cpg.method.name("free").parameter.argument
+      val sink                                  = cpg.call.name("free").argumentExact("elem")
       sink.reachableByFlows(source).l.map(flowToResultPairs).distinct.size shouldBe 4
     }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CallMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CallMethods.scala
@@ -25,9 +25,9 @@ class CallMethods(val node: Call) extends AnyVal with NodeExtension with HasLoca
     }
 
   def arguments(pattern: String): Iterator[Expression] =
-    argument.where { _.argumentName(pattern) }
+    argument.argumentName(pattern)
   def argumentsExact(name: String): Iterator[Expression] =
-    argument.filter { expr => expr.argumentName.contains(name) }
+    argument.argumentNameExact(name)
 
   // TODO define as named step in the schema
   def argument: Iterator[Expression] =

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CallMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CallMethods.scala
@@ -20,7 +20,9 @@ class CallMethods(val node: Call) extends AnyVal with NodeExtension with HasLoca
     node.receiverOut.collectAll[Expression]
 
   def arguments(index: Int): Iterator[Expression] =
-    argument.filter { expr => expr.argumentName.isEmpty && expr.argumentIndex == index }
+    node._argumentOut.collect {
+      case expr: Expression if expr.argumentIndex == index => expr
+    }
 
   def arguments(pattern: String): Iterator[Expression] =
     argument.where { _.argumentName(pattern) }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CallMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CallMethods.scala
@@ -20,9 +20,12 @@ class CallMethods(val node: Call) extends AnyVal with NodeExtension with HasLoca
     node.receiverOut.collectAll[Expression]
 
   def arguments(index: Int): Iterator[Expression] =
-    node._argumentOut.collect {
-      case expr: Expression if expr.argumentIndex == index => expr
-    }
+    argument.filter { expr => expr.argumentName.isEmpty && expr.argumentIndex == index }
+
+  def arguments(pattern: String): Iterator[Expression] =
+    argument.where { _.argumentName(pattern) }
+  def argumentsExact(name: String): Iterator[Expression] =
+    argument.filter { expr => expr.argumentName.contains(name) }
 
   // TODO define as named step in the schema
   def argument: Iterator[Expression] =
@@ -32,9 +35,7 @@ class CallMethods(val node: Call) extends AnyVal with NodeExtension with HasLoca
     arguments(index).next
 
   def argumentOption(index: Int): Option[Expression] =
-    node._argumentOut.collectFirst {
-      case expr: Expression if expr.argumentIndex == index => expr
-    }
+    arguments(index).nextOption
 
   def macroExpansion: Iterator[Expression] = {
     if (node.dispatchType != DispatchTypes.INLINED) return Iterator.empty

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/ExpressionMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/ExpressionMethods.scala
@@ -61,7 +61,7 @@ class ExpressionMethods(val node: Expression) extends AnyVal with NodeExtension 
   def parameter(implicit callResolver: ICallResolver): Iterator[MethodParameterIn] = {
     val predicate: MethodParameterIn => Boolean = node.argumentName match {
       case Some(name) => _.name == name
-      case None       => _.index == node.argumentIndex
+      case None => param => param.index == node.argumentIndex || (param.isVariadic && param.index < node.argumentIndex)
     }
 
     for {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodParameterInMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodParameterInMethods.scala
@@ -1,11 +1,23 @@
 package io.shiftleft.semanticcpg.language.nodemethods
 
-import io.shiftleft.codepropertygraph.generated.nodes.{MethodParameterIn, NewLocation}
+import io.shiftleft.codepropertygraph.generated.nodes.{Expression, MethodParameterIn, NewLocation}
 import io.shiftleft.semanticcpg.NodeExtension
 import io.shiftleft.semanticcpg.language.*
 
 class MethodParameterInMethods(val paramIn: MethodParameterIn) extends AnyVal with NodeExtension with HasLocation {
   override def location: NewLocation = {
     LocationCreator.defaultCreateLocation(paramIn)
+  }
+
+  /** Traverse to arguments (actual parameters) associated with this formal parameter */
+  def argument(implicit callResolver: ICallResolver): Iterator[Expression] = {
+    for {
+      call <- callResolver.getMethodCallsites(paramIn.method)
+      case (arg: Expression) <- call._argumentOut
+      if arg.argumentName match {
+        case Some(name) => name == paramIn.name
+        case None       => arg.argumentIndex == paramIn.index
+      }
+    } yield arg
   }
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodParameterInMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodParameterInMethods.scala
@@ -1,23 +1,11 @@
 package io.shiftleft.semanticcpg.language.nodemethods
 
-import io.shiftleft.codepropertygraph.generated.nodes.{Expression, MethodParameterIn, NewLocation}
+import io.shiftleft.codepropertygraph.generated.nodes.{MethodParameterIn, NewLocation}
 import io.shiftleft.semanticcpg.NodeExtension
 import io.shiftleft.semanticcpg.language.*
 
 class MethodParameterInMethods(val paramIn: MethodParameterIn) extends AnyVal with NodeExtension with HasLocation {
   override def location: NewLocation = {
     LocationCreator.defaultCreateLocation(paramIn)
-  }
-
-  /** Traverse to arguments (actual parameters) associated with this formal parameter */
-  def argument(implicit callResolver: ICallResolver): Iterator[Expression] = {
-    for {
-      call <- callResolver.getMethodCallsites(paramIn.method)
-      case (arg: Expression) <- call._argumentOut
-      if arg.argumentName match {
-        case Some(name) => name == paramIn.name
-        case None       => arg.argumentIndex == paramIn.index
-      }
-    } yield arg
   }
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/CallTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/CallTraversal.scala
@@ -40,6 +40,16 @@ class CallTraversal(val traversal: Iterator[Call]) extends AnyVal {
   def argument(i: Integer): Iterator[Expression] =
     traversal.flatMap(_.arguments(i))
 
+  /** argument of the call with matching name
+    */
+  def argument(pattern: String): Iterator[Expression] =
+    traversal.flatMap(_.arguments(pattern))
+
+  /** `i'th` arguments of the call
+    */
+  def argumentExact(name: String): Iterator[Expression] =
+    traversal.flatMap(_.argumentsExact(name))
+
   /** To formal method return parameter
     */
   def toMethodReturn(implicit callResolver: ICallResolver): Iterator[MethodReturn] =

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/CallTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/CallTraversal.scala
@@ -30,22 +30,22 @@ class CallTraversal(val traversal: Iterator[Call]) extends AnyVal {
   def receiver: Iterator[Expression] =
     traversal.flatMap(_.receiver)
 
-  /** Arguments of the call
+  /** Arguments of the calls
     */
   def argument: Iterator[Expression] =
     traversal.flatMap(_.argument)
 
-  /** `i'th` arguments of the call
+  /** `i'th` arguments of the calls
     */
   def argument(i: Integer): Iterator[Expression] =
     traversal.flatMap(_.arguments(i))
 
-  /** argument of the call with matching name
+  /** argument of the calls with matching name
     */
   def argument(pattern: String): Iterator[Expression] =
     traversal.flatMap(_.arguments(pattern))
 
-  /** `i'th` arguments of the call
+  /** arguments of the calls with this exact name
     */
   def argumentExact(name: String): Iterator[Expression] =
     traversal.flatMap(_.argumentsExact(name))

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterOutTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterOutTraversal.scala
@@ -1,5 +1,6 @@
 package io.shiftleft.semanticcpg.language.types.structure
 
+import flatgraph.help.Doc
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.*
 
@@ -7,7 +8,7 @@ class MethodParameterOutTraversal(val traversal: Iterator[MethodParameterOut]) e
 
   def paramIn: Iterator[MethodParameterIn] = {
     // TODO define a named step in schema
-    traversal.flatMap(_.parameterLinkIn.collectAll[MethodParameterIn])
+    traversal.flatMap(_.parameterLinkIn)
   }
 
   /* method parameter indexes are  based, i.e. first parameter has index  (that's how java2cpg generates it) */
@@ -24,14 +25,7 @@ class MethodParameterOutTraversal(val traversal: Iterator[MethodParameterOut]) e
   def indexTo(num: Int): Iterator[MethodParameterOut] =
     traversal.filter(_.index <= num)
 
-  def argument: Iterator[Expression] =
-    for {
-      paramOut <- traversal
-      method = paramOut.method
-      call <- method._callIn
-      arg  <- call._argumentOut.collectAll[Expression]
-      // TODO define 'parameterLinkIn' as named step in schema
-      if paramOut.parameterLinkIn.collectAll[MethodParameterIn].index.headOption.contains(arg.argumentIndex)
-    } yield arg
-
+  @Doc(info = "Traverse to arguments (actual parameters) associated with this formal parameter")
+  def argument(implicit callResolver: ICallResolver): Iterator[Expression] =
+    paramIn.argument
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterTraversal.scala
@@ -3,7 +3,6 @@ package io.shiftleft.semanticcpg.language.types.structure
 import io.shiftleft.codepropertygraph.generated.help.{Doc, Traversal}
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.*
-import io.shiftleft.semanticcpg.language.nodemethods.MethodParameterInMethods
 
 import scala.jdk.CollectionConverters.*
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterTraversal.scala
@@ -3,6 +3,7 @@ package io.shiftleft.semanticcpg.language.types.structure
 import io.shiftleft.codepropertygraph.generated.help.{Doc, Traversal}
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.language.nodemethods.MethodParameterInMethods
 
 import scala.jdk.CollectionConverters.*
 
@@ -28,11 +29,6 @@ class MethodParameterTraversal(val traversal: Iterator[MethodParameterIn]) exten
   /** Traverse to arguments (actual parameters) associated with this formal parameter */
   @Doc(info = "Traverse to arguments (actual parameters) associated with this formal parameter")
   def argument(implicit callResolver: ICallResolver): Iterator[Expression] =
-    for {
-      paramIn <- traversal
-      call    <- callResolver.getMethodCallsites(paramIn.method)
-      arg     <- call._argumentOut.collectAll[Expression]
-      if arg.argumentIndex == paramIn.index
-    } yield arg
+    traversal.flatMap(param => MethodParameterInMethods(param).argument)
 
 }


### PR DESCRIPTION
At first I had changed the numbered `call.arguments(i)` query to not return named arguments. That's why I changed some frontend tests to query by argument name. In the end, I felt that went a bit too far as a potentially breaking change. So that DSL step continues to just look at the value of the `argumentIndex` property without considering whether there is a `argumentName` or not.

(I've kept the changes to the tests anyway, because 1) it's more correct in the context of the test to query for a named argument and 2) it provides some test coverage for the DSL step.)

One Ruby dataflow is now ignored that wasn't previously - it sort of accidentally worked until now, since the first (named) argument happened to get matched to the name-variadic parameter that also happens to have index 1. Change the order of the named arguments, and the test would have always failed. I'd say ignoring the test is a more honest assessment of what works and what doesn't wrt to flows through name-variadic parameters. Otoh, the oss dataflow engine now does find flows through named arguments when a parameter with the same name exists.