### PR TITLE
Populate static receiver field for php calls

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreatorHelper.scala
@@ -92,7 +92,7 @@ trait AstCreatorHelper(disableFileContent: Boolean)(implicit withSchemaValidatio
     }
   }
 
-  private def getTypeDeclPrefix: Option[String] =
+  protected def getTypeDeclPrefix: Option[String] =
     scope.getEnclosingTypeDeclTypeName.filterNot(_ == NamespaceTraversal.globalNamespaceName)
 
   protected def codeForMethodCall(call: PhpCallExpr, targetAst: Ast, name: String): String = {

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
@@ -139,7 +139,14 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
       case _                                             => getMfn(call, name)
     }
 
-    val callRoot = callNode(call, code, name, fullName, dispatchType, None, Some(Defines.Any))
+    val staticReceiver = call.target.collect {
+      case nameExpr: PhpNameExpr if nameExpr.name == NameConstants.Self =>
+        getTypeDeclPrefix.map(name => s"$name$MetaTypeDeclExtension")
+      case nameExpr: PhpNameExpr =>
+        Option(s"${nameExpr.name}$MetaTypeDeclExtension")
+    }.flatten
+
+    val callRoot = callNode(call, code, name, fullName, dispatchType, None, Some(Defines.Any), staticReceiver)
 
     callAst(callRoot, arguments)
   }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/CallTests.scala
@@ -143,6 +143,7 @@ class CallTests extends PhpCode2CpgFixture {
       barCall.receiver.isEmpty shouldBe true
       barCall.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
       barCall.code shouldBe "self::bar($x)"
+      barCall.staticReceiver shouldBe Some("ClassA<metaclass>")
     }
   }
 
@@ -337,6 +338,7 @@ class CallTests extends PhpCode2CpgFixture {
       test1.name shouldBe "test1"
       test1.methodFullName shouldBe "Foo\\Bar\\baz<metaclass>.test1"
       test1.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+      test1.staticReceiver shouldBe Some("Foo\\Bar\\baz<metaclass>")
     }
 
     "be unknown in the case of dynamic calls" in {
@@ -344,6 +346,7 @@ class CallTests extends PhpCode2CpgFixture {
       test2.name shouldBe "test2"
       test2.methodFullName shouldBe s"${Defines.UnresolvedNamespace}.test2"
       test2.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
+      test2.staticReceiver shouldBe None
     }
   }
 
@@ -384,5 +387,4 @@ class CallTests extends PhpCode2CpgFixture {
     construct.typeFullName shouldBe Defines.Any
     construct.dynamicTypeHintFullName shouldBe Seq.empty
   }
-
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstNodeBuilder.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstNodeBuilder.scala
@@ -239,7 +239,8 @@ trait AstNodeBuilder[Node, NodeProcessor] { this: NodeProcessor =>
     methodFullName: String,
     dispatchType: String,
     signature: Option[String],
-    typeFullName: Option[String]
+    typeFullName: Option[String],
+    staticReceiver: Option[String] = None
   ): NewCall = {
     val node_ =
       NewCall()
@@ -247,6 +248,7 @@ trait AstNodeBuilder[Node, NodeProcessor] { this: NodeProcessor =>
         .name(name)
         .methodFullName(methodFullName)
         .dispatchType(dispatchType)
+        .staticReceiver(staticReceiver)
         .lineNumber(line(node))
         .columnNumber(column(node))
     signature.foreach { s => node_.signature(s) }


### PR DESCRIPTION
This populates the `STATIC_RECEIVER` property added in https://github.com/ShiftLeftSecurity/codepropertygraph/pull/1830