### PR TITLE
Remove withErrorsToConsole from X2CpgFrontend.run().

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
@@ -232,14 +232,8 @@ trait X2CpgFrontend extends AutoCloseable {
     */
   @throws[Throwable]("if createCpg throws any Throwable")
   def run(config: ConfigType): Unit = {
-    withErrorsToConsole(config) { _ =>
-      createCpg(config) match {
-        case Success(cpg) =>
-          cpg.close() // persists to disk
-          Success(cpg)
-        case Failure(exception) =>
-          Failure(exception)
-      }
+    createCpg(config).map { cpg =>
+      cpg.close() // persists to disk
     } match {
       case Failure(exception) =>
         // We explicitly rethrow the exception so that every frontend will

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
@@ -1,6 +1,6 @@
 package io.joern.x2cpg
 
-import io.joern.x2cpg.X2Cpg.{applyDefaultOverlays, withErrorsToConsole}
+import io.joern.x2cpg.X2Cpg.applyDefaultOverlays
 import io.joern.x2cpg.layers.{Base, CallGraph, ControlFlow, TypeRelations}
 import io.joern.x2cpg.utils.Environment
 import io.joern.x2cpg.utils.server.FrontendHTTPServer
@@ -365,19 +365,6 @@ object X2Cpg {
           cpg.close()
           throw exception
       }
-    }
-  }
-
-  /** Given a function that receives a configuration and returns an arbitrary result type wrapped in a `Try`, evaluate
-    * the function, printing errors to the console.
-    */
-  def withErrorsToConsole[T <: X2CpgConfig[?]](config: T)(f: T => Try[?]): Try[?] = {
-    f(config) match {
-      case Failure(exception) =>
-        exception.printStackTrace()
-        Failure(exception)
-      case Success(v) =>
-        Success(v)
     }
   }
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/server/FrontendHTTPServer.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/server/FrontendHTTPServer.scala
@@ -106,6 +106,7 @@ class FrontendHTTPServer(executor: ExecutorService, handleRequest: Array[String]
 
         Try(handleRequest(arguments.toArray)) match {
           case Failure(exception) =>
+            exception.printStackTrace()
             resp.send(400, exception.getMessage)
           case Success(_) =>
             resp.send(200, outputDir)


### PR DESCRIPTION
This resulted in exceptions that are not caught by the frontend specific
code to be logged twice which can be very confusing.
The other log location is in X2CpgMain.main() which i deem more
appropriate.
