### PR TITLE
[javasrc2cpg] Fix invalid AST.

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForSimpleStatementsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForSimpleStatementsCreator.scala
@@ -20,8 +20,9 @@ import com.github.javaparser.ast.stmt.{
   TryStmt,
   WhileStmt
 }
-import com.github.javaparser.symbolsolver.javaparsermodel.contexts.{SwitchEntryContext}
+import com.github.javaparser.symbolsolver.javaparsermodel.contexts.SwitchEntryContext
 import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver
+import io.joern.javasrc2cpg.astcreation.expressions.PatternInitAndRefAsts
 import io.joern.javasrc2cpg.astcreation.{AstCreator, ExpectedType}
 import io.joern.javasrc2cpg.util.NameConstants
 import io.joern.x2cpg.Ast
@@ -271,7 +272,7 @@ trait AstForSimpleStatementsCreator { this: AstCreator =>
 
     val (initializerAst, referenceAst) = if (selectorMustBeIdentifierOrFieldAccess) {
       val initAndRefAsts = initAndRefAstsForPatternInitializer(stmt.getSelector, selectorAst)
-      (initAndRefAsts.get, Option(initAndRefAsts.get))
+      (initAndRefAsts.get, Option(initAndRefAsts))
     } else {
       (selectorAst, None)
     }
@@ -327,7 +328,7 @@ trait AstForSimpleStatementsCreator { this: AstCreator =>
     (defaultAst ++ explicitLabelAsts).toList
   }
 
-  private def astForSwitchEntry(entry: SwitchEntry, selectorReferenceAst: Option[Ast]): Seq[Ast] = {
+  private def astForSwitchEntry(entry: SwitchEntry, selectorReferenceAst: Option[PatternInitAndRefAsts]): Seq[Ast] = {
     // Fallthrough to/from a pattern is a compile error, so an entry can only have a pattern label if that is
     // the only label
     val labels    = entry.getLabels.asScala.toList
@@ -342,7 +343,7 @@ trait AstForSimpleStatementsCreator { this: AstCreator =>
 
       val instanceOfAst = labels.lastOption.collect { case patternExpr: PatternExpr =>
         selectorReferenceAst.map { selectorAst =>
-          instanceOfAstForPattern(patternExpr, selectorAst)
+          instanceOfAstForPattern(patternExpr, selectorAst.get)
         }
       }.flatten
 

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/PatternExprTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/PatternExprTests.scala
@@ -3440,7 +3440,6 @@ class PatternExprTests extends JavaSrcCode2CpgFixture {
                        |  }
                        |}
                        |""".stripMargin)
-
       "not have the local name mangled" in {
         inside(cpg.call.name("sink").l) { case List(firstSink, secondSink, thirdSink) =>
           inside(firstSink.argument.argumentIndex(1).isIdentifier.l) { case List(firstValue) =>
@@ -3483,6 +3482,10 @@ class PatternExprTests extends JavaSrcCode2CpgFixture {
             ifStmt.controlStructureType shouldBe ControlStructureTypes.IF
         }
       }
+      "have no AST node which appears in multiple locations in the AST" in {
+        cpg.astNode.filter(_._astIn.toList.size > 1).size shouldBe 0
+      }
+
     }
 
     "a variable on the rhs of a binary expression should not have a mangled name" should {


### PR DESCRIPTION
Selector AST of switch statements of kind identifier and field access
could end up multiple times as sub AST in the resulting methods AST
which is invalid.

Happened for:
```
switch(expr) {
  case Type1 identifier1 -> { ... }
  case Type2 identifier2 -> { ... }
}
```

Fix for https://shiftleftinc.atlassian.net/browse/SEN-4375?focusedCommentId=34914
