### PR TITLE
[jssrc2cpg] Bump astgen

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/jssrc2cpg/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 jssrc2cpg {
-    astgen_version: "3.31.0"
+    astgen_version: "3.33.0"
 }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTemplateDomCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTemplateDomCreator.scala
@@ -32,7 +32,7 @@ trait AstForTemplateDomCreator(implicit withSchemaValidation: ValidationMode) { 
     // Hence, we strip it away with astgen and restore it here.
     // parserResult.fileContent contains the unmodified Vue.js source code for the current file.
     // We look at the previous character there and re-add the colon if needed.
-    val colon = pos(jsxAttr.json)
+    val colon = start(jsxAttr.json)
       .collect {
         case position if position > 0 && parserResult.fileContent.substring(position - 1, position) == ":" => ":"
       }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/parser/BabelJsonParser.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/parser/BabelJsonParser.scala
@@ -4,8 +4,7 @@ import io.joern.x2cpg.astgen.BaseParserResult
 import io.shiftleft.utils.IOUtils
 import ujson.Value.Value
 
-import java.nio.file.Path
-import java.nio.file.Paths
+import java.nio.file.{Path, Paths}
 import scala.util.Try
 
 object BabelJsonParser {
@@ -15,17 +14,17 @@ object BabelJsonParser {
     fullPath: String,
     json: Value,
     fileContent: String,
-    typeMap: Map[Int, String],
+    typeMap: Map[String, String],
     fileLoc: Int
   ) extends BaseParserResult
 
-  private def loadTypeMap(file: Path): Try[Map[Int, String]] = Try {
+  private def loadTypeMap(file: Path): Try[Map[String, String]] = Try {
     val typeMapPathString = file.toString.replaceAll("\\.[^.]*$", "") + ".typemap"
     val typeMapPath       = Paths.get(typeMapPathString)
     if (typeMapPath.toFile.exists()) {
       val typeMapJsonContent = IOUtils.readEntireFile(typeMapPath)
       val typeMapJson        = ujson.read(typeMapJsonContent)
-      typeMapJson.obj.map { case (k, v) => k.toInt -> v.str }.toMap
+      typeMapJson.obj.map { case (k, v) => k -> v.str }.toMap
     } else {
       Map.empty
     }
@@ -36,7 +35,7 @@ object BabelJsonParser {
     ujson.read(jsonContent)
   }
 
-  private def generateParserResult(rootPath: Path, json: Value, typeMap: Map[Int, String]): Try[ParseResult] = Try {
+  private def generateParserResult(rootPath: Path, json: Value, typeMap: Map[String, String]): Try[ParseResult] = Try {
     val filename          = json("relativeName").str
     val fullPath          = Paths.get(rootPath.toString, filename)
     val sourceFileContent = IOUtils.readEntireFile(fullPath)

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/SimpleAstCreationPassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/SimpleAstCreationPassTests.scala
@@ -945,7 +945,7 @@ class SimpleAstCreationPassTests extends AstJsSrc2CpgSuite {
       args.name shouldBe "args"
       args.code shouldBe "...args"
       args.isVariadic shouldBe true
-      args.typeFullName shouldBe Defines.Any
+      args.typeFullName shouldBe Defines.Array
     }
 
     "have correct structure for decl assignment" in {

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/types/TSTypesTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/types/TSTypesTests.scala
@@ -42,7 +42,7 @@ class TSTypesTests extends AstJsSrc2CpgSuite {
     args.name shouldBe "args"
     args.code shouldBe "...args"
     args.isVariadic shouldBe true
-    args.typeFullName shouldBe Defines.Any
+    args.typeFullName shouldBe Defines.Array
   }
 
   "have return types for arrow functions" in {


### PR DESCRIPTION
Brings in the latest astgen with several improvements:

- The typemap that is generated with tsc is now range-based (source code range of the AST node). Previously, we could end up in a situation where the type for an AST node (addressed only with its start index in the file) was overridden.
E.g., `foo.bar()` -> `{ 0: "Foo" }` and the `bar` call would override that with the type for `foo.bar()` (call expression) because its also starting at index 0.

- Type for strings is now handled by astgen itself.

- Performance improvements for typemap generation.