### PR TITLE
[swiftsrc2cpg] Bump astgen version

### DIFF
--- a/joern-cli/frontends/swiftsrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 swiftsrc2cpg {
-    astgen_version: "0.2.9"
+    astgen_version: "0.3.0"
 }


### PR DESCRIPTION
Brings in an important fix to directory creation during AST json writing. Previously, that could fail with a memory access violation if two or more threads tried to create the same sub-directory (we use multi-threading during Swift AST parsing/writing in swiftastgen).