### PR TITLE
Temporarily disable swiftsrc2cpg tests on Windows

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,7 +45,7 @@ jobs:
         run: sbt clean test
       - name: Run tests
         if: matrix.os == 'windows-latest'
-        run: sbt clean 'set joerncli / swiftsrc2cpg / Test / skip := true' test
+        run: sbt clean 'set Projects.swiftsrc2cpg / Test / skip := true' test
 
   formatting:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,21 +25,27 @@ jobs:
         with:
           cache: false
           go-version: 1.18
-      - name: Set up Swift
-        if: matrix.os == 'windows-latest'
-        uses: SwiftyLab/setup-swift@latest
-        with:
-          check-latest: true
-          development: true
-          swift-version: "6.1"
+      # TODO: re-enable once https://github.com/actions/runner-images/issues/12764 is fixed
+      #- name: Set up Swift
+      #  if: matrix.os == 'windows-latest'
+      #  uses: SwiftyLab/setup-swift@latest
+      #  with:
+      #    check-latest: true
+      #    development: true
+      #    swift-version: "6.1"
       - name: Delete `.rustup` directory
         run: rm -rf /home/runner/.rustup # to save disk space
         if: runner.os == 'Linux'
       - name: Delete `.cargo` directory # to save disk space
         run: rm -rf /home/runner/.cargo
         if: runner.os == 'Linux'
+      # TODO: re-enable once https://github.com/actions/runner-images/issues/12764 is fixed
       - name: Run tests
+        if: matrix.os != 'windows-latest'
         run: sbt clean test
+      - name: Run tests
+        if: matrix.os == 'windows-latest'
+        run: sbt clean 'set joerncli / swiftsrc2cpg / Test / skip := true' test
 
   formatting:
     runs-on: ubuntu-latest

--- a/console/src/test/scala/io/joern/console/ConsoleTests.scala
+++ b/console/src/test/scala/io/joern/console/ConsoleTests.scala
@@ -142,13 +142,14 @@ class ConsoleTests extends AnyWordSpec with Matchers {
     }
 
     // TODO: re-enable once https://github.com/actions/runner-images/issues/12764 is fixed
-    "allow importing code from file with Swift frontend via apply" taggedAs NotInWindowsRunners in ConsoleFixture() { (console, _) =>
-      val code = "func foo() {};"
-      FileUtil.usingTemporaryFile("consoleTests", ".swift") { tmpFile =>
-        Files.writeString(tmpFile, code)
-        console.importCode(tmpFile.toString)
-        Set("foo").subsetOf(console.cpg.method.name.toSet) shouldBe true
-      }
+    "allow importing code from file with Swift frontend via apply" taggedAs NotInWindowsRunners in ConsoleFixture() {
+      (console, _) =>
+        val code = "func foo() {};"
+        FileUtil.usingTemporaryFile("consoleTests", ".swift") { tmpFile =>
+          Files.writeString(tmpFile, code)
+          console.importCode(tmpFile.toString)
+          Set("foo").subsetOf(console.cpg.method.name.toSet) shouldBe true
+        }
     }
 
     "allow importing code from file with Swift frontend" taggedAs NotInWindowsRunners in ConsoleFixture() {

--- a/console/src/test/scala/io/joern/console/ConsoleTests.scala
+++ b/console/src/test/scala/io/joern/console/ConsoleTests.scala
@@ -141,7 +141,8 @@ class ConsoleTests extends AnyWordSpec with Matchers {
       }
     }
 
-    "allow importing code from file with Swift frontend via apply" in ConsoleFixture() { (console, _) =>
+    // TODO: re-enable once https://github.com/actions/runner-images/issues/12764 is fixed
+    "allow importing code from file with Swift frontend via apply" taggedAs NotInWindowsRunners in ConsoleFixture() { (console, _) =>
       val code = "func foo() {};"
       FileUtil.usingTemporaryFile("consoleTests", ".swift") { tmpFile =>
         Files.writeString(tmpFile, code)


### PR DESCRIPTION
Until https://github.com/SwiftyLab/setup-swift/issues/416 is fixed.

True cause: Microsoft removed older SDK on 2022 installer https://github.com/actions/runner-images/issues/12776#issuecomment-3196143476

Otherwise, we are blocked. See, e.g., https://github.com/joernio/joern/pull/5625
