### PR TITLE
[pysrc2cpg] Ensure File node in case of parser exceptions.

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/ParsingErrorHandlingTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/ParsingErrorHandlingTests.scala
@@ -1,0 +1,35 @@
+package io.joern.pysrc2cpg.cpg
+
+import io.joern.pysrc2cpg.testfixtures.Py2CpgTestContext
+import io.shiftleft.semanticcpg.language.*
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
+
+class ParsingErrorHandlingTests extends AnyWordSpec with Matchers {
+
+  "A cpg with a file with a parsing error and file content enabled" should {
+    val code = """assert x, y
+                 |x[""".stripMargin
+    val cpg = Py2CpgTestContext
+      .addSource(code, "test.py")
+      .withEnabledFileContent(true)
+      .buildCpg
+    "still have a file node and the files content" in {
+      val List(file) = cpg.file.name("test.py").l
+      file.content shouldBe code
+    }
+  }
+
+  "A cpg with a file with a parsing error and file content disabled" should {
+    val cpg = Py2CpgTestContext
+      .addSource("""assert x, y
+          |x[""".stripMargin)
+      .withEnabledFileContent(false)
+      .buildCpg
+    "still have a file node but no file content" in {
+      val List(file) = cpg.file.name("test.py").l
+      file.content shouldBe "<empty>"
+    }
+  }
+
+}

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/testfixtures/Py2CpgTestContext.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/testfixtures/Py2CpgTestContext.scala
@@ -14,13 +14,24 @@ object Py2CpgTestContext {
     context.addSource(code, file)
     context.buildCpg
   }
+
+  def addSource(code: String, file: String = "test.py"): Py2CpgTestContext = {
+    val context = new Py2CpgTestContext()
+    context.addSource(code, file)
+  }
 }
 
 class Py2CpgTestContext {
 
-  private val codeAndFile     = mutable.ArrayBuffer.empty[Py2Cpg.InputPair]
-  private var buildResult     = Option.empty[Cpg]
-  private val absTestFilePath = "<absoluteTestPath>/"
+  private val codeAndFile       = mutable.ArrayBuffer.empty[Py2Cpg.InputPair]
+  private var buildResult       = Option.empty[Cpg]
+  private val absTestFilePath   = "<absoluteTestPath>/"
+  private var enableFileContent = true
+
+  def withEnabledFileContent(value: Boolean): Py2CpgTestContext = {
+    enableFileContent = value
+    this
+  }
 
   def addSource(code: String, file: String = "test.py"): Py2CpgTestContext = {
     if (buildResult.nonEmpty) {
@@ -42,7 +53,7 @@ class Py2CpgTestContext {
           cpg,
           absTestFilePath,
           schemaValidationMode = ValidationMode.Enabled,
-          enableFileContent = true
+          enableFileContent = enableFileContent
         )
       py2Cpg.buildCpg()
 


### PR DESCRIPTION
Create a File node with file content in presence of parser exception.
This is mainly to help with debugging in case where enableFileContent is
set to true.
