### PR TITLE
Fix maven dependency fetching on Windows

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/MavenDependencies.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/MavenDependencies.scala
@@ -47,8 +47,9 @@ object MavenDependencies {
   }
 
   private[dependency] def get(projectDir: Path): Option[collection.Seq[String]] = {
+    val isWindows = System.getProperty("os.name").toLowerCase.startsWith("windows")
     val lines = ExternalCommand
-      .run(command = fetchCommandWithOpts, workingDir = Option(projectDir))
+      .run(command = fetchCommandWithOpts, workingDir = Option(projectDir), isShellCommand = isWindows)
       .logIfFailed()
       .toTry match {
       case Success(lines) =>


### PR DESCRIPTION
Without this option set, the `mvn` command can't be found even if it is in the PATH. With this option set, dependency fetching breaks on Linux, so we need to do the OS check.