### PR TITLE
move walkUpAst and walkUpContains into companion object of CfgNodeMethods

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
@@ -123,14 +123,14 @@ class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
 
 object CfgNodeMethods {
 
-  /** Attention: this only works for some special CfgNodes that are guaranteed to always be direct children of a method
-    * \- that's why it's private!
+  /** Attention: this only works for some special CfgNodes that are guaranteed to always be direct children of a
+    * method... that's why it's private!
     */
   private def walkUpAst(node: CfgNode): Method =
     node.astParent.asInstanceOf[Method]
 
-  /** Attention: this only works for some special CfgNodes that are guaranteed to always be direct children of a method
-    * \- that's why it's private!
+  /** Attention: this only works for some special CfgNodes that are guaranteed to always be direct children of a
+    * method... that's why it's private!
     */
   private def walkUpContains(node: StoredNode): Method = {
     node._containsIn.loneElement("trying to walk `containsIn` edge") match {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
@@ -123,13 +123,15 @@ class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
 
 object CfgNodeMethods {
 
-  /** Attention: this only works for some special CfgNodes that are guaranteed to always
-    * be direct children of a method - that's why it's private! */
+  /** Attention: this only works for some special CfgNodes that are guaranteed to always be direct children of a method
+    * \- that's why it's private!
+    */
   private def walkUpAst(node: CfgNode): Method =
     node.astParent.asInstanceOf[Method]
 
-  /** Attention: this only works for some special CfgNodes that are guaranteed to always
-    * be direct children of a method - that's why it's private! */
+  /** Attention: this only works for some special CfgNodes that are guaranteed to always be direct children of a method
+    * \- that's why it's private!
+    */
   private def walkUpContains(node: StoredNode): Method = {
     node._containsIn.loneElement("trying to walk `containsIn` edge") match {
       case method: Method => method

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
@@ -129,7 +129,8 @@ object CfgNodeMethods {
   private def walkUpAst(node: CfgNode): Method =
     node.astParent.asInstanceOf[Method]
 
-  /** Attention: this only works for those `CfgNodes` that have `CONTAINS` edges (see `ContainsEdgePass`)... that's why it's private! 
+  /** Attention: this only works for those `CfgNodes` that have `CONTAINS` edges (see `ContainsEdgePass`)... that's why
+    * it's private!
     */
   private def walkUpContains(node: StoredNode): Method = {
     node._containsIn.loneElement("trying to walk `containsIn` edge") match {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
@@ -123,10 +123,14 @@ class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
 
 object CfgNodeMethods {
 
-  def walkUpAst(node: CfgNode): Method =
+  /** Attention: this only works for some special CfgNodes that are guaranteed to always
+    * be direct children of a method - that's why it's private! */
+  private def walkUpAst(node: CfgNode): Method =
     node.astParent.asInstanceOf[Method]
 
-  def walkUpContains(node: StoredNode): Method = {
+  /** Attention: this only works for some special CfgNodes that are guaranteed to always
+    * be direct children of a method - that's why it's private! */
+  private def walkUpContains(node: StoredNode): Method = {
     node._containsIn.loneElement("trying to walk `containsIn` edge") match {
       case method: Method => method
       case typeDecl: TypeDecl =>

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
@@ -129,8 +129,7 @@ object CfgNodeMethods {
   private def walkUpAst(node: CfgNode): Method =
     node.astParent.asInstanceOf[Method]
 
-  /** Attention: this only works for some special CfgNodes that are guaranteed to always be direct children of a
-    * method... that's why it's private!
+  /** Attention: this only works for those `CfgNodes` that have `CONTAINS` edges (see `ContainsEdgePass`)... that's why it's private! 
     */
   private def walkUpContains(node: StoredNode): Method = {
     node._containsIn.loneElement("trying to walk `containsIn` edge") match {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
@@ -7,6 +7,7 @@ import io.shiftleft.semanticcpg.language.*
 import scala.jdk.CollectionConverters.*
 
 class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
+  import CfgNodeMethods.*
 
   /** Successors in the CFG
     */
@@ -118,10 +119,14 @@ class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
     node.lineNumber.map(_.toLong.toHexString)
   }
 
-  private def walkUpAst(node: CfgNode): Method =
+}
+
+object CfgNodeMethods {
+
+  def walkUpAst(node: CfgNode): Method =
     node.astParent.asInstanceOf[Method]
 
-  private def walkUpContains(node: StoredNode): Method =
+  def walkUpContains(node: StoredNode): Method = {
     node._containsIn.loneElement("trying to walk `containsIn` edge") match {
       case method: Method => method
       case typeDecl: TypeDecl =>
@@ -137,5 +142,6 @@ class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
             null
         }
     }
+  }
 
 }


### PR DESCRIPTION
* these don't work on the node of the value class, so it's rather
  confusing
* their code was copied without changes in codescience, this way we can
  reuse it