### PR TITLE
[swiftsrc2cpg] Several improvements

### DIFF
--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstCreatorHelper.scala
@@ -150,6 +150,14 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
     global.usedTypes.putIfAbsent(typeFullName, true)
   }
 
+  protected def stripQuotes(str: String): String = str
+    .stripPrefix("\"")
+    .stripSuffix("\"")
+    .stripPrefix("'")
+    .stripSuffix("'")
+    .stripPrefix("`")
+    .stripSuffix("`")
+
   protected def scopeLocalUniqueName(targetName: String): String = {
     val name = if (targetName.nonEmpty) { s"<$targetName>" }
     else { "<anonymous>" }

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstCreatorHelper.scala
@@ -150,14 +150,6 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
     global.usedTypes.putIfAbsent(typeFullName, true)
   }
 
-  protected def stripQuotes(str: String): String = str
-    .stripPrefix("\"")
-    .stripSuffix("\"")
-    .stripPrefix("'")
-    .stripSuffix("'")
-    .stripPrefix("`")
-    .stripSuffix("`")
-
   protected def scopeLocalUniqueName(targetName: String): String = {
     val name = if (targetName.nonEmpty) { s"<$targetName>" }
     else { "<anonymous>" }

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForExprSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForExprSyntaxCreator.scala
@@ -2,38 +2,101 @@ package io.joern.swiftsrc2cpg.astcreation
 
 import io.joern.swiftsrc2cpg.parser.SwiftNodeSyntax.*
 import io.joern.swiftsrc2cpg.passes.GlobalBuiltins
-import io.joern.x2cpg.Ast
 import io.joern.x2cpg.datastructures.Stack.*
-import io.joern.x2cpg.ValidationMode
 import io.joern.x2cpg.frontendspecific.swiftsrc2cpg.Defines
-import io.shiftleft.codepropertygraph.generated.ControlStructureTypes
-import io.shiftleft.codepropertygraph.generated.DispatchTypes
-import io.shiftleft.codepropertygraph.generated.Operators
-import io.shiftleft.codepropertygraph.generated.nodes.NewCall
-import io.shiftleft.codepropertygraph.generated.nodes.NewNode
-import io.shiftleft.codepropertygraph.generated.EvaluationStrategies
+import io.joern.x2cpg.{Ast, ValidationMode}
+import io.shiftleft.codepropertygraph.generated.*
+import io.shiftleft.codepropertygraph.generated.nodes.{NewCall, NewNode}
 
 import scala.annotation.unused
 
 trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
   this: AstCreator =>
 
-  private def astForListLikeExpr(node: SwiftNode, elements: Seq[SwiftNode]): Ast = {
+  private val MaxInitializers = 1000
+
+  private def astForEmptyListLikeExpr(node: SwiftNode): Ast = {
     val op           = Operators.arrayInitializer
     val initCallNode = callNode(node, code(node), op, DispatchTypes.STATIC_DISPATCH)
+    callAst(initCallNode, List.empty)
+  }
 
-    val MAX_INITIALIZERS = 1000
-    val clauses          = elements.slice(0, MAX_INITIALIZERS)
+  private def astForListLikeExpr(node: SwiftNode, elements: Seq[SwiftNode]): Ast = {
+    if (elements.isEmpty) { astForEmptyListLikeExpr(node) }
+    else {
+      node match {
+        case _: (ArrayExprSyntax | TupleExprSyntax) =>
+          val op           = Operators.arrayInitializer
+          val initCallNode = callNode(node, code(node), op, DispatchTypes.STATIC_DISPATCH)
 
-    val args = clauses.map(x => astForNodeWithFunctionReference(x))
+          val clauses = elements.slice(0, MaxInitializers)
 
-    val ast = callAst(initCallNode, args)
-    if (elements.sizeIs > MAX_INITIALIZERS) {
-      val placeholder =
-        literalNode(node, "<too-many-initializers>", Defines.Any).argumentIndex(MAX_INITIALIZERS)
-      ast.withChild(Ast(placeholder)).withArgEdge(initCallNode, placeholder)
-    } else {
-      ast
+          val args = clauses.map(x => astForNodeWithFunctionReference(x))
+
+          val ast = callAst(initCallNode, args)
+          if (elements.sizeIs > MaxInitializers) {
+            val placeholder =
+              literalNode(node, "<too-many-initializers>", Defines.Any).argumentIndex(MaxInitializers)
+            ast.withChild(Ast(placeholder)).withArgEdge(initCallNode, placeholder)
+          } else {
+            ast
+          }
+        case other =>
+          val blockNode_ = blockNode(node, code(node), Defines.Any)
+
+          scope.pushNewBlockScope(blockNode_)
+          localAstParentStack.push(blockNode_)
+
+          val tmpName      = scopeLocalUniqueName("tmp")
+          val localTmpNode = localNode(node, tmpName, tmpName, Defines.Any).order(0)
+          diffGraph.addEdge(localAstParentStack.head, localTmpNode, EdgeTypes.AST)
+
+          val slicedElements = elements.slice(0, MaxInitializers).toList
+
+          val propertiesAsts = slicedElements.map {
+            case dictElement: DictionaryElementSyntax =>
+              val (lhsNode, rhsAst) = {
+                val key = dictElement.key
+                val fieldName = key match {
+                  case decl: (DeclReferenceExprSyntax | StringLiteralExprSyntax) =>
+                    stripQuotes(code(decl))
+                  case expr: ExprSyntax =>
+                    notHandledYet(dictElement)
+                    scopeLocalUniqueName("computed_object_property")
+                }
+                val keyNode = fieldIdentifierNode(key, fieldName, fieldName)
+                val ast     = astForNodeWithFunctionReference(dictElement.value)
+                (keyNode, ast)
+              }
+              val leftHandSideTmpNode = Ast(identifierNode(dictElement, tmpName))
+              val leftHandSideFieldAccessAst =
+                createFieldAccessCallAst(leftHandSideTmpNode, lhsNode, line(dictElement), column(dictElement))
+
+              createAssignmentCallAst(
+                leftHandSideFieldAccessAst,
+                rhsAst,
+                s"$tmpName.${lhsNode.canonicalName} = ${codeOf(rhsAst.nodes.head)}",
+                line(dictElement),
+                column(dictElement)
+              )
+            case other => astForNodeWithFunctionReference(other)
+          }
+
+          val tmpNode = identifierNode(node, tmpName)
+
+          scope.popScope()
+          localAstParentStack.pop()
+
+          val placeHolderAst = if (elements.sizeIs > MaxInitializers) {
+            val placeholder = literalNode(node, "<too-many-initializers>", Defines.Any)
+            Ast(placeholder)
+          } else {
+            Ast()
+          }
+
+          val childrenAsts = propertiesAsts :+ placeHolderAst :+ Ast(tmpNode)
+          blockAst(blockNode_, childrenAsts)
+      }
     }
   }
 
@@ -45,14 +108,15 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
 
   private def astForAsExprSyntax(node: AsExprSyntax): Ast = {
     val op      = Operators.cast
-    val lhsNode = node.`type`
-    val typ     = cleanType(code(lhsNode))
-    registerType(typ)
-    val lhsAst    = Ast(literalNode(lhsNode, code(lhsNode), None).dynamicTypeHintFullName(Seq(typ)))
-    val rhsAst    = astForNodeWithFunctionReference(node.expression)
-    val callNode_ = callNode(node, code(node), op, DispatchTypes.STATIC_DISPATCH).dynamicTypeHintFullName(Seq(typ))
-    val argAsts   = List(lhsAst, rhsAst)
-    callAst(callNode_, argAsts)
+    val tpeNode = node.`type`
+    val tpeCode = code(tpeNode)
+    val tpe     = cleanType(tpeCode)
+    registerType(tpe)
+    val cpgCastExpression = callNode(node, code(node), op, op, DispatchTypes.STATIC_DISPATCH, None, Some(tpe))
+    val expr              = astForNodeWithFunctionReference(node.expression)
+    val typeRefNode_      = typeRefNode(tpeNode, tpeCode, tpe)
+    val arg               = Ast(typeRefNode_)
+    callAst(cpgCastExpression, List(arg, expr))
   }
 
   private def astForAssignmentExprSyntax(node: AssignmentExprSyntax): Ast = notHandledYet(node)
@@ -94,7 +158,7 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
 
   private def astForDictionaryExprSyntax(node: DictionaryExprSyntax): Ast = {
     node.content match {
-      case _: SwiftToken                  => astForListLikeExpr(node, Seq.empty)
+      case t: SwiftToken                  => astForListLikeExpr(node, Seq(t))
       case d: DictionaryElementListSyntax => astForListLikeExpr(node, d.children)
     }
   }
@@ -198,7 +262,7 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
           }
         case _ =>
           val receiverAst = astForNodeWithFunctionReference(callee)
-          val thisNode    = identifierNode(callee, "this").dynamicTypeHintFullName(typeHintForThisExpression())
+          val thisNode    = identifierNode(callee, "this")
           scope.addVariableReference(thisNode.name, thisNode, Defines.Any, EvaluationStrategies.BY_REFERENCE)
           (receiverAst, thisNode, calleeCode)
       }
@@ -223,7 +287,10 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
   }
 
   private def astForInOutExprSyntax(node: InOutExprSyntax): Ast = {
-    astForNodeWithFunctionReference(node.expression)
+    val op        = Defines.PrefixOperatorMap(code(node.ampersand))
+    val argAst    = astForNodeWithFunctionReference(node.expression)
+    val callNode_ = callNode(node, code(node), op, DispatchTypes.STATIC_DISPATCH)
+    callAst(callNode_, List(argAst))
   }
 
   private def astForInfixOperatorExprSyntax(node: InfixOperatorExprSyntax): Ast = {

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForExprSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForExprSyntaxCreator.scala
@@ -55,27 +55,17 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
 
           val propertiesAsts = slicedElements.map {
             case dictElement: DictionaryElementSyntax =>
-              val (lhsNode, rhsAst) = {
-                val key = dictElement.key
-                val fieldName = key match {
-                  case decl: (DeclReferenceExprSyntax | StringLiteralExprSyntax) =>
-                    stripQuotes(code(decl))
-                  case expr: ExprSyntax =>
-                    notHandledYet(dictElement)
-                    scopeLocalUniqueName("computed_object_property")
-                }
-                val keyNode = fieldIdentifierNode(key, fieldName, fieldName)
-                val ast     = astForNodeWithFunctionReference(dictElement.value)
-                (keyNode, ast)
-              }
-              val leftHandSideTmpNode = Ast(identifierNode(dictElement, tmpName))
-              val leftHandSideFieldAccessAst =
-                createFieldAccessCallAst(leftHandSideTmpNode, lhsNode, line(dictElement), column(dictElement))
+              val lhsAst = astForNodeWithFunctionReference(dictElement.key)
+              val rhsAst = astForNodeWithFunctionReference(dictElement.value)
+
+              val lhsTmpNode = Ast(identifierNode(dictElement, tmpName))
+              val lhsIndexAccessCallAst =
+                createIndexAccessCallAst(lhsTmpNode, lhsAst, line(dictElement), column(dictElement))
 
               createAssignmentCallAst(
-                leftHandSideFieldAccessAst,
+                lhsIndexAccessCallAst,
                 rhsAst,
-                s"$tmpName.${lhsNode.canonicalName} = ${codeOf(rhsAst.nodes.head)}",
+                s"${codeOf(lhsIndexAccessCallAst.nodes.head)} = ${codeOf(rhsAst.nodes.head)}",
                 line(dictElement),
                 column(dictElement)
               )

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForPatternSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForPatternSyntaxCreator.scala
@@ -1,14 +1,10 @@
 package io.joern.swiftsrc2cpg.astcreation
 
 import io.joern.swiftsrc2cpg.parser.SwiftNodeSyntax.*
-import io.joern.x2cpg.Ast
-import io.joern.x2cpg.ValidationMode
+import io.joern.x2cpg.{Ast, ValidationMode}
 import io.joern.x2cpg.datastructures.VariableScopeManager
 import io.joern.x2cpg.frontendspecific.swiftsrc2cpg.Defines
-import io.shiftleft.codepropertygraph.generated.DispatchTypes
-import io.shiftleft.codepropertygraph.generated.EdgeTypes
-import io.shiftleft.codepropertygraph.generated.EvaluationStrategies
-import io.shiftleft.codepropertygraph.generated.Operators
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes, Operators}
 
 import scala.annotation.{tailrec, unused}
 
@@ -25,12 +21,14 @@ trait AstForPatternSyntaxCreator(implicit withSchemaValidation: ValidationMode) 
 
   private def astForIsTypePatternSyntax(node: IsTypePatternSyntax): Ast = {
     val op      = Operators.instanceOf
-    val lhsNode = node.`type`
-    val typ     = cleanType(code(lhsNode))
-    registerType(typ)
-    val lhsAst    = Ast(literalNode(lhsNode, code(lhsNode), None).dynamicTypeHintFullName(Seq(typ)))
-    val callNode_ = callNode(node, code(node), op, DispatchTypes.STATIC_DISPATCH).dynamicTypeHintFullName(Seq(typ))
-    callAst(callNode_, Seq(lhsAst))
+    val tpeNode = node.`type`
+    val tpeCode = code(tpeNode)
+    val tpe     = cleanType(tpeCode)
+    registerType(tpe)
+    val callNode_    = callNode(node, code(node), op, op, DispatchTypes.STATIC_DISPATCH, None, Some(tpe))
+    val typeRefNode_ = typeRefNode(tpeNode, tpeCode, tpe)
+    val arg          = Ast(typeRefNode_)
+    callAst(callNode_, List(arg))
   }
 
   private def astForMissingPatternSyntax(@unused node: MissingPatternSyntax): Ast = Ast()

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForSyntaxCreator.scala
@@ -133,12 +133,14 @@ trait AstForSyntaxCreator(implicit withSchemaValidation: ValidationMode) { this:
   }
 
   private def astForClosureSignatureSyntax(node: ClosureSignatureSyntax): Ast = notHandledYet(node)
+
   private def astForCodeBlockItemSyntax(node: CodeBlockItemSyntax): Ast = {
     astForNodeWithFunctionReferenceAndCall(node.item)
   }
   private def astForCodeBlockSyntax(node: CodeBlockSyntax): Ast = {
     astForNode(node.statements)
   }
+
   private def astForCompositionTypeElementSyntax(node: CompositionTypeElementSyntax): Ast = notHandledYet(node)
 
   private def astForConditionElementSyntax(node: ConditionElementSyntax): Ast = {
@@ -178,12 +180,8 @@ trait AstForSyntaxCreator(implicit withSchemaValidation: ValidationMode) { this:
 
   private def astForDesignatedTypeSyntax(node: DesignatedTypeSyntax): Ast = notHandledYet(node)
 
-  private def astForDictionaryElementSyntax(node: DictionaryElementSyntax): Ast = {
-    // TODO: check if handling Labels like that fits the Swift semantics:
-    val dstAst = astForNode(node.key)
-    val srcAst = astForNodeWithFunctionReference(node.value)
-    createAssignmentCallAst(dstAst, srcAst, code(node), line(node), column(node))
-  }
+  private def astForDictionaryElementSyntax(node: DictionaryElementSyntax): Ast =
+    Ast() // we handle dictionary elements in astForDictionaryExprSyntax
 
   private def astForDifferentiabilityArgumentSyntax(node: DifferentiabilityArgumentSyntax): Ast   = notHandledYet(node)
   private def astForDifferentiabilityArgumentsSyntax(node: DifferentiabilityArgumentsSyntax): Ast = notHandledYet(node)

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstNodeBuilder.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstNodeBuilder.scala
@@ -150,12 +150,12 @@ trait AstNodeBuilder(implicit withSchemaValidation: ValidationMode) { this: AstC
       .columnNumber(column)
   }
 
-  protected def literalNode(node: SwiftNode, code: String, dynamicTypeOption: Option[String]): NewLiteral = {
-    val typeFullName = dynamicTypeOption match {
+  protected def literalNode(node: SwiftNode, code: String, possibleTypes: Option[String]): NewLiteral = {
+    val typeFullName = possibleTypes match {
       case Some(value) if Defines.SwiftTypes.contains(value) => value
       case _                                                 => Defines.Any
     }
-    literalNode(node, code, typeFullName, dynamicTypeOption.toList)
+    literalNode(node, code, typeFullName).possibleTypes(possibleTypes.toList)
   }
 
   protected def createAssignmentCallAst(
@@ -178,11 +178,11 @@ trait AstNodeBuilder(implicit withSchemaValidation: ValidationMode) { this: AstC
   }
 
   protected def identifierNode(node: SwiftNode, name: String): NewIdentifier = {
-    val dynamicInstanceTypeOption = name match {
-      case "this" | "self" | "Self" => typeHintForThisExpression().headOption
-      case _                        => None
+    val tpe = name match {
+      case "this" | "self" | "Self" => typeHintForThisExpression().headOption.getOrElse(Defines.Any)
+      case _                        => Defines.Any
     }
-    identifierNode(node, name, name, Defines.Any, dynamicInstanceTypeOption.toList)
+    identifierNode(node, name, name, tpe)
   }
 
   def staticInitMethodAstAndBlock(

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstNodeBuilder.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstNodeBuilder.scala
@@ -170,7 +170,7 @@ trait AstNodeBuilder(implicit withSchemaValidation: ValidationMode) { this: AstC
     callAst(callNode, arguments)
   }
 
-  protected def typeHintForThisExpression(): Seq[String] = {
+  private def typeHintForThisExpression(): Seq[String] = {
     dynamicInstanceTypeStack.headOption match {
       case Some(tpe) => Seq(tpe)
       case None      => methodAstParentStack.collectFirst { case t: NewTypeDecl => t.fullName }.toSeq

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/dataflow/DataFlowTests.scala
@@ -1,11 +1,9 @@
 package io.joern.swiftsrc2cpg.dataflow
 
 import io.joern.dataflowengineoss.language.*
-import io.joern.dataflowengineoss.queryengine.EngineConfig
-import io.joern.dataflowengineoss.queryengine.EngineContext
+import io.joern.dataflowengineoss.queryengine.{EngineConfig, EngineContext}
 import io.joern.swiftsrc2cpg.testfixtures.DataFlowCodeToCpgSuite
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
-import io.shiftleft.codepropertygraph.generated.nodes.Identifier
 import io.shiftleft.codepropertygraph.generated.nodes.Literal
 import io.shiftleft.semanticcpg.language.*
 

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/ExpressionTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/ExpressionTests.scala
@@ -25,6 +25,42 @@ class ExpressionTests extends AstSwiftSrc2CpgSuite {
       }
     }
 
+    "testBinaryPlus" in {
+      val cpg = code("let a = b + c")
+      inside(cpg.call.nameExact(Operators.addition).l) { case List(call: Call) =>
+        call.code shouldBe "b + c"
+        inside(call.argument.l) { case List(b: Identifier, c: Identifier) =>
+          b.name shouldBe "b"
+          c.name shouldBe "c"
+        }
+      }
+    }
+
+    "testBinarySubstraction" in {
+      val cpg = code("let a = b - c")
+      inside(cpg.call.nameExact(Operators.subtraction).l) { case List(call: Call) =>
+        call.code shouldBe "b - c"
+        inside(call.argument.l) { case List(b: Identifier, c: Identifier) =>
+          b.name shouldBe "b"
+          c.name shouldBe "c"
+        }
+      }
+    }
+
+    "testAddressOf" in {
+      val cpg = code("let d = Data(a: &b + offset, count: &c - offset)")
+      inside(cpg.call.nameExact(Operators.addressOf).l) { case List(bCall: Call, cCall: Call) =>
+        bCall.code shouldBe "&b"
+        cCall.code shouldBe "&c"
+        inside(bCall.argument.l) { case List(b: Identifier) =>
+          b.name shouldBe "b"
+        }
+        inside(cCall.argument.l) { case List(c: Identifier) =>
+          c.name shouldBe "c"
+        }
+      }
+    }
+
     "testSequence1" in {
       val cpg = code("a ? b : c ? d : e")
       inside(cpg.method.name("<global>").ast.isCall.l) { case List(call: Call, nestedCall: Call) =>

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/ToplevelLibraryTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/ToplevelLibraryTests.scala
@@ -34,8 +34,8 @@ class ToplevelLibraryTests extends AstSwiftSrc2CpgSuite {
       |""".stripMargin)
       cpg.call.code.sorted.l shouldBe List("func <lambda>0 = { }", "let x = 42", "x + x", "x + x", "{ 5 }()")
       cpg.method.fullName.sorted.l shouldBe List(
+        "<operator>.addition",
         "<operator>.assignment",
-        "<operator>.plus",
         "Test0.swift:<global>",
         "Test0.swift:<global>:<lambda>0:ANY()",
         "Test0.swift:<global>:<lambda>1:ANY()"

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/swiftsrc2cpg/Defines.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/swiftsrc2cpg/Defines.scala
@@ -45,6 +45,7 @@ object Defines {
     ">"   -> Operators.greaterThan,
     "=="  -> Operators.equals,
     "%"   -> Operators.modulo,
+    "&"   -> Operators.addressOf,
     "..." -> "<operator>.splat"
   ).withDefault { key =>
     logger.info(s"Prefix operator '$key' not handled yet")
@@ -86,11 +87,11 @@ object Defines {
     "!="   -> Operators.notEquals,
     "==="  -> Operators.equals,
     "!=="  -> Operators.notEquals,
-    "&+"   -> Operators.plus,
-    "+"    -> Operators.plus,
+    "&+"   -> Operators.addition,
+    "+"    -> Operators.addition,
     "&+="  -> Operators.assignmentPlus,
-    "&-"   -> Operators.minus,
-    "-"    -> Operators.minus,
+    "&-"   -> Operators.subtraction,
+    "-"    -> Operators.subtraction,
     "&-="  -> Operators.assignmentMinus,
     "&/"   -> Operators.division,
     "/"    -> Operators.division,


### PR DESCRIPTION
 * dictionary, tuple, and list lowering
 * proper typeRefNode in cast expressions
 * no dynamicTypeHintFullName anymore; just possibleTypes if applicable
 * added support for missing addressOf calls
 * fixed wrong Operators.plus calls; it's Operators.addition
 * fixed wrong Operators.minus calls; it's Operators.subtraction