### PR TITLE
[php] Add `ListExpr` support in foreach loop

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreatorHelper.scala
@@ -213,4 +213,19 @@ trait AstCreatorHelper(disableFileContent: Boolean)(implicit withSchemaValidatio
   }
 
   protected def isBuiltinFunc(name: String): Boolean = PhpBuiltins.FuncNames.contains(name)
+
+  protected def createListExprCodeField(listExpr: PhpListExpr): String = {
+    val name = PhpOperators.listFunc
+    val args = listExpr.items.flatten
+      .map {
+        case PhpArrayItem(_, _ @PhpVariable(name: PhpNameExpr, _), _, _, _) => s"$$${name.name}"
+        case PhpArrayItem(_, value: PhpListExpr, _, _, _)                   => createListExprCodeField(value)
+        case _ =>
+          logger.warn("Invalid arg type for code field")
+          ""
+      }
+      .mkString(",")
+
+    s"$name($args)"
+  }
 }

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreatorHelper.scala
@@ -220,8 +220,8 @@ trait AstCreatorHelper(disableFileContent: Boolean)(implicit withSchemaValidatio
       .map {
         case PhpArrayItem(_, _ @PhpVariable(name: PhpNameExpr, _), _, _, _) => s"$$${name.name}"
         case PhpArrayItem(_, value: PhpListExpr, _, _, _)                   => createListExprCodeField(value)
-        case _ =>
-          logger.warn("Invalid arg type for code field")
+        case x =>
+          logger.warn(s"Invalid arg type for code field: ${x.getClass}")
           ""
       }
       .mkString(",")

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
@@ -147,7 +147,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
         // Rewrite `$xs[] = <value_expr>` as `array_push($xs, <value_expr>)` to simplify finding dataflows.
         astForEmptyArrayDimAssign(assignment, arrayDimFetch)
       case arrayExpr: (PhpArrayExpr | PhpListExpr) =>
-        astForArrayUnpack(assignment, arrayExpr)
+        astForArrayUnpack(assignment, arrayExpr, astForExpr(assignment.source))
       case _ =>
         val operatorName = assignment.assignOp
 
@@ -241,7 +241,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
 
   /** Lower the array/list unpack. For example `[$a, $b] = $arr;` will be lowered to `$a = $arr[0]; $b = $arr[1];`
     */
-  private def astForArrayUnpack(assignment: PhpAssignment, target: PhpArrayExpr | PhpListExpr): Ast = {
+  protected def astForArrayUnpack(assignment: PhpNode, target: PhpArrayExpr | PhpListExpr, sourceAst: Ast): Ast = {
     val loweredAssignNodes = mutable.ListBuffer.empty[Ast]
 
     // create a Identifier ast for given name
@@ -316,7 +316,6 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
       }
     }
 
-    val sourceAst = astForExpr(assignment.source)
     val itemsOf = (exp: PhpArrayExpr | PhpListExpr) =>
       exp match {
         case x: PhpArrayExpr => x.items

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
@@ -33,6 +33,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
       case evalExpr: PhpEvalExpr                       => astForEval(evalExpr)
       case exitExpr: PhpExitExpr                       => astForExit(exitExpr)
       case arrayExpr: PhpArrayExpr                     => astForArrayExpr(arrayExpr)
+      case listExpr: PhpListExpr                       => astForListExpr(listExpr)
       case newExpr: PhpNewExpr                         => astForNewExpr(newExpr)
       case matchExpr: PhpMatchExpr                     => astForMatchExpr(matchExpr)
       case yieldExpr: PhpYieldExpr                     => astForYieldExpr(yieldExpr)
@@ -701,6 +702,39 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
         logger.error(s"ArrayDimFetchExpr without dimensions should be handled in assignment: $errorPosition")
         Ast()
     }
+  }
+
+  private def astForListExpr(expr: PhpListExpr): Ast = {
+    /* TODO: Handling list in a way that will actually work with dataflow tracking is somewhat more complicated than
+     *  this and will likely need a fairly ugly lowering.
+     *
+     * In short, the case:
+     *   list($a, $b) = $arr;
+     * can be lowered to:
+     *   $a = $arr[0];
+     *   $b = $arr[1];
+     *
+     * the case:
+     *   list("id" => $a, "name" => $b) = $arr;
+     * can be lowered to:
+     *   $a = $arr["id"];
+     *   $b = $arr["name"];
+     *
+     * and the case:
+     *   foreach ($arr as list($a, $b)) { ... }
+     * can be lowered as above for each $arr[i];
+     *
+     * The below is just a placeholder to prevent crashes while figuring out the cleanest way to
+     * implement the above lowering or to think of a better way to do it.
+     */
+
+    val name     = PhpOperators.listFunc
+    val args     = expr.items.flatten.map { item => astForExpr(item.value) }
+    val listCode = s"$name(${args.map(_.rootCodeOrEmpty).mkString(",")})"
+    val listNode = operatorCallNode(expr, listCode, name, None)
+      .methodFullName(PhpOperators.listFunc)
+
+    callAst(listNode, args)
   }
 
   private def astForNewExpr(expr: PhpNewExpr): Ast = {

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
@@ -705,29 +705,8 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
   }
 
   private def astForListExpr(expr: PhpListExpr): Ast = {
-    /* TODO: Handling list in a way that will actually work with dataflow tracking is somewhat more complicated than
-     *  this and will likely need a fairly ugly lowering.
-     *
-     * In short, the case:
-     *   list($a, $b) = $arr;
-     * can be lowered to:
-     *   $a = $arr[0];
-     *   $b = $arr[1];
-     *
-     * the case:
-     *   list("id" => $a, "name" => $b) = $arr;
-     * can be lowered to:
-     *   $a = $arr["id"];
-     *   $b = $arr["name"];
-     *
-     * and the case:
-     *   foreach ($arr as list($a, $b)) { ... }
-     * can be lowered as above for each $arr[i];
-     *
-     * The below is just a placeholder to prevent crashes while figuring out the cleanest way to
-     * implement the above lowering or to think of a better way to do it.
-     */
-
+    // This is only used in `AstForControlStructureesCreator::astForForeachStatement:assignItemTargetAst` so that the
+    // code field can be populated.
     val name     = PhpOperators.listFunc
     val args     = expr.items.flatten.map { item => astForExpr(item.value) }
     val listCode = s"$name(${args.map(_.rootCodeOrEmpty).mkString(",")})"

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
@@ -33,7 +33,6 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
       case evalExpr: PhpEvalExpr                       => astForEval(evalExpr)
       case exitExpr: PhpExitExpr                       => astForExit(exitExpr)
       case arrayExpr: PhpArrayExpr                     => astForArrayExpr(arrayExpr)
-      case listExpr: PhpListExpr                       => astForListExpr(listExpr)
       case newExpr: PhpNewExpr                         => astForNewExpr(newExpr)
       case matchExpr: PhpMatchExpr                     => astForMatchExpr(matchExpr)
       case yieldExpr: PhpYieldExpr                     => astForYieldExpr(yieldExpr)
@@ -702,18 +701,6 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
         logger.error(s"ArrayDimFetchExpr without dimensions should be handled in assignment: $errorPosition")
         Ast()
     }
-  }
-
-  private def astForListExpr(expr: PhpListExpr): Ast = {
-    // This is only used in `AstForControlStructureesCreator::astForForeachStatement:assignItemTargetAst` so that the
-    // code field can be populated.
-    val name     = PhpOperators.listFunc
-    val args     = expr.items.flatten.map { item => astForExpr(item.value) }
-    val listCode = s"$name(${args.map(_.rootCodeOrEmpty).mkString(",")})"
-    val listNode = operatorCallNode(expr, listCode, name, None)
-      .methodFullName(PhpOperators.listFunc)
-
-    callAst(listNode, args)
   }
 
   private def astForNewExpr(expr: PhpNewExpr): Ast = {

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/dataflow/IntraMethodDataflowTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/dataflow/IntraMethodDataflowTests.scala
@@ -75,4 +75,34 @@ class IntraMethodDataflowTests extends PhpCode2CpgFixture(runOssDataflow = true)
     val flows  = sink.reachableByFlows(source)
     flows.size shouldBe 2
   }
+
+  "flow from list unpacking in foreach loop" in {
+    val cpg = code(
+      """<?php
+        |foreach($arr as list($a, $b)) {
+        | echo $a;
+        | echo $b;
+        |}
+        |""".stripMargin)
+    val source = cpg.identifier("arr")
+    val sink = cpg.call("echo").argument(1)
+    val flows = sink.reachableByFlows(source)
+    flows.size shouldBe 2
+  }
+
+  "flow from nested list unpacking in foreach loop" in {
+    val cpg = code(
+      """<?php
+        |foreach($arr as list($a, list($b, $c))) {
+        |   echo $a;
+        |   echo $b;
+        |   echo $c;
+        | }
+        |""".stripMargin)
+
+    val source = cpg.identifier("arr")
+    val sink = cpg.call("echo").argument(1)
+    val flows = sink.reachableByFlows(source)
+    flows.size shouldBe 3
+  }
 }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/dataflow/IntraMethodDataflowTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/dataflow/IntraMethodDataflowTests.scala
@@ -77,22 +77,20 @@ class IntraMethodDataflowTests extends PhpCode2CpgFixture(runOssDataflow = true)
   }
 
   "flow from list unpacking in foreach loop" in {
-    val cpg = code(
-      """<?php
+    val cpg = code("""<?php
         |foreach($arr as list($a, $b)) {
         | echo $a;
         | echo $b;
         |}
         |""".stripMargin)
     val source = cpg.identifier("arr")
-    val sink = cpg.call("echo").argument(1)
-    val flows = sink.reachableByFlows(source)
+    val sink   = cpg.call("echo").argument(1)
+    val flows  = sink.reachableByFlows(source)
     flows.size shouldBe 2
   }
 
   "flow from nested list unpacking in foreach loop" in {
-    val cpg = code(
-      """<?php
+    val cpg = code("""<?php
         |foreach($arr as list($a, list($b, $c))) {
         |   echo $a;
         |   echo $b;
@@ -101,8 +99,8 @@ class IntraMethodDataflowTests extends PhpCode2CpgFixture(runOssDataflow = true)
         |""".stripMargin)
 
     val source = cpg.identifier("arr")
-    val sink = cpg.call("echo").argument(1)
-    val flows = sink.reachableByFlows(source)
+    val sink   = cpg.call("echo").argument(1)
+    val flows  = sink.reachableByFlows(source)
     flows.size shouldBe 3
   }
 }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/ControlStructureTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/ControlStructureTests.scala
@@ -1342,7 +1342,6 @@ class ControlStructureTests extends PhpCode2CpgFixture {
     }
 
     "foreach structure" in {
-      cpg.method.name("foo").dotAst.l.foreach(println)
       inside(cpg.method.name("foo").body.astChildren.l) {
         case (iterLocal: Local) :: (aLocal: Local) :: (bLocal: Local) :: (cLocal: Local) :: (foreachStruct: ControlStructure) :: Nil =>
           iterLocal.name shouldBe "foo@iter_tmp-0"
@@ -1484,11 +1483,189 @@ class ControlStructureTests extends PhpCode2CpgFixture {
     }
   }
 
-  "foreach loop with nested list construct" in {
-    val cpg = code(
-      """<?php
-        |foreach($data as list($a, list($b, $c)) {}
-        |""".stripMargin)
+  "foreach loop with nested list construct" should {
+    val cpg = code("""<?php
+                     |function foo($data) {
+                     | foreach($data as list($a, list($b, $c))) {
+                     |   echo $a;
+                     |   echo $b;
+                     | }
+                     |}
+                     |""".stripMargin)
+    def assignmentTests(assignmentCall: Call, variableName: String, tmpIndex: Int, arrayIndex: Int): Unit = {
+      assignmentCall.methodFullName shouldBe Operators.assignment
 
+      inside(assignmentCall.argument.l) { case List(lhsIdent: Identifier, rhsIdxAccess: Call) =>
+        lhsIdent.name shouldBe variableName
+        lhsIdent.code shouldBe s"$$${variableName}"
+
+        rhsIdxAccess.methodFullName shouldBe Operators.indexAccess
+        rhsIdxAccess.code shouldBe s"$$foo@tmp-${tmpIndex}[${arrayIndex}]" // $foo@tmp-0 is the name of the variable holding the current value
+        val List(idxLhs: Identifier, idxRhs: Literal) = rhsIdxAccess.argument.l: @unchecked
+        idxLhs.name shouldBe s"foo@tmp-${tmpIndex}"
+        idxLhs.code shouldBe s"$$foo@tmp-${tmpIndex}"
+      }
+    }
+
+    "foreach structure" in {
+      inside(cpg.method.name("foo").body.astChildren.l) {
+        case (iterLocal: Local) :: (aLocal: Local) :: (bLocal: Local) :: (cLocal: Local) :: (foreachStruct: ControlStructure) :: Nil =>
+          iterLocal.name shouldBe "foo@iter_tmp-0"
+          aLocal.name shouldBe "a"
+          bLocal.name shouldBe "b"
+          cLocal.name shouldBe "c"
+          foreachStruct.code shouldBe "foreach ($data as list($a,list($b,$c)))"
+        case xs => fail(s"Expected five astChildren, got ${xs.code.mkString("[", ",", "]")}")
+      }
+    }
+
+    "Init AST structures" in {
+      inside(cpg.method.name("foo").body.astChildren.isControlStructure.astChildren.l) {
+        case (initAsts: Block) :: _ :: _ :: _ =>
+          inside(initAsts.astChildren.l) { case List(iterInit: Call, valInitBlock: Block) =>
+            iterInit.name shouldBe Operators.assignment
+            iterInit.code shouldBe "$foo@iter_tmp-0 = $data"
+            inside(iterInit.argument.l) { case List(iterTemp: Identifier, iterExpr: Identifier) =>
+              iterTemp.name shouldBe "foo@iter_tmp-0"
+              iterTemp.code shouldBe "$foo@iter_tmp-0"
+              iterTemp.argumentIndex shouldBe 1
+
+              iterExpr.name shouldBe "data"
+              iterExpr.code shouldBe "$data"
+              iterExpr.argumentIndex shouldBe 2
+            }
+
+            val List(valInit: Call, aInit: Call, tmp1Init: Call, tmp2Init: Call, bInit: Call, cInit: Call) =
+              valInitBlock.astChildren.isBlock.astChildren.l: @unchecked
+            valInit.name shouldBe Operators.assignment
+            valInit.code shouldBe "$foo@tmp-0 = $foo@iter_tmp-0->current()"
+            inside(valInit.argument.l) { case List(valId: Identifier, currentCall: Call) =>
+              valId.name shouldBe "foo@tmp-0"
+              valId.code shouldBe "$foo@tmp-0"
+              valId.argumentIndex shouldBe 1
+
+              currentCall.name shouldBe "current"
+              currentCall.methodFullName shouldBe s"Iterator.current"
+              currentCall.code shouldBe "$foo@iter_tmp-0->current()"
+              inside(currentCall.argument(0).start.l) { case List(iterRecv: Identifier) =>
+                iterRecv.name shouldBe "foo@iter_tmp-0"
+                iterRecv.argumentIndex shouldBe 0
+              }
+            }
+
+            tmp2Init.methodFullName shouldBe Operators.assignment
+            tmp2Init.code shouldBe "$foo@tmp-2 = $foo@tmp-1"
+            inside(tmp2Init.argument.l) { case List(lhsIdent: Identifier, rhsIdent: Identifier) =>
+              lhsIdent.name shouldBe "foo@tmp-2"
+              lhsIdent.code shouldBe "$foo@tmp-2"
+
+              rhsIdent.name shouldBe "foo@tmp-1"
+              rhsIdent.code shouldBe "$foo@tmp-1"
+            }
+
+            assignmentTests(aInit, variableName = "a", tmpIndex = 0, arrayIndex = 0)
+            assignmentTests(bInit, variableName = "b", tmpIndex = 2, arrayIndex = 0)
+            assignmentTests(cInit, variableName = "c", tmpIndex = 2, arrayIndex = 1)
+
+            assignmentTests(tmp1Init, variableName = "foo@tmp-1", tmpIndex = 0, arrayIndex = 1)
+          }
+        case xs => fail(s"Expected four children for control structure, got ${xs.code.mkString("[", ",", "]")}")
+      }
+    }
+
+    "Update AST structures" in {
+      inside(cpg.method.name("foo").body.astChildren.isControlStructure.astChildren.l) {
+        case _ :: _ :: (updateAsts: Block) :: (body: Block) :: Nil =>
+          inside(updateAsts.astChildren.l) { case List(nextCall: Call, valAssignBlock: Block) =>
+            nextCall.name shouldBe "next"
+            nextCall.methodFullName shouldBe "Iterator.next"
+            nextCall.code shouldBe "$foo@iter_tmp-0->next()"
+            inside(nextCall.argument(0).start.l) { case List(iterTmp: Identifier) =>
+              iterTmp.name shouldBe "foo@iter_tmp-0"
+              iterTmp.code shouldBe "$foo@iter_tmp-0"
+              iterTmp.argumentIndex shouldBe 0
+            }
+
+            val List(valInit: Call, aInit: Call, tmp1Init: Call, tmp2Init: Call, bInit: Call, cInit: Call) =
+              valAssignBlock.astChildren.isBlock.astChildren.l: @unchecked
+            valInit.name shouldBe Operators.assignment
+            valInit.code shouldBe "$foo@tmp-0 = $foo@iter_tmp-0->current()"
+            inside(valInit.argument.l) { case List(valId: Identifier, currentCall: Call) =>
+              valId.name shouldBe "foo@tmp-0"
+              valId.code shouldBe "$foo@tmp-0"
+              valId.argumentIndex shouldBe 1
+
+              currentCall.name shouldBe "current"
+              currentCall.methodFullName shouldBe s"Iterator.current"
+              currentCall.code shouldBe "$foo@iter_tmp-0->current()"
+              inside(currentCall.argument(0).start.l) { case List(iterRecv: Identifier) =>
+                iterRecv.name shouldBe "foo@iter_tmp-0"
+                iterRecv.argumentIndex shouldBe 0
+              }
+            }
+
+            tmp2Init.methodFullName shouldBe Operators.assignment
+            tmp2Init.code shouldBe "$foo@tmp-2 = $foo@tmp-1"
+            inside(tmp2Init.argument.l) { case List(lhsIdent: Identifier, rhsIdent: Identifier) =>
+              lhsIdent.name shouldBe "foo@tmp-2"
+              lhsIdent.code shouldBe "$foo@tmp-2"
+
+              rhsIdent.name shouldBe "foo@tmp-1"
+              rhsIdent.code shouldBe "$foo@tmp-1"
+            }
+
+            assignmentTests(aInit, variableName = "a", tmpIndex = 0, arrayIndex = 0)
+            assignmentTests(bInit, variableName = "b", tmpIndex = 2, arrayIndex = 0)
+            assignmentTests(cInit, variableName = "c", tmpIndex = 2, arrayIndex = 1)
+
+            assignmentTests(tmp1Init, variableName = "foo@tmp-1", tmpIndex = 0, arrayIndex = 1)
+          }
+
+          inside(body.astChildren.l) { case List(echoCallA: Call, echoCallB: Call) =>
+            echoCallA.code shouldBe "echo $a"
+            echoCallB.code shouldBe "echo $b"
+          }
+        case xs => fail(s"Expected four children for control structure, got ${xs.code.mkString("[", ",", "]")}")
+      }
+    }
+
+    "create OR `!isNull` checks" in {
+      /*
+      For nested list deconstruction, we have !a || (!b || !c) instead of (!a || !b) || !c because we process
+      the nested list first, which gives the (!b || !c), and then we use that result to create the !a || (!b || !c)
+       */
+      inside(cpg.controlStructure.isFor.condition.l) {
+        case parentOr :: Nil =>
+          inside(parentOr.astChildren.l) {
+            case (logicalNot: Call) :: (nestedOr: Call) :: Nil =>
+              nestedOr.methodFullName shouldBe Operators.or
+              val List(orLeftArg: Call, orRightArg: Call) = nestedOr.argument.l: @unchecked
+              orLeftArg.methodFullName shouldBe Operators.logicalNot
+              orRightArg.methodFullName shouldBe Operators.logicalNot
+
+              val List(orLeftArgNullCall: Call) = orLeftArg.argument.l: @unchecked
+              orLeftArgNullCall.methodFullName shouldBe PhpOperators.isNull
+
+              val List(bVar) = orLeftArgNullCall.argument.l: @unchecked
+              bVar.code shouldBe "$b"
+
+              val List(orRightArgNullCall: Call) = orRightArg.argument.l: @unchecked
+              orRightArgNullCall.methodFullName shouldBe PhpOperators.isNull
+
+              val List(cVar) = orRightArgNullCall.argument.l: @unchecked
+              cVar.code shouldBe "$c"
+
+              logicalNot.methodFullName shouldBe Operators.logicalNot
+              val List(notArg: Call) = logicalNot.argument.l: @unchecked
+              notArg.methodFullName shouldBe PhpOperators.isNull
+
+              val List(aVar: Identifier) = notArg.argument.l: @unchecked
+              aVar.code shouldBe "$a"
+
+            case xs => fail(s"Expected two children calls for condition, got, ${xs.code.mkString("[", ",", "]")}")
+          }
+        case xs => fail(s"Expected one condition for FOR construct, got ${xs.code.mkString("[", ",", "]")}")
+      }
+    }
   }
 }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/ControlStructureTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/ControlStructureTests.scala
@@ -1315,4 +1315,180 @@ class ControlStructureTests extends PhpCode2CpgFixture {
       echoCall.code shouldBe "echo $val"
     }
   }
+
+  "foreach loop with listExpr" should {
+    val cpg = code("""<?php
+        |function foo($data) {
+        | foreach($data as list($a, $b, $c)) {
+        |   echo $a;
+        |   echo $b;
+        | }
+        |}
+        |""".stripMargin)
+
+    def assignmentTests(assignmentCall: Call, variableName: String, arrayIndex: Int): Unit = {
+      assignmentCall.methodFullName shouldBe Operators.assignment
+
+      inside(assignmentCall.argument.l) { case List(lhsIdent: Identifier, rhsIdxAccess: Call) =>
+        lhsIdent.name shouldBe variableName
+        lhsIdent.code shouldBe s"$$${variableName}"
+
+        rhsIdxAccess.methodFullName shouldBe Operators.indexAccess
+        rhsIdxAccess.code shouldBe s"$$foo@tmp-0[${arrayIndex}]" // $foo@tmp-0 is the name of the variable holding the current value
+        val List(idxLhs: Identifier, idxRhs: Literal) = rhsIdxAccess.argument.l: @unchecked
+        idxLhs.name shouldBe "foo@tmp-0"
+        idxLhs.code shouldBe "$foo@tmp-0"
+      }
+    }
+
+    "foreach structure" in {
+      cpg.method.name("foo").dotAst.l.foreach(println)
+      inside(cpg.method.name("foo").body.astChildren.l) {
+        case (iterLocal: Local) :: (aLocal: Local) :: (bLocal: Local) :: (cLocal: Local) :: (foreachStruct: ControlStructure) :: Nil =>
+          iterLocal.name shouldBe "foo@iter_tmp-0"
+          aLocal.name shouldBe "a"
+          bLocal.name shouldBe "b"
+          cLocal.name shouldBe "c"
+          foreachStruct.code shouldBe "foreach ($data as list($a,$b,$c))"
+        case xs => fail(s"Expected five astChildren, got ${xs.code.mkString("[", ",", "]")}")
+      }
+    }
+
+    "Init AST structures" in {
+      inside(cpg.method.name("foo").body.astChildren.isControlStructure.astChildren.l) {
+        case (initAsts: Block) :: _ :: _ :: _ =>
+          inside(initAsts.astChildren.l) { case List(iterInit: Call, valInitBlock: Block) =>
+            iterInit.name shouldBe Operators.assignment
+            iterInit.code shouldBe "$foo@iter_tmp-0 = $data"
+            inside(iterInit.argument.l) { case List(iterTemp: Identifier, iterExpr: Identifier) =>
+              iterTemp.name shouldBe "foo@iter_tmp-0"
+              iterTemp.code shouldBe "$foo@iter_tmp-0"
+              iterTemp.argumentIndex shouldBe 1
+
+              iterExpr.name shouldBe "data"
+              iterExpr.code shouldBe "$data"
+              iterExpr.argumentIndex shouldBe 2
+            }
+
+            val List(valInit: Call, aInit: Call, bInit: Call, cInit: Call) =
+              valInitBlock.astChildren.isBlock.astChildren.l: @unchecked
+            valInit.name shouldBe Operators.assignment
+            valInit.code shouldBe "$foo@tmp-0 = $foo@iter_tmp-0->current()"
+            inside(valInit.argument.l) { case List(valId: Identifier, currentCall: Call) =>
+              valId.name shouldBe "foo@tmp-0"
+              valId.code shouldBe "$foo@tmp-0"
+              valId.argumentIndex shouldBe 1
+
+              currentCall.name shouldBe "current"
+              currentCall.methodFullName shouldBe s"Iterator.current"
+              currentCall.code shouldBe "$foo@iter_tmp-0->current()"
+              inside(currentCall.argument(0).start.l) { case List(iterRecv: Identifier) =>
+                iterRecv.name shouldBe "foo@iter_tmp-0"
+                iterRecv.argumentIndex shouldBe 0
+              }
+            }
+
+            assignmentTests(aInit, variableName = "a", arrayIndex = 0)
+            assignmentTests(bInit, variableName = "b", arrayIndex = 1)
+            assignmentTests(cInit, variableName = "c", arrayIndex = 2)
+          }
+        case xs => fail(s"Expected four children for control structure, got ${xs.code.mkString("[", ",", "]")}")
+      }
+    }
+
+    "Update AST structures" in {
+      inside(cpg.method.name("foo").body.astChildren.isControlStructure.astChildren.l) {
+        case _ :: _ :: (updateAsts: Block) :: (body: Block) :: Nil =>
+          inside(updateAsts.astChildren.l) { case List(nextCall: Call, valAssignBlock: Block) =>
+            nextCall.name shouldBe "next"
+            nextCall.methodFullName shouldBe "Iterator.next"
+            nextCall.code shouldBe "$foo@iter_tmp-0->next()"
+            inside(nextCall.argument(0).start.l) { case List(iterTmp: Identifier) =>
+              iterTmp.name shouldBe "foo@iter_tmp-0"
+              iterTmp.code shouldBe "$foo@iter_tmp-0"
+              iterTmp.argumentIndex shouldBe 0
+            }
+
+            val List(valInit: Call, aInit: Call, bInit: Call, cInit: Call) =
+              valAssignBlock.astChildren.isBlock.astChildren.l: @unchecked
+            valInit.name shouldBe Operators.assignment
+            valInit.code shouldBe "$foo@tmp-0 = $foo@iter_tmp-0->current()"
+            inside(valInit.argument.l) { case List(valId: Identifier, currentCall: Call) =>
+              valId.name shouldBe "foo@tmp-0"
+              valId.code shouldBe "$foo@tmp-0"
+              valId.argumentIndex shouldBe 1
+
+              currentCall.name shouldBe "current"
+              currentCall.methodFullName shouldBe s"Iterator.current"
+              currentCall.code shouldBe "$foo@iter_tmp-0->current()"
+              inside(currentCall.argument(0).start.l) { case List(iterRecv: Identifier) =>
+                iterRecv.name shouldBe "foo@iter_tmp-0"
+                iterRecv.argumentIndex shouldBe 0
+              }
+            }
+
+            assignmentTests(aInit, variableName = "a", arrayIndex = 0)
+            assignmentTests(bInit, variableName = "b", arrayIndex = 1)
+            assignmentTests(cInit, variableName = "c", arrayIndex = 2)
+          }
+
+          inside(body.astChildren.l) { case List(echoCallA: Call, echoCallB: Call) =>
+            echoCallA.code shouldBe "echo $a"
+            echoCallB.code shouldBe "echo $b"
+          }
+        case xs => fail(s"Expected four children for control structure, got ${xs.code.mkString("[", ",", "]")}")
+      }
+    }
+
+    "create OR `!isNull` checks" in {
+      /*
+      ```php
+      $data = [[1, 2]]
+      foreach($data as list($a, $b, $c)
+      ```
+      The above sample is still valid Php code and runs as long as we don't use the $c variable in the loop (only a warning is emitted when running the code). This means
+      that the `!isNull` condition should be an OR since the loop still executes above, even though $c is a null-value
+       */
+      inside(cpg.controlStructure.isFor.condition.l) {
+        case parentOr :: Nil =>
+          inside(parentOr.astChildren.l) {
+            case (nestedOr: Call) :: (logicalNot: Call) :: Nil =>
+              nestedOr.methodFullName shouldBe Operators.or
+              val List(orLeftArg: Call, orRightArg: Call) = nestedOr.argument.l: @unchecked
+              orLeftArg.methodFullName shouldBe Operators.logicalNot
+              orRightArg.methodFullName shouldBe Operators.logicalNot
+
+              val List(orLeftArgNullCall: Call) = orLeftArg.argument.l: @unchecked
+              orLeftArgNullCall.methodFullName shouldBe PhpOperators.isNull
+
+              val List(aVar) = orLeftArgNullCall.argument.l: @unchecked
+              aVar.code shouldBe "$a"
+
+              val List(orRightArgNullCall: Call) = orRightArg.argument.l: @unchecked
+              orRightArgNullCall.methodFullName shouldBe PhpOperators.isNull
+
+              val List(bVar) = orRightArgNullCall.argument.l: @unchecked
+              bVar.code shouldBe "$b"
+
+              logicalNot.methodFullName shouldBe Operators.logicalNot
+              val List(notArg: Call) = logicalNot.argument.l: @unchecked
+              notArg.methodFullName shouldBe PhpOperators.isNull
+
+              val List(cVar: Identifier) = notArg.argument.l: @unchecked
+              cVar.code shouldBe "$c"
+
+            case xs => fail(s"Expected two children calls for condition, got, ${xs.code.mkString("[", ",", "]")}")
+          }
+        case xs => fail(s"Expected one condition for FOR construct, got ${xs.code.mkString("[", ",", "]")}")
+      }
+    }
+  }
+
+  "foreach loop with nested list construct" in {
+    val cpg = code(
+      """<?php
+        |foreach($data as list($a, list($b, $c)) {}
+        |""".stripMargin)
+
+  }
 }


### PR DESCRIPTION
* Added `PhpListExpr` deconstruction support in foreach loop
* Removed `astForListExp` as it is no longer used

```php
$data = [[1, 2]]
foreach ($data as list($a, $b)) {
  echo $a; // prints 1
  echo $b; // prints 2
}
```