### PR TITLE
[JoernExport] fix bug when dump cpg to neo4jcsv with joernexport

### DIFF
--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernExport.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernExport.scala
@@ -153,6 +153,7 @@ object JoernExport {
               windowsFilenameDeduplicationHelper
             )
             val outFileName = outDir.resolve(relativeFilename)
+            Files.createDirectories(outFileName)
             exporter.runExport(cpg.graph.schema, nodes, subGraph.edges, outFileName)
           }
           .reduce(plus)


### PR DESCRIPTION
Issue 5593
`joern-export cpg.bin --repr cpg --format neo4jcsv --out neo4j-import`

The code for creating the directory is missing before generating the csv, will cause `java.io.FileNotFoundException`