### PR TITLE
[jssrc2cpg] Bump astgen

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/jssrc2cpg/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 jssrc2cpg {
-    astgen_version: "3.30.0"
+    astgen_version: "3.31.0"
 }


### PR DESCRIPTION
Brings in the latest astgen. We only submit single files to tsc now (instead of the whole project that is scanned) which results in a massive performance gain.