### PR TITLE
[php] update logic as to when to add <metaclass> to static call

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreatorHelper.scala
@@ -49,11 +49,15 @@ trait AstCreatorHelper(disableFileContent: Boolean)(implicit withSchemaValidatio
     identifierNode(originNode, name, s"$$$name", typeFullName)
   }
 
-  protected def composeMethodFullName(methodName: String, isStatic: Boolean, appendClass: Boolean = false): String = {
+  protected def composeMethodFullName(
+    methodName: String,
+    isStatic: Boolean,
+    appendMetaTypeDeclExt: Boolean = false
+  ): String = {
     if (methodName == NamespaceTraversal.globalNamespaceName) {
       globalNamespace.fullName
     } else {
-      val className = if (appendClass) {
+      val className = if (appendMetaTypeDeclExt) {
         getTypeDeclPrefix.map(name => s"${name}$MetaTypeDeclExtension")
       } else {
         getTypeDeclPrefix

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
@@ -97,7 +97,8 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     val fullName = call.target match {
       // Static method call with a known class name
       case Some(nameExpr: PhpNameExpr) if call.isStatic =>
-        if (nameExpr.name == NameConstants.Self) composeMethodFullName(name, call.isStatic, appendClass = true)
+        if (nameExpr.name == NameConstants.Self)
+          composeMethodFullName(name, call.isStatic, appendMetaTypeDeclExt = !scope.isSurroundedByMetaclassTypeDecl)
         else s"${nameExpr.name}$MetaTypeDeclExtension$StaticMethodDelimiter$name"
       case Some(expr) =>
         s"$UnresolvedNamespace\\$codePrefix"

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/utils/Scope.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/utils/Scope.scala
@@ -104,6 +104,9 @@ class Scope(summary: Map[String, Seq[SymbolSummary]] = Map.empty)(implicit nextC
     methods
   }
 
+  def isSurroundedByMetaclassTypeDecl: Boolean =
+    stack.map(_.scopeNode.node).collectFirst { case td: NewTypeDecl if td.name.endsWith("<metaclass>") => td }.isDefined
+
   def getEnclosingNamespaceNames: List[String] =
     stack.map(_.scopeNode.node).collect { case ns: NewNamespaceBlock => ns.name }.reverse
 

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/CallTests.scala
@@ -188,4 +188,18 @@ class CallTests extends PhpCode2CpgFixture {
     val call = cpg.call("test").head
     call.code shouldBe "test(...$args)"
   }
+
+  "static call in a static function to a static function" in {
+    val cpg = code("""<?php
+        |class Foo {
+        |  static function foo() {
+        |    self::bar();
+        |  }
+        |
+        |  private static function bar() {}
+        |}
+        |""".stripMargin)
+
+    cpg.method.name("foo").call.name("bar").methodFullName.l shouldBe List("Foo<metaclass>::bar")
+  }
 }


### PR DESCRIPTION
Fixed a bug where the `<metaclass>` was being added to a call name twice. This was happening when you had a static call in a static function:
```php
class Foo {
  public static function foo() {
    self::bar();
  }
 
  private static function bar()
}
```