### PR TITLE
[swiftsrc2cpg][c2cpg][jssrc2cpg] Improve reporting and logging in AstCreationPasses

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
@@ -108,6 +108,7 @@ class AstCreationPass(
           Try {
             val localDiff = new AstCreator(relPath, global, config, translationUnit, headerFileFinder).createAst()
             diffGraph.absorb(localDiff)
+            logger.debug(s"Generated a CPG for: '$relPath'")
           } match {
             case Failure(exception) =>
               logger.warn(s"Failed to generate a CPG for: '$relPath'", exception)

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/passes/AstCreationPass.scala
@@ -1,6 +1,5 @@
 package io.joern.csharpsrc2cpg.passes
 
-import io.joern.csharpsrc2cpg.Config
 import io.joern.csharpsrc2cpg.astcreation.AstCreator
 import io.joern.x2cpg.utils.{Report, TimeUtils}
 import io.shiftleft.codepropertygraph.generated.Cpg
@@ -8,8 +7,8 @@ import io.shiftleft.passes.ForkJoinParallelCpgPass
 import io.shiftleft.utils.IOUtils
 import org.slf4j.{Logger, LoggerFactory}
 
-import scala.util.{Try, Success, Failure}
 import java.nio.file.Paths
+import scala.util.{Failure, Success, Try}
 
 class AstCreationPass(cpg: Cpg, astCreators: Seq[AstCreator], report: Report)
     extends ForkJoinParallelCpgPass[AstCreator](cpg) {

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/AstCreationPass.scala
@@ -41,7 +41,7 @@ class AstCreationPass(cpg: Cpg, astGenRunnerResult: AstGenRunnerResult, config: 
         case Success(fileContent) => fileContent.size
         case Failure(exception) =>
           logger.warn(s"Failed to read file: '$filePath'", exception)
-          0
+          -1
       }
       report.addReportInfo(fileName, fileLOC)
     }
@@ -59,10 +59,10 @@ class AstCreationPass(cpg: Cpg, astGenRunnerResult: AstGenRunnerResult, config: 
             diffGraph.absorb(localDiff)
           } match {
             case Failure(exception) =>
-              logger.warn(s"Failed to generate a CPG for: '${parseResult.fullPath}'", exception)
+              logger.warn(s"Failed to generate a CPG for: '${parseResult.filename}'", exception)
               (false, parseResult.filename)
             case Success(_) =>
-              logger.debug(s"Generated a CPG for: '${parseResult.fullPath}'")
+              logger.debug(s"Generated a CPG for: '${parseResult.filename}'")
               (true, parseResult.filename)
           }
         case Failure(exception) =>

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 swiftsrc2cpg {
-    astgen_version: "0.2.8"
+    astgen_version: "0.2.9"
 }

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/parser/SwiftJsonParser.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/parser/SwiftJsonParser.scala
@@ -9,7 +9,7 @@ import scala.util.Try
 
 object SwiftJsonParser {
 
-  case class ParseResult(filename: String, fullPath: String, ast: SwiftNode, fileContent: String)
+  case class ParseResult(filename: String, fullPath: String, ast: SwiftNode, fileContent: String, loc: Int)
 
   def readFile(file: Path): Try[ParseResult] = Try {
     val jsonContent       = IOUtils.readEntireFile(file)
@@ -18,7 +18,8 @@ object SwiftJsonParser {
     val fullPath          = Paths.get(json("fullFilePath").str)
     val sourceFileContent = json("content").str
     val ast               = SwiftNodeSyntax.createSwiftNode(json)
-    ParseResult(filename, fullPath.toString, ast, sourceFileContent)
+    val loc               = json("loc").num.toInt
+    ParseResult(filename, fullPath.toString, ast, sourceFileContent, loc)
   }
 
 }

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/passes/AstCreationPass.scala
@@ -32,7 +32,12 @@ class AstCreationPass(cpg: Cpg, astGenRunnerResult: AstGenRunnerResult, config: 
   override def finish(): Unit = {
     astGenRunnerResult.skippedFiles.foreach { skippedFile =>
       val filePath = Paths.get(skippedFile)
-      val fileLOC  = IOUtils.readLinesInFile(filePath).size
+      val fileLOC = Try(IOUtils.readLinesInFile(filePath)) match {
+        case Success(fileContent) => fileContent.size
+        case Failure(exception) =>
+          logger.warn(s"Failed to read file: '$filePath'", exception)
+          -1
+      }
       report.addReportInfo(skippedFile, fileLOC)
     }
   }
@@ -40,23 +45,22 @@ class AstCreationPass(cpg: Cpg, astGenRunnerResult: AstGenRunnerResult, config: 
   override def runOnPart(diffGraph: DiffGraphBuilder, input: String): Unit = {
     val ((gotCpg, filename), duration) = TimeUtils.time {
       SwiftJsonParser.readFile(Paths.get(input)) match {
-        case Failure(exception) =>
-          logger.warn(s"Failed to read '$input'", exception)
-          (false, input)
         case Success(parseResult) =>
-          val fileLOC = IOUtils.readLinesInFile(Paths.get(parseResult.fullPath)).size
-          report.addReportInfo(parseResult.filename, fileLOC, parsed = true)
+          report.addReportInfo(parseResult.filename, parseResult.loc, parsed = true)
           Try {
             val localDiff = new AstCreator(config, global, parseResult).createAst()
             diffGraph.absorb(localDiff)
           } match {
             case Failure(exception) =>
-              logger.warn(s"Failed to generate a CPG for: '${parseResult.fullPath}'", exception)
+              logger.warn(s"Failed to generate a CPG for: '${parseResult.filename}'", exception)
               (false, parseResult.filename)
             case Success(_) =>
-              logger.info(s"Generated a CPG for: '${parseResult.fullPath}'")
+              logger.debug(s"Generated a CPG for: '${parseResult.filename}'")
               (true, parseResult.filename)
           }
+        case Failure(exception) =>
+          logger.warn(s"Failed to read '$input'", exception)
+          (false, input)
       }
     }
     report.updateReport(filename, cpg = gotCpg, duration)

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/Report.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/Report.scala
@@ -68,7 +68,7 @@ class Report {
       Seq(
         "Total",
         "",
-        s"${reports.map(_._2.loc).sum}",
+        s"${reports.filter(_._2.loc >= 0).map(_._2.loc).sum}",
         s"${reports.count(_._2.parsed)}/$numOfReports",
         s"${reports.count(_._2.cpgGen)}/$numOfReports",
         ""


### PR DESCRIPTION
- enhanced logging for CPG generation in these frontends to use consistent messages and log levels
- updated `SwiftJsonParser` to include LOC in `ParseResult` and refactored its AstCreationPass to use this value for reporting
- fixed total LOC calculation in `Report` to exclude files with negative LOC
- bumped Swift `astgen_version` to `0.2.9` (includes the LOC directly so no duplicate file reading)