### PR TITLE
[php] Create meta `TYPE_DECL` (.<class>) for class-like structures

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
@@ -278,6 +278,7 @@ object AstCreator {
     val Default: String      = "default"
     val HaltCompiler: String = "__halt_compiler"
     val This: String         = "this"
+    val Self: String         = "self"
     val Unknown: String      = "UNKNOWN"
     val Closure: String      = "__closure"
     val Class: String        = "class"

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
@@ -97,7 +97,7 @@ class AstCreator(
       Seq.empty[PhpAttributeGroup]
     )
 
-    val globalTypeDeclAst = astForClassLikeStmt(globalTypeDeclStmt)
+    val globalTypeDeclAst = astForGlobalDecl(globalTypeDeclStmt, globalTypeDeclStmt.name.get)
 
     scope.popScope() // globalNamespace
 
@@ -118,7 +118,7 @@ class AstCreator(
       case switchStmt: PhpSwitchStmt       => astForSwitchStmt(switchStmt) :: Nil
       case tryStmt: PhpTryStmt             => astForTryStmt(tryStmt) :: Nil
       case returnStmt: PhpReturnStmt       => astForReturnStmt(returnStmt) :: Nil
-      case classLikeStmt: PhpClassLikeStmt => astForClassLikeStmt(classLikeStmt) :: Nil
+      case classLikeStmt: PhpClassLikeStmt => astForClassLikeStmt(classLikeStmt)
       case gotoStmt: PhpGotoStmt           => astForGotoStmt(gotoStmt) :: Nil
       case labelStmt: PhpLabelStmt         => astForLabelStmt(labelStmt) :: Nil
       case namespace: PhpNamespaceStmt     => astForNamespaceStmt(namespace) :: Nil

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreatorHelper.scala
@@ -54,7 +54,7 @@ trait AstCreatorHelper(disableFileContent: Boolean)(implicit withSchemaValidatio
       globalNamespace.fullName
     } else {
       val className = if (appendClass) {
-        getTypeDeclPrefix.map(name => s"${name}.<class>")
+        getTypeDeclPrefix.map(name => s"${name}$MetaTypeDeclExtension")
       } else {
         getTypeDeclPrefix
       }

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreatorHelper.scala
@@ -49,11 +49,16 @@ trait AstCreatorHelper(disableFileContent: Boolean)(implicit withSchemaValidatio
     identifierNode(originNode, name, s"$$$name", typeFullName)
   }
 
-  protected def composeMethodFullName(methodName: String, isStatic: Boolean): String = {
+  protected def composeMethodFullName(methodName: String, isStatic: Boolean, appendClass: Boolean = false): String = {
     if (methodName == NamespaceTraversal.globalNamespaceName) {
       globalNamespace.fullName
     } else {
-      val className       = getTypeDeclPrefix
+      val className = if (appendClass) {
+        getTypeDeclPrefix.map(name => s"${name}.<class>")
+      } else {
+        getTypeDeclPrefix
+      }
+
       val methodDelimiter = if (isStatic) StaticMethodDelimiter else InstanceMethodDelimiter
 
       val nameWithClass = List(className, Some(methodName)).flatten.mkString(methodDelimiter)

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
@@ -97,7 +97,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     val fullName = call.target match {
       // Static method call with a known class name
       case Some(nameExpr: PhpNameExpr) if call.isStatic =>
-        if (nameExpr.name == "self") composeMethodFullName(name, call.isStatic, appendClass = true)
+        if (nameExpr.name == NameConstants.Self) composeMethodFullName(name, call.isStatic, appendClass = true)
         else s"${nameExpr.name}$MetaTypeDeclExtension$StaticMethodDelimiter$name"
       case Some(expr) =>
         s"$UnresolvedNamespace\\$codePrefix"
@@ -206,12 +206,12 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
       callAst(fieldAccessNode, List(identifier, fieldIdentifier).map(Ast(_))).withRefEdges(identifier, thisParam.toList)
     } else {
       val selfIdentifier = {
-        val name = "self"
+        val name = NameConstants.Self
         val typ  = scope.getEnclosingTypeDeclTypeName
         identifierNode(originNode, name, name, typ.getOrElse(Defines.Any), typ.toList)
       }
       val fieldIdentifier = fieldIdentifierNode(originNode, memberNode.name, memberNode.name)
-      val code            = s"self::${memberNode.code.replaceAll("(static|case|const) ", "")}"
+      val code            = s"${NameConstants.Self}::${memberNode.code.replaceAll("(static|case|const) ", "")}"
       val fieldAccessNode = operatorCallNode(originNode, code, Operators.fieldAccess, None)
       callAst(fieldAccessNode, List(selfIdentifier, fieldIdentifier).map(Ast(_)))
     }

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
@@ -98,7 +98,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
       // Static method call with a known class name
       case Some(nameExpr: PhpNameExpr) if call.isStatic =>
         if (nameExpr.name == "self") composeMethodFullName(name, call.isStatic, appendClass = true)
-        else s"${nameExpr.name}.<class>$StaticMethodDelimiter$name"
+        else s"${nameExpr.name}$MetaTypeDeclExtension$StaticMethodDelimiter$name"
       case Some(expr) =>
         s"$UnresolvedNamespace\\$codePrefix"
       case None if PhpBuiltins.FuncNames.contains(name) =>

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
@@ -97,8 +97,8 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     val fullName = call.target match {
       // Static method call with a known class name
       case Some(nameExpr: PhpNameExpr) if call.isStatic =>
-        if (nameExpr.name == "self") composeMethodFullName(name, call.isStatic)
-        else s"${nameExpr.name}$StaticMethodDelimiter$name"
+        if (nameExpr.name == "self") composeMethodFullName(name, call.isStatic, appendClass = true)
+        else s"${nameExpr.name}.<class>$StaticMethodDelimiter$name"
       case Some(expr) =>
         s"$UnresolvedNamespace\\$codePrefix"
       case None if PhpBuiltins.FuncNames.contains(name) =>

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/Domain.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/Domain.scala
@@ -81,6 +81,7 @@ object Domain {
   val InstanceMethodDelimiter = "->"
   // Used for creating the default constructor.
   val ConstructorMethodName = "__construct"
+  val MetaTypeDeclExtension = "<metaclass>"
 
   final case class PhpAttributes(lineNumber: Option[Int], kind: Option[Int], startFilePos: Int, endFilePos: Int)
   object PhpAttributes {

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/LocalCreationPass.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/LocalCreationPass.scala
@@ -41,7 +41,7 @@ abstract class LocalCreationPass[ScopeType <: AstNode](cpg: Cpg)
   ): List[(NewLocal, List[Identifier])] = {
     identifierMap
       .map { case identifierName -> identifiers =>
-        val code = s"$$$identifierName"
+        val code = if identifierName == "self" then s"$identifierName" else s"$$$identifierName"
         val local =
           localNode(identifiers.head, identifierName, code, Defines.Any, closureBindingId = None)
         (local -> identifiers)

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/LocalCreationPass.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/LocalCreationPass.scala
@@ -1,6 +1,6 @@
 package io.joern.php2cpg.passes
 
-import io.joern.php2cpg.astcreation.AstCreator
+import io.joern.php2cpg.astcreation.AstCreator.NameConstants
 import io.joern.php2cpg.parser.Domain
 import io.joern.php2cpg.parser.Domain.PhpOperators
 import io.joern.x2cpg.{AstNodeBuilder, Defines}
@@ -41,7 +41,7 @@ abstract class LocalCreationPass[ScopeType <: AstNode](cpg: Cpg)
   ): List[(NewLocal, List[Identifier])] = {
     identifierMap
       .map { case identifierName -> identifiers =>
-        val code = if identifierName == "self" then s"$identifierName" else s"$$$identifierName"
+        val code = if identifierName == NameConstants.Self then s"$identifierName" else s"$$$identifierName"
         val local =
           localNode(identifiers.head, identifierName, code, Defines.Any, closureBindingId = None)
         (local -> identifiers)

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/CallTests.scala
@@ -72,7 +72,7 @@ class CallTests extends PhpCode2CpgFixture {
     "have the correct method node defined" in {
       inside(cpg.call.l) { case List(fooCall) =>
         fooCall.name shouldBe "foo"
-        fooCall.methodFullName shouldBe s"Foo::foo"
+        fooCall.methodFullName shouldBe s"Foo.<class>::foo"
         fooCall.receiver.isEmpty shouldBe true
         fooCall.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
         fooCall.lineNumber shouldBe Some(2)
@@ -117,7 +117,7 @@ class CallTests extends PhpCode2CpgFixture {
     "resolve the correct method full name" in {
       val List(barCall) = cpg.call("bar").take(1).l
       barCall.name shouldBe "bar"
-      barCall.methodFullName shouldBe s"ClassA::bar"
+      barCall.methodFullName shouldBe s"ClassA.<class>::bar"
       barCall.receiver.isEmpty shouldBe true
       barCall.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
       barCall.code shouldBe "self::bar($x)"

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/CallTests.scala
@@ -2,6 +2,7 @@ package io.joern.php2cpg.querying
 
 import io.joern.php2cpg.astcreation.AstCreator.NameConstants
 import io.joern.php2cpg.testfixtures.PhpCode2CpgFixture
+import io.joern.php2cpg.parser.Domain
 import io.joern.x2cpg.Defines
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier}
@@ -72,7 +73,7 @@ class CallTests extends PhpCode2CpgFixture {
     "have the correct method node defined" in {
       inside(cpg.call.l) { case List(fooCall) =>
         fooCall.name shouldBe "foo"
-        fooCall.methodFullName shouldBe s"Foo.<class>::foo"
+        fooCall.methodFullName shouldBe s"Foo${Domain.MetaTypeDeclExtension}::foo"
         fooCall.receiver.isEmpty shouldBe true
         fooCall.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
         fooCall.lineNumber shouldBe Some(2)
@@ -117,7 +118,7 @@ class CallTests extends PhpCode2CpgFixture {
     "resolve the correct method full name" in {
       val List(barCall) = cpg.call("bar").take(1).l
       barCall.name shouldBe "bar"
-      barCall.methodFullName shouldBe s"ClassA.<class>::bar"
+      barCall.methodFullName shouldBe s"ClassA${Domain.MetaTypeDeclExtension}::bar"
       barCall.receiver.isEmpty shouldBe true
       barCall.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
       barCall.code shouldBe "self::bar($x)"

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/MemberTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/MemberTests.scala
@@ -21,15 +21,16 @@ class MemberTests extends PhpCode2CpgFixture {
     val cpg = code(source, "foo.php").withConfig(Config().withDisableFileContent(false))
 
     "have member nodes representing them" in {
-      inside(cpg.typeDecl.name("Foo.<class>").member.sortBy(_.name).toList) { case List(aMember, bMember, cMember) =>
-        aMember.name shouldBe "A"
-        aMember.code shouldBe "const A"
+      inside(cpg.typeDecl.name(s"Foo${Domain.MetaTypeDeclExtension}").member.sortBy(_.name).toList) {
+        case List(aMember, bMember, cMember) =>
+          aMember.name shouldBe "A"
+          aMember.code shouldBe "const A"
 
-        bMember.name shouldBe "B"
-        bMember.code shouldBe "const B"
+          bMember.name shouldBe "B"
+          bMember.code shouldBe "const B"
 
-        cMember.name shouldBe "C"
-        cMember.code shouldBe "const C"
+          cMember.name shouldBe "C"
+          cMember.code shouldBe "const C"
       }
     }
 

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/MemberTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/MemberTests.scala
@@ -21,7 +21,7 @@ class MemberTests extends PhpCode2CpgFixture {
     val cpg = code(source, "foo.php").withConfig(Config().withDisableFileContent(false))
 
     "have member nodes representing them" in {
-      inside(cpg.typeDecl.name("Foo").member.sortBy(_.name).toList) { case List(aMember, bMember, cMember) =>
+      inside(cpg.typeDecl.name("Foo.<class>").member.sortBy(_.name).toList) { case List(aMember, bMember, cMember) =>
         aMember.name shouldBe "A"
         aMember.code shouldBe "const A"
 

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/NamespaceTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/NamespaceTests.scala
@@ -1,6 +1,7 @@
 package io.joern.php2cpg.querying
 
 import io.joern.php2cpg.testfixtures.PhpCode2CpgFixture
+import io.joern.php2cpg.parser.Domain
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.codepropertygraph.generated.nodes.Method
 
@@ -117,7 +118,7 @@ class NamespaceTests extends PhpCode2CpgFixture {
         |""".stripMargin)
 
     cpg.method.name("foo").fullName.l shouldBe List("A->foo")
-    cpg.method.name("bar").fullName.l shouldBe List("A.<class>::bar")
+    cpg.method.name("bar").fullName.l shouldBe List(s"A${Domain.MetaTypeDeclExtension}::bar")
   }
 
   "static and instance methods in namespaced code should be correct" in {
@@ -131,7 +132,7 @@ class NamespaceTests extends PhpCode2CpgFixture {
         |""".stripMargin)
 
     cpg.method.name("foo").fullName.l shouldBe List("ns\\A->foo")
-    cpg.method.name("bar").fullName.l shouldBe List("ns\\A.<class>::bar")
+    cpg.method.name("bar").fullName.l shouldBe List(s"ns\\A${Domain.MetaTypeDeclExtension}::bar")
   }
 
   "global namespace block should have the relative filename prepended to fullName" in {

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/NamespaceTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/NamespaceTests.scala
@@ -117,7 +117,7 @@ class NamespaceTests extends PhpCode2CpgFixture {
         |""".stripMargin)
 
     cpg.method.name("foo").fullName.l shouldBe List("A->foo")
-    cpg.method.name("bar").fullName.l shouldBe List("A::bar")
+    cpg.method.name("bar").fullName.l shouldBe List("A.<class>::bar")
   }
 
   "static and instance methods in namespaced code should be correct" in {
@@ -131,7 +131,7 @@ class NamespaceTests extends PhpCode2CpgFixture {
         |""".stripMargin)
 
     cpg.method.name("foo").fullName.l shouldBe List("ns\\A->foo")
-    cpg.method.name("bar").fullName.l shouldBe List("ns\\A::bar")
+    cpg.method.name("bar").fullName.l shouldBe List("ns\\A.<class>::bar")
   }
 
   "global namespace block should have the relative filename prepended to fullName" in {

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/TypeDeclTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/TypeDeclTests.scala
@@ -567,7 +567,7 @@ class TypeDeclTests extends PhpCode2CpgFixture {
     "create a singleton type decl" in {
       inside(cpg.typeDecl.name(s"Foo${Domain.MetaTypeDeclExtension}").l) {
         case fooTypeDecl :: Nil =>
-          fooTypeDecl.modifier.modifierType.l shouldBe List(ModifierTypes.STATIC)
+          fooTypeDecl.fullName shouldBe s"Foo${Domain.MetaTypeDeclExtension}"
         case xs => fail(s"Expected one singleton type decl, got ${xs.code.mkString("[", ",", "]")}")
       }
     }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/TypeNodeTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/TypeNodeTests.scala
@@ -15,11 +15,47 @@ class TypeNodeTests extends PhpCode2CpgFixture {
      |""".stripMargin)
 
     "have type nodes created for the TypeDecl and inherited types" in {
-      cpg.typ.fullName.toSet shouldEqual Set("ANY", "foo\\A", "foo\\B", "foo\\C", "foo\\D")
+      cpg.typ.fullName.toSet shouldEqual Set(
+        "ANY",
+        "foo\\B",
+        "foo\\B.<class>",
+        "foo\\C",
+        "foo\\D",
+        "foo\\A",
+        "foo\\A.<class>",
+        "foo\\C.<class>",
+        "foo\\D.<class>"
+      )
     }
 
     "have TypeDecl stubs created for inherited types" in {
-      cpg.typeDecl.external.fullName.toSet shouldEqual Set("ANY", "foo\\B", "foo\\C", "foo\\D")
+      cpg.typeDecl.external.fullName.toSet shouldEqual Set(
+        "ANY",
+        "foo\\B",
+        "foo\\B.<class>",
+        "foo\\C",
+        "foo\\C.<class>",
+        "foo\\D",
+        "foo\\D.<class>"
+      )
+    }
+  }
+
+  "TypeDecls with inheritsFrom edges" should {
+    val cpg = code("""<?php
+        |interface Foo {}
+        |class Bar {}
+        |class Baz extends Bar implements Foo {}
+        |""".stripMargin)
+
+    "have baseTypeDecl for dynamic TYPE_DECL" in {
+      cpg.typeDecl.name("Baz").baseTypeDecl.l.map(_.name) shouldBe List("Bar", "Foo")
+      cpg.typeDecl.name("Baz").baseTypeDeclTransitive.l.map(_.name) shouldBe List("Bar", "Foo")
+    }
+
+    "have baseTypeDecl steps for meta TYPE_DECL (.<class>)" in {
+      cpg.typeDecl.name("Baz.<class>").baseTypeDecl.l.map(_.name) shouldBe List("Bar.<class>", "Foo.<class>")
+      cpg.typeDecl.name("Baz.<class>").baseTypeDeclTransitive.l.map(_.name) shouldBe List("Bar.<class>", "Foo.<class>")
     }
   }
 

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/TypeNodeTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/TypeNodeTests.scala
@@ -1,11 +1,8 @@
 package io.joern.php2cpg.querying
 
 import io.joern.php2cpg.testfixtures.PhpCode2CpgFixture
-import io.joern.x2cpg.Defines
-import io.shiftleft.codepropertygraph.generated.{ModifierTypes, Operators}
-import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, Literal, Local, Member, Method}
+import io.joern.php2cpg.parser.Domain
 import io.shiftleft.semanticcpg.language.*
-import io.shiftleft.codepropertygraph.generated.nodes.Block
 
 class TypeNodeTests extends PhpCode2CpgFixture {
   "TypeDecls with inheritsFrom types" should {
@@ -17,14 +14,14 @@ class TypeNodeTests extends PhpCode2CpgFixture {
     "have type nodes created for the TypeDecl and inherited types" in {
       cpg.typ.fullName.toSet shouldEqual Set(
         "ANY",
-        "foo\\B",
-        "foo\\B.<class>",
-        "foo\\C",
-        "foo\\D",
         "foo\\A",
-        "foo\\A.<class>",
-        "foo\\C.<class>",
-        "foo\\D.<class>"
+        "foo\\B",
+        "foo\\C",
+        s"foo\\B${Domain.MetaTypeDeclExtension}",
+        s"foo\\D${Domain.MetaTypeDeclExtension}",
+        "foo\\D",
+        s"foo\\A${Domain.MetaTypeDeclExtension}",
+        s"foo\\C${Domain.MetaTypeDeclExtension}"
       )
     }
 
@@ -32,11 +29,11 @@ class TypeNodeTests extends PhpCode2CpgFixture {
       cpg.typeDecl.external.fullName.toSet shouldEqual Set(
         "ANY",
         "foo\\B",
-        "foo\\B.<class>",
+        s"foo\\B${Domain.MetaTypeDeclExtension}",
         "foo\\C",
-        "foo\\C.<class>",
+        s"foo\\C${Domain.MetaTypeDeclExtension}",
         "foo\\D",
-        "foo\\D.<class>"
+        s"foo\\D${Domain.MetaTypeDeclExtension}"
       )
     }
   }
@@ -53,9 +50,15 @@ class TypeNodeTests extends PhpCode2CpgFixture {
       cpg.typeDecl.name("Baz").baseTypeDeclTransitive.l.map(_.name) shouldBe List("Bar", "Foo")
     }
 
-    "have baseTypeDecl steps for meta TYPE_DECL (.<class>)" in {
-      cpg.typeDecl.name("Baz.<class>").baseTypeDecl.l.map(_.name) shouldBe List("Bar.<class>", "Foo.<class>")
-      cpg.typeDecl.name("Baz.<class>").baseTypeDeclTransitive.l.map(_.name) shouldBe List("Bar.<class>", "Foo.<class>")
+    "have baseTypeDecl steps for meta TYPE_DECL (<metaclass>)" in {
+      cpg.typeDecl.name(s"Baz${Domain.MetaTypeDeclExtension}").baseTypeDecl.l.map(_.name) shouldBe List(
+        s"Bar${Domain.MetaTypeDeclExtension}",
+        s"Foo${Domain.MetaTypeDeclExtension}"
+      )
+      cpg.typeDecl.name(s"Baz${Domain.MetaTypeDeclExtension}").baseTypeDeclTransitive.l.map(_.name) shouldBe List(
+        s"Bar${Domain.MetaTypeDeclExtension}",
+        s"Foo${Domain.MetaTypeDeclExtension}"
+      )
     }
   }
 


### PR DESCRIPTION
* Create a meta `TYPE_DECL` node, which is a sibling to the normal `TYPE_DECL` node for named classes, anonymous classes and enums (handled like class structures in `php2cpg`)
* Move `<clinit>` (static init method), all static methods, all static variables and consts to the meta `TYPE_DECL`
* Moved the AST generation for the global type decl into it's own function, was creating too much convolution in the `astForNamedClass` function
* updated required test expectations to account for the new `.<class>` type decl that is introduced.