### PR TITLE
[php] Fix Field Identifier Representation

### DIFF
--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/CallTests.scala
@@ -5,7 +5,7 @@ import io.joern.php2cpg.testfixtures.PhpCode2CpgFixture
 import io.joern.php2cpg.parser.Domain
 import io.joern.x2cpg.Defines
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
-import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier}
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, FieldIdentifier, Identifier}
 import io.shiftleft.semanticcpg.language.*
 
 class CallTests extends PhpCode2CpgFixture {
@@ -164,11 +164,11 @@ class CallTests extends PhpCode2CpgFixture {
         fRecv.code shouldBe "$$f->$foo"
         fRecv.lineNumber shouldBe Some(2)
 
-        inside(fRecv.argument.l) { case List(fVar: Identifier, fooVar: Identifier) =>
+        inside(fRecv.argument.l) { case List(fVar: Identifier, fooVar: FieldIdentifier) =>
           fVar.name shouldBe "f"
           fVar.code shouldBe "$$f"
 
-          fooVar.name shouldBe "foo"
+          fooVar.canonicalName shouldBe "foo"
           fooVar.code shouldBe "$foo"
         }
 

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/FieldAccessTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/FieldAccessTests.scala
@@ -41,14 +41,14 @@ class FieldAccessTests extends PhpCode2CpgFixture {
       fieldAccess.code shouldBe "$$obj->$field"
       fieldAccess.lineNumber shouldBe Some(2)
 
-      inside(fieldAccess.argument.l) { case List(objIdentifier: Identifier, field: Identifier) =>
+      inside(fieldAccess.argument.l) { case List(objIdentifier: Identifier, fieldIdentifier: FieldIdentifier) =>
         objIdentifier.name shouldBe "obj"
         objIdentifier.code shouldBe "$$obj"
         objIdentifier.lineNumber shouldBe Some(2)
 
-        field.name shouldBe "field"
-        field.code shouldBe "$field"
-        field.lineNumber shouldBe Some(2)
+        fieldIdentifier.canonicalName shouldBe "field"
+        fieldIdentifier.code shouldBe "$field"
+        fieldIdentifier.lineNumber shouldBe Some(2)
       }
     }
   }
@@ -87,12 +87,12 @@ class FieldAccessTests extends PhpCode2CpgFixture {
       fieldAccess.code shouldBe "className::$field"
       fieldAccess.lineNumber shouldBe Some(2)
 
-      inside(fieldAccess.argument.l) { case List(classIdentifier: Identifier, fieldIdentifier: Identifier) =>
+      inside(fieldAccess.argument.l) { case List(classIdentifier: Identifier, fieldIdentifier: FieldIdentifier) =>
         classIdentifier.name shouldBe "className"
         classIdentifier.code shouldBe "className"
         classIdentifier.lineNumber shouldBe Some(2)
 
-        fieldIdentifier.name shouldBe "field"
+        fieldIdentifier.canonicalName shouldBe "field"
         fieldIdentifier.code shouldBe "$field"
         fieldIdentifier.lineNumber shouldBe Some(2)
       }


### PR DESCRIPTION
At current, many field access calls have `Identifier` RHS nodes, whereas a `FieldIdentifier` node would be the correct node.

Breaks up the diff of https://github.com/joernio/joern/pull/5493