### PR TITLE
[php] Normalize code before composing full name

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreatorHelper.scala
@@ -98,7 +98,8 @@ trait AstCreatorHelper(disableFileContent: Boolean)(implicit withSchemaValidatio
     def normalizeMethodCode(code: String): String =
       code
         .filterNot(c => c == '?' || c == ' ')
-        .replaceAll(s"($StaticMethodDelimiter|$InstanceMethodDelimiter)", MethodDelimiter)
+        .replace(StaticMethodDelimiter, MethodDelimiter)
+        .replace(InstanceMethodDelimiter, MethodDelimiter)
 
     if (call.isStatic) {
       val className =

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
@@ -62,9 +62,9 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     val nameAst = Option.unless(call.methodName.isInstanceOf[PhpNameExpr])(astForExpr(call.methodName))
     val name =
       nameAst
-        .map(_.rootCodeOrEmpty)
+        .map(_.rootCodeOrEmpty.toLowerCase)
         .getOrElse(call.methodName match {
-          case nameExpr: PhpNameExpr => nameExpr.name
+          case nameExpr: PhpNameExpr => nameExpr.name.toLowerCase
           case other =>
             logger.error(s"Found unexpected call target type: Crash for now to handle properly later: $other")
             ???

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
@@ -62,9 +62,9 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     val nameAst = Option.unless(call.methodName.isInstanceOf[PhpNameExpr])(astForExpr(call.methodName))
     val name =
       nameAst
-        .map(_.rootCodeOrEmpty.toLowerCase)
+        .map(_.rootCodeOrEmpty)
         .getOrElse(call.methodName match {
-          case nameExpr: PhpNameExpr => nameExpr.name.toLowerCase
+          case nameExpr: PhpNameExpr => nameExpr.name
           case other =>
             logger.error(s"Found unexpected call target type: Crash for now to handle properly later: $other")
             ???

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/CallTests.scala
@@ -236,4 +236,16 @@ class CallTests extends PhpCode2CpgFixture {
          |""".stripMargin)
     cpg.method.name("foz").call.name("boz").methodFullName.l shouldBe List("Foo.foo.anon-class-0<metaclass>.boz")
   }
+
+  "a chained call from an external namespace should have normalized '.' method delimiters, and name should be lower-cased" in {
+    val cpg = code("""
+        |<?
+        |use Foo\Bar\Http;
+        |
+        |Http::retry(3)->tiMeOut(10);
+        |""".stripMargin)
+
+    cpg.call("timeout").methodFullName.head shouldBe "Foo\\Bar\\Http<metaclass>.retry.timeout"
+  }
+
 }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/CallTests.scala
@@ -237,12 +237,12 @@ class CallTests extends PhpCode2CpgFixture {
     cpg.method.name("foz").call.name("boz").methodFullName.l shouldBe List("Foo.foo.anon-class-0<metaclass>.boz")
   }
 
-  "a chained call from an external namespace should have normalized '.' method delimiters, and name should be lower-cased" in {
+  "a chained call from an external namespace should have normalized '.' method delimiters" in {
     val cpg = code("""
         |<?
         |use Foo\Bar\Http;
         |
-        |Http::retry(3)->tiMeOut(10);
+        |Http::retry(3)->timeout(10);
         |""".stripMargin)
 
     cpg.call("timeout").methodFullName.head shouldBe "Foo\\Bar\\Http<metaclass>.retry.timeout"


### PR DESCRIPTION
As the PHP frontend composes full names from method code, this appropriately handled `::`, `->`, and `?`.