### PR TITLE
[jssrc2cpg] Update astgen

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/jssrc2cpg/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 jssrc2cpg {
-    astgen_version: "3.24.0"
+    astgen_version: "3.28.0"
 }


### PR DESCRIPTION
Contains an important fix to tsc type map generation (could end up in an infinite loop at certain JS constructs).
See: https://github.com/joernio/astgen/pull/34

Was reported via Discord: https://discord.com/channels/832209896089976854/842699104383533076/1374703465858863247 