### PR TITLE
[c2cpg] Support for cast expressions

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForExpressionsCreator.scala
@@ -443,22 +443,23 @@ trait AstForExpressionsCreator { this: AstCreator =>
   }
 
   private def astForCastExpression(castExpression: IASTCastExpression): Ast = {
-    val cpgCastExpression =
-      callNode(
-        castExpression,
-        code(castExpression),
-        Operators.cast,
-        Operators.cast,
-        DispatchTypes.STATIC_DISPATCH,
-        None,
-        Some(Defines.Any)
-      )
+    val op  = Operators.cast
+    val tpe = typeFor(castExpression.getTypeId.getDeclSpecifier)
 
-    val expr    = astForExpression(castExpression.getOperand)
-    val argNode = castExpression.getTypeId
-    val arg     = unknownNode(argNode, code(argNode))
+    val cpgCastExpression = callNode(
+      castExpression,
+      code(castExpression),
+      op,
+      op,
+      DispatchTypes.STATIC_DISPATCH,
+      None,
+      Some(registerType(tpe))
+    )
 
-    callAst(cpgCastExpression, List(Ast(arg), expr))
+    val expr         = astForExpression(castExpression.getOperand)
+    val typeRefNode_ = typeRefNode(castExpression.getTypeId, code(castExpression.getTypeId), tpe)
+    val arg          = Ast(typeRefNode_)
+    callAst(cpgCastExpression, List(arg, expr))
   }
 
   private def astsForConstructorInitializer(initializer: IASTInitializer): List[Ast] = {
@@ -499,12 +500,13 @@ trait AstForExpressionsCreator { this: AstCreator =>
   }
 
   private def astForTypeIdInitExpression(typeIdInit: IASTTypeIdInitializerExpression): Ast = {
-    val name = Operators.cast
+    val op  = Operators.cast
+    val tpe = typeFor(typeIdInit.getTypeId.getDeclSpecifier)
     val cpgCastExpression =
-      callNode(typeIdInit, code(typeIdInit), name, name, DispatchTypes.STATIC_DISPATCH, None, Some(Defines.Any))
-    val typeAst = unknownNode(typeIdInit.getTypeId, code(typeIdInit.getTypeId))
-    val expr    = astForNode(typeIdInit.getInitializer)
-    callAst(cpgCastExpression, List(Ast(typeAst), expr))
+      callNode(typeIdInit, code(typeIdInit), op, op, DispatchTypes.STATIC_DISPATCH, None, Some(registerType(tpe)))
+    val typeRefAst = Ast(typeRefNode(typeIdInit.getTypeId, code(typeIdInit.getTypeId), tpe))
+    val expr       = astForNode(typeIdInit.getInitializer)
+    callAst(cpgCastExpression, List(typeRefAst, expr))
   }
 
   private def astForConstructorExpression(c: ICPPASTSimpleTypeConstructorExpression): Ast = {


### PR DESCRIPTION
We now do no longer generate unknown nodes there.
Instead, a TypeRef is used just like e.g., in javasrc2cpg.