### PR TITLE
[jssrc2cpg] Improve log message for exceptions in file filtering.

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/utils/AstGenRunner.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/utils/AstGenRunner.scala
@@ -294,7 +294,7 @@ class AstGenRunner(config: Config) {
         case Success(result)    => result
         case Failure(exception) =>
           // Log the exception for debugging purposes
-          logger.error("An error occurred while processing the file path during filtering file stage : ", exception)
+          logger.warn(s"An error occurred while processing file path $file during filtering stage : ", exception)
           false
       }
     }


### PR DESCRIPTION
Now log the actual file path string and reduce log level to `warn`.
