### PR TITLE
[swiftsrc2cpg][c2cpg] Initial round of refactorings

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreator.scala
@@ -67,7 +67,6 @@ class AstCreator(
     val depsAndImportsAsts = astsForDependenciesAndImports(iASTTranslationUnit)
     val commentsAsts       = astsForComments(iASTTranslationUnit)
     val childrenAsts       = depsAndImportsAsts ++ Seq(translationUnitAst) ++ commentsAsts
-    setOrder(childrenAsts)
     Ast(namespaceBlock).withChildren(childrenAsts)
   }
 
@@ -89,7 +88,6 @@ class AstCreator(
     val blockNode_ = blockNode(iASTTranslationUnit)
     scope.pushNewMethodScope(fakeGlobalMethod.fullName, fakeGlobalMethod.name, blockNode_, None)
     val declsAsts = allDecls.flatMap(astsForDeclaration)
-    setOrder(declsAsts)
 
     val methodReturn = methodReturnNode(iASTTranslationUnit, Defines.Any)
     Ast(fakeGlobalTypeDecl).withChild(

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
@@ -220,20 +220,6 @@ trait AstCreatorHelper { this: AstCreator =>
     }
   }
 
-  protected def setOrder(asts: Seq[Ast]): Unit = {
-    var order = 1
-    asts.foreach { a =>
-      a.root match {
-        case Some(x: AstNodeNew) =>
-          x.order = order
-          order = order + 1
-        case None => // do nothing
-        case _ =>
-          order = order + 1
-      }
-    }
-  }
-
   private def genFileOffsetTable(): Array[Int] = {
     cdtAst.getRawSignature.toCharArray.zipWithIndex.collect { case ('\n', idx) => idx + 1 }
   }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForExpressionsCreator.scala
@@ -147,7 +147,6 @@ trait AstForExpressionsCreator { this: AstCreator =>
         val blockNode_ = blockNode(exprList)
         scope.pushNewBlockScope(blockNode_)
         val childAsts = other.map(nullSafeAst)
-        setOrder(childAsts)
         scope.popScope()
         blockAst(blockNode(exprList), childAsts.toList)
     }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForStatementsCreator.scala
@@ -36,7 +36,6 @@ trait AstForStatementsCreator { this: AstCreator =>
       .typeFullName(registerType(Defines.Void))
     scope.pushNewBlockScope(node)
     val childAsts = blockStmt.getStatements.flatMap(astsForStatement).toList
-    setOrder(childAsts)
     scope.popScope()
     blockAst(node, childAsts)
   }
@@ -283,10 +282,9 @@ trait AstForStatementsCreator { this: AstCreator =>
       case other if other != null =>
         val bNode = blockNode(other)
         scope.pushNewBlockScope(bNode)
-        val a = astsForStatement(other)
-        setOrder(a)
+        val statementAsts = astsForStatement(other)
         scope.popScope()
-        blockAst(bNode, a.toList)
+        blockAst(bNode, statementAsts.toList)
       case _ => Ast()
     }
     val catchAsts = tryStmt.getCatchHandlers.toSeq.map(astForCatchHandler)
@@ -492,8 +490,7 @@ trait AstForStatementsCreator { this: AstCreator =>
 
     val bodyAst                = nullSafeAst(forStmt.getBody)
     val whileLoopBlockChildren = loopVariableAssignmentAst +: bodyAst
-    setOrder(whileLoopBlockChildren)
-    val whileLoopBlockAst = blockAst(whileLoopBlockNode, whileLoopBlockChildren.toList)
+    val whileLoopBlockAst      = blockAst(whileLoopBlockNode, whileLoopBlockChildren.toList)
 
     // end while loop block:
     scope.popScope()
@@ -501,9 +498,7 @@ trait AstForStatementsCreator { this: AstCreator =>
     // end surrounding block:
     scope.popScope()
 
-    val blockChildren =
-      List(iteratorAssignmentAst, Ast(loopVariableNode), whileLoopAst.withChild(whileLoopBlockAst))
-    setOrder(blockChildren)
+    val blockChildren = List(iteratorAssignmentAst, Ast(loopVariableNode), whileLoopAst.withChild(whileLoopBlockAst))
     blockAst(blockNode, blockChildren)
   }
 
@@ -531,10 +526,9 @@ trait AstForStatementsCreator { this: AstCreator =>
       case s: CPPASTIfStatement if s.getConditionExpression == null =>
         val exprBlock = blockNode(s.getConditionDeclaration)
         scope.pushNewBlockScope(exprBlock)
-        val a = astsForDeclaration(s.getConditionDeclaration)
-        setOrder(a)
+        val declAsts = astsForDeclaration(s.getConditionDeclaration)
         scope.popScope()
-        blockAst(exprBlock, a.toList)
+        blockAst(exprBlock, declAsts.toList)
     }
 
     val ifNode = controlStructureNode(ifStmt, ControlStructureTypes.IF, code(ifStmt))
@@ -544,10 +538,9 @@ trait AstForStatementsCreator { this: AstCreator =>
       case other if other != null =>
         val thenBlock = blockNode(other)
         scope.pushNewBlockScope(thenBlock)
-        val a = astsForStatement(other)
-        setOrder(a)
+        val statementAsts = astsForStatement(other)
         scope.popScope()
-        blockAst(thenBlock, a.toList)
+        blockAst(thenBlock, statementAsts.toList)
       case _ => Ast()
     }
 
@@ -560,10 +553,9 @@ trait AstForStatementsCreator { this: AstCreator =>
         val elseNode  = controlStructureNode(ifStmt.getElseClause, ControlStructureTypes.ELSE, "else")
         val elseBlock = blockNode(other)
         scope.pushNewBlockScope(elseBlock)
-        val a = astsForStatement(other)
-        setOrder(a)
+        val statementAsts = astsForStatement(other)
         scope.popScope()
-        Ast(elseNode).withChild(blockAst(elseBlock, a.toList))
+        Ast(elseNode).withChild(blockAst(elseBlock, statementAsts.toList))
       case _ => Ast()
     }
     initAsts :+ controlStructureAst(ifNode, Option(conditionAst), Seq(thenAst, elseAst))

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForTypesCreator.scala
@@ -335,7 +335,6 @@ trait AstForTypesCreator { this: AstCreator =>
     scope.pushNewMethodScope(fullName, name, namespaceBlockNode_, None)
     scope.pushNewBlockScope(blockNode_)
     val childrenAsts = namespaceDefinition.getDeclarations.flatMap(astsForDeclaration).toIndexedSeq
-    setOrder(childrenAsts)
     methodAstParentStack.pop()
     scope.popScope()
     scope.popScope()
@@ -361,10 +360,9 @@ trait AstForTypesCreator { this: AstCreator =>
   private def astForStructuredBindingDeclaration(decl: ICPPASTStructuredBindingDeclaration): Ast = {
     val node = blockNode(decl)
     scope.pushNewBlockScope(node)
-    val childAsts = decl.getNames.toList.map(astForNode)
+    val childrenAsts = decl.getNames.toList.map(astForNode)
     scope.popScope()
-    setOrder(childAsts)
-    blockAst(node, childAsts)
+    blockAst(node, childrenAsts)
   }
 
   private def astsForLinkageSpecification(l: ICPPASTLinkageSpecification): Seq[Ast] = {

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroHandler.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroHandler.scala
@@ -46,9 +46,7 @@ trait MacroHandler { this: AstCreator =>
         // to be connected via AST edges under a CALL. E.g., LOCALs but only if it is not already a BLOCK.
         val childAst = ast.root match {
           case Some(_: NewBlock) => ast
-          case _ =>
-            setOrder(List(ast))
-            blockAst(blockNode(node), List(ast))
+          case _                 => blockAst(blockNode(node), List(ast))
         }
         setArgumentIndices(List(childAst), callAst.argEdges.size + 1)
         callAst.withChild(childAst)

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/SwiftSrc2Cpg.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/SwiftSrc2Cpg.scala
@@ -17,11 +17,11 @@ import scala.util.Try
 
 class SwiftSrc2Cpg extends X2CpgFrontend[Config] {
 
-  private val report: Report = new Report()
-
   def createCpg(config: Config): Try[Cpg] = {
     withNewEmptyCpg(config.outputPath, config) { (cpg, config) =>
       FileUtil.usingTemporaryDirectory("swiftsrc2cpgOut") { tmpDir =>
+        val report: Report = new Report()
+
         val astGenResult = new AstGenRunner(config).execute(tmpDir)
         val hash         = HashUtil.sha256(astGenResult.parsedFiles.map(file => Paths.get(file)))
 

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForDeclSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForDeclSyntaxCreator.scala
@@ -174,7 +174,7 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     val (mAst, bAst) = if (methodBlockContent.isEmpty) {
       (methodStubAst(methodNode_, Seq.empty, methodReturnNode_, modifiers), Ast())
     } else {
-      setArgumentIndices(methodBlockContent)
+      setOrder(methodBlockContent)
       val bodyAst = blockAst(NewBlock(), methodBlockContent)
       (methodAstWithAnnotations(methodNode_, Seq.empty, bodyAst, methodReturnNode_, modifiers), bodyAst)
     }
@@ -287,12 +287,16 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
         Option(createFakeConstructor(node, typeDeclNode, methodBlockContent = constructorContent))
     }
 
-  private def isClassMethodOrUninitializedMember(node: DeclSyntax): Boolean =
-    node.isInstanceOf[AccessorDeclSyntax] ||
-      node.isInstanceOf[InitializerDeclSyntax] ||
-      node.isInstanceOf[DeinitializerDeclSyntax] ||
-      node.isInstanceOf[FunctionDeclSyntax] ||
-      !isInitializedMember(node)
+  private def isClassMethodOrUninitializedMember(node: DeclSyntax): Boolean = {
+    node match {
+      case _: AccessorDeclSyntax                => true
+      case _: InitializerDeclSyntax             => true
+      case _: DeinitializerDeclSyntax           => true
+      case _: FunctionDeclSyntax                => true
+      case other if !isInitializedMember(other) => true
+      case _                                    => false
+    }
+  }
 
   private def astForDeclAttributes(node: TypeDeclLike | VariableDeclSyntax): Seq[Ast] = {
     node match {
@@ -431,7 +435,7 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
       case head :: Nil => head
       case _ =>
         val block = blockNode(node, code(node), Defines.Any)
-        setArgumentIndices(bindingAsts)
+        setOrder(bindingAsts)
         blockAst(block, bindingAsts.toList)
     }
   }
@@ -732,7 +736,7 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     val methodReturnNode_ = methodReturnNode(node, returnType)
 
     val bodyAsts = methodBlockContent ++ bodyStmtAsts
-    setArgumentIndices(bodyAsts)
+    setOrder(bodyAsts)
     val blockAst_ = blockAst(block, bodyAsts)
     val astForMethod =
       methodAstWithAnnotations(
@@ -958,7 +962,7 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
       case head :: Nil => head
       case others =>
         val block = blockNode(node, code(node), Defines.Any)
-        setArgumentIndices(others)
+        setOrder(others)
         blockAst(block, others.toList)
     }
   }

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForDeclSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForDeclSyntaxCreator.scala
@@ -174,7 +174,6 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     val (mAst, bAst) = if (methodBlockContent.isEmpty) {
       (methodStubAst(methodNode_, Seq.empty, methodReturnNode_, modifiers), Ast())
     } else {
-      setOrder(methodBlockContent)
       val bodyAst = blockAst(NewBlock(), methodBlockContent)
       (methodAstWithAnnotations(methodNode_, Seq.empty, bodyAst, methodReturnNode_, modifiers), bodyAst)
     }
@@ -435,7 +434,6 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
       case head :: Nil => head
       case _ =>
         val block = blockNode(node, code(node), Defines.Any)
-        setOrder(bindingAsts)
         blockAst(block, bindingAsts.toList)
     }
   }
@@ -735,9 +733,7 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
 
     val methodReturnNode_ = methodReturnNode(node, returnType)
 
-    val bodyAsts = methodBlockContent ++ bodyStmtAsts
-    setOrder(bodyAsts)
-    val blockAst_ = blockAst(block, bodyAsts)
+    val blockAst_ = blockAst(block, methodBlockContent ++ bodyStmtAsts)
     val astForMethod =
       methodAstWithAnnotations(
         methodNode_,
@@ -962,7 +958,6 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
       case head :: Nil => head
       case others =>
         val block = blockNode(node, code(node), Defines.Any)
-        setOrder(others)
         blockAst(block, others.toList)
     }
   }

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForExprSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForExprSyntaxCreator.scala
@@ -442,7 +442,6 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
         } else {
           asts
         }
-        setOrder(cAsts)
         (tAsts.toList, cAsts.toList)
       case i: IfConfigDeclSyntax =>
         (List.empty, List(astForIfConfigDeclSyntax(i)))
@@ -462,10 +461,7 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     val blockNode_ = blockNode(node).order(2)
     scope.pushNewBlockScope(blockNode_)
     localAstParentStack.push(blockNode_)
-
     val casesAsts = node.cases.children.toList.flatMap(astsForSwitchCase)
-    setOrder(casesAsts)
-
     scope.popScope()
     localAstParentStack.pop()
 

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForStmtSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForStmtSyntaxCreator.scala
@@ -64,7 +64,6 @@ trait AstForStmtSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     val catchNode = controlStructureNode(catchClause, ControlStructureTypes.CATCH, code(catchClause))
     val declAst   = astForNode(catchClause.catchItems)
     val bodyAst   = astForNode(catchClause.body)
-    setOrder(List(declAst, bodyAst))
     Ast(catchNode).withChild(declAst).withChild(bodyAst)
   }
 
@@ -229,8 +228,7 @@ trait AstForStmtSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     val bodyAst = astForForStmtBody(node)
 
     val whileLoopBlockChildren = List(loopVariableAssignmentAst, bodyAst)
-    setOrder(whileLoopBlockChildren)
-    val whileLoopBlockAst = blockAst(whileLoopBlockNode, whileLoopBlockChildren)
+    val whileLoopBlockAst      = blockAst(whileLoopBlockNode, whileLoopBlockChildren)
 
     scope.popScope()
     localAstParentStack.pop()
@@ -241,7 +239,6 @@ trait AstForStmtSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
 
     val blockChildren =
       List(iteratorAssignmentAst, Ast(resultNode), Ast(loopVariableNode), whileLoopAst.withChild(whileLoopBlockAst))
-    setOrder(blockChildren)
     blockAst(blockNode_, blockChildren)
   }
 
@@ -358,8 +355,7 @@ trait AstForStmtSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     val bodyAst = astForForStmtBody(node)
 
     val whileLoopBlockChildren = List(loopVariableAssignmentAst, bodyAst)
-    setOrder(whileLoopBlockChildren)
-    val whileLoopBlockAst = blockAst(whileLoopBlockNode, whileLoopBlockChildren)
+    val whileLoopBlockAst      = blockAst(whileLoopBlockNode, whileLoopBlockChildren)
 
     scope.popScope()
     localAstParentStack.pop()
@@ -369,7 +365,6 @@ trait AstForStmtSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     localAstParentStack.pop()
 
     val blockChildren = List(iteratorAssignmentAst, Ast(resultNode), whileLoopAst.withChild(whileLoopBlockAst))
-    setOrder(blockChildren)
     blockAst(blockNode_, blockChildren)
   }
 
@@ -501,8 +496,7 @@ trait AstForStmtSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     val bodyAst = astForForStmtBody(node)
 
     val whileLoopBlockChildren = loopVariableAssignmentAsts :+ bodyAst
-    setOrder(whileLoopBlockChildren)
-    val whileLoopBlockAst = blockAst(whileLoopBlockNode, whileLoopBlockChildren.toList)
+    val whileLoopBlockAst      = blockAst(whileLoopBlockNode, whileLoopBlockChildren.toList)
 
     scope.popScope()
     localAstParentStack.pop()
@@ -515,7 +509,6 @@ trait AstForStmtSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
       List(iteratorAssignmentAst, Ast(resultNode)) ++ loopVariableNodes.map(Ast(_)) :+ whileLoopAst.withChild(
         whileLoopBlockAst
       )
-    setOrder(blockNodeChildren)
     blockAst(blockNode_, blockNodeChildren)
   }
 
@@ -548,17 +541,13 @@ trait AstForStmtSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
 
   private def astForLabeledStmtSyntax(node: LabeledStmtSyntax): Ast = {
     val labeledNode = jumpTargetNode(node, code(node.label), code(node))
-
-    val blockNode_ = blockNode(node)
+    val blockNode_  = blockNode(node)
     scope.pushNewBlockScope(blockNode_)
     localAstParentStack.push(blockNode_)
     val bodyAst = astForNodeWithFunctionReference(node.statement)
     scope.popScope()
     localAstParentStack.pop()
-
-    val labelAsts = List(Ast(labeledNode), bodyAst)
-    setOrder(labelAsts)
-    blockAst(blockNode_, labelAsts)
+    blockAst(blockNode_, List(Ast(labeledNode), bodyAst))
   }
 
   private def astForMissingStmtSyntax(node: MissingStmtSyntax): Ast = notHandledYet(node)

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForSyntaxCollectionCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForSyntaxCollectionCreator.scala
@@ -155,7 +155,7 @@ trait AstForSyntaxCollectionCreator(implicit withSchemaValidation: ValidationMod
     scope.pushNewBlockScope(blockNode_)
     localAstParentStack.push(blockNode_)
     val asts = node.children.toList.flatMap(astsForSwitchCase)
-    setArgumentIndices(asts)
+    setOrder(asts)
     localAstParentStack.pop()
     scope.popScope()
     blockAst(blockNode_, asts)

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForSyntaxCollectionCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForSyntaxCollectionCreator.scala
@@ -155,7 +155,6 @@ trait AstForSyntaxCollectionCreator(implicit withSchemaValidation: ValidationMod
     scope.pushNewBlockScope(blockNode_)
     localAstParentStack.push(blockNode_)
     val asts = node.children.toList.flatMap(astsForSwitchCase)
-    setOrder(asts)
     localAstParentStack.pop()
     scope.popScope()
     blockAst(blockNode_, asts)

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForTypeSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForTypeSyntaxCreator.scala
@@ -1,11 +1,9 @@
 package io.joern.swiftsrc2cpg.astcreation
 
 import io.joern.swiftsrc2cpg.parser.SwiftNodeSyntax.*
-import io.joern.swiftsrc2cpg.parser.SwiftNodeSyntax.TypeSyntax
-import io.joern.x2cpg.Ast
-import io.joern.x2cpg.ValidationMode
-import io.shiftleft.codepropertygraph.generated.nodes.NewTypeDecl
+import io.joern.x2cpg.{Ast, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
+import io.shiftleft.codepropertygraph.generated.nodes.NewTypeDecl
 
 import scala.annotation.unused
 

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/passes/AstCreationPass.scala
@@ -25,7 +25,7 @@ class AstCreationPass(cpg: Cpg, astGenRunnerResult: AstGenRunnerResult, config: 
 
   private val global = new Global()
 
-  def typesSeen(): List[String] = global.usedTypes.keys().asScala.filterNot(_ == Defines.Any).toList
+  def typesSeen(): List[String] = global.usedTypes.keys().asScala.filterNot(Defines.SwiftTypes.contains).toList
 
   override def generateParts(): Array[String] = astGenRunnerResult.parsedFiles.toArray
 

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/utils/ExternalCommand.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/utils/ExternalCommand.scala
@@ -16,6 +16,15 @@ object ExternalCommand {
         // SwiftAstGen exits with exit code != 0 on Windows.
         // To catch with we specifically handle the empty stdErr here.
         Success(stdOut)
+      case ExternalCommandResult(_, stdOut, stdErr, _)
+          if stdErr.isEmpty && stdOut.isEmpty && scala.util.Properties.isWin =>
+        // SwiftAstGen exits with exit code != 0 on Windows
+        // and empty stdOut and stdErr if the Swift runtime is not installed at all
+        Failure(new RuntimeException("""
+            | Unable to execute SwiftAstGen!
+            | On Windows systems Swift needs to be installed.
+            | Please see: https://www.swift.org/install/windows/
+            |""".stripMargin))
       case ExternalCommandResult(_, stdOut, _, _) =>
         Failure(new RuntimeException(stdOut.mkString(System.lineSeparator())))
     }

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/GuardTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/GuardTests.scala
@@ -20,7 +20,7 @@ class GuardTests extends AstSwiftSrc2CpgSuite {
         |""".stripMargin)
       val List(methodBlock) = cpg.method.nameExact("noConditionNoElse").block.l
       val List(guardIf)     = methodBlock.astChildren.isControlStructure.l
-      guardIf.argumentIndex shouldBe 1
+      guardIf.order shouldBe 1
       guardIf.code shouldBe "guard {} else {}"
       guardIf.controlStructureType shouldBe ControlStructureTypes.IF
       guardIf.condition.code.l shouldBe List("<lambda>0")
@@ -42,7 +42,7 @@ class GuardTests extends AstSwiftSrc2CpgSuite {
         |""".stripMargin)
       val List(whileBlock) = cpg.controlStructure.controlStructureType(ControlStructureTypes.WHILE).whenTrue.l
       val List(guardIf)    = whileBlock.astChildren.isControlStructure.l
-      guardIf.argumentIndex shouldBe 1
+      guardIf.order shouldBe 1
       guardIf.code should startWith("guard i % 2 == 0")
       guardIf.controlStructureType shouldBe ControlStructureTypes.IF
       guardIf.condition.code.l shouldBe List("i % 2 == 0")
@@ -63,10 +63,10 @@ class GuardTests extends AstSwiftSrc2CpgSuite {
         |""".stripMargin)
       val List(methodBlock) = cpg.method.nameExact("checkOddEven").block.l
       val List(call)        = methodBlock.astChildren.isCall.l
-      call.argumentIndex shouldBe 1
+      call.order shouldBe 1
       call.code shouldBe "var number = 24"
       val List(guardIf) = methodBlock.astChildren.isControlStructure.l
-      guardIf.argumentIndex shouldBe 2
+      guardIf.order shouldBe 2
       guardIf.code should startWith("guard number % 2 == 0")
       guardIf.controlStructureType shouldBe ControlStructureTypes.IF
       guardIf.condition.code.l shouldBe List("number % 2 == 0")
@@ -90,10 +90,10 @@ class GuardTests extends AstSwiftSrc2CpgSuite {
         |""".stripMargin)
       val List(methodBlock) = cpg.method.nameExact("checkJobEligibility").block.l
       val List(call)        = methodBlock.astChildren.isCall.l
-      call.argumentIndex shouldBe 1
+      call.order shouldBe 1
       call.code shouldBe "var age = 33"
       val List(guardIf) = methodBlock.astChildren.isControlStructure.l
-      guardIf.argumentIndex shouldBe 2
+      guardIf.order shouldBe 2
       guardIf.code should startWith("guard age >= 18, age <= 40")
       guardIf.controlStructureType shouldBe ControlStructureTypes.IF
       guardIf.condition.astChildren.code.l shouldBe List("age >= 18", "age <= 40")
@@ -118,10 +118,10 @@ class GuardTests extends AstSwiftSrc2CpgSuite {
       val List(methodBlock) = cpg.method.nameExact("checkAge").block.l
       methodBlock.local.name.l shouldBe List("myAge", "age", "this", "print")
       val List(call) = methodBlock.astChildren.isCall.l
-      call.argumentIndex shouldBe 1
+      call.order shouldBe 1
       call.code shouldBe "var age: Int? = 22"
       val List(guardIf) = methodBlock.astChildren.isControlStructure.l
-      guardIf.argumentIndex shouldBe 2
+      guardIf.order shouldBe 2
       guardIf.code should startWith("guard let myAge = age")
       guardIf.controlStructureType shouldBe ControlStructureTypes.IF
       guardIf.condition.code.l shouldBe List("let myAge = age")
@@ -151,12 +151,12 @@ class GuardTests extends AstSwiftSrc2CpgSuite {
         |""".stripMargin)
       val List(methodBlock)  = cpg.method.nameExact("multipleLinear").block.l
       val List(callA, callB) = methodBlock.astChildren.isCall.l
-      callA.argumentIndex shouldBe 1
+      callA.order shouldBe 1
       callA.code shouldBe "var a = true"
-      callB.argumentIndex shouldBe 2
+      callB.order shouldBe 2
       callB.code shouldBe "var b = true"
       val List(guardIfA) = methodBlock.astChildren.isControlStructure.l
-      guardIfA.argumentIndex shouldBe 3
+      guardIfA.order shouldBe 3
       guardIfA.code should startWith("guard a else")
       guardIfA.controlStructureType shouldBe ControlStructureTypes.IF
       guardIfA.condition.code.l shouldBe List("a")
@@ -189,12 +189,12 @@ class GuardTests extends AstSwiftSrc2CpgSuite {
         |""".stripMargin)
       val List(methodBlock)  = cpg.method.nameExact("multipleNested").block.l
       val List(callA, callB) = methodBlock.astChildren.isCall.l
-      callA.argumentIndex shouldBe 1
+      callA.order shouldBe 1
       callA.code shouldBe "var a = true"
-      callB.argumentIndex shouldBe 2
+      callB.order shouldBe 2
       callB.code shouldBe "var b = true"
       val List(guardIfA) = methodBlock.astChildren.isControlStructure.l
-      guardIfA.argumentIndex shouldBe 3
+      guardIfA.order shouldBe 3
       guardIfA.code should startWith("guard a else")
       guardIfA.controlStructureType shouldBe ControlStructureTypes.IF
       guardIfA.condition.code.l shouldBe List("a")


### PR DESCRIPTION
~~And set block children order instead of argumentIndex.~~

Removed setting explicit order by relying on `io.joern.x2cpg.Ast#setOrderWhereNotSet`

Just some initial cleanups before starting with PRs for new features.