### PR TITLE
[kotlin2cpg] Populate offset and offset fields

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Kotlin2Cpg.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Kotlin2Cpg.scala
@@ -235,7 +235,8 @@ class Kotlin2Cpg extends X2CpgFrontend[Config] with UsesService {
       new MetaDataPass(cpg, Languages.KOTLIN, config.inputPath).createAndApply()
 
       val bindingContext = createBindingContext(environment)
-      val astCreator     = new AstCreationPass(sourceFiles, bindingContext, cpg)(config.schemaValidation)
+      val astCreator =
+        new AstCreationPass(sourceFiles, bindingContext, cpg, config.disableFileContent)(config.schemaValidation)
       astCreator.createAndApply()
 
       Disposer.dispose(environment.getProjectEnvironment.getParentDisposable)

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreationPass.scala
@@ -11,9 +11,13 @@ import org.slf4j.LoggerFactory
 
 import scala.jdk.CollectionConverters.EnumerationHasAsScala
 
-class AstCreationPass(filesWithMeta: Iterable[KtFileWithMeta], bindingContext: BindingContext, cpg: Cpg)(implicit
-  withSchemaValidation: ValidationMode
-) extends ForkJoinParallelCpgPass[KtFileWithMeta](cpg) {
+class AstCreationPass(
+  filesWithMeta: Iterable[KtFileWithMeta],
+  bindingContext: BindingContext,
+  cpg: Cpg,
+  disableFileContent: Boolean
+)(implicit withSchemaValidation: ValidationMode)
+    extends ForkJoinParallelCpgPass[KtFileWithMeta](cpg) {
 
   private val logger         = LoggerFactory.getLogger(getClass)
   private val global: Global = new Global()
@@ -23,7 +27,7 @@ class AstCreationPass(filesWithMeta: Iterable[KtFileWithMeta], bindingContext: B
   override def generateParts(): Array[KtFileWithMeta] = filesWithMeta.toArray
 
   override def runOnPart(diffGraph: DiffGraphBuilder, fileWithMeta: KtFileWithMeta): Unit = {
-    diffGraph.absorb(new AstCreator(fileWithMeta, bindingContext, global).createAst())
+    diffGraph.absorb(new AstCreator(fileWithMeta, bindingContext, global, disableFileContent).createAst())
     logger.debug(s"AST created for file at `${fileWithMeta.f.getVirtualFilePath}`.")
   }
 

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/AnonymousFunctionsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/AnonymousFunctionsTests.scala
@@ -1,5 +1,6 @@
 package io.joern.kotlin2cpg.querying
 
+import io.joern.kotlin2cpg.Config
 import io.joern.kotlin2cpg.testfixtures.KotlinCode2CpgFixture
 import io.joern.x2cpg.Defines
 import io.shiftleft.codepropertygraph.generated.{EvaluationStrategies, ModifierTypes}
@@ -21,6 +22,7 @@ class AnonymousFunctionsTests extends KotlinCode2CpgFixture(withOssDataflow = fa
         |    return out
         |}
         |""".stripMargin)
+      .withConfig(Config().withDisableFileContent(false))
 
     "should contain a METHOD node for the anonymous fn with the correct props set" in {
       val List(m) = cpg.method.fullName(".*lambda.*0.*").l
@@ -44,6 +46,10 @@ class AnonymousFunctionsTests extends KotlinCode2CpgFixture(withOssDataflow = fa
       val List(p) = cpg.method.fullName(".*lambda.*").parameter.l
       p.code shouldBe "item"
       p.typeFullName shouldBe "int"
+    }
+
+    "should have the offset and offsetEnd fields set correctly for the lambda method" in {
+      cpg.method.fullName(".*lambda.*").sourceCode.l shouldBe List("fun(item: Int): Boolean { return item > 0 }")
     }
   }
 
@@ -56,6 +62,7 @@ class AnonymousFunctionsTests extends KotlinCode2CpgFixture(withOssDataflow = fa
         |    return out
         |}
         |""".stripMargin)
+      .withConfig(Config().withDisableFileContent(false))
 
     "should contain a METHOD node for the anonymous fn with the correct props set" in {
       val List(m) = cpg.method.fullName(".*lambda.*0.*").l
@@ -79,6 +86,10 @@ class AnonymousFunctionsTests extends KotlinCode2CpgFixture(withOssDataflow = fa
       val List(p) = cpg.method.fullName(".*lambda.*").parameter.l
       p.code shouldBe "item"
       p.typeFullName shouldBe "int"
+    }
+
+    "should have the offset and offsetEnd fields set correctly for the lambda method" in {
+      cpg.method.fullName(".*lambda.*").sourceCode.l shouldBe List("fun(item) = item > 0")
     }
   }
 }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/MethodTests.scala
@@ -6,6 +6,33 @@ import io.shiftleft.codepropertygraph.generated.nodes.{Block, Call, Return}
 import io.shiftleft.semanticcpg.language.*
 
 class MethodTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
+  "CPG for code with UTF8 symbols" should {
+    val cpg = code("""
+        |fun double(x: Int): Int {
+        |  // ✅ This is a comment with UTF8.
+        |  return x * 2
+        |}
+        |
+        |fun main(args : Array<String>) {
+        |  println("The double of 2 is: " + double(2))
+        |}
+        |""".stripMargin)
+      .withConfig(Config().withDisableFileContent(false))
+
+    "should have the correct offsets set for the double method" in {
+      cpg.method.name("double").sourceCode.l shouldBe List("""fun double(x: Int): Int {
+          |  // ✅ This is a comment with UTF8.
+          |  return x * 2
+          |}""".stripMargin)
+    }
+
+    "should have the correct offsets set for the main method" in {
+      cpg.method.name("main").sourceCode.l shouldBe List("""fun main(args : Array<String>) {
+          |  println("The double of 2 is: " + double(2))
+          |}""".stripMargin)
+    }
+  }
+
   "CPG for code with simple method defined at package-level" should {
     val cpg = code("""
        |fun double(x: Int): Int {


### PR DESCRIPTION
This PR populates the offset fields for all node types, but only tests methods and type decls since these are the only node types for which this is currently used. 