### PR TITLE
[jssrc2cpg] Bump astgen (again)

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/jssrc2cpg/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 jssrc2cpg {
-    astgen_version: "3.33.0"
+    astgen_version: "3.34.0"
 }


### PR DESCRIPTION
This is hopefully the last bump for this week.

This brings yet another performance fix for astgen. Time for https://github.com/swc-project/ts-parser-test-ref down to ~15 sec from ~2 minutes on my machine.