### PR TITLE
[php] Incorporate Imports into Scope

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
@@ -65,9 +65,9 @@ class Php2Cpg extends X2CpgFrontend[Config] {
           // twice to build the AST. This helps resolve symbols during the latter parse. Compared to parsing once, and
           // holding the AST in-memory, it was decided that parsing did not incur a significant speed impact, and lower
           // memory was prioritized.
-          var buffer = Option.empty[Seq[SymbolSummary]]
+          var buffer = Option.empty[Map[String, Seq[SymbolSummary]]]
           new SymbolSummaryPass(config, cpg, parser, summary => buffer = Option(summary)).createAndApply()
-          new AstCreationPass(config, cpg, parser, buffer.getOrElse(Nil)).createAndApply()
+          new AstCreationPass(config, cpg, parser, buffer.getOrElse(Map.empty)).createAndApply()
         }
         new AstParentInfoPass(cpg).createAndApply()
         new AnyTypePass(cpg).createAndApply()

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
@@ -1,32 +1,26 @@
 package io.joern.php2cpg.astcreation
 
-import io.joern.php2cpg.astcreation.AstCreator.{NameConstants, TypeConstants, operatorSymbols}
-import io.joern.php2cpg.datastructures.ArrayIndexTracker
+import io.joern.php2cpg.astcreation.AstCreator.{NameConstants, TypeConstants}
 import io.joern.php2cpg.parser.Domain.*
-import io.joern.php2cpg.parser.Domain.PhpModifiers.containsAccessModifier
 import io.joern.php2cpg.passes.SymbolSummaryPass.SymbolSummary
 import io.joern.php2cpg.utils.Scope
 import io.joern.x2cpg.Ast.storeInDiffGraph
-import io.joern.x2cpg.Defines.{StaticInitMethodName, UnresolvedNamespace, UnresolvedSignature}
 import io.joern.x2cpg.utils.AstPropertiesUtil.RootProperties
-import io.joern.x2cpg.utils.IntervalKeyPool
-import io.joern.x2cpg.{Ast, AstCreatorBase, AstNodeBuilder, Defines, ValidationMode}
+import io.joern.x2cpg.{Ast, AstCreatorBase, Defines, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.*
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 import io.shiftleft.utils.IOUtils
 import org.slf4j.{Logger, LoggerFactory}
 
-import java.nio.charset.StandardCharsets
 import java.nio.file.Path
-import scala.collection.mutable
 
 class AstCreator(
   protected val relativeFileName: String,
   fileName: String,
   phpAst: PhpFile,
   disableFileContent: Boolean,
-  summary: Seq[SymbolSummary]
+  summary: Map[String, Seq[SymbolSummary]]
 )(implicit withSchemaValidation: ValidationMode)
     extends AstCreatorBase[PhpNode, AstCreator](relativeFileName)
     with AstCreatorHelper(disableFileContent)

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/AstCreationPass.scala
@@ -11,7 +11,7 @@ import io.shiftleft.semanticcpg.utils.FileUtil.*
 
 import java.nio.file.Paths
 
-class AstCreationPass(config: Config, cpg: Cpg, parser: PhpParser, summary: Seq[SymbolSummary])
+class AstCreationPass(config: Config, cpg: Cpg, parser: PhpParser, summary: Map[String, Seq[SymbolSummary]])
     extends ForkJoinParallelCpgPass[Array[String]](cpg)
     with AstParsingPass(config, parser) {
 

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/AstCreationPass.scala
@@ -22,7 +22,7 @@ class AstCreationPass(config: Config, cpg: Cpg, parser: PhpParser, summary: Seq[
       Paths.get(config.inputPath).relativize(Paths.get(fileName)).toString
     }
     builder.absorb(
-      new AstCreator(relativeFilename, fileName, result, config.disableFileContent)(config.schemaValidation)
+      new AstCreator(relativeFilename, fileName, result, config.disableFileContent, summary)(config.schemaValidation)
         .createAst()
     )
   }

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/SymbolSummaryPass.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/SymbolSummaryPass.scala
@@ -82,13 +82,8 @@ class SymbolSummaryPass(
     classLike.name match {
       case None => Nil
       case Some(nameExpr) =>
-        val name          = nameExpr.name
         val classFullName = nameExpr.fullName(stack)
-        val constructor =
-          if !classLike.hasConstructor then Nil
-          else PhpFunction(s"$classFullName\\${Domain.ConstructorMethodName}") :: Nil
-        val children = constructor ++ classLike.stmts.flatMap(visit(_, name +: stack))
-        PhpClass(classFullName) :: children
+        PhpClass(classFullName) :: Nil // children are ignored, as they cannot be imported directly
     }
 
 }

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/SymbolSummaryPass.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/SymbolSummaryPass.scala
@@ -38,7 +38,7 @@ class SymbolSummaryPass(
   }
 
   override def finish(): Unit = {
-    val summaryMap = summary.asScala.toSeq.distinct.groupBy(_.name).view.mapValues(xs => xs.sorted).toMap
+    val summaryMap = summary.asScala.toSeq.distinct.groupBy(_.name)
     captureSummary(summaryMap)
   }
 

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/SymbolSummaryPass.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/SymbolSummaryPass.scala
@@ -38,7 +38,7 @@ class SymbolSummaryPass(
   }
 
   override def finish(): Unit = {
-    val summaryMap = summary.asScala.toSeq.distinct.groupBy(_.name)
+    val summaryMap = summary.asScala.toSeq.distinct.groupBy(_.name).view.mapValues(xs => xs.sorted).toMap
     captureSummary(summaryMap)
   }
 

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/SymbolSummaryPass.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/SymbolSummaryPass.scala
@@ -111,6 +111,12 @@ object SymbolSummaryPass {
       *   two separate objects if they cannot be combined, or a single combined object if otherwise.
       */
     def +(o: SymbolSummary): Seq[SymbolSummary]
+
+    /** @return
+      *   the identifier of the symbol.
+      */
+    def name: String
+
   }
 
   sealed trait HasChildren { this: SymbolSummary =>
@@ -162,6 +168,15 @@ object SymbolSummaryPass {
       o match {
         case f: PhpMember if f.name == this.name => this :: Nil
         case _                                   => this :: o :: Nil
+      }
+    }
+  }
+
+  case class PhpExternal(name: String) extends SymbolSummary {
+    override def +(o: SymbolSummary): Seq[SymbolSummary] = {
+      o match {
+        case f: PhpExternal if f.name == this.name => this :: Nil
+        case _                                     => this :: o :: Nil
       }
     }
   }

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/SymbolSummaryPass.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/SymbolSummaryPass.scala
@@ -27,10 +27,10 @@ class SymbolSummaryPass(config: Config, cpg: Cpg, parser: PhpParser, captureSumm
     val stack: NamespaceScopeStack = Seq(fullName)
 
     val children = result.children.flatMap {
-      case namespace: PhpNamespaceStmt if namespace.name.isEmpty => namespace.stmts.flatMap(visit(_, stack))
-      case stmt                                                  => visit(stmt, stack).toList
+      case namespace: PhpNamespaceStmt if namespace.name.isEmpty => namespace.stmts.flatMap(visit(_, stack, None))
+      case stmt                                                  => visit(stmt, stack, None).toList
     }.dedup
-    summary.add(PhpNamespace(fullName, children))
+    summary.add(globalNamespace(children))
   }
 
   override def finish(): Unit = {
@@ -38,46 +38,63 @@ class SymbolSummaryPass(config: Config, cpg: Cpg, parser: PhpParser, captureSumm
     captureSummary(dedupSummary)
   }
 
-  private def visit(node: PhpNode, stack: NamespaceScopeStack): Seq[SymbolSummary] = {
+  private def visit(
+    node: PhpNode,
+    stack: NamespaceScopeStack,
+    parent: Option[SymbolSummary & HasChildren]
+  ): Seq[SymbolSummary] = {
     node match {
-      case stmt: PhpNamespaceStmt                                  => visitNamespaceStmt(stmt, stack)
-      case method: PhpMethodDecl                                   => visitMethodDecl(method)
-      case classLike: PhpClassLikeStmt if classLike.name.isDefined => visitClassDecl(classLike, stack)
-      case cs: PhpConstStmt                                        => cs.consts.map(c => PhpMember(c.name.name))
-      case cp: PhpPropertyStmt                                     => cp.variables.map(c => PhpMember(c.name.name))
-      case _                                                       => Nil
+      case stmt: PhpNamespaceStmt                                  => visitNamespaceStmt(stmt, stack, parent)
+      case method: PhpMethodDecl                                   => visitMethodDecl(method, parent)
+      case classLike: PhpClassLikeStmt if classLike.name.isDefined => visitClassDecl(classLike, stack, parent)
+      case cs: PhpConstStmt                                        => cs.consts.map(c => PhpMember(c.name.name, parent))
+      case cp: PhpPropertyStmt => cp.variables.map(c => PhpMember(c.name.name, parent))
+      case _                   => Nil
     }
   }
 
-  private def visitNamespaceStmt(stmt: PhpNamespaceStmt, stack: NamespaceScopeStack): Seq[SymbolSummary] = {
+  private def visitNamespaceStmt(
+    stmt: PhpNamespaceStmt,
+    stack: NamespaceScopeStack,
+    parent: Option[SymbolSummary & HasChildren]
+  ): Seq[SymbolSummary] = {
     stmt.name match {
-      case None                            => stmt.stmts.flatMap(visit(_, stack)).dedup
-      case Some(name) if stack.sizeIs == 1 =>
+      case None                                => stmt.stmts.flatMap(visit(_, stack, parent)).dedup
+      case Some(fullName) if stack.sizeIs == 1 =>
         // We are the first namespace declaration in a possibly nested namespace, so this name should be fully separated
-        val nameParts               = name.name.split("\\\\")
+        val nameParts               = fullName.name.split("\\\\")
+        val name                    = nameParts.last
         val namespaceScopeToPrepend = (nameParts.reverse ++ stack).toSeq
-        val children                = stmt.stmts.flatMap(stmt => visit(stmt, namespaceScopeToPrepend)).dedup
-        nameParts.reverse.tail.foldLeft(PhpNamespace(nameParts.last, children))((acc, name) =>
-          PhpNamespace(name, acc :: Nil)
+        val children                = stmt.stmts.flatMap(stmt => visit(stmt, namespaceScopeToPrepend, None)).dedup
+        nameParts.reverse.tail.foldLeft(PhpNamespace(name, name, children, parent))((acc, name) =>
+          PhpNamespace(name, name, acc :: Nil, None) // This will be re-wired by the caller to be its parent
         ) :: Nil
-      case Some(name) =>
+      case Some(fullName) =>
         // We are not the first namespace in a possibly nested namespace, thus we should only use the last part
-        val nameParts = name.name.split("\\\\")
-        val children  = stmt.stmts.flatMap(stmt => visit(stmt, nameParts.last +: stack)).dedup
-        PhpNamespace(nameParts.last, children) :: Nil
+        val nameParts = fullName.name.split("\\\\")
+        val name      = nameParts.last
+        val children  = stmt.stmts.flatMap(stmt => visit(stmt, nameParts.last +: stack, None)).dedup
+        PhpNamespace(name, name, children, parent) :: Nil
     }
   }
 
-  private def visitMethodDecl(method: PhpMethodDecl): Seq[SymbolSummary] = {
+  private def visitMethodDecl(
+    method: PhpMethodDecl,
+    parent: Option[SymbolSummary & HasChildren]
+  ): Seq[SymbolSummary] = {
     val name = method.name.name
-    PhpFunction(name) :: Nil
+    PhpFunction(name, parent) :: Nil
   }
 
-  private def visitClassDecl(classLike: PhpClassLikeStmt, stack: NamespaceScopeStack): Seq[SymbolSummary] = {
+  private def visitClassDecl(
+    classLike: PhpClassLikeStmt,
+    stack: NamespaceScopeStack,
+    parent: Option[SymbolSummary & HasChildren]
+  ): Seq[SymbolSummary] = {
     val name        = classLike.name.map(_.name).get
-    val constructor = if !classLike.hasConstructor then Nil else PhpFunction(Domain.ConstructorMethodName) :: Nil
-    val children    = constructor ++ classLike.stmts.flatMap(visit(_, stack))
-    PhpClass(name, children) :: Nil
+    val constructor = if !classLike.hasConstructor then Nil else PhpFunction(Domain.ConstructorMethodName, None) :: Nil
+    val children    = constructor ++ classLike.stmts.flatMap(visit(_, stack, None))
+    PhpClass(name, children, parent) :: Nil // This will re-wire children to link to PhpClass
   }
 
 }
@@ -85,6 +102,11 @@ class SymbolSummaryPass(config: Config, cpg: Cpg, parser: PhpParser, captureSumm
 object SymbolSummaryPass {
 
   private type NamespaceScopeStack = Seq[String]
+
+  def globalNamespace(children: Seq[SymbolSummary] = Nil): PhpNamespace = {
+    val name = MetaDataPass.getGlobalNamespaceBlockFullName(None)
+    PhpNamespace(name, name, children, None)
+  }
 
   private implicit class SummarySeqExt(xs: Seq[SymbolSummary]) {
 
@@ -104,6 +126,23 @@ object SymbolSummaryPass {
 
   sealed trait SymbolSummary {
 
+    /** The link back to the parent object.
+      * @return
+      *   the parent symbol summary.
+      */
+    def _parent: Option[SymbolSummary & HasChildren]
+
+    /** Follows up the tree to the parent, excluding other siblings along the way.
+      * @return
+      *   the global-level symbol summary, containing a path to this symbol summary the only leaf.
+      */
+    def sparseTree: SymbolSummary = {
+      _parent match {
+        case None    => this
+        case Some(p) => p.withChildren(this :: Nil).sparseTree
+      }
+    }
+
     /** Combines two symbol summary objects at the same namespace/AST level.
       * @param o
       *   the object to combine with.
@@ -113,15 +152,29 @@ object SymbolSummaryPass {
     def +(o: SymbolSummary): Seq[SymbolSummary]
 
     /** @return
-      *   the identifier of the symbol.
+      *   the identifier of the symbol as per its definition.
       */
     def name: String
+
+    /** @return
+      *   the identifier of the symbol as defined by the importing script.
+      */
+    def alias: String
+
+    /** @param parent
+      *   the parent to link this child to.
+      * @return
+      *   a new copy of this node, with the parent field linked to the given parent.
+      */
+    def _withParent(parent: SymbolSummary & HasChildren): SymbolSummary
 
   }
 
   sealed trait HasChildren { this: SymbolSummary =>
 
     def children: Seq[SymbolSummary]
+
+    def withChildren(newChildren: Seq[SymbolSummary]): SymbolSummary & HasChildren
 
     protected def combineChildren(o: SymbolSummary & HasChildren): Seq[SymbolSummary] = {
       (this.children ++ o.children).foldLeft(Seq.empty[SymbolSummary])((acc, next) =>
@@ -134,51 +187,164 @@ object SymbolSummaryPass {
 
   }
 
-  case class PhpNamespace(name: String, children: Seq[SymbolSummary]) extends SymbolSummary with HasChildren {
+  case class PhpNamespace(
+    name: String,
+    alias: String,
+    children: Seq[SymbolSummary],
+    _parent: Option[SymbolSummary & HasChildren]
+  ) extends SymbolSummary
+      with HasChildren {
     override def +(o: SymbolSummary): Seq[SymbolSummary] = {
       o match {
         case n: PhpNamespace if n.name == this.name =>
-          PhpNamespace(name, combineChildren(n)) :: Nil
+          new PhpNamespace(name, alias, combineChildren(n), this._parent) :: Nil
         case _ => this :: o :: Nil
       }
     }
+
+    override def withChildren(newChildren: Seq[SymbolSummary]): SymbolSummary & HasChildren = {
+      this.copy(children = newChildren)
+    }
+
+    override def _withParent(parent: SymbolSummary & HasChildren): SymbolSummary = this.copy(_parent = Option(parent))
   }
 
-  case class PhpFunction(name: String) extends SymbolSummary {
+  /** Constructs a PhpNamespace object with a parent pointer pointing to its parent attached to the children nodes.
+    * Using immutable structures in this way means we should not traverse this tree top-down.
+    */
+  object PhpNamespace {
+
+    def apply(name: String, children: Seq[SymbolSummary]): PhpNamespace = PhpNamespace(name, name, children, None)
+
+    def apply(
+      name: String,
+      alias: String,
+      children: Seq[SymbolSummary],
+      maybeParent: Option[SymbolSummary & HasChildren] = None
+    ): PhpNamespace = {
+      val self = maybeParent match {
+        case None => new PhpNamespace(name, alias, Nil, Option(globalNamespace()))
+        case Some(parent) => new PhpNamespace(name, alias, Nil, Option(parent))
+      }
+      self.copy(children = children.map(_._withParent(self)))
+    }
+
+    def unapply(x: PhpNamespace): (String, Seq[SymbolSummary]) =
+      (x.name, x.children)
+  }
+
+  case class PhpFunction(name: String, alias: String, _parent: Option[SymbolSummary & HasChildren])
+      extends SymbolSummary {
     override def +(o: SymbolSummary): Seq[SymbolSummary] = {
       o match {
         case f: PhpFunction if f.name == this.name => this :: Nil
         case _                                     => this :: o :: Nil
       }
     }
+
+    override def _withParent(parent: SymbolSummary & HasChildren): SymbolSummary = this.copy(_parent = Option(parent))
+
   }
 
-  case class PhpClass(name: String, children: Seq[SymbolSummary]) extends SymbolSummary with HasChildren {
+  object PhpFunction {
+
+    def apply(name: String): PhpFunction = PhpFunction(name, name)
+
+    def apply(name: String, maybeParent: Option[SymbolSummary & HasChildren]): PhpFunction =
+      PhpFunction(name, name, maybeParent)
+
+    def apply(name: String, alias: String): PhpFunction = new PhpFunction(name, alias, Option(globalNamespace()))
+
+    def unapply(x: PhpFunction): Option[String] = Option(x.name)
+  }
+
+  case class PhpClass(
+    name: String,
+    alias: String,
+    children: Seq[SymbolSummary],
+    _parent: Option[SymbolSummary & HasChildren]
+  ) extends SymbolSummary
+      with HasChildren {
     override def +(o: SymbolSummary): Seq[SymbolSummary] = {
       o match {
         case c: PhpClass if c.name == this.name =>
-          PhpClass(name, combineChildren(c)) :: Nil
+          new PhpClass(name, alias, combineChildren(c), this._parent) :: Nil
         case _ => this :: o :: Nil
       }
     }
+
+    override def withChildren(newChildren: Seq[SymbolSummary]): SymbolSummary & HasChildren =
+      this.copy(children = newChildren)
+
+    override def _withParent(parent: SymbolSummary & HasChildren): SymbolSummary = this.copy(_parent = Option(parent))
   }
 
-  case class PhpMember(name: String) extends SymbolSummary {
+  object PhpClass {
+
+    def apply(name: String, children: Seq[SymbolSummary], maybeParent: Option[SymbolSummary & HasChildren]): PhpClass =
+      PhpClass(name, name, children, maybeParent)
+
+    /** Constructs a PhpClass object with a parent pointer pointing to its parent attached to the children nodes. Using
+      * immutable structures in this way means we should not traverse this tree top-down.
+      */
+    def apply(
+      name: String,
+      alias: String,
+      children: Seq[SymbolSummary],
+      maybeParent: Option[SymbolSummary & HasChildren] = None
+    ): PhpClass = {
+      maybeParent match {
+        case None => new PhpClass(name, alias, children, Option(globalNamespace()))
+        case Some(parent) =>
+          val self = new PhpClass(name, alias, Nil, Option(parent))
+          self.copy(children = children.map(_._withParent(self)))
+      }
+    }
+
+    def unapply(x: PhpClass): (String, Seq[SymbolSummary]) =
+      (x.name, x.children)
+  }
+
+  case class PhpMember(name: String, alias: String, _parent: Option[SymbolSummary & HasChildren])
+      extends SymbolSummary {
     override def +(o: SymbolSummary): Seq[SymbolSummary] = {
       o match {
         case f: PhpMember if f.name == this.name => this :: Nil
         case _                                   => this :: o :: Nil
       }
     }
+
+    override def _withParent(parent: SymbolSummary & HasChildren): SymbolSummary = this.copy(_parent = Option(parent))
+
   }
 
-  case class PhpExternal(name: String) extends SymbolSummary {
+  object PhpMember {
+    def apply(name: String, maybeParent: Option[SymbolSummary & HasChildren]): PhpMember =
+      new PhpMember(name, name, maybeParent)
+
+    def apply(name: String): PhpMember = new PhpMember(name, name, Option(globalNamespace()))
+
+    def unapply(x: PhpMember): Option[String] = Option(x.name)
+  }
+
+  case class PhpExternal(name: String, alias: String, _parent: Option[SymbolSummary & HasChildren])
+      extends SymbolSummary {
     override def +(o: SymbolSummary): Seq[SymbolSummary] = {
       o match {
         case f: PhpExternal if f.name == this.name => this :: Nil
         case _                                     => this :: o :: Nil
       }
     }
+
+    override def _withParent(parent: SymbolSummary & HasChildren): SymbolSummary = this.copy(_parent = Option(parent))
+  }
+
+  object PhpExternal {
+    def apply(name: String): PhpExternal = PhpExternal(name, name)
+
+    def apply(name: String, alias: String): PhpExternal = new PhpExternal(name, alias, Option(globalNamespace()))
+
+    def unapply(x: PhpExternal): String = x.name
   }
 
 }

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/SymbolSummaryPass.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/SymbolSummaryPass.scala
@@ -9,13 +9,18 @@ import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.passes.ForkJoinParallelCpgPass
 import scala.jdk.CollectionConverters.*
 
-/** Gathers all the symbols from types and methods one can import from each PHP script and namespace.
+/** Gathers all the symbols from namespaces, types, and methods one can import from each PHP script and namespace. Class
+  * constants cannot be imported directly, thus we do not handle them.
   *
   * @param captureSummary
   *   when the pass has finished summarizing all files, this method captures the result. This is thread safe.
   */
-class SymbolSummaryPass(config: Config, cpg: Cpg, parser: PhpParser, captureSummary: Seq[SymbolSummary] => Unit)
-    extends ForkJoinParallelCpgPass[BatchOfPhpScripts](cpg)
+class SymbolSummaryPass(
+  config: Config,
+  cpg: Cpg,
+  parser: PhpParser,
+  captureSummary: Map[String, Seq[SymbolSummary]] => Unit
+) extends ForkJoinParallelCpgPass[BatchOfPhpScripts](cpg)
     with AstParsingPass(config, parser) {
 
   private val summary = new java.util.concurrent.ConcurrentLinkedQueue[SymbolSummary]()
@@ -23,79 +28,68 @@ class SymbolSummaryPass(config: Config, cpg: Cpg, parser: PhpParser, captureSumm
   import io.joern.php2cpg.passes.SymbolSummaryPass.*
 
   override def processPart(builder: DiffGraphBuilder, fileName: String, result: Domain.PhpFile): Unit = {
-    val fullName                   = MetaDataPass.getGlobalNamespaceBlockFullName(None)
-    val stack: NamespaceScopeStack = Seq(fullName)
+    val stack: NamespaceScopeStack = Seq.empty
 
-    val children = result.children.flatMap {
-      case namespace: PhpNamespaceStmt if namespace.name.isEmpty => namespace.stmts.flatMap(visit(_, stack, None))
-      case stmt                                                  => visit(stmt, stack, None).toList
-    }.dedup
-    summary.add(globalNamespace(children))
+    val summaries = result.children.flatMap {
+      case namespace: PhpNamespaceStmt if namespace.name.isEmpty => namespace.stmts.flatMap(visit(_, stack))
+      case stmt                                                  => visit(stmt, stack).toList
+    }.distinct
+    summary.addAll(summaries.asJava)
   }
 
   override def finish(): Unit = {
-    val dedupSummary = summary.asScala.toSeq.dedup
-    captureSummary(dedupSummary)
+    val summaryMap = summary.asScala.toSeq.distinct.groupBy(_.name)
+    captureSummary(summaryMap)
   }
 
-  private def visit(
-    node: PhpNode,
-    stack: NamespaceScopeStack,
-    parent: Option[SymbolSummary & HasChildren]
-  ): Seq[SymbolSummary] = {
+  private def visit(node: PhpNode, stack: NamespaceScopeStack): Seq[SymbolSummary] = {
     node match {
-      case stmt: PhpNamespaceStmt                                  => visitNamespaceStmt(stmt, stack, parent)
-      case method: PhpMethodDecl                                   => visitMethodDecl(method, parent)
-      case classLike: PhpClassLikeStmt if classLike.name.isDefined => visitClassDecl(classLike, stack, parent)
-      case cs: PhpConstStmt                                        => cs.consts.map(c => PhpMember(c.name.name, parent))
-      case cp: PhpPropertyStmt => cp.variables.map(c => PhpMember(c.name.name, parent))
-      case _                   => Nil
+      case stmt: PhpNamespaceStmt                                  => visitNamespaceStmt(stmt, stack)
+      case method: PhpMethodDecl                                   => visitMethodDecl(method, stack)
+      case classLike: PhpClassLikeStmt if classLike.name.isDefined => visitClassDecl(classLike, stack)
+      case _                                                       => Nil
     }
   }
 
-  private def visitNamespaceStmt(
-    stmt: PhpNamespaceStmt,
-    stack: NamespaceScopeStack,
-    parent: Option[SymbolSummary & HasChildren]
-  ): Seq[SymbolSummary] = {
-    stmt.name match {
-      case None                                => stmt.stmts.flatMap(visit(_, stack, parent)).dedup
-      case Some(fullName) if stack.sizeIs == 1 =>
+  private def visitNamespaceStmt(stmt: PhpNamespaceStmt, stack: NamespaceScopeStack): Seq[SymbolSummary] = {
+    stmt.name.map(_.name) match {
+      case None                            => stmt.stmts.flatMap(visit(_, stack))
+      case Some(fullName) if stack.isEmpty =>
         // We are the first namespace declaration in a possibly nested namespace, so this name should be fully separated
-        val nameParts               = fullName.name.split("\\\\")
-        val name                    = nameParts.last
-        val namespaceScopeToPrepend = (nameParts.reverse ++ stack).toSeq
-        val children                = stmt.stmts.flatMap(stmt => visit(stmt, namespaceScopeToPrepend, None)).dedup
-        nameParts.reverse.tail.foldLeft(PhpNamespace(name, name, children, parent))((acc, name) =>
-          PhpNamespace(name, name, acc :: Nil, None) // This will be re-wired by the caller to be its parent
-        ) :: Nil
+        val nameParts = fullName.split("\\\\")
+        val name      = nameParts.head
+        val newStack  = (nameParts.reverse ++ stack).toSeq
+        val children  = stmt.stmts.flatMap(stmt => visit(stmt, newStack)).distinct
+        val namespaces = nameParts.tail.foldRight(PhpNamespace(name) :: Nil)((name, acc) => {
+          val newName = acc.lastOption.map(_.name).toList :+ name mkString "\\"
+          PhpNamespace(newName) :: acc
+        })
+        namespaces ++ children
       case Some(fullName) =>
         // We are not the first namespace in a possibly nested namespace, thus we should only use the last part
-        val nameParts = fullName.name.split("\\\\")
-        val name      = nameParts.last
-        val children  = stmt.stmts.flatMap(stmt => visit(stmt, nameParts.last +: stack, None)).dedup
-        PhpNamespace(name, name, children, parent) :: Nil
+        val nameParts = fullName.split("\\\\")
+        val children  = stmt.stmts.flatMap(stmt => visit(stmt, nameParts.last +: stack)).distinct
+        PhpNamespace(fullName) :: children
     }
   }
 
-  private def visitMethodDecl(
-    method: PhpMethodDecl,
-    parent: Option[SymbolSummary & HasChildren]
-  ): Seq[SymbolSummary] = {
-    val name = method.name.name
-    PhpFunction(name, parent) :: Nil
+  private def visitMethodDecl(method: PhpMethodDecl, stack: NamespaceScopeStack): Seq[SymbolSummary] = {
+    val name = method.name.fullName(stack)
+    PhpFunction(name) :: Nil
   }
 
-  private def visitClassDecl(
-    classLike: PhpClassLikeStmt,
-    stack: NamespaceScopeStack,
-    parent: Option[SymbolSummary & HasChildren]
-  ): Seq[SymbolSummary] = {
-    val name        = classLike.name.map(_.name).get
-    val constructor = if !classLike.hasConstructor then Nil else PhpFunction(Domain.ConstructorMethodName, None) :: Nil
-    val children    = constructor ++ classLike.stmts.flatMap(visit(_, stack, None))
-    PhpClass(name, children, parent) :: Nil // This will re-wire children to link to PhpClass
-  }
+  private def visitClassDecl(classLike: PhpClassLikeStmt, stack: NamespaceScopeStack): Seq[SymbolSummary] =
+    classLike.name match {
+      case None => Nil
+      case Some(nameExpr) =>
+        val name          = nameExpr.name
+        val classFullName = nameExpr.fullName(stack)
+        val constructor =
+          if !classLike.hasConstructor then Nil
+          else PhpFunction(s"$classFullName\\${Domain.ConstructorMethodName}") :: Nil
+        val children = constructor ++ classLike.stmts.flatMap(visit(_, name +: stack))
+        PhpClass(classFullName) :: children
+    }
 
 }
 
@@ -103,248 +97,27 @@ object SymbolSummaryPass {
 
   private type NamespaceScopeStack = Seq[String]
 
-  def globalNamespace(children: Seq[SymbolSummary] = Nil): PhpNamespace = {
-    val name = MetaDataPass.getGlobalNamespaceBlockFullName(None)
-    PhpNamespace(name, name, children, None)
-  }
+  private implicit class NameExprExt(nameExpr: PhpNameExpr) {
 
-  private implicit class SummarySeqExt(xs: Seq[SymbolSummary]) {
-
-    /** Deduplicates a sequence of summaries at a specific namespace level. Particularly useful for namespaces declared
-      * adjacent to one another.
-      */
-    def dedup: Seq[SymbolSummary] = {
-      xs.foldLeft(Seq.empty[SymbolSummary])((acc, next) =>
-        acc match {
-          case Nil          => next :: Nil
-          case head :: tail => head + next ++ tail
-        }
-      )
-    }
+    def fullName(stack: NamespaceScopeStack): String = stack.reverse :+ nameExpr.name mkString "\\"
 
   }
 
   sealed trait SymbolSummary {
 
-    /** The link back to the parent object.
-      * @return
-      *   the parent symbol summary.
-      */
-    def _parent: Option[SymbolSummary & HasChildren]
-
-    /** Follows up the tree to the parent, excluding other siblings along the way.
-      * @return
-      *   the global-level symbol summary, containing a path to this symbol summary the only leaf.
-      */
-    def sparseTree: SymbolSummary = {
-      _parent match {
-        case None    => this
-        case Some(p) => p.withChildren(this :: Nil).sparseTree
-      }
-    }
-
-    /** Combines two symbol summary objects at the same namespace/AST level.
-      * @param o
-      *   the object to combine with.
-      * @return
-      *   two separate objects if they cannot be combined, or a single combined object if otherwise.
-      */
-    def +(o: SymbolSummary): Seq[SymbolSummary]
-
     /** @return
-      *   the identifier of the symbol as per its definition.
+      *   the fully qualified identifier of the symbol as per its definition.
       */
     def name: String
 
-    /** @return
-      *   the identifier of the symbol as defined by the importing script.
-      */
-    def alias: String
-
-    /** @param parent
-      *   the parent to link this child to.
-      * @return
-      *   a new copy of this node, with the parent field linked to the given parent.
-      */
-    def _withParent(parent: SymbolSummary & HasChildren): SymbolSummary
-
   }
 
-  sealed trait HasChildren { this: SymbolSummary =>
+  case class PhpNamespace(name: String) extends SymbolSummary
 
-    def children: Seq[SymbolSummary]
+  case class PhpFunction(name: String) extends SymbolSummary
 
-    def withChildren(newChildren: Seq[SymbolSummary]): SymbolSummary & HasChildren
+  case class PhpClass(name: String) extends SymbolSummary
 
-    protected def combineChildren(o: SymbolSummary & HasChildren): Seq[SymbolSummary] = {
-      (this.children ++ o.children).foldLeft(Seq.empty[SymbolSummary])((acc, next) =>
-        acc match {
-          case Nil          => next :: Nil
-          case head :: tail => head + next ++ tail
-        }
-      )
-    }
-
-  }
-
-  case class PhpNamespace(
-    name: String,
-    alias: String,
-    children: Seq[SymbolSummary],
-    _parent: Option[SymbolSummary & HasChildren]
-  ) extends SymbolSummary
-      with HasChildren {
-    override def +(o: SymbolSummary): Seq[SymbolSummary] = {
-      o match {
-        case n: PhpNamespace if n.name == this.name =>
-          new PhpNamespace(name, alias, combineChildren(n), this._parent) :: Nil
-        case _ => this :: o :: Nil
-      }
-    }
-
-    override def withChildren(newChildren: Seq[SymbolSummary]): SymbolSummary & HasChildren = {
-      this.copy(children = newChildren)
-    }
-
-    override def _withParent(parent: SymbolSummary & HasChildren): SymbolSummary = this.copy(_parent = Option(parent))
-  }
-
-  /** Constructs a PhpNamespace object with a parent pointer pointing to its parent attached to the children nodes.
-    * Using immutable structures in this way means we should not traverse this tree top-down.
-    */
-  object PhpNamespace {
-
-    def apply(name: String, children: Seq[SymbolSummary]): PhpNamespace = PhpNamespace(name, name, children, None)
-
-    def apply(
-      name: String,
-      alias: String,
-      children: Seq[SymbolSummary],
-      maybeParent: Option[SymbolSummary & HasChildren] = None
-    ): PhpNamespace = {
-      val self = maybeParent match {
-        case None => new PhpNamespace(name, alias, Nil, Option(globalNamespace()))
-        case Some(parent) => new PhpNamespace(name, alias, Nil, Option(parent))
-      }
-      self.copy(children = children.map(_._withParent(self)))
-    }
-
-    def unapply(x: PhpNamespace): (String, Seq[SymbolSummary]) =
-      (x.name, x.children)
-  }
-
-  case class PhpFunction(name: String, alias: String, _parent: Option[SymbolSummary & HasChildren])
-      extends SymbolSummary {
-    override def +(o: SymbolSummary): Seq[SymbolSummary] = {
-      o match {
-        case f: PhpFunction if f.name == this.name => this :: Nil
-        case _                                     => this :: o :: Nil
-      }
-    }
-
-    override def _withParent(parent: SymbolSummary & HasChildren): SymbolSummary = this.copy(_parent = Option(parent))
-
-  }
-
-  object PhpFunction {
-
-    def apply(name: String): PhpFunction = PhpFunction(name, name)
-
-    def apply(name: String, maybeParent: Option[SymbolSummary & HasChildren]): PhpFunction =
-      PhpFunction(name, name, maybeParent)
-
-    def apply(name: String, alias: String): PhpFunction = new PhpFunction(name, alias, Option(globalNamespace()))
-
-    def unapply(x: PhpFunction): Option[String] = Option(x.name)
-  }
-
-  case class PhpClass(
-    name: String,
-    alias: String,
-    children: Seq[SymbolSummary],
-    _parent: Option[SymbolSummary & HasChildren]
-  ) extends SymbolSummary
-      with HasChildren {
-    override def +(o: SymbolSummary): Seq[SymbolSummary] = {
-      o match {
-        case c: PhpClass if c.name == this.name =>
-          new PhpClass(name, alias, combineChildren(c), this._parent) :: Nil
-        case _ => this :: o :: Nil
-      }
-    }
-
-    override def withChildren(newChildren: Seq[SymbolSummary]): SymbolSummary & HasChildren =
-      this.copy(children = newChildren)
-
-    override def _withParent(parent: SymbolSummary & HasChildren): SymbolSummary = this.copy(_parent = Option(parent))
-  }
-
-  object PhpClass {
-
-    def apply(name: String, children: Seq[SymbolSummary], maybeParent: Option[SymbolSummary & HasChildren]): PhpClass =
-      PhpClass(name, name, children, maybeParent)
-
-    /** Constructs a PhpClass object with a parent pointer pointing to its parent attached to the children nodes. Using
-      * immutable structures in this way means we should not traverse this tree top-down.
-      */
-    def apply(
-      name: String,
-      alias: String,
-      children: Seq[SymbolSummary],
-      maybeParent: Option[SymbolSummary & HasChildren] = None
-    ): PhpClass = {
-      maybeParent match {
-        case None => new PhpClass(name, alias, children, Option(globalNamespace()))
-        case Some(parent) =>
-          val self = new PhpClass(name, alias, Nil, Option(parent))
-          self.copy(children = children.map(_._withParent(self)))
-      }
-    }
-
-    def unapply(x: PhpClass): (String, Seq[SymbolSummary]) =
-      (x.name, x.children)
-  }
-
-  case class PhpMember(name: String, alias: String, _parent: Option[SymbolSummary & HasChildren])
-      extends SymbolSummary {
-    override def +(o: SymbolSummary): Seq[SymbolSummary] = {
-      o match {
-        case f: PhpMember if f.name == this.name => this :: Nil
-        case _                                   => this :: o :: Nil
-      }
-    }
-
-    override def _withParent(parent: SymbolSummary & HasChildren): SymbolSummary = this.copy(_parent = Option(parent))
-
-  }
-
-  object PhpMember {
-    def apply(name: String, maybeParent: Option[SymbolSummary & HasChildren]): PhpMember =
-      new PhpMember(name, name, maybeParent)
-
-    def apply(name: String): PhpMember = new PhpMember(name, name, Option(globalNamespace()))
-
-    def unapply(x: PhpMember): Option[String] = Option(x.name)
-  }
-
-  case class PhpExternal(name: String, alias: String, _parent: Option[SymbolSummary & HasChildren])
-      extends SymbolSummary {
-    override def +(o: SymbolSummary): Seq[SymbolSummary] = {
-      o match {
-        case f: PhpExternal if f.name == this.name => this :: Nil
-        case _                                     => this :: o :: Nil
-      }
-    }
-
-    override def _withParent(parent: SymbolSummary & HasChildren): SymbolSummary = this.copy(_parent = Option(parent))
-  }
-
-  object PhpExternal {
-    def apply(name: String): PhpExternal = PhpExternal(name, name)
-
-    def apply(name: String, alias: String): PhpExternal = new PhpExternal(name, alias, Option(globalNamespace()))
-
-    def unapply(x: PhpExternal): String = x.name
-  }
+  case class PhpExternal(name: String) extends SymbolSummary
 
 }

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/utils/Scope.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/utils/Scope.scala
@@ -174,21 +174,25 @@ class Scope(summary: Map[String, Seq[SymbolSummary]] = Map.empty)(implicit nextC
     imports.foreach { imporT =>
       imporT.importedEntity.foreach { importName =>
         summary.get(importName).foreach { hits =>
-          val name  = importName.split("\\\\").last
-          val alias = imporT.importedAs.getOrElse(name)
-          importedSymbols = importedSymbols + (alias -> hits)
+          imporT.importedAs match {
+            case Some(alias) => importedSymbols = importedSymbols + (alias -> hits)
+            case None =>
+              val name = importName.split("\\\\").last
+              importedSymbols = importedSymbols + (name -> hits)
+          }
         }
       }
     }
   }
 
   /** Attempts to resolve a simple symbol.
+    *
+    * Note: This will be extended to notify the caller if this identifier is instead a local variable.
     */
-  def resolveImportedSymbol(symbol: String): Option[SymbolSummary] = {
+  def resolveIdentifier(symbol: String): Option[SymbolSummary] = {
     importedSymbols.get(symbol) match {
-      case Some(x :: Nil) => Option(x)
-      case Some(xs)       => xs.sorted.headOption // incorporates import precedence
-      case None           => None
+      case Some(xs) => xs.headOption // this is already sorted by precedence, with head being the correct option
+      case None     => None
     }
   }
 

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/utils/Scope.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/utils/Scope.scala
@@ -13,6 +13,7 @@ import io.shiftleft.codepropertygraph.generated.nodes.{
   NewNode,
   NewTypeDecl
 }
+import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 import org.slf4j.LoggerFactory
 
 import scala.collection.mutable
@@ -27,8 +28,8 @@ class Scope(summary: Seq[SymbolSummary] = Nil)(implicit nextClosureName: () => S
   private val anonymousMethods                                    = mutable.ArrayBuffer[Ast]()
   private var tmpVarCounter                                       = 0
   private var tmpClassCounter                                     = 0
-  // Maps imported strings to the most likely symbol
-  private val importedSymbols = mutable.Map.empty[String, SymbolSummary]
+  // Builds a tree of imported symbols, which is essentially a subset of `summary`
+  private var importedSymbols = Seq.empty[SymbolSummary]
 
   def pushNewScope(scopeNode: NewNode): Unit = {
     scopeNode match {
@@ -175,37 +176,18 @@ class Scope(summary: Seq[SymbolSummary] = Nil)(implicit nextClosureName: () => S
   }
 
   def useImport(imports: Seq[NewImport]): Unit = {
-
-    def findImport(next: String, worklist: Seq[String], summary: SymbolSummary): SymbolSummary = {
-      lazy val default = PhpExternal(next)
-
-      if (worklist.isEmpty) {
-        // TODO: Check if this matches PHP's import precedence
-        summary match {
-          case namespace @ PhpNamespace(name, _) if next == name => namespace
-          case func @ PhpFunction(name) if next == name          => func
-          case clazz @ PhpClass(name, _) if next == name         => clazz
-          case member @ PhpMember(name) if next == name          => member
-          case _                                                 => default
-        }
-      } else {
-        summary match {
-          case x: HasChildren if next == x.name =>
-            x.children.map(findImport(worklist.head, worklist.tail, _)).headOption.getOrElse(default)
-          case _ => default
-        }
-      }
-    }
-
     summary.headOption.foreach { globalSummarySymbol =>
       imports.foreach { imporT =>
         imporT.importedEntity.foreach { importName =>
           importName.split("\\\\").toList match {
-            case Nil         => // ignore
+            case Nil => // ignore
             case importParts =>
-              // TODO: We should be a building a rooted tree.
               val matchingSymbol = findImport(globalSummarySymbol.name, importParts, summary.head)
-              importedSymbols.put(importName, matchingSymbol)
+              val sparseTree     = matchingSymbol.sparseTree
+              importedSymbols = importedSymbols match {
+                case head :: _ => head + sparseTree
+                case Nil       => sparseTree :: Nil
+              }
           }
         }
       }
@@ -213,11 +195,46 @@ class Scope(summary: Seq[SymbolSummary] = Nil)(implicit nextClosureName: () => S
   }
 
   /** Attempts to resolve a fully or partially qualified symbol
-    * @param symbol
-    * @return
     */
   def resolveImportedSymbol(symbol: String): Option[SymbolSummary] = {
-    summary.headOption
+    importedSymbols.headOption.flatMap(resolveSymbol(symbol, _))
+  }
+  
+  private def resolveSymbol(symbol: String, summary: SymbolSummary): Option[SymbolSummary] = {
+    summary match {
+      case x if x.alias == symbol => Option(x)
+      case x: HasChildren => x.children.map(resolveSymbol(symbol, _)).collectFirst {
+        case Some(x) => x
+      }
+      case _ => Option(PhpExternal(symbol)) // TODO: Might be undesired
+    }
+  }
+
+  private def findImport(worklist: Seq[String], summary: SymbolSummary): SymbolSummary =
+    findImport(NamespaceTraversal.globalNamespaceName, worklist, summary)
+
+  private def findImport(next: String, worklist: Seq[String], summary: SymbolSummary): SymbolSummary = {
+    lazy val default = PhpExternal(next)
+
+    if (worklist.isEmpty) {
+      // TODO: Check if this matches PHP's import precedence
+      summary match {
+        case namespace @ PhpNamespace(name, _) if next == name => namespace
+        case func @ PhpFunction(name) if next == name          => func
+        case clazz @ PhpClass(name, _) if next == name         => clazz
+        case member @ PhpMember(name) if next == name          => member
+        case _                                                 => default
+      }
+    } else {
+      summary match {
+        case x: HasChildren if next == x.name =>
+          x.children
+            .map(findImport(worklist.head, worklist.tail, _))
+            .headOption
+            .getOrElse(default.copy(_parent = Option(x)))
+        case _ => default
+      }
+    }
   }
 
 }

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/utils/Scope.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/utils/Scope.scala
@@ -5,15 +5,7 @@ import io.joern.php2cpg.passes.SymbolSummaryPass.*
 import io.joern.x2cpg.Ast
 import io.joern.x2cpg.datastructures.{NamespaceLikeScope, ScopeElement, Scope as X2CpgScope}
 import io.shiftleft.codepropertygraph.generated.NodeTypes
-import io.shiftleft.codepropertygraph.generated.nodes.{
-  NewBlock,
-  NewImport,
-  NewMethod,
-  NewNamespaceBlock,
-  NewNode,
-  NewTypeDecl
-}
-import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
+import io.shiftleft.codepropertygraph.generated.nodes.*
 import org.slf4j.LoggerFactory
 
 import scala.collection.mutable
@@ -28,8 +20,7 @@ class Scope(summary: Map[String, Seq[SymbolSummary]] = Map.empty)(implicit nextC
   private val anonymousMethods                                    = mutable.ArrayBuffer[Ast]()
   private var tmpVarCounter                                       = 0
   private var tmpClassCounter                                     = 0
-  // Builds a tree of imported symbols, which is essentially a subset of `summary`
-  private var importedSymbols = Map.empty[String, Seq[SymbolSummary]]
+  private var importedSymbols                                     = Map.empty[String, Seq[SymbolSummary]]
 
   def pushNewScope(scopeNode: NewNode): Unit = {
     scopeNode match {
@@ -191,8 +182,10 @@ class Scope(summary: Map[String, Seq[SymbolSummary]] = Map.empty)(implicit nextC
     */
   def resolveImportedSymbol(symbol: String): Option[SymbolSummary] = {
     importedSymbols.get(symbol) match {
-      case Some(xs) => xs.headOption // TODO: Handle multiple options
-      case None     => None
+      case Some(x :: Nil) => Option(x)
+      case Some(xs) =>
+        xs.sorted.headOption // incorporates import precedence
+      case None => None
     }
   }
 

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/utils/Scope.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/utils/Scope.scala
@@ -166,6 +166,10 @@ class Scope(summary: Map[String, Seq[SymbolSummary]] = Map.empty)(implicit nextC
     returnString
   }
 
+  /** Declares imports to load into this scope.
+    * @param imports
+    *   the import nodes generated from parsing PhpUseStmt and PhpGroupUseStmt nodes.
+    */
   def useImport(imports: Seq[NewImport]): Unit = {
     imports.foreach { imporT =>
       imporT.importedEntity.foreach { importName =>
@@ -178,14 +182,13 @@ class Scope(summary: Map[String, Seq[SymbolSummary]] = Map.empty)(implicit nextC
     }
   }
 
-  /** Attempts to resolve a fully or partially qualified symbol
+  /** Attempts to resolve a simple symbol.
     */
   def resolveImportedSymbol(symbol: String): Option[SymbolSummary] = {
     importedSymbols.get(symbol) match {
       case Some(x :: Nil) => Option(x)
-      case Some(xs) =>
-        xs.sorted.headOption // incorporates import precedence
-      case None => None
+      case Some(xs)       => xs.sorted.headOption // incorporates import precedence
+      case None           => None
     }
   }
 

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/datastructures/PhpScopeTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/datastructures/PhpScopeTests.scala
@@ -1,5 +1,6 @@
 package io.joern.php2cpg.datastructures
 
+import io.joern.php2cpg.passes.SymbolSummaryPass
 import io.joern.php2cpg.passes.SymbolSummaryPass.*
 import io.joern.php2cpg.utils.Scope
 import io.shiftleft.codepropertygraph.generated.nodes.NewImport
@@ -21,12 +22,22 @@ class PhpScopeTests extends AnyWordSpec with Matchers {
     }
   }
 
+  "a nested function in the summary should resolve when imported" in {
+    val scope = scopeFrom(PhpNamespace("Foo", PhpFunction("bar"):: Nil))
+    scope.imporT("Foo\\foo")
+    scope.testResolve("foo") {
+      case PhpFunction(name) if name == "foo" => succeed
+      case symbol => fail(s"Unable to resolve correct symbol (given $symbol)")
+    }
+  }
+
 }
 
 object PhpScopeTests {
 
   def scopeFrom(symbols: SymbolSummary*): Scope = {
-    Scope(symbols)(() => "nan")
+    val summary = SymbolSummaryPass.globalNamespace(symbols) :: Nil
+    Scope(summary)(() => "nan")
   }
 
   implicit class ScopeExt(scope: Scope) {

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/datastructures/PhpScopeTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/datastructures/PhpScopeTests.scala
@@ -89,18 +89,19 @@ object PhpScopeTests {
     }
 
     def testResolve[T <: SymbolSummary](symbol: String)(expectation: T => Assertion): Assertion = {
-      scope.resolveImportedSymbol(symbol) match {
-        case Some(symbol) => try {
-          expectation(symbol.asInstanceOf[T])
-        } catch {
-          case _: Exception => fail(s"Unable to resolve correct symbol (given $symbol)")
-        }
-        case None         => fail("Unable to resolve imported symbol")
+      scope.resolveIdentifier(symbol) match {
+        case Some(symbol) =>
+          try {
+            expectation(symbol.asInstanceOf[T])
+          } catch {
+            case _: Exception => fail(s"Unable to resolve correct symbol (given $symbol)")
+          }
+        case None => fail("Unable to resolve imported symbol")
       }
     }
 
     def testResolveFailure(symbol: String): Assertion = {
-      scope.resolveImportedSymbol(symbol) match {
+      scope.resolveIdentifier(symbol) match {
         case Some(symbol) => fail(s"Incorrectly resolved '$symbol'")
         case None         => succeed
       }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/datastructures/PhpScopeTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/datastructures/PhpScopeTests.scala
@@ -55,6 +55,33 @@ class PhpScopeTests extends AnyWordSpec with Matchers {
     scope.testResolveFailure("Bar")
   }
 
+  "when namespace and class share the same path, the class should be selected over the namespace" in {
+    val scope = scopeFrom(PhpNamespace("Foo"), PhpClass("Foo"))
+    scope.imporT("Foo")
+    scope.testResolve("Foo") {
+      case PhpClass(name) if name == "Foo" => succeed
+      case symbol                          => fail(s"Unable to resolve correct symbol (given $symbol)")
+    }
+  }
+
+  "when namespace, class, and function share the same path, the class should be selected over the namespace" in {
+    val scope = scopeFrom(PhpNamespace("Foo"), PhpClass("Foo"), PhpFunction("Foo"))
+    scope.imporT("Foo")
+    scope.testResolve("Foo") {
+      case PhpClass(name) if name == "Foo" => succeed
+      case symbol                          => fail(s"Unable to resolve correct symbol (given $symbol)")
+    }
+  }
+
+  "when namespace and function share the same path, the function should be selected over the namespace" in {
+    val scope = scopeFrom(PhpNamespace("Foo"), PhpFunction("Foo"))
+    scope.imporT("Foo")
+    scope.testResolve("Foo") {
+      case PhpFunction(name) if name == "Foo" => succeed
+      case symbol                             => fail(s"Unable to resolve correct symbol (given $symbol)")
+    }
+  }
+
 }
 
 object PhpScopeTests {

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/datastructures/PhpScopeTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/datastructures/PhpScopeTests.scala
@@ -1,0 +1,47 @@
+package io.joern.php2cpg.datastructures
+
+import io.joern.php2cpg.passes.SymbolSummaryPass.*
+import io.joern.php2cpg.utils.Scope
+import io.shiftleft.codepropertygraph.generated.nodes.NewImport
+import org.scalatest.Assertion
+import org.scalatest.Assertions.fail
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class PhpScopeTests extends AnyWordSpec with Matchers {
+
+  import PhpScopeTests.*
+
+  "a function in the summary should resolve when imported" in {
+    val scope = scopeFrom(PhpFunction("foo"))
+    scope.imporT("foo")
+    scope.testResolve("foo") {
+      case PhpFunction(name) if name == "foo" => succeed
+      case symbol                             => fail(s"Unable to resolve correct symbol (given $symbol)")
+    }
+  }
+
+}
+
+object PhpScopeTests {
+
+  def scopeFrom(symbols: SymbolSummary*): Scope = {
+    Scope(symbols)(() => "nan")
+  }
+
+  implicit class ScopeExt(scope: Scope) {
+
+    def imporT(path: String): Scope = {
+      scope.useImport(NewImport().importedEntity(path) :: Nil)
+      scope
+    }
+
+    def testResolve(symbol: String)(expectation: SymbolSummary => Assertion): Assertion = {
+      scope.resolveImportedSymbol(symbol) match {
+        case Some(symbol) => expectation(symbol)
+        case None         => fail("Unable to resolve imported symbol")
+      }
+    }
+
+  }
+}

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/passes/PhpSymbolSummaryPassTest.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/passes/PhpSymbolSummaryPassTest.scala
@@ -35,13 +35,8 @@ class PhpSymbolSummaryPassTest extends AnyWordSpec with Matchers {
         |  }
         |}
         |""".stripMargin :: Nil,
-      {
-        case Seq(
-              "Foo" -> (PhpClass("Foo") :: Nil),
-              "Foo\\__construct" -> (PhpFunction("Foo\\__construct") :: Nil),
-              "Foo\\foo" -> (PhpFunction("Foo\\foo") :: Nil)
-            ) =>
-          succeed
+      { case Seq("Foo" -> (PhpClass("Foo") :: Nil)) =>
+        succeed
       }
     )
   }
@@ -56,8 +51,7 @@ class PhpSymbolSummaryPassTest extends AnyWordSpec with Matchers {
         case Seq(
               "Foo" -> (PhpNamespace("Foo") :: Nil),
               "Foo\\Bar" -> (PhpNamespace("Foo\\Bar") :: Nil),
-              "Foo\\Bar\\Baz" -> (PhpClass("Foo\\Bar\\Baz") :: Nil),
-              "Foo\\Bar\\Baz\\__construct" -> (PhpFunction("Foo\\Bar\\Baz\\__construct") :: Nil)
+              "Foo\\Bar\\Baz" -> (PhpClass("Foo\\Bar\\Baz") :: Nil)
             ) =>
           succeed
       }
@@ -79,9 +73,7 @@ class PhpSymbolSummaryPassTest extends AnyWordSpec with Matchers {
               "Foo" -> (PhpNamespace("Foo") :: Nil),
               "Foo\\Bar" -> (PhpNamespace("Foo\\Bar") :: Nil),
               "Foo\\Bar\\Baz" -> (PhpClass("Foo\\Bar\\Baz") :: Nil),
-              "Foo\\Bar\\Baz\\__construct" -> (PhpFunction("Foo\\Bar\\Baz\\__construct") :: Nil),
-              "Foo\\Bar\\Faz" -> (PhpClass("Foo\\Bar\\Faz") :: Nil),
-              "Foo\\Bar\\Faz\\__construct" -> (PhpFunction("Foo\\Bar\\Faz\\__construct") :: Nil)
+              "Foo\\Bar\\Faz" -> (PhpClass("Foo\\Bar\\Faz") :: Nil)
             ) =>
           succeed
       }
@@ -103,9 +95,7 @@ class PhpSymbolSummaryPassTest extends AnyWordSpec with Matchers {
               "Foo" -> (PhpNamespace("Foo") :: Nil),
               "Foo\\Bar" -> (PhpNamespace("Foo\\Bar") :: Nil),
               "Foo\\Bar\\Baz" -> (PhpClass("Foo\\Bar\\Baz") :: Nil),
-              "Foo\\Bar\\Baz\\__construct" -> (PhpFunction("Foo\\Bar\\Baz\\__construct") :: Nil),
-              "Foo\\Faz" -> (PhpClass("Foo\\Faz") :: Nil),
-              "Foo\\Faz\\__construct" -> (PhpFunction("Foo\\Faz\\__construct") :: Nil)
+              "Foo\\Faz" -> (PhpClass("Foo\\Faz") :: Nil)
             ) =>
           succeed
       }
@@ -148,9 +138,7 @@ class PhpSymbolSummaryPassTest extends AnyWordSpec with Matchers {
               "Foo" -> (PhpNamespace("Foo") :: Nil),
               "Foo\\Bar" -> (PhpNamespace("Foo\\Bar") :: Nil),
               "Foo\\Bar\\Baz" -> (PhpClass("Foo\\Bar\\Baz") :: Nil),
-              "Foo\\Bar\\Baz\\__construct" -> (PhpFunction("Foo\\Bar\\Baz\\__construct") :: Nil),
-              "Foo\\Faz" -> (PhpClass("Foo\\Faz") :: Nil),
-              "Foo\\Faz\\__construct" -> (PhpFunction("Foo\\Faz\\__construct") :: Nil)
+              "Foo\\Faz" -> (PhpClass("Foo\\Faz") :: Nil)
             ) =>
           succeed
       }


### PR DESCRIPTION
* Modifies the scope object to incorporate summaries and knowledge of imports into the scope 
* Using import information, it is able to map a symbol or alias to an imported entity that has appeared from the summary pass
* Simplified the summary pass to not be nested, but rather flattened, and use string paths similar to PHP notation
* When a symbol is resolved, the kind of symbol is also returned, i.e., class, function, namespace, etc.

Note: Excluded class member summarization (anything nested under a class) as PHP class members cannot be imported directly.