### PR TITLE
Use indexAccess operator for php field access calls with arbitrary expressions

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
@@ -517,7 +517,6 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
 
     val fieldAst = fieldName match {
       case None =>
-        logger.debug(s"Unable to determine field identifier node from ${fieldNode.getClass} (parent node $expr)")
         astForExpr(fieldNode)
       case Some(name) => Ast(fieldIdentifierNode(expr, name.stripPrefix("$"), name))
     }

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
@@ -524,7 +524,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
 
     val operatorName = fieldName match {
       case Some(_) => Operators.fieldAccess
-      case None => Operators.indexAccess
+      case None    => Operators.indexAccess
     }
 
     val accessSymbol =
@@ -532,9 +532,13 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
       else if (expr.isNullsafe) s"?$InstanceMethodDelimiter"
       else InstanceMethodDelimiter
 
-    val targetAst       = astForExpr(expr.expr)
-    val targetCode      = targetAst.rootCodeOrEmpty
-    val code            = s"$targetCode$accessSymbol${fieldAst.rootCodeOrEmpty}"
+    val targetAst  = astForExpr(expr.expr)
+    val targetCode = targetAst.rootCodeOrEmpty
+    val fieldAstCode = fieldName match {
+      case Some(_) => fieldAst.rootCodeOrEmpty
+      case None    => s"{${fieldAst.rootCodeOrEmpty}}"
+    }
+    val code            = s"$targetCode$accessSymbol$fieldAstCode"
     val fieldAccessNode = operatorCallNode(expr, code, operatorName, None)
     callAst(fieldAccessNode, Seq(targetAst, fieldAst))
   }


### PR DESCRIPTION
This PR changes the representation for php property accesses with arbitrary expressions on the RHS, for example:
```
$obj->{foo()}
```

Previously, these were represented as field access calls, but this causes a crash in the back-end since it breaks the assumption that a field access calls have an identifier or field identifier as the second argument. Instead, these are now represented as index access calls, per the suggestion from @maltek 