### PR TITLE
[frontends] Remove setting CLOSURE_ORIGINAL_NAME property

### DIFF
--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/LambdaExpressionTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/LambdaExpressionTests.scala
@@ -97,8 +97,8 @@ class LambdaExpressionTests extends AstC2CpgSuite(FileDefaults.CppExt) {
     }
 
     "create closure bindings for captured identifiers" in {
-      cpg.all.collectAll[ClosureBinding].sortBy(_.closureOriginalName) match {
-        case Seq(fallbackClosureBinding) =>
+      cpg.all.collectAll[ClosureBinding].l match {
+        case List(fallbackClosureBinding) =>
           val fallbackLocal = cpg.method.name(".*lambda.*").local.name("fallback").head
           fallbackClosureBinding.closureBindingId shouldBe fallbackLocal.closureBindingId
 
@@ -445,9 +445,9 @@ class LambdaExpressionTests extends AstC2CpgSuite(FileDefaults.CppExt) {
 
     "be captured precisely" in {
       cpg.all.collectAll[ClosureBinding].l match {
-        case myValue :: Nil =>
+        case List(myValue) =>
           myValue.evaluationStrategy shouldBe EvaluationStrategies.BY_VALUE
-          myValue.closureOriginalName.head shouldBe "myValue"
+          myValue.closureBindingId shouldBe Some("Test0.cpp:<global>.Foo.foo.<lambda>0:string(string):myValue")
           myValue._localViaRefOut.get.name shouldBe "myValue"
           myValue._captureIn.collectFirst { case x: MethodRef =>
             x.methodFullName
@@ -478,9 +478,9 @@ class LambdaExpressionTests extends AstC2CpgSuite(FileDefaults.CppExt) {
 
     "be captured precisely" in {
       cpg.all.collectAll[ClosureBinding].l match {
-        case myValue :: Nil =>
+        case List(myValue) =>
           myValue.evaluationStrategy shouldBe EvaluationStrategies.BY_REFERENCE
-          myValue.closureOriginalName.head shouldBe "myValue"
+          myValue.closureBindingId shouldBe Some("Test0.cpp:<global>.Foo.foo.<lambda>0:string(string):myValue")
           myValue._localViaRefOut.get.name shouldBe "myValue"
           myValue._captureIn.collectFirst { case x: MethodRef =>
             x.methodFullName

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/LocalQueryTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/querying/LocalQueryTests.scala
@@ -147,7 +147,7 @@ class LocalQueryTests extends C2CpgSuite {
       methodRef.parentExpression.l shouldBe cpg.namespaceBlock("Foo").astChildren.isBlock.l
       val List(binding) = x1.closureBinding.l
       binding.closureBindingId shouldBe Some("Test0.cpp:Foo.foo:void():x")
-      binding.closureOriginalName shouldBe Some("x")
+      binding._localViaRefOut.get.name shouldBe "x"
       binding._captureIn.l shouldBe List(methodRef)
       val List(id1) = x1.referencingIdentifiers.l
       id1.name shouldBe "x"

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForLambdasCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForLambdasCreator.scala
@@ -274,7 +274,7 @@ private[expressions] trait AstForLambdasCreator { this: AstCreator =>
       .groupBy(_.name)
       .map { case (name, variables) =>
         val closureBindingId = s"$filename:$lambdaMethodName:$name"
-        val closureBinding   = closureBindingNode(closureBindingId, name, EvaluationStrategies.BY_SHARING)
+        val closureBinding   = closureBindingNode(closureBindingId, EvaluationStrategies.BY_SHARING)
 
         val scopeVariable = variables.head
         val capturedLocal = localNode(

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LambdaTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LambdaTests.scala
@@ -124,10 +124,8 @@ class LambdaTests extends JavaSrcCode2CpgFixture {
     }
 
     "create closure bindings for captured identifiers" in {
-      cpg.all.collectAll[ClosureBinding].sortBy(_.closureOriginalName) match {
-        case Seq(fallbackClosureBinding) =>
-          fallbackClosureBinding.label shouldBe "CLOSURE_BINDING"
-
+      cpg.all.collectAll[ClosureBinding].l match {
+        case List(fallbackClosureBinding) =>
           val fallbackLocal = cpg.method.name(".*lambda.*").local.name("fallback").head
           fallbackClosureBinding.closureBindingId shouldBe fallbackLocal.closureBindingId
 
@@ -143,7 +141,6 @@ class LambdaTests extends JavaSrcCode2CpgFixture {
               outMethod.methodFullName shouldBe "Foo.<lambda>0:java.lang.String(java.lang.String)"
             case result => fail(s"Expected single METHOD_REF but got $result")
           }
-
         case result => fail(s"Expected 2 closure bindings for captured variables but got $result")
       }
     }
@@ -706,7 +703,7 @@ class LambdaTests extends JavaSrcCode2CpgFixture {
     "be captured precisely" in {
       cpg.all.collectAll[ClosureBinding].l match {
         case myValue :: Nil =>
-          myValue.closureOriginalName.head shouldBe "myValue"
+          myValue.closureBindingId shouldBe Some("Test0.java:<lambda>0:myValue")
           myValue._localViaRefOut.get.name shouldBe "myValue"
           myValue._captureIn.collectFirst { case x: MethodRef =>
             x.methodFullName

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/MixedAstCreationPassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/MixedAstCreationPassTests.scala
@@ -253,11 +253,9 @@ class MixedAstCreationPassTests extends AstJsSrc2CpgSuite {
       val List(fooLocalX)      = fooBlock.astChildren.isLocal.nameExact("x").l
       val List(barRef)         = fooBlock.astChildren.isCall.astChildren.isMethodRef.l
       val List(closureBinding) = barRef.captureOut.l
-      closureBinding.closureBindingId shouldBe Option("Test0.js::program:foo:bar:x")
-      closureBinding.closureOriginalName shouldBe Option("x")
-      closureBinding.evaluationStrategy shouldBe EvaluationStrategies.BY_REFERENCE
-
       closureBinding.refOut.head shouldBe fooLocalX
+      closureBinding.closureBindingId shouldBe Option("Test0.js::program:foo:bar:x")
+      closureBinding.evaluationStrategy shouldBe EvaluationStrategies.BY_REFERENCE
 
       val List(barMethod)      = cpg.method.nameExact("bar").l
       val List(barMethodBlock) = barMethod.astChildren.isBlock.l
@@ -287,15 +285,13 @@ class MixedAstCreationPassTests extends AstJsSrc2CpgSuite {
 
       val List(closureBindForY, closureBindForX) = barRef.captureOut.cast[ClosureBinding].l
 
-      closureBindForX.closureOriginalName shouldBe Option("x")
+      closureBindForX.refOut.head shouldBe fooLocalX
       closureBindForX.closureBindingId shouldBe Option("Test0.js::program:foo:bar:x")
       closureBindForX.evaluationStrategy shouldBe EvaluationStrategies.BY_REFERENCE
-      closureBindForX.refOut.head shouldBe fooLocalX
 
-      closureBindForY.closureOriginalName shouldBe Option("y")
+      closureBindForY.refOut.head shouldBe fooLocalY
       closureBindForY.closureBindingId shouldBe Option("Test0.js::program:foo:bar:y")
       closureBindForY.evaluationStrategy shouldBe EvaluationStrategies.BY_REFERENCE
-      closureBindForY.refOut.head shouldBe fooLocalY
 
       val List(barMethod)                    = cpg.method.nameExact("bar").l
       val List(barMethodBlock)               = barMethod.astChildren.isBlock.l
@@ -333,9 +329,8 @@ class MixedAstCreationPassTests extends AstJsSrc2CpgSuite {
 
       val List(closureBindingXInFoo) = barRef.captureOut.l
       closureBindingXInFoo.closureBindingId shouldBe Option("Test0.js::program:foo:bar:x")
-      closureBindingXInFoo.closureOriginalName shouldBe Option("x")
-      closureBindingXInFoo.evaluationStrategy shouldBe EvaluationStrategies.BY_REFERENCE
       closureBindingXInFoo.refOut.head shouldBe fooLocalX
+      closureBindingXInFoo.evaluationStrategy shouldBe EvaluationStrategies.BY_REFERENCE
 
       val List(barMethod)      = cpg.method.nameExact("bar").l
       val List(barMethodBlock) = barMethod.astChildren.isBlock.l
@@ -349,9 +344,8 @@ class MixedAstCreationPassTests extends AstJsSrc2CpgSuite {
       val List(bazRef)               = barMethodBlock.astChildren.isCall.astChildren.isMethodRef.l
       val List(closureBindingXInBar) = bazRef.captureOut.l
       closureBindingXInBar.closureBindingId shouldBe Option("Test0.js::program:foo:bar:baz:x")
-      closureBindingXInBar.closureOriginalName shouldBe Option("x")
-      closureBindingXInBar.evaluationStrategy shouldBe EvaluationStrategies.BY_REFERENCE
       closureBindingXInBar.refOut.head shouldBe barLocalX
+      closureBindingXInBar.evaluationStrategy shouldBe EvaluationStrategies.BY_REFERENCE
 
       val List(bazMethod)      = cpg.method.nameExact("baz").l
       val List(bazMethodBlock) = bazMethod.astChildren.isBlock.l
@@ -384,9 +378,8 @@ class MixedAstCreationPassTests extends AstJsSrc2CpgSuite {
       val List(barRef)               = fooBlock.astChildren.isCall.astChildren.isMethodRef.l
       val List(closureBindingXInFoo) = barRef.captureOut.l
       closureBindingXInFoo.closureBindingId shouldBe Option("Test0.js::program:foo:bar:x")
-      closureBindingXInFoo.closureOriginalName shouldBe Option("x")
-      closureBindingXInFoo.evaluationStrategy shouldBe EvaluationStrategies.BY_REFERENCE
       closureBindingXInFoo.refOut.head shouldBe fooLocalX
+      closureBindingXInFoo.evaluationStrategy shouldBe EvaluationStrategies.BY_REFERENCE
 
       val List(barMethod)      = cpg.method.nameExact("bar").l
       val List(barMethodBlock) = barMethod.astChildren.isBlock.l
@@ -401,9 +394,8 @@ class MixedAstCreationPassTests extends AstJsSrc2CpgSuite {
       val List(bazRef)               = barMethodInnerBlock.astChildren.isCall.astChildren.isMethodRef.l
       val List(closureBindingXInBar) = bazRef.captureOut.l
       closureBindingXInBar.closureBindingId shouldBe Option("Test0.js::program:foo:bar:baz:x")
-      closureBindingXInBar.closureOriginalName shouldBe Option("x")
-      closureBindingXInBar.evaluationStrategy shouldBe EvaluationStrategies.BY_REFERENCE
       closureBindingXInBar.refOut.head shouldBe barLocalX
+      closureBindingXInBar.evaluationStrategy shouldBe EvaluationStrategies.BY_REFERENCE
 
       val List(bazMethod)      = cpg.method.nameExact("baz").l
       val List(bazMethodBlock) = bazMethod.astChildren.isBlock.l
@@ -433,9 +425,8 @@ class MixedAstCreationPassTests extends AstJsSrc2CpgSuite {
       val List(barRef)               = fooBlock.astChildren.isCall.astChildren.isMethodRef.l
       val List(closureBindingXInFoo) = barRef.captureOut.l
       closureBindingXInFoo.closureBindingId shouldBe Option("Test0.js::program:foo:bar:x")
-      closureBindingXInFoo.closureOriginalName shouldBe Option("x")
-      closureBindingXInFoo.evaluationStrategy shouldBe EvaluationStrategies.BY_REFERENCE
       closureBindingXInFoo.refOut.head shouldBe fooLocalX
+      closureBindingXInFoo.evaluationStrategy shouldBe EvaluationStrategies.BY_REFERENCE
 
       val List(barMethod)      = cpg.method.nameExact("bar").l
       val List(barMethodBlock) = barMethod.astChildren.isBlock.l
@@ -446,9 +437,8 @@ class MixedAstCreationPassTests extends AstJsSrc2CpgSuite {
       val List(bazRef)               = barMethodBlock.astChildren.isCall.astChildren.isMethodRef.l
       val List(closureBindingXInBar) = bazRef.captureOut.l
       closureBindingXInBar.closureBindingId shouldBe Option("Test0.js::program:foo:bar:baz:x")
-      closureBindingXInBar.closureOriginalName shouldBe Option("x")
-      closureBindingXInBar.evaluationStrategy shouldBe EvaluationStrategies.BY_REFERENCE
       closureBindingXInBar.refOut.head shouldBe barLocalX
+      closureBindingXInBar.evaluationStrategy shouldBe EvaluationStrategies.BY_REFERENCE
 
       val List(bazMethod)      = cpg.method.nameExact("baz").l
       val List(bazMethodBlock) = bazMethod.astChildren.isBlock.l
@@ -477,17 +467,15 @@ class MixedAstCreationPassTests extends AstJsSrc2CpgSuite {
 
       val List(closureBindingXAnon1) = anon1Ref.captureOut.l
       closureBindingXAnon1.closureBindingId shouldBe Option("Test0.js::program:foo:<lambda>0:x")
-      closureBindingXAnon1.closureOriginalName shouldBe Option("x")
-      closureBindingXAnon1.evaluationStrategy shouldBe EvaluationStrategies.BY_REFERENCE
       closureBindingXAnon1.refOut.head shouldBe fooLocalX
+      closureBindingXAnon1.evaluationStrategy shouldBe EvaluationStrategies.BY_REFERENCE
 
       val List(anon2Ref) =
         fooBlock.astChildren.isCall.astChildren.isMethodRef.methodFullNameExact("Test0.js::program:foo:<lambda>1").l
       val List(closureBindingXAnon2) = anon2Ref.captureOut.l
       closureBindingXAnon2.closureBindingId shouldBe Option("Test0.js::program:foo:<lambda>1:x")
-      closureBindingXAnon2.closureOriginalName shouldBe Option("x")
-      closureBindingXAnon2.evaluationStrategy shouldBe EvaluationStrategies.BY_REFERENCE
       closureBindingXAnon2.refOut.head shouldBe fooLocalX
+      closureBindingXAnon2.evaluationStrategy shouldBe EvaluationStrategies.BY_REFERENCE
     }
 
     "have correct closure bindings" in {
@@ -505,9 +493,8 @@ class MixedAstCreationPassTests extends AstJsSrc2CpgSuite {
       val List(barRef)         = fooBlock.astChildren.isCall.astChildren.isMethodRef.l
       val List(closureBinding) = barRef.captureOut.l
       closureBinding.closureBindingId shouldBe Option("Test0.js::program:foo:bar:x")
-      closureBinding.closureOriginalName shouldBe Option("x")
-      closureBinding.evaluationStrategy shouldBe EvaluationStrategies.BY_REFERENCE
       closureBinding.refOut.head shouldBe fooLocalX
+      closureBinding.evaluationStrategy shouldBe EvaluationStrategies.BY_REFERENCE
 
       val List(barMethod)      = cpg.method.nameExact("bar").l
       val List(barMethodBlock) = barMethod.astChildren.isBlock.l

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForFunctionsCreator.scala
@@ -295,8 +295,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) {
       .map { capturedNodeContext =>
         val uuidBytes        = stringForUUID(fn, capturedNodeContext.name, capturedNodeContext.typeFullName)
         val closureBindingId = nameUUIDFromBytes(uuidBytes.getBytes).toString
-        val closureBinding =
-          closureBindingNode(closureBindingId, capturedNodeContext.name, EvaluationStrategies.BY_REFERENCE)
+        val closureBinding   = closureBindingNode(closureBindingId, EvaluationStrategies.BY_REFERENCE)
         (closureBinding, capturedNodeContext)
       }
 
@@ -399,8 +398,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) {
       .map { capturedNodeContext =>
         val uuidBytes        = stringForUUID(expr, capturedNodeContext.name, capturedNodeContext.typeFullName)
         val closureBindingId = nameUUIDFromBytes(uuidBytes.getBytes).toString
-        val closureBinding =
-          closureBindingNode(closureBindingId, capturedNodeContext.name, EvaluationStrategies.BY_REFERENCE)
+        val closureBinding   = closureBindingNode(closureBindingId, EvaluationStrategies.BY_REFERENCE)
         (closureBinding, capturedNodeContext)
       }
 

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LambdaTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LambdaTests.scala
@@ -1,21 +1,11 @@
 package io.joern.kotlin2cpg.querying
 
-import io.joern.kotlin2cpg.{Config, Constants}
 import io.joern.kotlin2cpg.testfixtures.KotlinCode2CpgFixture
+import io.joern.kotlin2cpg.{Config, Constants}
 import io.joern.x2cpg.Defines
-import io.shiftleft.codepropertygraph.generated.DispatchTypes
-import io.shiftleft.codepropertygraph.generated.EdgeTypes
-import io.shiftleft.codepropertygraph.generated.EvaluationStrategies
-import io.shiftleft.codepropertygraph.generated.ModifierTypes
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes, EvaluationStrategies, ModifierTypes}
 import io.shiftleft.codepropertygraph.generated.edges.Capture
-import io.shiftleft.codepropertygraph.generated.nodes.Binding
-import io.shiftleft.codepropertygraph.generated.nodes.Block
-import io.shiftleft.codepropertygraph.generated.nodes.Call
-import io.shiftleft.codepropertygraph.generated.nodes.ClosureBinding
-import io.shiftleft.codepropertygraph.generated.nodes.Local
-import io.shiftleft.codepropertygraph.generated.nodes.MethodRef
-import io.shiftleft.codepropertygraph.generated.nodes.Return
-import io.shiftleft.codepropertygraph.generated.nodes.TypeDecl
+import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.*
 
 class LambdaTests extends KotlinCode2CpgFixture(withOssDataflow = false, withDefaultJars = true) {
@@ -34,11 +24,11 @@ class LambdaTests extends KotlinCode2CpgFixture(withOssDataflow = false, withDef
 
     "should contain a CLOSURE_BINDING node for the captured parameter with the correct props set" in {
       val List(cb) = cpg.all.collectAll[ClosureBinding].l
-      cb.closureOriginalName shouldBe Some("p")
       cb.evaluationStrategy shouldBe EvaluationStrategies.BY_REFERENCE
       cb.closureBindingId should not be None
 
       cb._refOut.size shouldBe 1
+      cb._methodParameterInViaRefOut.get.name shouldBe "p"
     }
 
     "should contain a CALL node for the `let` invocation" in {
@@ -76,8 +66,7 @@ class LambdaTests extends KotlinCode2CpgFixture(withOssDataflow = false, withDef
     }
 
     "should contain a CLOSURE_BINDING node for captured `baz` with the correct props set" in {
-      val List(cb) = cpg.all.collectAll[ClosureBinding].filter(_.closureOriginalName.getOrElse("") == "baz").l
-      cb.closureOriginalName shouldBe Some("baz")
+      val List(cb) = cpg.closureBinding.filter(_._localViaRefOut.name.l == List("baz")).l
       cb.evaluationStrategy shouldBe EvaluationStrategies.BY_REFERENCE
       cb.closureBindingId should not be None
 

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForFunctionsCreator.scala
@@ -40,7 +40,6 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
 
       val closureBindingNode = NewClosureBinding()
         .closureBindingId(closureBindingId)
-        .closureOriginalName(local.name)
         .evaluationStrategy(EvaluationStrategies.BY_SHARING)
 
       // The ref edge to the captured local is added in the ClosureRefPass

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/ClosureRefPass.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/ClosureRefPass.scala
@@ -1,13 +1,10 @@
 package io.joern.php2cpg.passes
 
-import io.shiftleft.codepropertygraph.generated.Cpg
-import io.shiftleft.codepropertygraph.generated.nodes.{ClosureBinding, Method, MethodRef}
+import io.shiftleft.codepropertygraph.generated.{Cpg, EdgeTypes}
+import io.shiftleft.codepropertygraph.generated.nodes.{ClosureBinding, Local, Method, MethodRef}
 import io.shiftleft.passes.ForkJoinParallelCpgPass
 import io.shiftleft.semanticcpg.language.*
 import org.slf4j.LoggerFactory
-import io.shiftleft.codepropertygraph.generated.EdgeTypes
-import io.shiftleft.codepropertygraph.generated.nodes.AstNode
-import io.shiftleft.codepropertygraph.generated.nodes.Local
 
 class ClosureRefPass(cpg: Cpg) extends ForkJoinParallelCpgPass[ClosureBinding](cpg) {
   private val logger = LoggerFactory.getLogger(this.getClass)
@@ -30,7 +27,7 @@ class ClosureRefPass(cpg: Cpg) extends ForkJoinParallelCpgPass[ClosureBinding](c
         addRefToCapturedNode(diffGraph, closureBinding, getMethod(methodRef))
 
       case methodRefs =>
-        logger.error(s"Mutliple MethodRefs corresponding to closureBinding ${closureBinding.closureBindingId}")
+        logger.error(s"Multiple MethodRefs corresponding to closureBinding ${closureBinding.closureBindingId}")
         logger.debug(s"${closureBinding.closureBindingId} MethodRefs = ${methodRefs}")
     }
   }
@@ -47,8 +44,8 @@ class ClosureRefPass(cpg: Cpg) extends ForkJoinParallelCpgPass[ClosureBinding](c
     method match {
       case None =>
         logger.warn(s"No parent method for methodRef for ${closureBinding.closureBindingId}. REF edge will be missing")
-
       case Some(method) =>
+        // TODO: this needs a rewrite without using closureOriginalName
         closureBinding.closureOriginalName.foreach { name =>
           lazy val locals =
             method.start.repeat(_.astChildren.filterNot(_.isMethod))(_.emit(_.isLocal)).collectAll[Local]

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/ClosureTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/ClosureTests.scala
@@ -93,9 +93,8 @@ class ClosureTests extends PhpCode2CpgFixture {
         use1.name shouldBe "use1"
         use1.code shouldBe "$use1"
         use1.closureBindingId shouldBe Some(s"foo.php:$expectedName:use1")
-        inside(cpg.all.collectAll[ClosureBinding].filter(_.closureBindingId == use1.closureBindingId).l) {
-          case List(closureBinding) =>
-            closureBinding.closureOriginalName shouldBe Some("use1")
+        inside(cpg.closureBinding.filter(_.closureBindingId == use1.closureBindingId).l) { case List(closureBinding) =>
+          closureBinding._localViaRefOut shouldBe Some(use1)
         }
 
         use2.name shouldBe "use2"
@@ -107,10 +106,9 @@ class ClosureTests extends PhpCode2CpgFixture {
     }
 
     "have a ref edge from the closure binding for a use to the captured node" in {
-      inside(cpg.all.collectAll[ClosureBinding].filter(_.closureOriginalName.contains("use1")).l) {
-        case List(closureBinding) =>
-          val capturedNode = cpg.method.nameExact("<global>").local.name("use1").head
-          closureBinding.refOut.toList shouldBe List(capturedNode)
+      inside(cpg.closureBinding.l.filter(_._localViaRefOut.name.l == List("use1"))) { case List(closureBinding) =>
+        val capturedNode = cpg.method.nameExact("<global>").local.name("use1").head
+        closureBinding.refOut.toList shouldBe List(capturedNode)
       }
     }
 

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/NodeBuilder.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/NodeBuilder.scala
@@ -130,7 +130,6 @@ class NodeBuilder(diffGraph: DiffGraphBuilder) {
       .NewClosureBinding()
       .closureBindingId(Some(closureBindingId))
       .evaluationStrategy(EvaluationStrategies.BY_REFERENCE)
-      .closureOriginalName(None)
     addNodeToDiff(closureBindingNode)
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -3,18 +3,10 @@ package io.joern.rubysrc2cpg.astcreation
 import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.*
 import io.joern.rubysrc2cpg.datastructures.{ConstructorScope, MethodScope}
 import io.joern.rubysrc2cpg.passes.Defines
-import io.joern.rubysrc2cpg.utils.FreshNameGenerator
-import io.joern.x2cpg.{Ast, AstEdge, ValidationMode, Defines as XDefines}
-import io.shiftleft.codepropertygraph.generated.nodes.*
-import io.shiftleft.codepropertygraph.generated.{
-  DispatchTypes,
-  EdgeTypes,
-  EvaluationStrategies,
-  ModifierTypes,
-  NodeTypes,
-  Operators
-}
 import io.joern.x2cpg.AstNodeBuilder.{bindingNode, closureBindingNode}
+import io.joern.x2cpg.{Ast, AstEdge, ValidationMode}
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.codepropertygraph.generated.*
 
 import scala.collection.mutable
 
@@ -252,7 +244,6 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
 
         val closureBinding = closureBindingNode(
           closureBindingId = closureBindingId,
-          originalName = name,
           evaluationStrategy = EvaluationStrategies.BY_REFERENCE
         )
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
@@ -232,19 +232,16 @@ class DoBlockTests extends RubyCode2CpgFixture {
     "annotate the nodes via CAPTURE bindings" in {
       cpg.all.collectAll[ClosureBinding].l match {
         case myValue :: Nil =>
-          myValue.closureOriginalName shouldBe Option("myValue")
           inside(myValue._localViaRefOut) {
             case Some(local) =>
               local.name shouldBe "myValue"
               local.method.fullName.headOption shouldBe Option(s"Test0.rb:$Main")
             case None => fail("Expected closure binding refer to the captured local")
           }
-
           inside(myValue._captureIn.l) {
             case (x: TypeRef) :: Nil => x.typeFullName shouldBe s"Test0.rb:$Main.<lambda>0&Proc"
             case xs                  => fail(s"Expected single method ref binding but got [${xs.mkString(",")}]")
           }
-
         case xs =>
           fail(s"Expected single closure binding but got [${xs.mkString(",")}]")
       }

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -124,9 +124,8 @@ class SimpleAstCreationPassTest extends AstSwiftSrc2CpgSuite {
       val List(barRef)         = fooBlock.astChildren.isCall.astChildren.isMethodRef.l
       val List(closureBinding) = barRef.captureOut.l
       closureBinding.closureBindingId shouldBe Option("Test0.swift:<global>:foo:bar:x")
-      closureBinding.closureOriginalName shouldBe Option("x")
-      closureBinding.evaluationStrategy shouldBe EvaluationStrategies.BY_REFERENCE
       closureBinding.refOut.head shouldBe fooLocalX
+      closureBinding.evaluationStrategy shouldBe EvaluationStrategies.BY_REFERENCE
 
       val List(barMethod)      = cpg.method.nameExact("bar").l
       val List(barMethodBlock) = barMethod.astChildren.isBlock.l

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstNodeBuilder.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstNodeBuilder.scala
@@ -452,15 +452,8 @@ object AstNodeBuilder {
       .signature(signature)
   }
 
-  private[joern] def closureBindingNode(
-    closureBindingId: String,
-    originalName: String,
-    evaluationStrategy: String
-  ): NewClosureBinding = {
-    NewClosureBinding()
-      .closureBindingId(closureBindingId)
-      .closureOriginalName(originalName)
-      .evaluationStrategy(evaluationStrategy)
+  private[joern] def closureBindingNode(closureBindingId: String, evaluationStrategy: String): NewClosureBinding = {
+    NewClosureBinding().closureBindingId(closureBindingId).evaluationStrategy(evaluationStrategy)
   }
 
   private[joern] def dependencyNode(name: String, groupId: String, version: String): NewDependency = {

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/datastructures/VariableScopeManager.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/datastructures/VariableScopeManager.scala
@@ -285,7 +285,7 @@ class VariableScopeManager {
                 val id = s"$prefix${methodScope.methodFullName}:${origin.variableName}"
                 capturedLocals.updateWith(id) {
                   case None =>
-                    val closureBinding = closureBindingNode(id, origin.variableName, origin.evaluationStrategy)
+                    val closureBinding = closureBindingNode(id, origin.evaluationStrategy)
                     methodScope.capturingRefNode.foreach(diffGraph.addEdge(_, closureBinding, EdgeTypes.CAPTURE))
                     nextReference = closureBinding
                     val localNode = createLocalForUnresolvedReference(diffGraph, methodScope.scopeNode, origin)

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/NodeBuilders.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/NodeBuilders.scala
@@ -69,15 +69,8 @@ object NodeBuilders {
     "Deprecated in favour of the corresponding method io.joern.x2cpg.AstNodeBuilder and will be removed in a future version",
     "4.0.314"
   )
-  def newClosureBindingNode(
-    closureBindingId: String,
-    originalName: String,
-    evaluationStrategy: String
-  ): NewClosureBinding = {
-    NewClosureBinding()
-      .closureBindingId(closureBindingId)
-      .closureOriginalName(originalName)
-      .evaluationStrategy(evaluationStrategy)
+  def newClosureBindingNode(closureBindingId: String, evaluationStrategy: String): NewClosureBinding = {
+    NewClosureBinding().closureBindingId(closureBindingId).evaluationStrategy(evaluationStrategy)
   }
 
   @deprecated(


### PR DESCRIPTION
First step towards: https://github.com/ShiftLeftSecurity/codescience/issues/8347

Note: php2cpg creates ref edges using that property to find the corresponding locals. This needs a major rewrite. cc @ml86 cc @AndreiDreyer 
See: https://github.com/joernio/joern/pull/5527
