### PR TITLE
[sbt] Auto-reload sbt when application.conf changes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -113,4 +113,5 @@ publish / skip := true // don't publish the root project
 
 ThisBuild / Test / packageBin / publishArtifact := true
 
+// trigger an sbt reload when any `application.conf` file changes
 Global / checkBuildSources / fileInputs += (baseDirectory.value.toGlob / ** / "resources" / "application.conf")


### PR DESCRIPTION
Auto-reload `sbt` when `application.conf` changes.

[Screencast from 2025-08-26 08-40-31.webm](https://github.com/user-attachments/assets/fdb01fee-9a8e-4038-889a-60b5b7e71d75)
