### PR TITLE
[c2cpg] Handle unsupported co_await gracefully 

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForStatementsCreator.scala
@@ -16,9 +16,12 @@ import org.eclipse.cdt.core.dom.ast.*
 import org.eclipse.cdt.core.dom.ast.cpp.*
 import org.eclipse.cdt.core.dom.ast.gnu.IGNUASTGotoStatement
 import org.eclipse.cdt.internal.core.dom.parser.c.CASTIfStatement
-import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTIfStatement
-import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTNamespaceAlias
-import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTSimpleDeclaration
+import org.eclipse.cdt.internal.core.dom.parser.cpp.{
+  CPPASTDeclarationStatement,
+  CPPASTIfStatement,
+  CPPASTNamespaceAlias,
+  CPPASTSimpleDeclaration
+}
 import org.eclipse.cdt.internal.core.model.ASTStringUtil
 
 import java.nio.file.Paths
@@ -41,6 +44,12 @@ trait AstForStatementsCreator { this: AstCreator =>
   }
 
   protected def astsForStatement(statement: IASTStatement): Seq[Ast] = {
+    // CDT does not support co_await yet. That leads to completely wrong parse trees that
+    // can't be recovered at all. Instead, we filter and warn here.
+    if (statement.getRawSignature.startsWith("co_await ")) {
+      return Seq(Ast(unknownNode(statement, statement.getRawSignature)))
+    }
+
     val r = statement match {
       case expr: IASTExpressionStatement          => Seq(astForExpression(expr.getExpression))
       case block: IASTCompoundStatement           => Seq(astForBlockStatement(block, blockNode(block)))

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/cpp/features20/Cpp20FeaturesTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/cpp/features20/Cpp20FeaturesTests.scala
@@ -20,7 +20,7 @@ class Cpp20FeaturesTests extends AstC2CpgSuite(fileSuffix = FileDefaults.CppExt)
       val List(unknown) = cpg.method.nameExact("main").block.astChildren.collectAll[Unknown].l
       // Also the call to 'f' can't be parsed in this case. It ends up as a function declaration.
       // There is no way to recover from that broken 'co_await' parsing at the moment
-      unknown.code shouldBe "co_await f()"
+      unknown.code shouldBe "co_await f();"
     }
 
     "handle coroutines" in {

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/cpp/features20/Cpp20FeaturesTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/cpp/features20/Cpp20FeaturesTests.scala
@@ -4,11 +4,24 @@ import io.joern.c2cpg.astcreation.Defines
 import io.joern.c2cpg.parser.FileDefaults
 import io.joern.c2cpg.testfixtures.AstC2CpgSuite
 import io.shiftleft.codepropertygraph.generated.ControlStructureTypes
+import io.shiftleft.codepropertygraph.generated.nodes.Unknown
 import io.shiftleft.semanticcpg.language.*
 
 class Cpp20FeaturesTests extends AstC2CpgSuite(fileSuffix = FileDefaults.CppExt) {
 
   "C++20 feature support" should {
+
+    "generate an unknown node for unsupported co_await" in {
+      val cpg = code("""
+          |int main() {
+          |  co_await f();
+          |}
+          |""".stripMargin)
+      val List(unknown) = cpg.method.nameExact("main").block.astChildren.collectAll[Unknown].l
+      // Also the call to 'f' can't be parsed in this case. It ends up as a function declaration.
+      // There is no way to recover from that broken 'co_await' parsing at the moment
+      unknown.code shouldBe "co_await f()"
+    }
 
     "handle coroutines" in {
       val cpg = code("""


### PR DESCRIPTION
Do not proceed to generate nonsense from the broken parse tree. Warn the user instead.