### PR TITLE
Bump cpg and fix tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name                     := "joern"
 ThisBuild / organization := "io.joern"
 ThisBuild / scalaVersion := "3.6.4"
 
-val cpgVersion = "1.7.36"
+val cpgVersion = "1.7.38"
 
 lazy val joerncli          = Projects.joerncli
 lazy val querydb           = Projects.querydb

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/X2CpgTests.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/X2CpgTests.scala
@@ -1,5 +1,7 @@
 package io.joern.x2cpg
 
+import io.shiftleft.codepropertygraph.generated.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes.NewFile
 import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.semanticcpg.utils.FileUtil
 import org.scalatest.matchers.should.Matchers
@@ -8,6 +10,15 @@ import org.scalatest.wordspec.AnyWordSpec
 import java.nio.file.Files
 
 class X2CpgTests extends AnyWordSpec with Matchers {
+
+  // Empty CPGs don't get written to disk, so just add a random node.
+  private def getCpg(filename: String): Cpg = {
+    val cpg       = X2Cpg.newEmptyCpg(Some(filename))
+    val diffGraph = Cpg.newDiffGraphBuilder
+    diffGraph.addNode(NewFile())
+    flatgraph.DiffGraphApplier.applyDiff(cpg.graph, diffGraph)
+    cpg
+  }
 
   "initCpg" should {
 
@@ -21,18 +32,18 @@ class X2CpgTests extends AnyWordSpec with Matchers {
       val file = FileUtil.newTemporaryFile("x2cpg")
       FileUtil.delete(file)
       Files.exists(file) shouldBe false
-      val cpg = X2Cpg.newEmptyCpg(Some(file.toString))
+      val cpg = getCpg(file.toString)
       cpg.close()
       Files.exists(file) shouldBe true
       Files.size(file) should not be 0
     }
 
-    "overwrite existing file to create empty CPG" in {
+    "overwrite existing file to create CPG" in {
       FileUtil.usingTemporaryFile("x2cpg") { file =>
         Files.exists(file) shouldBe true
         Files.size(file) shouldBe 0
-        val cpg = X2Cpg.newEmptyCpg(Some(file.toString))
-        cpg.graph.allNodes.hasNext shouldBe false
+        val cpg = getCpg(file.toString)
+        cpg.graph.allNodes.size shouldBe 1
         cpg.close()
         Files.exists(file) shouldBe true
         Files.size(file) should not be 0


### PR DESCRIPTION
With https://github.com/joernio/flatgraph/pull/326, empty CPGs are no longer written to disk which broke these 2 tests.