### PR TITLE
CpgGenerator: use ExternalCommand facilities for verifying success

### DIFF
--- a/console/src/main/scala/io/joern/console/cpgcreation/CpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/CpgGenerator.scala
@@ -43,7 +43,7 @@ abstract class CpgGenerator() {
            |""".stripMargin
       )
 
-      ExternalCommand.run(cmd, additionalContext = cmd.toString.logIfFailed().verifySuccess()
+      ExternalCommand.run(cmd, additionalContext = cmd.toString).logIfFailed().verifySuccess()
     }
 
   protected lazy val maxMemoryParameter = {

--- a/console/src/main/scala/io/joern/console/cpgcreation/CpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/CpgGenerator.scala
@@ -43,8 +43,7 @@ abstract class CpgGenerator() {
            |""".stripMargin
       )
 
-      val exitValue = ExternalCommand.run(cmd).exitCode
-      assert(exitValue == 0, s"Error running shell command: exitValue=$exitValue; $cmd")
+      ExternalCommand.run(cmd).logIfFailed().verifySuccess()
     }
 
   protected lazy val maxMemoryParameter = {

--- a/console/src/main/scala/io/joern/console/cpgcreation/CpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/CpgGenerator.scala
@@ -43,7 +43,7 @@ abstract class CpgGenerator() {
            |""".stripMargin
       )
 
-      ExternalCommand.run(cmd).logIfFailed().verifySuccess()
+      ExternalCommand.run(cmd, additionalContext = cmd.toString.logIfFailed().verifySuccess()
     }
 
   protected lazy val maxMemoryParameter = {


### PR DESCRIPTION
so that error messages contain the stderr/stdout of the failed command