### PR TITLE
[dataflow] Fix identifier overapproximation as starting point

### DIFF
--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/package.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/package.scala
@@ -40,9 +40,8 @@ package object dataflowengineoss {
   def firstIdentifierFromCapturedScopes(i: Declaration): List[Identifier] =
     i.capturedByMethodRef.referencedMethod
       .flatMap(m =>
-        m.local
+        m.ast.isIdentifier // this includes closures defined under method
           .nameExact(i.name)
-          .referencingIdentifiers
           .sortBy(x => (x.lineNumber, x.columnNumber))
           .headOption
       )

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/package.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/package.scala
@@ -34,12 +34,18 @@ package object dataflowengineoss {
       .target
   }
 
-  def identifierToFirstUsages(node: Identifier): List[Identifier] = node.refsTo.flatMap(identifiersFromCapturedScopes).l
+  def identifierToFirstUsages(node: Identifier): List[Identifier] =
+    node.refsTo.flatMap(firstIdentifierFromCapturedScopes).l
 
-  def identifiersFromCapturedScopes(i: Declaration): List[Identifier] =
-    i.capturedByMethodRef.referencedMethod.ast.isIdentifier
-      .nameExact(i.name)
-      .sortBy(x => (x.lineNumber, x.columnNumber))
+  def firstIdentifierFromCapturedScopes(i: Declaration): List[Identifier] =
+    i.capturedByMethodRef.referencedMethod
+      .flatMap(m =>
+        m.local
+          .nameExact(i.name)
+          .referencingIdentifiers
+          .sortBy(x => (x.lineNumber, x.columnNumber))
+          .headOption
+      )
       .l
 
 }

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DdgGenerator.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/DdgGenerator.scala
@@ -169,12 +169,9 @@ class DdgGenerator(semantics: Semantics) {
 
     def addEdgesToCapturedIdentifiersAndParameters(): Unit = {
       val identifierDestPairs =
-        method._identifierViaContainsOut
-          .flatMap { identifier =>
-            identifierToFirstUsages(identifier).map(usage => (identifier, usage))
-          }
-          .l
-          .distinctBy(_._2.method)
+        method._identifierViaContainsOut.flatMap { identifier =>
+          identifierToFirstUsages(identifier).map(usage => (identifier, usage))
+        }.l
 
       identifierDestPairs
         .foreach { case (src, dst) =>

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
@@ -50,7 +50,6 @@ class Engine(context: EngineContext) {
     reset()
     val sourcesSet = sources.toSet
     val tasks      = createOneTaskPerSink(sinks)
-    val parents    = sourcesSet.map(_.astParent.propertiesMap.get("CODE"))
     solveTasks(tasks, sourcesSet, sinks)
   }
 
@@ -146,9 +145,8 @@ class Engine(context: EngineContext) {
   private def extractResultsFromTable(sinks: List[CfgNode]): List[TableEntry] = {
     sinks.flatMap { sink =>
       mainResultTable.get(TaskFingerprint(sink, List(), 0)) match {
-        case Some(results) =>
-          results
-        case _ => Vector()
+        case Some(results) => results
+        case _             => Vector()
       }
     }
   }

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/Engine.scala
@@ -50,6 +50,7 @@ class Engine(context: EngineContext) {
     reset()
     val sourcesSet = sources.toSet
     val tasks      = createOneTaskPerSink(sinks)
+    val parents    = sourcesSet.map(_.astParent.propertiesMap.get("CODE"))
     solveTasks(tasks, sourcesSet, sinks)
   }
 
@@ -145,8 +146,9 @@ class Engine(context: EngineContext) {
   private def extractResultsFromTable(sinks: List[CfgNode]): List[TableEntry] = {
     sinks.flatMap { sink =>
       mainResultTable.get(TaskFingerprint(sink, List(), 0)) match {
-        case Some(results) => results
-        case _             => Vector()
+        case Some(results) =>
+          results
+        case _ => Vector()
       }
     }
   }

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
@@ -2,7 +2,7 @@ package io.joern.dataflowengineoss.queryengine
 
 import io.joern.dataflowengineoss.globalFromLiteral
 import io.joern.x2cpg.Defines
-import io.shiftleft.codepropertygraph.generated.Cpg
+import io.shiftleft.codepropertygraph.generated.{Cpg, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.language.operatorextension.allAssignmentTypes
@@ -226,6 +226,7 @@ abstract class BaseSourceToStartingPoints extends Callable[Unit] {
 
   private def withFieldAndIndexAccesses(nodes: List[CfgNode]): List[CfgNode] =
     nodes.flatMap {
+      case identifier: Identifier if identifier.isArgument.nonEmpty => identifier :: Nil
       case moduleVar: Identifier if moduleVar.isModuleVariable =>
         moduleVar :: moduleVariableToFirstUsagesAcrossProgram(moduleVar)
       case identifier: Identifier => identifier :: fieldAndIndexAccesses(identifier)

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/queryengine/SourcesToStartingPoints.scala
@@ -2,7 +2,7 @@ package io.joern.dataflowengineoss.queryengine
 
 import io.joern.dataflowengineoss.globalFromLiteral
 import io.joern.x2cpg.Defines
-import io.shiftleft.codepropertygraph.generated.{Cpg, Operators}
+import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.language.operatorextension.allAssignmentTypes

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dataflow/DataFlowTests.scala
@@ -1652,7 +1652,6 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
       val src  = cpg.call("fgets").argument(1).l
       val sink = cpg.call("system").argument(1).l
       val flow = sink.reachableByFlows(src)
-      println(flow.map(flowToResultPairs).toSetMutable)
       sink.reachableByFlows(src).size shouldBe 0
     }
   }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/dataflow/DataFlowTests.scala
@@ -2183,7 +2183,6 @@ class DataFlowTestsWithCallDepth extends DataFlowCodeToCpgSuite {
         |""".stripMargin)
 
     "not find a flow from top-level identifiers to call inside function" in {
-      import io.joern.dataflowengineoss.language.*
       val one   = cpg.literal.code("1").l
       val two   = cpg.literal.code("2").l
       val three = cpg.literal.code("3").l

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
@@ -1184,9 +1184,9 @@ class RegexDefinedFlowsDataFlowTests
         |print(Foo.func())
         |""".stripMargin)
     "be found" in {
-      val src = cpg.identifier("Foo").l
+      val src = cpg.call("func").receiver.l
       val snk = cpg.call("print").argument(1).l
-      snk.reachableByFlows(src).size shouldBe 3
+      snk.reachableByFlows(src).size shouldBe 1
     }
   }
   "Import statement with method ref sample four" in {

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/dataflow/DataFlowTests.scala
@@ -11,7 +11,7 @@ import io.joern.dataflowengineoss.semanticsloader.{
   PassThroughMapping
 }
 import io.joern.pysrc2cpg.testfixtures.PySrc2CpgFixture
-import io.shiftleft.codepropertygraph.generated.Cpg
+import io.shiftleft.codepropertygraph.generated.{Cpg, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.{Literal, Member, Method}
 import io.shiftleft.semanticcpg.language.*
 
@@ -422,8 +422,7 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
         |    y['B'] = x['A']
         |    sink(y)
         |""".stripMargin)
-
-    val sources = cpg.identifier("x").l
+    val sources = cpg.assignment.target.isIdentifier.nameExact("y").l
     val sinks   = cpg.call("sink").argument.l
     val flows   = sinks.reachableByFlows(sources)
     flows.size shouldBe 1
@@ -442,8 +441,8 @@ class DataFlowTests extends PySrc2CpgFixture(withOssDataflow = true) {
         |       return sink(d)
         |""".stripMargin)
 
-    val sources = cpg.call("<operator>.indexAccess").argument.isIdentifier.l
-    val sinks   = cpg.call("sink").l
+    val sources = cpg.call(Operators.indexAccess).where(_.code(".*['(x|y|z)'].*")).l
+    val sinks   = cpg.call("sink").argument.l
     sinks.reachableByFlows(sources).size should not be 0
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/dataflow/ClassTests.scala
@@ -159,7 +159,7 @@ class ClassTests extends RubyCode2CpgFixture(withPostProcessing = true, withData
 
     val source = cpg.identifier.name("x").l
     val sink   = cpg.call.name("puts").l
-    sink.reachableByFlows(source).size shouldBe 2
+    sink.reachableByFlows(source).size shouldBe 1
   }
 
   // TODO:

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/dataflow/DataFlowTests.scala
@@ -46,13 +46,13 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
       implicit val callResolver: NoResolve.type = NoResolve
       val source                                = cpg.identifier
       val sink                                  = cpg.call.name("free").argumentExact("elem")
-      sink.reachableByFlows(source).l.map(flowToResultPairs).distinct.size shouldBe 4
+      sink.reachableByFlows(source).l.map(flowToResultPairs).distinct.size shouldBe 3
     }
 
     "find flows to `free`" in {
       val source = cpg.identifier
       val sink   = cpg.call.name("free")
-      sink.reachableByFlows(source).l.map(flowToResultPairs).distinct.size shouldBe 4
+      sink.reachableByFlows(source).l.map(flowToResultPairs).distinct.size shouldBe 3
     }
 
     "find flows from identifiers to return values of `flow`" in {


### PR DESCRIPTION
Fixed an overapproximation in `SourcesToStartingPoints` that propagates an identifier as a source in many more places than it should, ending the propagation if the identifier is an argument to some call or operation already.

Resolves https://github.com/joernio/joern/issues/5520
(see ticket for discussion)

Note: This is branched off of https://github.com/joernio/joern/pull/5522
Resolves: https://github.com/joernio/joern/issues/5511