### PR TITLE
[swiftsrc2cpg] Fix for @objc annotations and typerefs from type declarations

### DIFF
--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstCreator.scala
@@ -90,25 +90,8 @@ class AstCreator(val config: Config, val global: Global, val parserResult: Parse
     )
   }
 
-  protected def astForNodeWithFunctionReferenceAndCall(node: SwiftNode): Ast = {
-    node match {
-      case func: FunctionDeclLike =>
-        astForFunctionLike(func, shouldCreateFunctionReference = true, shouldCreateAssignmentCall = true).ast
-      case _ =>
-        astForNode(node)
-    }
-  }
-
-  protected def astForNodeWithFunctionReference(node: SwiftNode): Ast = {
-    node match {
-      case func: FunctionDeclLike =>
-        astForFunctionLike(func, shouldCreateFunctionReference = true).ast
-      case _ =>
-        astForNode(node)
-    }
-  }
-
   protected def astForNode(node: SwiftNode): Ast = node match {
+    case func: FunctionDeclLike             => astForFunctionLike(func)
     case swiftToken: SwiftToken             => astForSwiftToken(swiftToken)
     case syntax: Syntax                     => astForSyntax(syntax)
     case exprSyntax: ExprSyntax             => astForExprSyntax(exprSyntax)

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForDeclSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForDeclSyntaxCreator.scala
@@ -558,7 +558,7 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
         s.modifiers.children.flatMap(c => astForNode(c).root.map(_.asInstanceOf[NewModifier]))
       case _: ClosureExprSyntax => Seq.empty
     }
-    val constructorModifier = if (node.isInstanceOf[InitializerDeclSyntax]) {
+    val constructorModifier = if (isConstructor(node)) {
       Seq(NewModifier().modifierType(ModifierTypes.CONSTRUCTOR))
     } else { Seq.empty }
     (constructorModifier ++ virtualModifier ++ modifiers).zipWithIndex.map { case (m, index) =>
@@ -624,7 +624,7 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     registerType(returnType)
     val methodFullNameAndSignature = s"$methodFullName:$signature"
 
-    val shouldCreateFunctionReference = typeRefIdStack.headOption.isEmpty
+    val shouldCreateFunctionReference = typeRefIdStack.headOption.isEmpty && !isConstructor(node)
     val methodRefNode_ = if (!shouldCreateFunctionReference) { None }
     else { Option(methodRefNode(node, methodName, methodFullNameAndSignature, methodFullNameAndSignature)) }
     val capturingRefNode = if (shouldCreateFunctionReference) { methodRefNode_ }

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForDeclSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForDeclSyntaxCreator.scala
@@ -62,12 +62,8 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
       diffGraph.addEdge(typeDeclNode_, mod, EdgeTypes.AST)
     }
 
-    diffGraph.addEdge(methodAstParentStack.head, typeDeclNode_, EdgeTypes.AST)
-
     createDeclConstructor(node, typeDeclNode_, List.empty)
-
-    val typeRefNode_ = typeRefNode(node, code(node), typeFullName)
-    Ast(typeRefNode_)
+    Ast(typeDeclNode_)
   }
 
   private def isConstructor(node: SwiftNode): Boolean = node match {
@@ -339,13 +335,8 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
       diffGraph.addEdge(typeDeclNode_, mod, EdgeTypes.AST)
     }
 
-    diffGraph.addEdge(methodAstParentStack.head, typeDeclNode_, EdgeTypes.AST)
-
-    val typeRefNode_ = typeRefNode(node, code(node), typeFullName)
-
     methodAstParentStack.push(typeDeclNode_)
     dynamicInstanceTypeStack.push(typeFullName)
-    typeRefIdStack.push(typeRefNode_)
     scope.pushNewMethodScope(typeFullName, typeName, typeDeclNode_, None)
 
     val allClassMembers = declMembers(node, withConstructor = false).toList
@@ -368,7 +359,6 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
 
     methodAstParentStack.pop()
     dynamicInstanceTypeStack.pop()
-    typeRefIdStack.pop()
     scope.popScope()
 
     if (staticMemberInitCalls.nonEmpty) {
@@ -383,7 +373,7 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
       diffGraph.addEdge(typeDeclNode_, init.method, EdgeTypes.AST)
     }
 
-    Ast(typeRefNode_)
+    Ast(typeDeclNode_)
   }
 
   private def astForDeinitializerDeclSyntax(node: DeinitializerDeclSyntax): Ast = {
@@ -490,13 +480,8 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
       diffGraph.addEdge(typeDeclNode_, mod, EdgeTypes.AST)
     }
 
-    diffGraph.addEdge(methodAstParentStack.head, typeDeclNode_, EdgeTypes.AST)
-
-    val typeRefNode_ = typeRefNode(node, code(node), typeFullName)
-
     methodAstParentStack.push(typeDeclNode_)
     dynamicInstanceTypeStack.push(typeFullName)
-    typeRefIdStack.push(typeRefNode_)
     scope.pushNewMethodScope(typeFullName, typeName, typeDeclNode_, None)
 
     val allClassMembers = declMembers(node, withConstructor = false).toList
@@ -519,7 +504,6 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
 
     methodAstParentStack.pop()
     dynamicInstanceTypeStack.pop()
-    typeRefIdStack.pop()
     scope.popScope()
 
     if (staticMemberInitCalls.nonEmpty) {
@@ -534,7 +518,7 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
       diffGraph.addEdge(typeDeclNode_, init.method, EdgeTypes.AST)
     }
 
-    Ast(typeRefNode_)
+    Ast(typeDeclNode_)
   }
 
   private def modifiersForDecl(node: TypeDeclLike | EnumCaseDeclSyntax): Seq[NewModifier] = {
@@ -884,12 +868,8 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
       diffGraph.addEdge(typeDeclNode_, mod, EdgeTypes.AST)
     }
 
-    diffGraph.addEdge(methodAstParentStack.head, typeDeclNode_, EdgeTypes.AST)
-
     createDeclConstructor(node, typeDeclNode_, List.empty)
-
-    val typeRefNode_ = typeRefNode(node, code(node), typeFullName)
-    Ast(typeRefNode_)
+    Ast(typeDeclNode_)
   }
 
   private def astForVariableDeclSyntax(node: VariableDeclSyntax): Ast = {

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForDeclSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForDeclSyntaxCreator.scala
@@ -1,13 +1,12 @@
 package io.joern.swiftsrc2cpg.astcreation
 
 import io.joern.swiftsrc2cpg.parser.SwiftNodeSyntax.*
-import io.joern.x2cpg.AstNodeBuilder.{bindingNode, dependencyNode}
-import io.joern.x2cpg.{Ast, ValidationMode}
+import io.joern.x2cpg.AstNodeBuilder.dependencyNode
 import io.joern.x2cpg.datastructures.Stack.*
 import io.joern.x2cpg.datastructures.VariableScopeManager
 import io.joern.x2cpg.frontendspecific.swiftsrc2cpg.Defines
-import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes, EvaluationStrategies, ModifierTypes}
-import io.shiftleft.codepropertygraph.generated.PropertyDefaults
+import io.joern.x2cpg.{Ast, ValidationMode}
+import io.shiftleft.codepropertygraph.generated.*
 import io.shiftleft.codepropertygraph.generated.nodes.*
 
 import scala.annotation.unused
@@ -22,7 +21,7 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     DeinitializerDeclSyntax | ClosureExprSyntax | SubscriptDeclSyntax
 
   private def astForAccessorDeclSyntax(node: AccessorDeclSyntax): Ast = {
-    astForNodeWithFunctionReference(node)
+    astForNode(node)
   }
 
   private def astForActorDeclSyntax(node: ActorDeclSyntax): Ast = {
@@ -147,7 +146,7 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     node: TypeDeclLike,
     typeDeclNode: NewTypeDecl,
     methodBlockContent: List[Ast] = List.empty
-  ): AstAndMethod = {
+  ): Unit = {
     val constructorName = io.joern.x2cpg.Defines.ConstructorMethodName
     val methodFullName  = s"${typeDeclNode.fullName}:$constructorName"
     val methodNode_ = methodNode(node, constructorName, constructorName, methodFullName, None, parserResult.filename)
@@ -170,9 +169,7 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
 
     Ast.storeInDiffGraph(mAst, diffGraph)
     Ast.storeInDiffGraph(functionTypeAndTypeDeclAst, diffGraph)
-    diffGraph.addEdge(methodAstParentStack.head, methodNode_, EdgeTypes.AST)
-
-    AstAndMethod(Ast(), methodNode_, bAst)
+    diffGraph.addEdge(typeDeclNode, methodNode_, EdgeTypes.AST)
   }
 
   private def declSyntaxFromIfConfigClauseSyntax(node: IfConfigClauseSyntax): Seq[DeclSyntax] = {
@@ -212,12 +209,14 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     val typeFullName = typeNameForDeclSyntax(node)
     node match {
       case d: FunctionDeclLike =>
-        val function = astForFunctionLike(d).method
-        val binding  = bindingNode("", "", "")
-        diffGraph.addEdge(typeDeclNode, binding, EdgeTypes.BINDS)
-        diffGraph.addEdge(binding, function, EdgeTypes.REF)
-        val memberNode_ = memberNode(d, function.name, code(d), typeFullName, Seq(function.fullName))
-        diffGraph.addEdge(typeDeclNode, memberNode_, EdgeTypes.AST)
+        astForFunctionLike(d).root.collect {
+          case function: NewMethod =>
+            val memberNode_ = memberNode(d, function.name, code(d), typeFullName, Seq(function.fullName))
+            diffGraph.addEdge(typeDeclNode, memberNode_, EdgeTypes.AST)
+          case methoRef: NewMethodRef =>
+            val memberNode_ = memberNode(d, methoRef.code, code(d), typeFullName, Seq(methoRef.methodFullName))
+            diffGraph.addEdge(typeDeclNode, memberNode_, EdgeTypes.AST)
+        }
         Ast()
       case ifConf: IfConfigDeclSyntax =>
         val declElements = declSyntaxFromIfConfigDeclSyntax(ifConf)
@@ -258,12 +257,14 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     typeDeclNode: NewTypeDecl,
     constructorContent: List[Ast],
     constructorBlock: Ast = Ast()
-  ): Option[AstAndMethod] =
+  ): Unit =
     findDeclConstructor(node) match {
       case Some(constructor: InitializerDeclSyntax) =>
-        val result = astForFunctionLike(constructor, methodBlockContent = constructorContent)
-        diffGraph.addEdge(result.method, NewModifier().modifierType(ModifierTypes.CONSTRUCTOR), EdgeTypes.AST)
-        Option(result)
+        val ast = astForFunctionLike(constructor, methodBlockContent = constructorContent)
+        ast.root.foreach { node =>
+          Ast.storeInDiffGraph(ast, diffGraph)
+          diffGraph.addEdge(methodAstParentStack.head, node, EdgeTypes.AST)
+        }
       case _ if constructorBlock.root.isDefined =>
         constructorBlock.root.foreach { r =>
           constructorContent.foreach { c =>
@@ -271,9 +272,8 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
             c.root.foreach(diffGraph.addEdge(r, _, EdgeTypes.AST))
           }
         }
-        None
       case _ =>
-        Option(createFakeConstructor(node, typeDeclNode, methodBlockContent = constructorContent))
+        createFakeConstructor(node, typeDeclNode, methodBlockContent = constructorContent)
     }
 
   private def isClassMethodOrUninitializedMember(node: DeclSyntax): Boolean = {
@@ -377,7 +377,7 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
   }
 
   private def astForDeinitializerDeclSyntax(node: DeinitializerDeclSyntax): Ast = {
-    astForNodeWithFunctionReference(node)
+    astForNode(node)
   }
 
   private def astForEditorPlaceholderDeclSyntax(node: EditorPlaceholderDeclSyntax): Ast = {
@@ -545,7 +545,7 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
   }
 
   private def modifiersForFunctionLike(node: FunctionDeclLike): Seq[NewModifier] = {
-    val virtualModifier = NewModifier().modifierType(ModifierTypes.VIRTUAL)
+    val virtualModifier = Seq(NewModifier().modifierType(ModifierTypes.VIRTUAL))
     val modifiers = node match {
       case f: FunctionDeclSyntax =>
         f.modifiers.children.flatMap(c => astForNode(c).root.map(_.asInstanceOf[NewModifier]))
@@ -558,7 +558,10 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
         s.modifiers.children.flatMap(c => astForNode(c).root.map(_.asInstanceOf[NewModifier]))
       case _: ClosureExprSyntax => Seq.empty
     }
-    (virtualModifier +: modifiers).zipWithIndex.map { case (m, index) =>
+    val constructorModifier = if (node.isInstanceOf[InitializerDeclSyntax]) {
+      Seq(NewModifier().modifierType(ModifierTypes.CONSTRUCTOR))
+    } else { Seq.empty }
+    (constructorModifier ++ virtualModifier ++ modifiers).zipWithIndex.map { case (m, index) =>
       m.order(index)
     }
   }
@@ -578,12 +581,7 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     }
   }
 
-  protected def astForFunctionLike(
-    node: FunctionDeclLike,
-    shouldCreateFunctionReference: Boolean = false,
-    shouldCreateAssignmentCall: Boolean = false,
-    methodBlockContent: List[Ast] = List.empty
-  ): AstAndMethod = {
+  protected def astForFunctionLike(node: FunctionDeclLike, methodBlockContent: List[Ast] = List.empty): Ast = {
     // TODO: handle genericParameterClause
     // TODO: handle genericWhereClause
 
@@ -625,29 +623,12 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     }
     registerType(returnType)
     val methodFullNameAndSignature = s"$methodFullName:$signature"
+
+    val shouldCreateFunctionReference = typeRefIdStack.headOption.isEmpty
     val methodRefNode_ = if (!shouldCreateFunctionReference) { None }
     else { Option(methodRefNode(node, methodName, methodFullNameAndSignature, methodFullNameAndSignature)) }
-
-    val callAst = if (shouldCreateAssignmentCall && shouldCreateFunctionReference) {
-      val idNode  = identifierNode(node, methodName)
-      val idLocal = localNode(node, methodName, methodName, methodFullNameAndSignature).order(0)
-      diffGraph.addEdge(localAstParentStack.head, idLocal, EdgeTypes.AST)
-      scope.addVariable(methodName, idLocal, Defines.Any, VariableScopeManager.ScopeType.BlockScope)
-      scope.addVariableReference(methodName, idNode, Defines.Any, EvaluationStrategies.BY_REFERENCE)
-      val assignmentCode = s"func $methodName = ${code(node)}"
-      val assignment =
-        createAssignmentCallAst(Ast(idNode), Ast(methodRefNode_.get), assignmentCode, line(node), column(node))
-      assignment
-    } else {
-      Ast()
-    }
-
-    val capturingRefNode =
-      if (shouldCreateFunctionReference) {
-        methodRefNode_
-      } else {
-        typeRefIdStack.headOption
-      }
+    val capturingRefNode = if (shouldCreateFunctionReference) { methodRefNode_ }
+    else { typeRefIdStack.headOption }
 
     val codeString  = code(node)
     val methodNode_ = methodNode(node, methodName, codeString, methodFullNameAndSignature, Option(signature), filename)
@@ -689,16 +670,13 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
 
     val bodyStmtAsts = body match {
       case Some(bodyNode: AccessorDeclListSyntax) =>
-        bodyNode.children.toList match {
-          case Nil      => List.empty[Ast]
-          case children => children.map(astForNodeWithFunctionReferenceAndCall)
-        }
+        bodyNode.children.toList.map(astForNode)
       case Some(bodyNode: CodeBlockSyntax) =>
         bodyNode.statements.children.toList match {
           case Nil => List.empty[Ast]
           case head :: Nil if head.item.isInstanceOf[ClosureExprSyntax] =>
             val retCode = code(head)
-            List(returnAst(returnNode(head, retCode), List(astForNodeWithFunctionReference(head.item))))
+            List(returnAst(returnNode(head, retCode), List(astForNode(head.item))))
           case children =>
             astsForBlockElements(children)
         }
@@ -707,7 +685,7 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
           case Nil => List.empty[Ast]
           case head :: Nil if !head.item.isInstanceOf[ReturnStmtSyntax] =>
             val retCode = code(head)
-            List(returnAst(returnNode(head, retCode), List(astForNodeWithFunctionReference(head.item))))
+            List(returnAst(returnNode(head, retCode), List(astForNode(head.item))))
           case children =>
             astsForBlockElements(children)
         }
@@ -732,19 +710,21 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     localAstParentStack.pop()
     methodAstParentStack.pop()
 
-    val typeDeclAst = createFunctionTypeAndTypeDeclAst(node, methodNode_, methodName, methodFullNameAndSignature)
-    Ast.storeInDiffGraph(astForMethod, diffGraph)
-    Ast.storeInDiffGraph(typeDeclAst, diffGraph)
-    diffGraph.addEdge(methodAstParentStack.head, methodNode_, EdgeTypes.AST)
-
     methodRefNode_ match {
-      case Some(ref) if callAst.nodes.isEmpty => AstAndMethod(Ast(ref), methodNode_, blockAst_)
-      case _                                  => AstAndMethod(callAst, methodNode_, blockAst_)
+      case Some(ref) =>
+        val typeDeclAst = createFunctionTypeAndTypeDeclAst(node, methodNode_, methodName, methodFullNameAndSignature)
+        Ast.storeInDiffGraph(astForMethod, diffGraph)
+        Ast.storeInDiffGraph(typeDeclAst, diffGraph)
+        diffGraph.addEdge(methodAstParentStack.head, methodNode_, EdgeTypes.AST)
+        Ast(ref)
+      case None =>
+        val typeDeclAst = createFunctionTypeAndTypeDeclAst(node, methodNode_, methodName, methodFullNameAndSignature)
+        astForMethod.merge(typeDeclAst)
     }
   }
 
   private def astForFunctionDeclSyntax(node: FunctionDeclSyntax): Ast = {
-    astForFunctionLike(node).ast
+    astForFunctionLike(node)
   }
 
   protected def ifConfigDeclConditionIsSatisfied(node: IfConfigClauseSyntax): Boolean = {
@@ -797,7 +777,7 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
   }
 
   private def astForInitializerDeclSyntax(node: InitializerDeclSyntax): Ast = {
-    astForNodeWithFunctionReference(node)
+    astForNode(node)
   }
 
   private def astForMacroDeclSyntax(node: MacroDeclSyntax): Ast = notHandledYet(node)
@@ -805,7 +785,7 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
   private def astForMacroExpansionDeclSyntax(node: MacroExpansionDeclSyntax): Ast = {
     val name = code(node.macroName)
     val argAsts = astForNode(node.arguments) +:
-      node.trailingClosure.toList.map(astForNodeWithFunctionReference) :+
+      node.trailingClosure.toList.map(astForNode) :+
       astForNode(node.additionalTrailingClosures)
     val callNode =
       NewCall()

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForDeclSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForDeclSyntaxCreator.scala
@@ -893,7 +893,7 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
           Seq(scopeLocalUniqueName("wildcard"))
       }
 
-      names.flatMap { name =>
+      names.map { name =>
         val cleanedName  = cleanName(name)
         val typeFullName = cleanName(binding.typeAnnotation.fold(Defines.Any)(t => cleanType(code(t.`type`))))
         registerType(typeFullName)
@@ -901,9 +901,9 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
         scope.addVariable(cleanedName, nLocalNode, typeFullName, scopeType)
         diffGraph.addEdge(localAstParentStack.head, nLocalNode, EdgeTypes.AST)
 
-        val initAstMaybe = binding.initializer.map(astForNode)
-        if (initAstMaybe.isEmpty) {
-          Seq(Ast())
+        val initAsts = (binding.initializer.map(astForNode) ++ binding.accessorBlock.map(astForNode)).toSeq
+        if (initAsts.isEmpty) {
+          Ast()
         } else {
           val patternIdentifier = identifierNode(binding.pattern, cleanedName).typeFullName(typeFullName)
           scope.addVariableReference(cleanedName, patternIdentifier, typeFullName, EvaluationStrategies.BY_REFERENCE)
@@ -917,15 +917,23 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
           val initCode          = binding.initializer.fold("")(i => s" ${code(i).strip()}")
           val accessorBlockCode = binding.accessorBlock.fold("")(a => s" ${code(a).strip()}")
           val typeCode          = binding.typeAnnotation.fold("")(t => code(t).strip())
+
+          val rhsAst = initAsts match {
+            case Nil         => Ast()
+            case head :: Nil => head
+            case others =>
+              val block = blockNode(node, code(node), Defines.Any)
+              blockAst(block, others.toList)
+          }
+
           val assignmentAst = createAssignmentCallAst(
             patternAst,
-            initAstMaybe.head,
+            rhsAst,
             s"$kind $cleanedName$typeCode$initCode$accessorBlockCode".strip(),
             line = line(binding),
             column = column(binding)
           )
-          val accessorBlockAst = binding.accessorBlock.map(astForNode).toSeq
-          Seq(assignmentAst) ++ accessorBlockAst
+          assignmentAst
         }
       }
     }

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForExprSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForExprSyntaxCreator.scala
@@ -31,7 +31,7 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
 
           val clauses = elements.slice(0, MaxInitializers)
 
-          val args = clauses.map(x => astForNodeWithFunctionReference(x))
+          val args = clauses.map(astForNode)
 
           val ast = callAst(initCallNode, args)
           if (elements.sizeIs > MaxInitializers) {
@@ -55,8 +55,8 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
 
           val propertiesAsts = slicedElements.map {
             case dictElement: DictionaryElementSyntax =>
-              val lhsAst = astForNodeWithFunctionReference(dictElement.key)
-              val rhsAst = astForNodeWithFunctionReference(dictElement.value)
+              val lhsAst = astForNode(dictElement.key)
+              val rhsAst = astForNode(dictElement.value)
 
               val lhsTmpNode = Ast(identifierNode(dictElement, tmpName))
               val lhsIndexAccessCallAst =
@@ -69,7 +69,7 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
                 line(dictElement),
                 column(dictElement)
               )
-            case other => astForNodeWithFunctionReference(other)
+            case other => astForNode(other)
           }
 
           val tmpNode = identifierNode(node, tmpName)
@@ -103,7 +103,7 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     val tpe     = cleanType(tpeCode)
     registerType(tpe)
     val cpgCastExpression = callNode(node, code(node), op, op, DispatchTypes.STATIC_DISPATCH, None, Some(tpe))
-    val expr              = astForNodeWithFunctionReference(node.expression)
+    val expr              = astForNode(node.expression)
     val typeRefNode_      = typeRefNode(tpeNode, tpeCode, tpe)
     val arg               = Ast(typeRefNode_)
     callAst(cpgCastExpression, List(arg, expr))
@@ -113,7 +113,7 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
 
   private def astForAwaitExprSyntax(node: AwaitExprSyntax): Ast = {
     val callNode_ = callNode(node, code(node), "<operator>.await", DispatchTypes.STATIC_DISPATCH)
-    val argAsts   = List(astForNodeWithFunctionReference(node.expression))
+    val argAsts   = List(astForNode(node.expression))
     callAst(callNode_, argAsts)
   }
 
@@ -124,22 +124,22 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
   }
 
   private def astForBorrowExprSyntax(node: BorrowExprSyntax): Ast = {
-    astForNodeWithFunctionReference(node.expression)
+    astForNode(node.expression)
   }
 
   private def astForCanImportExprSyntax(node: CanImportExprSyntax): Ast               = notHandledYet(node)
   private def astForCanImportVersionInfoSyntax(node: CanImportVersionInfoSyntax): Ast = notHandledYet(node)
 
   private def astForClosureExprSyntax(node: ClosureExprSyntax): Ast = {
-    astForNodeWithFunctionReference(node)
+    astForNode(node)
   }
 
   private def astForConsumeExprSyntax(node: ConsumeExprSyntax): Ast = {
-    astForNodeWithFunctionReference(node.expression)
+    astForNode(node.expression)
   }
 
   private def astForCopyExprSyntax(node: CopyExprSyntax): Ast = {
-    astForNodeWithFunctionReference(node.expression)
+    astForNode(node.expression)
   }
 
   private def astForDeclReferenceExprSyntax(node: DeclReferenceExprSyntax): Ast = {
@@ -171,7 +171,7 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
   }
 
   private def astForForceUnwrapExprSyntax(node: ForceUnwrapExprSyntax): Ast = {
-    astForNodeWithFunctionReference(node.expression)
+    astForNode(node.expression)
   }
 
   private def createBuiltinStaticCall(callExpr: FunctionCallExprSyntax, callee: ExprSyntax, fullName: String): Ast = {
@@ -222,17 +222,17 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
           base match {
             case None =>
               // referencing implicit this
-              val receiverAst = astForNodeWithFunctionReference(callee)
+              val receiverAst = astForNode(callee)
               val baseNode    = identifierNode(m, "this")
               scope.addVariableReference("this", baseNode, Defines.Any, EvaluationStrategies.BY_REFERENCE)
               (receiverAst, baseNode, code(member))
             case Some(d: DeclReferenceExprSyntax) if code(d) == "this" || code(d) == "self" =>
-              val receiverAst = astForNodeWithFunctionReference(callee)
+              val receiverAst = astForNode(callee)
               val baseNode    = identifierNode(d, code(d))
               scope.addVariableReference(code(d), baseNode, Defines.Any, EvaluationStrategies.BY_REFERENCE)
               (receiverAst, baseNode, code(member))
             case Some(d: DeclReferenceExprSyntax) =>
-              val receiverAst = astForNodeWithFunctionReference(callee)
+              val receiverAst = astForNode(callee)
               val baseNode    = identifierNode(d, code(d))
               scope.addVariableReference(code(d), baseNode, Defines.Any, EvaluationStrategies.BY_REFERENCE)
               (receiverAst, baseNode, code(member))
@@ -240,7 +240,7 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
               val tmpVarName  = scopeLocalUniqueName("tmp")
               val baseTmpNode = identifierNode(otherBase, tmpVarName)
               scope.addVariableReference(tmpVarName, baseTmpNode, Defines.Any, EvaluationStrategies.BY_REFERENCE)
-              val baseAst   = astForNodeWithFunctionReference(otherBase)
+              val baseAst   = astForNode(otherBase)
               val codeField = s"(${codeOf(baseTmpNode)} = ${codeOf(baseAst.nodes.head)})"
               val tmpAssignmentAst =
                 createAssignmentCallAst(Ast(baseTmpNode), baseAst, codeField, line(otherBase), column(otherBase))
@@ -251,7 +251,7 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
               (fieldAccessAst, thisTmpNode, code(member))
           }
         case _ =>
-          val receiverAst = astForNodeWithFunctionReference(callee)
+          val receiverAst = astForNode(callee)
           val thisNode    = identifierNode(callee, "this")
           scope.addVariableReference(thisNode.name, thisNode, Defines.Any, EvaluationStrategies.BY_REFERENCE)
           (receiverAst, thisNode, calleeCode)
@@ -278,15 +278,15 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
 
   private def astForInOutExprSyntax(node: InOutExprSyntax): Ast = {
     val op        = Defines.PrefixOperatorMap(code(node.ampersand))
-    val argAst    = astForNodeWithFunctionReference(node.expression)
+    val argAst    = astForNode(node.expression)
     val callNode_ = callNode(node, code(node), op, DispatchTypes.STATIC_DISPATCH)
     callAst(callNode_, List(argAst))
   }
 
   private def astForInfixOperatorExprSyntax(node: InfixOperatorExprSyntax): Ast = {
     val op        = Defines.InfixOperatorMap(code(node.operator))
-    val lhsAst    = astForNodeWithFunctionReference(node.leftOperand)
-    val rhsAst    = astForNodeWithFunctionReference(node.rightOperand)
+    val lhsAst    = astForNode(node.leftOperand)
+    val rhsAst    = astForNode(node.rightOperand)
     val callNode_ = callNode(node, code(node), op, DispatchTypes.STATIC_DISPATCH)
     val argAsts   = List(lhsAst, rhsAst)
     callAst(callNode_, argAsts)
@@ -297,7 +297,7 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
   }
 
   private def astForIsExprSyntax(node: IsExprSyntax): Ast = {
-    val lhsAst    = astForNodeWithFunctionReference(node.expression)
+    val lhsAst    = astForNode(node.expression)
     val rhsAst    = astForNode(node.`type`)
     val callNode_ = callNode(node, code(node), Operators.instanceOf, DispatchTypes.STATIC_DISPATCH)
     val argAsts   = List(lhsAst, rhsAst)
@@ -309,7 +309,7 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
   private def astForMacroExpansionExprSyntax(node: MacroExpansionExprSyntax): Ast = {
     val name = code(node.macroName)
     val argAsts = astForNode(node.arguments) +:
-      node.trailingClosure.toList.map(astForNodeWithFunctionReference) :+
+      node.trailingClosure.toList.map(astForNode) :+
       astForNode(node.additionalTrailingClosures)
     val callNode =
       NewCall()
@@ -337,7 +337,7 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
         scope.addVariableReference(code(d), baseNode, Defines.Any, EvaluationStrategies.BY_REFERENCE)
         Ast(baseNode)
       case Some(otherBase) =>
-        astForNodeWithFunctionReference(otherBase)
+        astForNode(otherBase)
     }
 
     member.baseName match {
@@ -358,15 +358,15 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
   }
 
   private def astForOptionalChainingExprSyntax(node: OptionalChainingExprSyntax): Ast = {
-    astForNodeWithFunctionReference(node.expression)
+    astForNode(node.expression)
   }
 
   private def astForPackElementExprSyntax(node: PackElementExprSyntax): Ast = {
-    astForNodeWithFunctionReference(node.pack)
+    astForNode(node.pack)
   }
 
   private def astForPackExpansionExprSyntax(node: PackExpansionExprSyntax): Ast = {
-    astForNodeWithFunctionReference(node.repetitionPattern)
+    astForNode(node.repetitionPattern)
   }
 
   private def astForPatternExprSyntax(node: PatternExprSyntax): Ast = {
@@ -418,14 +418,14 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
   private def astForPostfixOperatorExprSyntax(node: PostfixOperatorExprSyntax): Ast = {
     val operatorMethod = Defines.PostfixOperatorMap(code(node.operator))
     val unaryCall      = callNode(node, code(node), operatorMethod, operatorMethod, DispatchTypes.STATIC_DISPATCH)
-    val expressionAst  = astForNodeWithFunctionReference(node.expression)
+    val expressionAst  = astForNode(node.expression)
     callAst(unaryCall, List(expressionAst))
   }
 
   private def astForPrefixOperatorExprSyntax(node: PrefixOperatorExprSyntax): Ast = {
     val operatorMethod = Defines.PrefixOperatorMap(code(node.operator))
     val unaryCall      = callNode(node, code(node), operatorMethod, operatorMethod, DispatchTypes.STATIC_DISPATCH)
-    val expressionAst  = astForNodeWithFunctionReference(node.expression)
+    val expressionAst  = astForNode(node.expression)
     callAst(unaryCall, List(expressionAst))
   }
 
@@ -444,7 +444,7 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
   }
 
   private def astForSubscriptCallExprSyntax(node: SubscriptCallExprSyntax): Ast = {
-    val baseAst   = astForNodeWithFunctionReference(node.calledExpression)
+    val baseAst   = astForNode(node.calledExpression)
     val memberAst = astForNode(node.arguments)
     val additionalArgsAsts = node.trailingClosure.toList.map(astForNode) ++
       node.additionalTrailingClosures.children.map(c => astForNode(c.closure))
@@ -462,13 +462,13 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
         val (tAsts, flowAst) = s.label match {
           case i: SwitchCaseLabelSyntax =>
             val children         = i.caseItems.children
-            val childrenTestAsts = children.map(c => astForNodeWithFunctionReference(c.pattern))
+            val childrenTestAsts = children.map(c => astForNode(c.pattern))
             val childrenFlowAsts = children.collect {
               case child if child.whereClause.isDefined =>
                 val whereClause = child.whereClause.get
                 val ifNode =
                   controlStructureNode(whereClause.condition, ControlStructureTypes.IF, code(whereClause.condition))
-                val whereAst = astForNodeWithFunctionReference(whereClause)
+                val whereAst = astForNode(whereClause)
                 val whereClauseCallNode = callNode(
                   whereClause.condition,
                   s"!(${code(whereClause.condition)})",
@@ -509,7 +509,7 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     // The semantics of switch statement children is partially defined by their order value.
     // The blockAst must have order == 2. Only to avoid collision we set switchExpressionAst to 1
     // because the semantics of it is already indicated via the condition edge.
-    val switchExpressionAst = astForNodeWithFunctionReference(node.subject)
+    val switchExpressionAst = astForNode(node.subject)
     setOrderExplicitly(switchExpressionAst, 1)
 
     val blockNode_ = blockNode(node).order(2)
@@ -529,9 +529,9 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     val name = Operators.conditional
     val call = callNode(node, code(node), name, DispatchTypes.STATIC_DISPATCH)
 
-    val condAst = astForNodeWithFunctionReference(node.condition)
-    val posAst  = astForNodeWithFunctionReference(node.thenExpression)
-    val negAst  = astForNodeWithFunctionReference(node.elseExpression)
+    val condAst = astForNode(node.condition)
+    val posAst  = astForNode(node.thenExpression)
+    val negAst  = astForNode(node.elseExpression)
 
     val children = List(condAst, posAst, negAst)
     callAst(call, children)
@@ -546,7 +546,7 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
   private def astForTupleExprSyntax(node: TupleExprSyntax): Ast = {
     node.elements.children.toList match {
       case Nil         => astForListLikeExpr(node, Seq.empty)
-      case head :: Nil => astForNodeWithFunctionReference(head)
+      case head :: Nil => astForNode(head)
       case other       => astForListLikeExpr(node, other)
     }
   }

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForPatternSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForPatternSyntaxCreator.scala
@@ -12,7 +12,7 @@ trait AstForPatternSyntaxCreator(implicit withSchemaValidation: ValidationMode) 
   this: AstCreator =>
 
   private def astForExpressionPatternSyntax(node: ExpressionPatternSyntax): Ast = {
-    astForNodeWithFunctionReference(node.expression)
+    astForNode(node.expression)
   }
 
   private def astForIdentifierPatternSyntax(node: IdentifierPatternSyntax): Ast = {

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForStmtSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForStmtSyntaxCreator.scala
@@ -70,7 +70,7 @@ trait AstForStmtSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
   }
 
   private def astForExpressionStmtSyntax(node: ExpressionStmtSyntax): Ast = {
-    astForNodeWithFunctionReference(node.expression)
+    astForNode(node.expression)
   }
 
   private def astForFallThroughStmtSyntax(node: FallThroughStmtSyntax): Ast = {
@@ -104,7 +104,7 @@ trait AstForStmtSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
   }
 
   private def astForForStmtSyntaxWithWildcard(node: ForStmtSyntax): Ast = {
-    val initAsts = Seq(astForNodeWithFunctionReference(node.sequence))
+    val initAsts = Seq(astForNode(node.sequence))
     val bodyAst  = astForForStmtBody(node)
     val forNode  = controlStructureNode(node, ControlStructureTypes.FOR, code(node))
     forAst(forNode, Nil, initAsts, Nil, Nil, bodyAst)
@@ -139,7 +139,7 @@ trait AstForStmtSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
       // TODO: add operator to schema
       callNode(node, s"<operator>.iterator($collectionName)", "<operator>.iterator", DispatchTypes.STATIC_DISPATCH)
 
-    val objectKeysCallArgs = List(astForNodeWithFunctionReference(collection))
+    val objectKeysCallArgs = List(astForNode(collection))
     val objectKeysCallAst  = callAst(iteratorCall, objectKeysCallArgs)
 
     val iteratorAssignmentNode =
@@ -272,7 +272,7 @@ trait AstForStmtSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
       // TODO: add operator to schema
       callNode(node, s"<operator>.iterator($collectionName)", "<operator>.iterator", DispatchTypes.STATIC_DISPATCH)
 
-    val objectKeysCallArgs = List(astForNodeWithFunctionReference(collection))
+    val objectKeysCallArgs = List(astForNode(collection))
     val objectKeysCallAst  = callAst(iteratorCall, objectKeysCallArgs)
 
     val iteratorAssignmentNode =
@@ -395,7 +395,7 @@ trait AstForStmtSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     val iteratorCall =
       callNode(node, s"<operator>.iterator($collectionName)", "<operator>.iterator", DispatchTypes.STATIC_DISPATCH)
 
-    val objectKeysCallArgs = List(astForNodeWithFunctionReference(collection))
+    val objectKeysCallArgs = List(astForNode(collection))
     val objectKeysCallAst  = callAst(iteratorCall, objectKeysCallArgs)
 
     val iteratorAssignmentNode =
@@ -540,7 +540,7 @@ trait AstForStmtSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     val blockNode_  = blockNode(node)
     scope.pushNewBlockScope(blockNode_)
     localAstParentStack.push(blockNode_)
-    val bodyAst = astForNodeWithFunctionReference(node.statement)
+    val bodyAst = astForNode(node.statement)
     scope.popScope()
     localAstParentStack.pop()
     blockAst(blockNode_, List(Ast(labeledNode), bodyAst))
@@ -552,7 +552,7 @@ trait AstForStmtSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     val code = this.code(node)
     // In Swift, a repeat-while loop is semantically the same as a C do-while loop
     val doNode       = controlStructureNode(node, ControlStructureTypes.DO, code)
-    val conditionAst = astForNodeWithFunctionReference(node.condition)
+    val conditionAst = astForNode(node.condition)
     val bodyAst      = astForNode(node.body)
     setOrderExplicitly(conditionAst, 1)
     setOrderExplicitly(bodyAst, 2)
@@ -563,7 +563,7 @@ trait AstForStmtSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     val cpgReturn = returnNode(node, code(node))
     node.expression match {
       case Some(value) =>
-        val expr = astForNodeWithFunctionReference(value)
+        val expr = astForNode(value)
         val ast  = Ast(cpgReturn).withChild(expr)
         expr.root match {
           case Some(value) => ast.withArgEdge(cpgReturn, value)
@@ -579,13 +579,13 @@ trait AstForStmtSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
   private def astForThrowStmtSyntax(node: ThrowStmtSyntax): Ast = {
     val op        = "<operator>.throw"
     val callNode_ = callNode(node, code(node), op, op, DispatchTypes.STATIC_DISPATCH)
-    val exprAst   = astForNodeWithFunctionReference(node.expression)
+    val exprAst   = astForNode(node.expression)
     callAst(callNode_, List(exprAst))
   }
 
   private def astForWhileStmtSyntax(node: WhileStmtSyntax): Ast = {
     val code         = this.code(node)
-    val conditionAst = astForNodeWithFunctionReference(node.conditions)
+    val conditionAst = astForNode(node.conditions)
     val bodyAst      = astForNode(node.body)
     setOrderExplicitly(conditionAst, 1)
     setOrderExplicitly(bodyAst, 2)
@@ -600,7 +600,7 @@ trait AstForStmtSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
 
   private def astForYieldStmtSyntax(node: YieldStmtSyntax): Ast = {
     val cpgReturn = returnNode(node, code(node))
-    val expr      = astForNodeWithFunctionReference(node.yieldedExpressions)
+    val expr      = astForNode(node.yieldedExpressions)
     val ast       = Ast(cpgReturn).withChild(expr)
     expr.root match {
       case Some(value) => ast.withArgEdge(cpgReturn, value)

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForSyntaxCollectionCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForSyntaxCollectionCreator.scala
@@ -111,7 +111,9 @@ trait AstForSyntaxCollectionCreator(implicit withSchemaValidation: ValidationMod
     astForListSyntaxChildren(node, node.children)
   }
 
-  private def astForObjCSelectorPieceListSyntax(node: ObjCSelectorPieceListSyntax): Ast     = notHandledYet(node)
+  private def astForObjCSelectorPieceListSyntax(node: ObjCSelectorPieceListSyntax): Ast =
+    node.children.headOption.map(astForNode).getOrElse(Ast())
+
   private def astForPatternBindingListSyntax(node: PatternBindingListSyntax): Ast           = notHandledYet(node)
   private def astForPlatformVersionItemListSyntax(node: PlatformVersionItemListSyntax): Ast = notHandledYet(node)
   private def astForPrecedenceGroupAttributeListSyntax(node: PrecedenceGroupAttributeListSyntax): Ast = notHandledYet(

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForSyntaxCollectionCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForSyntaxCollectionCreator.scala
@@ -15,7 +15,7 @@ trait AstForSyntaxCollectionCreator(implicit withSchemaValidation: ValidationMod
   protected def astForListSyntaxChildren(node: SwiftNode, children: Seq[SwiftNode]): Ast = {
     children.toList match {
       case Nil         => Ast()
-      case head :: Nil => astForNodeWithFunctionReference(head)
+      case head :: Nil => astForNode(head)
       case elements =>
         val blockNode_ = blockNode(node, PropertyDefaults.Code, Defines.Any)
         scope.pushNewBlockScope(blockNode_)
@@ -124,10 +124,10 @@ trait AstForSyntaxCollectionCreator(implicit withSchemaValidation: ValidationMod
 
   private def astForSimpleStringLiteralSegmentListSyntax(node: SimpleStringLiteralSegmentListSyntax): Ast = {
     node.children match {
-      case child :: Nil => astForNodeWithFunctionReference(child)
+      case child :: Nil => astForNode(child)
       case children =>
         val stringFormatCall = callNode(node, code(node), Operators.formatString, DispatchTypes.STATIC_DISPATCH)
-        val childrenAsts     = children.map(astForNodeWithFunctionReference)
+        val childrenAsts     = children.map(astForNode)
         setArgumentIndices(childrenAsts)
         callAst(stringFormatCall, childrenAsts)
     }
@@ -139,10 +139,10 @@ trait AstForSyntaxCollectionCreator(implicit withSchemaValidation: ValidationMod
 
   private def astForStringLiteralSegmentListSyntax(node: StringLiteralSegmentListSyntax): Ast = {
     node.children match {
-      case child :: Nil => astForNodeWithFunctionReference(child)
+      case child :: Nil => astForNode(child)
       case children =>
         val stringFormatCall = callNode(node, code(node), Operators.formatString, DispatchTypes.STATIC_DISPATCH)
-        val childrenAsts     = children.map(astForNodeWithFunctionReference)
+        val childrenAsts     = children.map(astForNode)
         setArgumentIndices(childrenAsts)
         callAst(stringFormatCall, childrenAsts)
     }

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForSyntaxCreator.scala
@@ -285,7 +285,10 @@ trait AstForSyntaxCreator(implicit withSchemaValidation: ValidationMode) { this:
 
   private def astForMultipleTrailingClosureElementSyntax(node: MultipleTrailingClosureElementSyntax): Ast =
     notHandledYet(node)
-  private def astForObjCSelectorPieceSyntax(node: ObjCSelectorPieceSyntax): Ast = notHandledYet(node)
+
+  private def astForObjCSelectorPieceSyntax(node: ObjCSelectorPieceSyntax): Ast =
+    Ast(literalNode(node, code(node), Option(Defines.String)))
+
   private def astForOpaqueReturnTypeOfAttributeArgumentsSyntax(node: OpaqueReturnTypeOfAttributeArgumentsSyntax): Ast =
     notHandledYet(node)
   private def astForOperatorPrecedenceAndTypesSyntax(node: OperatorPrecedenceAndTypesSyntax): Ast = notHandledYet(node)

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForSyntaxCreator.scala
@@ -44,13 +44,13 @@ trait AstForSyntaxCreator(implicit withSchemaValidation: ValidationMode) { this:
   }
 
   private def astForArrayElementSyntax(node: ArrayElementSyntax): Ast = {
-    astForNodeWithFunctionReference(node.expression)
+    astForNode(node.expression)
   }
 
   private def astForAttributeSyntax(node: AttributeSyntax): Ast = {
     val argumentAsts = node.arguments match {
       case Some(argument) =>
-        val argumentAst    = astForNodeWithFunctionReference(argument)
+        val argumentAst    = astForNode(argument)
         val parameter      = NewAnnotationParameter().code("argument")
         val assign         = NewAnnotationParameterAssign().code(code(argument))
         val assignChildren = List(Ast(parameter), argumentAst)
@@ -135,7 +135,7 @@ trait AstForSyntaxCreator(implicit withSchemaValidation: ValidationMode) { this:
   private def astForClosureSignatureSyntax(node: ClosureSignatureSyntax): Ast = notHandledYet(node)
 
   private def astForCodeBlockItemSyntax(node: CodeBlockItemSyntax): Ast = {
-    astForNodeWithFunctionReferenceAndCall(node.item)
+    astForNode(node.item)
   }
   private def astForCodeBlockSyntax(node: CodeBlockSyntax): Ast = {
     astForNode(node.statements)
@@ -248,7 +248,7 @@ trait AstForSyntaxCreator(implicit withSchemaValidation: ValidationMode) { this:
   private def astForInheritedTypeSyntax(node: InheritedTypeSyntax): Ast             = notHandledYet(node)
 
   private def astForInitializerClauseSyntax(node: InitializerClauseSyntax): Ast = {
-    astForNodeWithFunctionReference(node.value)
+    astForNode(node.value)
   }
 
   private def astForKeyPathComponentSyntax(node: KeyPathComponentSyntax): Ast                   = notHandledYet(node)
@@ -260,10 +260,10 @@ trait AstForSyntaxCreator(implicit withSchemaValidation: ValidationMode) { this:
     node.label match {
       case Some(label) =>
         val name = code(label)
-        val ast  = astForNodeWithFunctionReference(node.expression)
+        val ast  = astForNode(node.expression)
         ast.root.collect { case i: ExpressionNew => i.argumentName(name) }
         ast
-      case None => astForNodeWithFunctionReference(node.expression)
+      case None => astForNode(node.expression)
     }
   }
 
@@ -357,7 +357,7 @@ trait AstForSyntaxCreator(implicit withSchemaValidation: ValidationMode) { this:
         val blockNode_ = blockNode(node, PropertyDefaults.Code, Defines.Any)
         scope.pushNewBlockScope(blockNode_)
         localAstParentStack.push(blockNode_)
-        val childrenAst = astForNodeWithFunctionReference(head)
+        val childrenAst = astForNode(head)
         localAstParentStack.pop()
         scope.popScope()
         blockAst(blockNode_, List(childrenAst))
@@ -398,7 +398,7 @@ trait AstForSyntaxCreator(implicit withSchemaValidation: ValidationMode) { this:
   private def astForVersionTupleSyntax(node: VersionTupleSyntax): Ast         = notHandledYet(node)
 
   private def astForWhereClauseSyntax(node: WhereClauseSyntax): Ast = {
-    astForNodeWithFunctionReference(node.condition)
+    astForNode(node.condition)
   }
 
   private def astForYieldedExpressionSyntax(node: YieldedExpressionSyntax): Ast               = notHandledYet(node)

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstNodeBuilder.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstNodeBuilder.scala
@@ -6,9 +6,7 @@ import io.joern.x2cpg.Ast
 import io.joern.x2cpg.ValidationMode
 import io.joern.x2cpg.frontendspecific.swiftsrc2cpg.Defines
 import io.shiftleft.codepropertygraph.generated.nodes.*
-import io.shiftleft.codepropertygraph.generated.DispatchTypes
-import io.shiftleft.codepropertygraph.generated.ModifierTypes
-import io.shiftleft.codepropertygraph.generated.Operators
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes, ModifierTypes, Operators}
 
 trait AstNodeBuilder(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
@@ -248,6 +246,12 @@ trait AstNodeBuilder(implicit withSchemaValidation: ValidationMode) { this: AstC
       )
     Ast.storeInDiffGraph(Ast(functionTypeDeclNode), diffGraph)
 
+    val parentTypeDeclNode = methodAstParentStack.find(_.isInstanceOf[NewTypeDecl])
+    parentTypeDeclNode.foreach { typeDeclNode =>
+      val typeDeclFunctionBinding = NewBinding().name("").signature("")
+      diffGraph.addEdge(typeDeclNode, typeDeclFunctionBinding, EdgeTypes.BINDS)
+      diffGraph.addEdge(typeDeclFunctionBinding, methodNode, EdgeTypes.REF)
+    }
     val bindingNode = NewBinding().name("").signature("")
     Ast(functionTypeDeclNode).withBindsEdge(functionTypeDeclNode, bindingNode).withRefEdge(bindingNode, methodNode)
   }

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/ActorTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/ActorTests.scala
@@ -16,7 +16,7 @@ class ActorTests extends AstSwiftSrc2CpgSuite {
       val List(myActor1) = cpg.typeDecl.nameExact("MyActor1").l
       myActor1.fullName shouldBe "Test0.swift:<global>:MyActor1"
       myActor1.member shouldBe empty
-      myActor1.boundMethod shouldBe empty
+      myActor1.boundMethod.fullName.l shouldBe List("Test0.swift:<global>:MyActor1:<init>")
     }
 
     "testActor2" in {
@@ -31,7 +31,8 @@ class ActorTests extends AstSwiftSrc2CpgSuite {
       val List(constructor) = myActor2.method.isConstructor.l
       constructor.name shouldBe "init"
       constructor.fullName shouldBe "Test0.swift:<global>:MyActor2:init:Test0.swift:<global>:MyActor2()"
-      val List(hello) = myActor2.boundMethod.l
+      val List(init, hello) = myActor2.boundMethod.l
+      init shouldBe constructor
       hello.name shouldBe "hello"
       hello.fullName shouldBe "Test0.swift:<global>:MyActor2:hello:ANY()"
     }

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/AsyncTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/AsyncTests.scala
@@ -91,8 +91,9 @@ class AsyncTests extends AstSwiftSrc2CpgSuite {
       |struct MyFuture {
       |  func await() -> Int { 0 }
       |}""".stripMargin)
-      val List(struct) = cpg.typeDecl.nameExact("MyFuture").l
-      val List(await)  = struct.boundMethod.l
+      val List(struct)      = cpg.typeDecl.nameExact("MyFuture").l
+      val List(init, await) = struct.boundMethod.l
+      init.fullName shouldBe "Test0.swift:<global>:MyFuture:<init>"
       await.name shouldBe "await"
       await.fullName shouldBe "Test0.swift:<global>:MyFuture:await:Int()"
       await.methodReturn.typeFullName shouldBe "Int"

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -161,6 +161,28 @@ class SimpleAstCreationPassTest extends AstSwiftSrc2CpgSuite {
       }
     }
 
+    "have correct structure for objc annotated class" in {
+      val cpg = code("""
+          |@objc(Foo)
+          |public class Foo {}
+          |""".stripMargin)
+      inside(cpg.typeDecl.nameExact("Foo").annotation.l) { case List(objc) =>
+        objc.code shouldBe "@objc(Foo)"
+        objc.name shouldBe "objc"
+        objc.fullName shouldBe "objc"
+        val List(paramAssignFoo) = objc.parameterAssign.l
+        paramAssignFoo.code shouldBe "Foo"
+        paramAssignFoo.order shouldBe 1
+        val List(paramFoo) = paramAssignFoo.parameter.l
+        paramFoo.code shouldBe "argument"
+        paramFoo.order shouldBe 1
+        val List(paramValueFoo) = paramAssignFoo.value.l
+        paramValueFoo.code shouldBe "Foo"
+        paramValueFoo.order shouldBe 2
+        paramValueFoo.argumentIndex shouldBe 2
+      }
+    }
+
     "have correct structure for named call arguments" in {
       val cpg = code("""
           |func logMessage(message: String, prefix: String, suffix: String) {

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -121,7 +121,7 @@ class SimpleAstCreationPassTest extends AstSwiftSrc2CpgSuite {
       val List(fooMethod)      = cpg.method.nameExact("foo").l
       val List(fooBlock)       = fooMethod.astChildren.isBlock.l
       val List(fooLocalX)      = fooBlock.astChildren.isLocal.nameExact("x").l
-      val List(barRef)         = fooBlock.astChildren.isCall.astChildren.isMethodRef.l
+      val List(barRef)         = fooBlock.astChildren.isMethodRef.l
       val List(closureBinding) = barRef.captureOut.l
       closureBinding.closureBindingId shouldBe Option("Test0.swift:<global>:foo:bar:x")
       closureBinding.refOut.head shouldBe fooLocalX

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/ToplevelLibraryTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/ToplevelLibraryTests.scala
@@ -32,7 +32,7 @@ class ToplevelLibraryTests extends AstSwiftSrc2CpgSuite {
       |{ }
       |({ 5 }())
       |""".stripMargin)
-      cpg.call.code.sorted.l shouldBe List("func <lambda>0 = { }", "let x = 42", "x + x", "x + x", "{ 5 }()")
+      cpg.call.code.sorted.l shouldBe List("let x = 42", "x + x", "x + x", "{ 5 }()")
       cpg.method.fullName.sorted.l shouldBe List(
         "<operator>.addition",
         "<operator>.assignment",


### PR DESCRIPTION
Swift does not support defining classes _on the fly_ at the position of an expression.
All types must be declared in advance, either globally or locally (inside a function), but not as anonymous or inline types. Hence, we never need typerefs there.
