### PR TITLE
[kotlin2cpg] Fix file content length restriction.

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstCreator.scala
@@ -382,7 +382,7 @@ class AstCreator(
     val declarationsAsts = ktFile.getDeclarations.asScala.flatMap(astsForDeclaration)
     val fileNode         = NewFile().name(fileWithMeta.relativizedPath)
     if (!disableFileContent) {
-      fileNode.content(code(fileWithMeta.f))
+      fileNode.content(fileWithMeta.f.getText)
     }
     val lambdaTypeDecls =
       lambdaBindingInfoQueue.flatMap(_.edgeMeta.collect { case (node: NewTypeDecl, _, _) => Ast(node) })


### PR DESCRIPTION
The kotlin frontend used the `code` function in order to populate the
file content property. That was not a bad idea since the `code` function
limits the returned string length. We now just use the complete string
coming from the kotlin API.
