### PR TITLE
[jssrc2cpg] Bump astgen

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/jssrc2cpg/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 jssrc2cpg {
-    astgen_version: "3.28.0"
+    astgen_version: "3.30.0"
 }


### PR DESCRIPTION
Brings in the latest version of astgen build with the latest yao-pkg/pkg instead of the deprecated vercel/pkg (since more than 2 years).