### PR TITLE
[php2cpg] Populate lineNumberEnd field for methods

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
@@ -55,6 +55,10 @@ class AstCreator(
 
   private def globalMethodDeclStmt(file: PhpFile, bodyStmts: List[PhpStmt]): PhpMethodDecl = {
     val modifiersList = List(ModifierTypes.VIRTUAL, ModifierTypes.PUBLIC, ModifierTypes.STATIC, ModifierTypes.MODULE)
+    // lineNumber and lineNumberEnd must be set to some value to avoid back-end crashes, so default to 0 if
+    // the file is empty.
+    val lineNumber    = bodyStmts.headOption.flatMap(line).getOrElse(0)
+    val lineNumberEnd = bodyStmts.lastOption.flatMap(lineEnd).getOrElse(0)
     PhpMethodDecl(
       name = PhpNameExpr(NamespaceTraversal.globalNamespaceName, file.attributes),
       params = Nil,
@@ -64,7 +68,7 @@ class AstCreator(
       returnByRef = false,
       namespacedName = None,
       isClassMethod = false,
-      attributes = file.attributes,
+      attributes = file.attributes.copy(Option(lineNumber), Option(lineNumberEnd)),
       attributeGroups = Seq.empty[PhpAttributeGroup]
     )
   }

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreatorHelper.scala
@@ -19,7 +19,7 @@ trait AstCreatorHelper(disableFileContent: Boolean)(implicit withSchemaValidatio
 
   protected def column(phpNode: PhpNode): Option[Int] = None
 
-  protected def lineEnd(phpNode: PhpNode): Option[Int] = None
+  protected def lineEnd(phpNode: PhpNode): Option[Int] = phpNode.attributes.lineEndNumber
 
   protected def columnEnd(phpNode: PhpNode): Option[Int] = None
 

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/MethodTests.scala
@@ -23,6 +23,7 @@ class MethodTests extends PhpCode2CpgFixture {
       fooMethod.fullName shouldBe "foo"
       fooMethod.signature shouldBe s"${Defines.UnresolvedSignature}(0)"
       fooMethod.lineNumber shouldBe Some(2)
+      fooMethod.lineNumberEnd shouldBe Some(2)
       fooMethod.code shouldBe "function foo()"
       fooMethod.astParentType shouldBe "METHOD"
       fooMethod.astParentFullName.endsWith("<global>") shouldBe true
@@ -41,6 +42,20 @@ class MethodTests extends PhpCode2CpgFixture {
         |  static $x, $y;
         |}
         |""".stripMargin)
+
+    "have the correct line numbers for the foo method" in {
+      inside(cpg.method("foo").l) { case List(fooMethod) =>
+        fooMethod.lineNumber shouldBe Some(2)
+        fooMethod.lineNumberEnd shouldBe Some(4)
+      }
+    }
+
+    "have the correct line numbers for the <global> method" in {
+      inside(cpg.method.nameExact("<global>").l) { case List(globalMethod) =>
+        globalMethod.lineNumber shouldBe Some(2)
+        globalMethod.lineNumberEnd shouldBe Some(4)
+      }
+    }
 
     "not leave orphan identifiers" in {
       cpg.identifier.filter(identifier => Try(identifier.astParent.isEmpty).getOrElse(true)).toList shouldBe Nil
@@ -156,6 +171,13 @@ class MethodTests extends PhpCode2CpgFixture {
     "set the content field correctly for the <global> method" in {
       inside(cpg.method.nameExact("<global>").l) { case List(globalMethod) =>
         globalMethod.sourceCode shouldBe sourceCode.stripPrefix("<?php").trim
+      }
+    }
+
+    "set line numbers correctly for the <global> method" in {
+      inside(cpg.method.nameExact("<global>").l) { case List(globalMethod) =>
+        globalMethod.lineNumber shouldBe Some(2)
+        globalMethod.lineNumberEnd shouldBe Some(5)
       }
     }
   }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/TypeDeclTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/TypeDeclTests.scala
@@ -248,6 +248,8 @@ class TypeDeclTests extends PhpCode2CpgFixture {
           clinitMethod.signature shouldBe "void()"
           clinitMethod.filename shouldBe "foo.php"
           clinitMethod.file.name.l shouldBe List("foo.php")
+          clinitMethod.lineNumber shouldBe Some(2)
+          clinitMethod.lineNumberEnd shouldBe Some(5)
 
           inside(clinitMethod.body.astChildren.l) { case List(self: Local, aAssign: Call, bAssign: Call) =>
             aAssign.code shouldBe "self::A = \"A\""

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstCreatorBase.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstCreatorBase.scala
@@ -108,22 +108,17 @@ abstract class AstCreatorBase[Node, NodeProcessor](filename: String)(implicit wi
     returnType: String,
     fileName: Option[String] = None
   ): Ast = {
-    // TODO Use methodNode builder method
-    val methodNode = NewMethod()
-      .name(Defines.StaticInitMethodName)
-      .fullName(fullName)
-      .lineNumber(line(node))
-      .columnNumber(column(node))
-    if (signature.isDefined) {
-      methodNode.signature(signature.get)
-    }
-    if (fileName.isDefined) {
-      methodNode.filename(fileName.get)
-    }
+    val methodNode_ = methodNode(
+      node,
+      Defines.StaticInitMethodName,
+      fullName,
+      signature.getOrElse(Method.PropertyDefaults.Signature),
+      fileName.getOrElse(Method.PropertyDefaults.Filename)
+    )
     val staticModifier = NewModifier().modifierType(ModifierTypes.STATIC)
     val body           = blockAst(NewBlock().typeFullName(Defines.Any), initAsts)
     val methodReturn   = methodReturnNode(node, returnType)
-    methodAst(methodNode, Nil, body, methodReturn, List(staticModifier))
+    methodAst(methodNode_, Nil, body, methodReturn, List(staticModifier))
   }
 
   /** For a given return node and arguments, create an AST that represents the return instruction. The main purpose of


### PR DESCRIPTION
This PR populates the `lineNumberEnd` field for methods in php2cpg which is required for autofix