### PR TITLE
Delombok resource limits

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Delombok.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Delombok.scala
@@ -6,10 +6,10 @@ import io.shiftleft.semanticcpg.utils.{ExternalCommand, FileUtil}
 import org.slf4j.LoggerFactory
 
 import java.nio.file.{Files, Path, Paths}
+import java.util.concurrent.Executors
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
-import scala.collection.parallel.CollectionConverters.*
 
 object Delombok {
 
@@ -56,6 +56,7 @@ object Delombok {
     val command =
       Seq(
         javaPath,
+        "-Xmx1G",
         "-cp",
         classPathArg,
         "lombok.launch.Main",
@@ -103,10 +104,27 @@ object Delombok {
 
       case Success(tempDir) =>
         FileUtil.deleteOnExit(tempDir)
-        PackageRootFinder
-          .packageRootsFromFiles(inputPath, fileInfo)
-          .par
-          .foreach(delombokPackageRoot(inputPath, _, tempDir, analysisJavaHome))
+
+        // Use a dedicated thread pool with exactly one thread per core to avoid
+        // ForkJoinPool compensation threads (which spawn additional workers).
+        val cores    = Runtime.getRuntime.availableProcessors()
+        val executor = Executors.newFixedThreadPool(cores)
+
+        try {
+          val packageRoots = PackageRootFinder.packageRootsFromFiles(inputPath, fileInfo)
+          val futures = packageRoots.map { relativeRoot =>
+            executor.submit(new Runnable {
+              override def run(): Unit =
+                delombokPackageRoot(inputPath, relativeRoot, tempDir, analysisJavaHome)
+            })
+          }
+
+          // Wait for all tasks to complete before continuing.
+          futures.foreach(_.get())
+        } finally {
+          executor.shutdown()
+        }
+
         DelombokRunResult(tempDir, true)
     }
   }


### PR DESCRIPTION
- Add -Xmx1G to spawned JVMs [instead of default 1/4 system ram]
- Use a fixed-size thread pool to avoid "compensation" threads that the default FJP spawns when it detects blocking (like for a subprocess)

This takes it from spawning 100s of delombok jvms for a large delombok effort to the expected jvm-per-core.