### PR TITLE
[pysrc2cpg] Fix for `from . import Bar`

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/ImportsPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/ImportsPassTests.scala
@@ -102,4 +102,13 @@ class ImportsPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
 
   }
 
+  "For an import from '.', it" should {
+    lazy val cpg = code("from . import Bar")
+    "create an IMPORT node" in {
+      val List(importNode) = cpg.imports.l
+      importNode.importedEntity shouldBe Some("Bar")
+      importNode.importedAs shouldBe Some("Bar")
+    }
+  }
+
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/pysrc2cpg/ImportsPass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/pysrc2cpg/ImportsPass.scala
@@ -36,7 +36,7 @@ class ImportsPass(cpg: Cpg) extends XImportsPass(cpg) {
             }
           }
           .getOrElse("")
-      case x => x
+      case x => x + s".$what"
     }
   }
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/pysrc2cpg/ImportsPass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/pysrc2cpg/ImportsPass.scala
@@ -14,11 +14,29 @@ class ImportsPass(cpg: Cpg) extends XImportsPass(cpg) {
 
   override def importedEntityFromCall(call: Call): String = {
     call.argument.code.l match {
-      case List("", what)       => what.split('.')(0)
-      case List(where, what)    => s"$where.$what"
+      case List("", what)    => what.split('.')(0)
+      case List(where, what) => s"${resolve(where, what, call)}"
+
       case List("", what, _)    => what
-      case List(where, what, _) => s"$where.$what"
+      case List(where, what, _) => s"${resolve(where, what, call)}"
       case _                    => ""
+    }
+  }
+
+  private def resolve(where: String, what: String, call: Call): String = {
+    where match {
+      case "." =>
+        call.file.name.headOption
+          .map { path =>
+            path.split(".").dropRight(1) match {
+              case Array() =>
+                what
+              case packagePathElems =>
+                packagePathElems.mkString(".") + s".$what"
+            }
+          }
+          .getOrElse("")
+      case x => x
     }
   }
 


### PR DESCRIPTION
In Python, it is possible to create imports of the following form:

```
from . import bar
```

Prior to this commit, this would lead to an imported entity of `..bar`. Now, it is `$package.bar`, where `$package` is the package of the current module.