### PR TITLE
[php] Fixed Chained Call Dead Code TargetAst

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
@@ -143,9 +143,8 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
   private def astForChainedCall(call: PhpCallExpr, name: String, target: PhpPropertyFetchExpr | PhpCallExpr): Ast = {
     val expr        = PhpPropertyFetchExpr(target, PhpNameExpr(name, call.attributes), false, false, call.attributes)
     val receiverAst = astForPropertyFetchExpr(expr)
-    val targetAst   = astForExpr(target)
 
-    val codePrefix = codeForMethodCall(call, targetAst, name)
+    val codePrefix = codeForMethodCall(call, receiverAst, name)
 
     val argumentAsts = call.args.map(astForCallArg)
     val argsCode     = getArgsCode(call, argumentAsts)


### PR DESCRIPTION
Fixed bug where targetAst was being generated but not used in AST creation, thus creating orphaned arguments.