### PR TITLE
[x2cpg] `FileVisitOption` now configurable

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/C2Cpg.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/C2Cpg.scala
@@ -59,7 +59,7 @@ class C2Cpg extends X2CpgFrontend[Config] {
           ignoredDefaultRegex = Option(C2Cpg.DefaultIgnoredFolders),
           ignoredFilesRegex = Option(config.ignoredFilesRegex),
           ignoredFilesPath = Option(config.ignoredFiles)
-        )
+        )(config.fileVisitOptions)
     } else { List.empty }
   }
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/HeaderFileFinder.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/HeaderFileFinder.scala
@@ -17,7 +17,7 @@ class HeaderFileFinder(config: Config) {
       ignoredDefaultRegex = Option(DefaultIgnoredFolders),
       ignoredFilesRegex = Option(config.ignoredFilesRegex),
       ignoredFilesPath = Option(config.ignoredFiles)
-    )
+    )(config.fileVisitOptions)
     .map(p => Paths.get(p))
     .groupMap(_.fileName)(_.toString)
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
@@ -62,7 +62,7 @@ class AstCreationPass(
         ignoredDefaultRegex = Option(C2Cpg.DefaultIgnoredFolders),
         ignoredFilesRegex = Option(config.ignoredFilesRegex),
         ignoredFilesPath = Option(config.ignoredFiles)
-      )
+      )(config.fileVisitOptions)
       .toArray
     if (config.withPreprocessedFiles) {
       allSourceFiles.filter {

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/PreprocessorPass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/PreprocessorPass.scala
@@ -51,7 +51,7 @@ class PreprocessorPass(config: Config) {
         ignoredDefaultRegex = Option(DefaultIgnoredFolders),
         ignoredFilesRegex = Option(config.ignoredFilesRegex),
         ignoredFilesPath = Option(config.ignoredFiles)
-      )
+      )(config.fileVisitOptions)
   }
 
   private def sourceFilesFromCompilationDatabase(compilationDatabaseFile: String): Iterable[String] = {

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/AstC2CpgFrontend.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/AstC2CpgFrontend.scala
@@ -34,7 +34,7 @@ trait AstC2CpgFrontend extends LanguageFrontend {
           ignoredDefaultRegex = Option(DefaultIgnoredFolders),
           ignoredFilesRegex = Option(config.ignoredFilesRegex),
           ignoredFilesPath = Option(config.ignoredFiles)
-        )
+        )(config.fileVisitOptions)
     } else List.empty
 
     val sourceFileExtensions = FileDefaults.SourceFileExtensions ++

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/CSharpSrc2Cpg.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/CSharpSrc2Cpg.scala
@@ -99,7 +99,7 @@ object CSharpSrc2Cpg {
       Option(config.defaultIgnoredFilesRegex),
       Option(config.ignoredFilesRegex),
       Option(config.ignoredFiles)
-    )
+    )(config.fileVisitOptions)
   }
 
   /** Addresses behaviour in Windows where a user-specific temp folder is used: parserResult.fullPath =

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/utils/AstGenRunner.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/utils/AstGenRunner.scala
@@ -94,7 +94,7 @@ class AstGenRunner(config: Config, includeFileRegex: String = "") extends AstGen
           Set(".json"),
           ignoredFilesRegex = Option(config.ignoredFilesRegex),
           ignoredFilesPath = Option(config.ignoredFiles)
-        )
+        )(config.fileVisitOptions)
         val parsedModFile = filterModFile(srcFiles, out)
         val parsed        = filterFiles(srcFiles, out)
         val skipped       = skippedFiles(in, result.toList)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/jpastprinter/JavaParserAstPrinter.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/jpastprinter/JavaParserAstPrinter.scala
@@ -21,7 +21,7 @@ object JavaParserAstPrinter {
         ignoredDefaultRegex = Option(JavaSrc2Cpg.DefaultIgnoredFilesRegex),
         ignoredFilesRegex = Option(config.ignoredFilesRegex),
         ignoredFilesPath = Option(config.ignoredFiles)
-      )
+      )(config.fileVisitOptions)
       .foreach { filename =>
         val relativeFilename = Path.of(config.inputPath).relativize(Path.of(filename)).toString
         sourceParser.parseAnalysisFile(relativeFilename, saveFileContent = false).foreach { case (compilationUnit, _) =>

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/SourceParser.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/SourceParser.scala
@@ -149,7 +149,7 @@ object SourceParser {
           ignoredDefaultRegex = Option(JavaSrc2Cpg.DefaultIgnoredFilesRegex),
           ignoredFilesRegex = Option(config.ignoredFilesRegex),
           ignoredFilesPath = Option(config.ignoredFiles)
-        )
+        )(config.fileVisitOptions)
       )
       .flatMap(FileInfo.getFileInfo(inputPath, _))
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/ConfigPass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/ConfigPass.scala
@@ -27,7 +27,7 @@ class ConfigPass(cpg: Cpg, config: Config, report: Report = new Report()) extend
 
   protected def configFiles(config: Config, extensions: Set[String]): Seq[Path] =
     SourceFiles
-      .determine(config.inputPath, extensions)
+      .determine(config.inputPath, extensions)(config.fileVisitOptions)
       .filterNot(_.contains(Defines.NodeModulesFolder))
       .filter(f => selectedExtensions.exists(f.endsWith))
       .map(Paths.get(_))

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/DependenciesPass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/DependenciesPass.scala
@@ -16,7 +16,7 @@ class DependenciesPass(cpg: Cpg, config: Config) extends CpgPass(cpg) {
 
   override def run(diffGraph: DiffGraphBuilder): Unit = {
     val packagesJsons = SourceFiles
-      .determine(config.inputPath, Set(".json"))
+      .determine(config.inputPath, Set(".json"))(config.fileVisitOptions)
       .filterNot(_.contains(Defines.NodeModulesFolder))
       .filter(f =>
         f.endsWith(PackageJsonParser.PackageJsonFilename) || f.endsWith(PackageJsonParser.PackageJsonLockFilename)

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Kotlin2Cpg.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Kotlin2Cpg.scala
@@ -84,7 +84,7 @@ class Kotlin2Cpg extends X2CpgFrontend[Config] with UsesService {
       Set(".kt"),
       ignoredFilesRegex = Option(config.ignoredFilesRegex),
       ignoredFilesPath = Option(config.ignoredFiles)
-    )
+    )(config.fileVisitOptions)
     if (filesWithKtExtension.isEmpty) {
       println(s"The provided input directory does not contain files ending in '.kt' `$sourceDir`. Exiting.")
       System.exit(1)
@@ -98,7 +98,7 @@ class Kotlin2Cpg extends X2CpgFrontend[Config] with UsesService {
       Set(".java"),
       ignoredFilesRegex = Option(config.ignoredFilesRegex),
       ignoredFilesPath = Option(config.ignoredFiles)
-    )
+    )(config.fileVisitOptions)
     if (filesWithJavaExtension.nonEmpty) {
       logger.info(s"Found ${filesWithJavaExtension.size} files with the `.java` extension.")
     }

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
@@ -96,7 +96,7 @@ class Php2Cpg extends X2CpgFrontend[Config] {
         Option(config.defaultIgnoredFilesRegex),
         Option(config.ignoredFilesRegex),
         Option(config.ignoredFiles)
-      )
+      )(config.fileVisitOptions)
       .filter(_.endsWith("composer.json"))
   }
 }

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/AstParsingPass.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/AstParsingPass.scala
@@ -23,7 +23,7 @@ trait AstParsingPass(config: Config, parser: PhpParser) { this: ForkJoinParallel
         PhpSourceFileExtensions,
         ignoredFilesRegex = Option(config.ignoredFilesRegex),
         ignoredFilesPath = Option(config.ignoredFiles)
-      )
+      )(config.fileVisitOptions)
       .toArray
     // We need to feed the php parser big groups of file in order
     // to speed up the parsing. Apparently it is some sort of slow

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/Py2CpgOnFileSystem.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/Py2CpgOnFileSystem.scala
@@ -71,7 +71,7 @@ class Py2CpgOnFileSystem extends X2CpgFrontend[Py2CpgOnFileSystemConfig] {
           Set(".py"),
           ignoredFilesRegex = Option(config.ignoredFilesRegex),
           ignoredFilesPath = Option(config.ignoredFiles)
-        )
+        )(config.fileVisitOptions)
         .map(x => Path.of(x))
         .filterNot { file =>
           isAutoDetectedVenv(config, file, inputPath) ||

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyAstGenRunner.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyAstGenRunner.scala
@@ -185,7 +185,7 @@ class RubyAstGenRunner(config: Config) extends AstGenRunnerBase(config) with Aut
           ignoredDefaultRegex = Option(specifiedConfig.defaultIgnoredFilesRegex),
           ignoredFilesRegex = Option(specifiedConfig.ignoredFilesRegex),
           ignoredFilesPath = Option(specifiedConfig.ignoredFiles)
-        )
+        )(config.fileVisitOptions)
         val parsed  = filterFiles(srcFiles, out)
         val skipped = skippedFiles(in, result.toList)
         DefaultAstGenRunnerResult(parsed, skipped)

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/utils/AstGenRunner.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/utils/AstGenRunner.scala
@@ -152,7 +152,9 @@ class AstGenRunner(config: Config) {
     logger.info(s"Parsed $numOfParsedFiles files.")
     if (numOfParsedFiles == 0) {
       logger.warn("You may want to check the DEBUG logs for a list of files that are ignored by default.")
-      SourceFiles.determine(in.toString, Set(".swift"), ignoredDefaultRegex = Option(AstGenDefaultIgnoreRegex))
+      SourceFiles.determine(in.toString, Set(".swift"), ignoredDefaultRegex = Option(AstGenDefaultIgnoreRegex))(
+        config.fileVisitOptions
+      )
     }
     files
   }
@@ -162,7 +164,10 @@ class AstGenRunner(config: Config) {
     logger.info(s"Running SwiftAstGen in '$in' ...")
     runAstGenNative(in, out) match {
       case Success(result) =>
-        val parsed  = checkParsedFiles(filterFiles(SourceFiles.determine(out.toString, Set(".json")), out), in)
+        val parsed = checkParsedFiles(
+          filterFiles(SourceFiles.determine(out.toString, Set(".json"))(config.fileVisitOptions), out),
+          in
+        )
         val skipped = skippedFiles(result.toList)
         AstGenRunnerResult(parsed, skipped)
       case Failure(f) =>

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/astgen/AstGenRunner.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/astgen/AstGenRunner.scala
@@ -178,7 +178,7 @@ trait AstGenRunnerBase(config: X2CpgConfig[?] & AstGenConfig[?]) {
           Set(".json"),
           ignoredFilesRegex = Option(config.ignoredFilesRegex),
           ignoredFilesPath = Option(config.ignoredFiles)
-        )
+        )(config.fileVisitOptions)
         val parsed  = filterFiles(srcFiles, out)
         val skipped = skippedFiles(in, result.toList)
         DefaultAstGenRunnerResult(parsed, skipped)

--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernParse.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernParse.scala
@@ -142,6 +142,7 @@ object JoernParse {
         generator
           .generate(config.inputPath, outputPath = config.outputCpgFile)
           .recover { case exception =>
+            exception.printStackTrace()
             throw new RuntimeException(
               s"Could not generate CPG with language = $language and input = ${config.inputPath}",
               exception


### PR DESCRIPTION
Enabled `--visit-options` as a frontend argument to augment the file visit options to frontends that use `SourceFiles.determine`

Resolves #5491