### PR TITLE
fix json serializer: define only for nodes, not for all Products

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Location.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Location.scala
@@ -4,6 +4,7 @@ import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.{Properties, PropertyNames}
 import io.shiftleft.semanticcpg.language.nodemethods.AstNodeMethods
 import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.language.Steps.JsonSerializeAsProduct
 
 import scala.annotation.tailrec
 
@@ -62,8 +63,8 @@ object LazyLocation extends LocationCreator {
 
 implicit val locationCreator: LocationCreator = LazyLocation
 
-class LazyLocation(storedNode: StoredNode) extends LocationInfo with Product {
-  def node: Option[AbstractNode] = Some(storedNode)
+class LazyLocation(storedNode: StoredNode) extends LocationInfo with JsonSerializeAsProduct {
+  def node: Option[AbstractNode] = Option(storedNode)
 
   def symbol: String = {
     storedNode match {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Steps.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Steps.scala
@@ -83,16 +83,14 @@ object Steps {
   private lazy val nodeSerializer = new CustomSerializer[AbstractNode](implicit format =>
     (
       { case _ => ??? }, // deserializer not required for now
-      { case node: Product =>
+      { case node: AbstractNode =>
         val elementMap = Map.newBuilder[String, Any]
         (0 until node.productArity).foreach { i =>
           val label   = node.productElementName(i)
           val element = node.productElement(i)
           elementMap.addOne(label -> element)
         }
-        if (node.isInstanceOf[AbstractNode]) {
-          elementMap.addOne("_label" -> node.asInstanceOf[AbstractNode].label)
-        }
+        elementMap.addOne("_label" -> node.label)
         if (node.isInstanceOf[StoredNode]) {
           elementMap.addOne("_id" -> node.asInstanceOf[StoredNode].id())
         }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Steps.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Steps.scala
@@ -16,6 +16,7 @@ import scala.jdk.CollectionConverters.*
   */
 @Traversal(elementType = classOf[AnyRef])
 class Steps[A](val traversal: Iterator[A]) extends AnyVal {
+  import Steps.*
 
   /** Execute the traversal and convert it to a mutable buffer
     */
@@ -70,7 +71,7 @@ class Steps[A](val traversal: Iterator[A]) extends AnyVal {
   def toJsonPretty: String = toJson(pretty = true)
 
   protected def toJson(pretty: Boolean): String = {
-    implicit val formats: Formats = org.json4s.DefaultFormats + Steps.nodeSerializer
+    implicit val formats: Formats = org.json4s.DefaultFormats + nodeSerializer + productSerializer
 
     val results = traversal.toList
     if (pretty) writePretty(results)
@@ -80,16 +81,19 @@ class Steps[A](val traversal: Iterator[A]) extends AnyVal {
 }
 
 object Steps {
-  private lazy val nodeSerializer = new CustomSerializer[AbstractNode](implicit format =>
+
+  /** Marker trait that allows us to selectively serialize types using the accessors from Product: productElement,
+    * productElementName etc. We do not want to define a serializer format for _all_ Products, because that would
+    * include many stdlib classes like List, for which have better suited formats exist already. See StepsTest.scala for
+    * more details and examples.
+    */
+  trait JsonSerializeAsProduct extends Product
+
+  private lazy val nodeSerializer = new CustomSerializer(implicit format =>
     (
       { case _ => ??? }, // deserializer not required for now
       { case node: AbstractNode =>
-        val elementMap = Map.newBuilder[String, Any]
-        (0 until node.productArity).foreach { i =>
-          val label   = node.productElementName(i)
-          val element = node.productElement(i)
-          elementMap.addOne(label -> element)
-        }
+        val elementMap = productElements(node)
         elementMap.addOne("_label" -> node.label)
         if (node.isInstanceOf[StoredNode]) {
           elementMap.addOne("_id" -> node.asInstanceOf[StoredNode].id())
@@ -98,4 +102,21 @@ object Steps {
       }
     )
   )
+
+  private lazy val productSerializer = new CustomSerializer(implicit format =>
+    (
+      { case _ => ??? }, // deserializer not required for now
+      { case node: JsonSerializeAsProduct => Extraction.decompose(productElements(node).result()) }
+    )
+  )
+
+  private def productElements(product: Product) = {
+    val elementMap = Map.newBuilder[String, Any]
+    (0 until product.productArity).foreach { i =>
+      val label = product.productElementName(i)
+      val value = product.productElement(i)
+      elementMap.addOne(label -> value)
+    }
+    elementMap
+  }
 }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
@@ -126,8 +126,17 @@ class StepsTest extends AnyWordSpec with Matchers {
     }
 
     "operating on NewNode" in {
-      def location = cpg.method.name("foo").location
+      val newNode = NewMethod().signature("def methodName: Int").columnNumber(50)
+      val json    = Seq(newNode).toJson
 
+      val parsedChildren = parse(json).children
+      val parsed         = parsedChildren.head // exactly one result for the above query
+      (parsed \ "signature") shouldBe JString("def methodName: Int")
+      (parsed \ "columnNumber") shouldBe JInt(50)
+    }
+
+    "operating on Location" in {
+      def location = cpg.method.name("foo").location
       location.size shouldBe 1
       val parsedChildren = parse(location.toJson).children
       val parsed         = parsedChildren.head // exactly one result for the above query

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
@@ -141,6 +141,10 @@ class StepsTest extends AnyWordSpec with Matchers {
       val parsed = parse(json).children.head // exactly one result for the above query
       parsed shouldBe JString("asignature")
     }
+
+    "operating on regular stdlib classes" in {
+      List(1, 2, 3).toJson shouldBe "[1,2,3]"
+    }
   }
 
   ".p for pretty printing" should {


### PR DESCRIPTION
prior to this change:
```
List((1,2,3)).toJson
// [{"head":1,"next":{"head":2,"next":{"head":3,"next":{}}}}]
```

now:
```
List((1,2,3)).toJson
// [1,2,3]
```

It's a regression that was introduced in https://github.com/joernio/joern/pull/5530
I have no idea why Michael Flanders made this change.
This is also adding a test so we catch it early next time round.