### PR TITLE
Lower arraydimfetch log level to warn

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
@@ -698,7 +698,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
 
       case None =>
         val errorPosition = s"$variableCode:${line(expr).getOrElse("")}:$relativeFileName"
-        logger.error(s"ArrayDimFetchExpr without dimensions should be handled in assignment: $errorPosition")
+        logger.warn(s"ArrayDimFetchExpr without dimensions should be handled in assignment: $errorPosition")
         Ast()
     }
   }


### PR DESCRIPTION
AST changes are probably needed to handle this case properly, but even with those hitting this case should never log an error