### PR TITLE
[x2cpg] Show usage on error for command line arguments

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
@@ -1,13 +1,12 @@
 package io.joern.x2cpg
 
 import io.joern.x2cpg.X2Cpg.{applyDefaultOverlays, withErrorsToConsole}
-import io.joern.x2cpg.frontendspecific.FrontendArgsDelimitor
 import io.joern.x2cpg.layers.{Base, CallGraph, ControlFlow, TypeRelations}
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext}
 import io.shiftleft.semanticcpg.utils.FileUtil
 import org.slf4j.LoggerFactory
-import scopt.OParser
+import scopt.{DefaultOParserSetup, OParser, OParserSetup}
 
 import java.io.PrintWriter
 import java.nio.file.{Files, Paths}
@@ -262,6 +261,10 @@ object X2Cpg {
 
   private val logger = LoggerFactory.getLogger(X2Cpg.getClass)
 
+  private val oParserSetup: OParserSetup = new DefaultOParserSetup {
+    override def showUsageOnError: Option[Boolean] = Some(true)
+  }
+
   /** Parse commands line arguments in `args` using an X2Cpg command line parser, extended with the frontend specific
     * options in `frontendSpecific` with the initial configuration set to `initialConf`. On success, the configuration
     * is returned wrapped into an Option. On failure, error messages are printed and, `None` is returned.
@@ -272,7 +275,7 @@ object X2Cpg {
     initialConf: R
   ): Option[R] = {
     val parser = commandLineParser(frontendSpecific)
-    OParser.parse(parser, args, initialConf)
+    OParser.parse(parser, args, initialConf, oParserSetup)
   }
 
   /** Create a command line parser that can be extended to add options specific for the frontend.


### PR DESCRIPTION
Before:

```
> swiftsrc2cpg.sh --fooo

Error: Unknown option --fooo
Error: Missing argument input-dir
Try --help for more information.
Error parsing the command line

Process finished with exit code 1
```

After:

```
> swiftsrc2cpg.sh --fooo

Error: Unknown option --fooo
Error: Missing argument input-dir
Usage: swiftsrc2cpg [options] input-dir

  input-dir                source directory
  -o, --output <value>     output filename
  --exclude <file1>        files or folders to exclude during CPG generation (paths relative to <input-dir> or absolute paths)
  --exclude-regex <value>  a regex specifying files to exclude during CPG generation (paths relative to <input-dir> are matched)
  --enable-early-schema-checking
                           enables early schema validation during AST creation (disabled by default)
  --enable-file-content    add the raw source code to the content field of FILE nodes to allow for method source retrieval via offset fields (disabled by default)
  --help                   display this help message
  --define <value>         define a name
Error parsing the command line

Process finished with exit code 1
```