### PR TITLE
[php] Constructor Tweaks

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
@@ -888,14 +888,14 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     val initArgs      = expr.args.map(astForCallArg)
     val initSignature = s"$UnresolvedSignature(${initArgs.size})"
     val initFullName  = s"$className$MethodDelimiter$ConstructorMethodName"
-    val initCode      = s"$initFullName(${initArgs.map(_.rootCodeOrEmpty).mkString(",")})"
+    val initCode      = s"new $className(${initArgs.map(_.rootCodeOrEmpty).mkString(",")})"
     val maybeTypeHint = scope.resolveIdentifier(className).map(_.name) // consider imported or defined types
     val initCallNode = callNode(
       expr,
       initCode,
       ConstructorMethodName,
       initFullName,
-      DispatchTypes.DYNAMIC_DISPATCH,
+      DispatchTypes.STATIC_DISPATCH,
       Some(initSignature),
       maybeTypeHint.orElse(Some(Defines.Any)) // TODO Review Note: Should the hint be under dynamicTypeHintFullName?
     )

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/CallTests.scala
@@ -368,4 +368,21 @@ class CallTests extends PhpCode2CpgFixture {
     lambdaRef.methodFullName shouldBe "Foo.bar.<lambda>0"
   }
 
+  "a call to a constructor should be static and have a correctly inferred method full name" in {
+    val cpg = code("""
+        |<?php
+        |use NNN\Foo;
+        |
+        |$foo = new NNN\Foo();
+        |""".stripMargin)
+
+    val construct = cpg.call.nameExact(Domain.ConstructorMethodName).head
+
+    construct.methodFullName shouldBe s"NNN\\Foo.${Domain.ConstructorMethodName}"
+    construct.code shouldBe s"new NNN\\Foo()"
+    construct.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+    construct.typeFullName shouldBe Defines.Any
+    construct.dynamicTypeHintFullName shouldBe Seq.empty
+  }
+
 }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/TypeDeclTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/TypeDeclTests.scala
@@ -104,7 +104,7 @@ class TypeDeclTests extends PhpCode2CpgFixture {
         initCall.name shouldBe "__construct"
         initCall.methodFullName shouldBe s"Foo.__construct"
         initCall.signature shouldBe s"${Defines.UnresolvedSignature}(1)"
-        initCall.code shouldBe "Foo.__construct(42)"
+        initCall.code shouldBe "new Foo(42)"
         inside(initCall.argument.l) { case List(tmpIdentifier: Identifier, literal: Literal) =>
           tmpIdentifier.name shouldBe "foo@tmp-0"
           tmpIdentifier.code shouldBe "$foo@tmp-0"
@@ -456,12 +456,12 @@ class TypeDeclTests extends PhpCode2CpgFixture {
     "generate __construct calls" in {
       inside(cpg.call.name("__construct").l) {
         case constructAnonClass0 :: constructAnonClass1 :: Nil =>
-          constructAnonClass0.code shouldBe "Test0.php:<global>.anon-class-0.__construct(10)"
+          constructAnonClass0.code shouldBe "new Test0.php:<global>.anon-class-0(10)"
           val List(anonClass0Param1: Identifier, anonClass0Param2: Literal) = constructAnonClass0.argument.l: @unchecked
           anonClass0Param1.code shouldBe "$Test0.php:<global>@tmp-0"
           anonClass0Param2.code shouldBe "10"
 
-          constructAnonClass1.code shouldBe "Test0.php:<global>.anon-class-1.__construct(30)"
+          constructAnonClass1.code shouldBe "new Test0.php:<global>.anon-class-1(30)"
           val List(anonClass1Param1: Identifier, anonClass1Param2: Literal) = constructAnonClass1.argument.l: @unchecked
           anonClass1Param1.code shouldBe "$Test0.php:<global>@tmp-1"
           anonClass1Param2.code shouldBe "30"


### PR DESCRIPTION
* Adjusted constructor `code` and `dispatchType` (to STATIC)
* Added constructor test
* Made adjustment to scope import/summary handling to handle both ways one can reference imports (either by last token, or full name)