### PR TITLE
Use SourceFiles.filterFile logic to also filter config files

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -27,7 +27,7 @@ class JavaSrc2Cpg extends X2CpgFrontend {
       astCreationPass.sourceParser.cleanupDelombokOutput()
       astCreationPass.clearJavaParserCaches()
       new OuterClassRefPass(cpg).createAndApply()
-      JavaConfigFileCreationPass(cpg).createAndApply()
+      JavaConfigFileCreationPass(cpg, config = config).createAndApply()
       if (!config.skipTypeInfPass) {
         TypeNodePass.withRegisteredTypes(astCreationPass.global.usedTypes.keys().asScala.toList, cpg).createAndApply()
         new TypeInferencePass(cpg).createAndApply()

--- a/joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests/excluded/excluded.properties
+++ b/joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests/excluded/excluded.properties
@@ -1,0 +1,1 @@
+basic excluded properties

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/passes/ConfigFileCreationPassTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/passes/ConfigFileCreationPassTests.scala
@@ -19,7 +19,7 @@ class ConfigFileCreationPassTests extends JavaSrcCode2CpgFixture {
 
   "it should find the correct config files" in {
     val cpg    = Cpg.from(_.addNode(NewMetaData().root(testConfigDir)))
-    val config = Config().withIgnoredFilesRegex(".*/excluded/.*").withDefaultIgnoredFilesRegex(Nil)
+    val config = Config().withIgnoredFilesRegex(".*excluded.*").withDefaultIgnoredFilesRegex(Nil)
 
     val foundFiles = new JavaConfigFileCreationPass(cpg, config = config).generateParts().map(_.absolutePathAsString)
     val absoluteConfigDir = Paths.get(testConfigDir).absolutePathAsString

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/passes/ConfigFileCreationPassTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/passes/ConfigFileCreationPassTests.scala
@@ -1,6 +1,7 @@
 package io.joern.javasrc2cpg.passes
 
 import flatgraph.misc.TestUtils.*
+import io.joern.javasrc2cpg.Config
 import io.joern.javasrc2cpg.testfixtures.JavaSrcCode2CpgFixture
 import io.joern.x2cpg.passes.frontend.JavaConfigFileCreationPass
 import io.shiftleft.semanticcpg.utils.FileUtil.*
@@ -17,9 +18,10 @@ class ConfigFileCreationPassTests extends JavaSrcCode2CpgFixture {
     ProjectRoot.relativise("joern-cli/frontends/javasrc2cpg/src/test/resources/config_tests")
 
   "it should find the correct config files" in {
-    val cpg = Cpg.from(_.addNode(NewMetaData().root(testConfigDir)))
+    val cpg    = Cpg.from(_.addNode(NewMetaData().root(testConfigDir)))
+    val config = Config().withIgnoredFilesRegex(".*/excluded/.*").withDefaultIgnoredFilesRegex(Nil)
 
-    val foundFiles        = new JavaConfigFileCreationPass(cpg).generateParts().map(_.absolutePathAsString)
+    val foundFiles = new JavaConfigFileCreationPass(cpg, config = config).generateParts().map(_.absolutePathAsString)
     val absoluteConfigDir = Paths.get(testConfigDir).absolutePathAsString
     foundFiles should contain theSameElementsAs Array(
       Paths.get(absoluteConfigDir, "application.conf").toString,

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
@@ -129,7 +129,7 @@ class Jimple2Cpg extends X2CpgFrontend {
       .withRegisteredTypes(global.usedTypes.keys().asScala.toList, cpg)
       .createAndApply()
     DeclarationRefPass(cpg).createAndApply()
-    JavaConfigFileCreationPass(cpg, Option(tmpDir.toString)).createAndApply()
+    JavaConfigFileCreationPass(cpg, Option(tmpDir.toString), config).createAndApply()
   }
 
   private def decompileClassFiles(classFiles: List[ClassFile], decompileJava: Boolean): Unit = {

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ConfigFileCreationPass.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ConfigFileCreationPass.scala
@@ -5,8 +5,8 @@ import io.shiftleft.codepropertygraph.generated.Cpg
 
 import java.nio.file.Path
 
-class ConfigFileCreationPass(cpg: Cpg, requirementsTxt: String = "requirement.txt")
-    extends XConfigFileCreationPass(cpg) {
+class ConfigFileCreationPass(cpg: Cpg, requirementsTxt: String = "requirement.txt", config: Py2CpgOnFileSystemConfig)
+    extends XConfigFileCreationPass(cpg, config = config) {
 
   override val configFileFilters: List[Path => Boolean] = List(
     // TOML files

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/Py2CpgOnFileSystem.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/Py2CpgOnFileSystem.scala
@@ -97,14 +97,7 @@ class Py2CpgOnFileSystem extends X2CpgFrontend {
           Py2Cpg.InputPair(content, inputPath.relativize(inputFile).toString)
         }
       }
-      val py2Cpg = new Py2Cpg(
-        inputProviders,
-        cpg,
-        config.inputPath,
-        config.requirementsTxt,
-        config.schemaValidation,
-        !config.disableFileContent
-      )
+      val py2Cpg = new Py2Cpg(inputProviders, cpg, config)
       py2Cpg.buildCpg()
     }
   }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/testfixtures/Py2CpgTestContext.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/testfixtures/Py2CpgTestContext.scala
@@ -25,7 +25,7 @@ class Py2CpgTestContext {
 
   private val codeAndFile       = mutable.ArrayBuffer.empty[Py2Cpg.InputPair]
   private var buildResult       = Option.empty[Cpg]
-  private val absTestFilePath   = "<absoluteTestPath>/"
+  private val absTestFilePath   = "absoluteTestPath/"
   private var enableFileContent = true
 
   def withEnabledFileContent(value: Boolean): Py2CpgTestContext = {

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/testfixtures/Py2CpgTestContext.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/testfixtures/Py2CpgTestContext.scala
@@ -1,6 +1,6 @@
 package io.joern.pysrc2cpg.testfixtures
 
-import io.joern.pysrc2cpg.Py2Cpg
+import io.joern.pysrc2cpg.{Py2Cpg, Py2CpgOnFileSystemConfig}
 import io.joern.x2cpg.ValidationMode
 import io.joern.x2cpg.X2Cpg.defaultOverlayCreators
 import io.shiftleft.codepropertygraph.generated.Cpg
@@ -45,16 +45,14 @@ class Py2CpgTestContext {
   }
 
   def buildCpg: Cpg = {
+    val config = Py2CpgOnFileSystemConfig()
+      .withInputPath(absTestFilePath)
+      .withSchemaValidation(ValidationMode.Enabled)
+      .withDisableFileContent(!enableFileContent)
     if (buildResult.isEmpty) {
       val cpg = new Cpg()
       val py2Cpg =
-        new Py2Cpg(
-          codeAndFile.map(inputPair => () => inputPair),
-          cpg,
-          absTestFilePath,
-          schemaValidationMode = ValidationMode.Enabled,
-          enableFileContent = enableFileContent
-        )
+        new Py2Cpg(codeAndFile.map(inputPair => () => inputPair), cpg, config)
       py2Cpg.buildCpg()
 
       val context = new LayerCreatorContext(cpg)

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/testfixtures/Py2CpgTestContext.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/testfixtures/Py2CpgTestContext.scala
@@ -5,6 +5,7 @@ import io.joern.x2cpg.ValidationMode
 import io.joern.x2cpg.X2Cpg.defaultOverlayCreators
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.semanticcpg.layers.LayerCreatorContext
+import io.shiftleft.semanticcpg.utils.FileUtil
 
 import scala.collection.mutable
 
@@ -45,8 +46,11 @@ class Py2CpgTestContext {
   }
 
   def buildCpg: Cpg = {
+    val cpgOutFile = FileUtil.newTemporaryFile(suffix = "cpg.bin")
+    FileUtil.deleteOnExit(cpgOutFile)
     val config = Py2CpgOnFileSystemConfig()
       .withInputPath(absTestFilePath)
+      .withOutputPath(cpgOutFile.toString)
       .withSchemaValidation(ValidationMode.Enabled)
       .withDisableFileContent(!enableFileContent)
     if (buildResult.isEmpty) {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
@@ -40,7 +40,7 @@ class RubySrc2Cpg extends X2CpgFrontend {
   override def createCpg(config: Config): Try[Cpg] = {
     withNewEmptyCpg(config.outputPath, config: Config) { (cpg, config) =>
       new MetaDataPass(cpg, Languages.RUBYSRC, config.inputPath).createAndApply()
-      new ConfigFileCreationPass(cpg).createAndApply()
+      new ConfigFileCreationPass(cpg, config).createAndApply()
       new DependencyPass(cpg).createAndApply()
       createCpgAction(cpg, config)
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/ConfigFileCreationPass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/ConfigFileCreationPass.scala
@@ -1,5 +1,6 @@
 package io.joern.rubysrc2cpg.passes
 
+import io.joern.rubysrc2cpg.Config
 import io.joern.x2cpg.passes.frontend.XConfigFileCreationPass
 import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Cpg
@@ -7,12 +8,11 @@ import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.utils.FileUtil
 
 import java.nio.file.{Path, Paths}
-
 import scala.util.Try
 
 /** Creates the CONFIGURATION layer from any existing `Gemfile` or `Gemfile.lock` files found at root level.
   */
-class ConfigFileCreationPass(cpg: Cpg) extends XConfigFileCreationPass(cpg) {
+class ConfigFileCreationPass(cpg: Cpg, config: Config) extends XConfigFileCreationPass(cpg, config = config) {
 
   private val validGemfilePaths = Try(Paths.get(cpg.metaData.root.headOption.getOrElse(""))).toOption match {
     case Some(rootPath) => Seq("Gemfile", "Gemfile.lock").map(rootPath / _)

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/SwiftSrc2Cpg.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/SwiftSrc2Cpg.scala
@@ -35,7 +35,7 @@ class SwiftSrc2Cpg extends X2CpgFrontend {
 
         new ExtensionInheritancePass(cpg).createAndApply()
         new MetaDataPass(cpg, hash, config.inputPath).createAndApply()
-        new ConfigFileCreationPass(cpg).createAndApply()
+        new ConfigFileCreationPass(cpg, config).createAndApply()
         new DependenciesPass(cpg).createAndApply()
         new FullNameUniquenessPass(cpg).createAndApply()
 

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/passes/ConfigFileCreationPass.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/passes/ConfigFileCreationPass.scala
@@ -5,7 +5,7 @@ import io.shiftleft.codepropertygraph.generated.Cpg
 
 import java.nio.file.Path
 
-class ConfigFileCreationPass(cpg: Cpg) extends XConfigFileCreationPass(cpg) {
+class ConfigFileCreationPass(cpg: Cpg, config: Config) extends XConfigFileCreationPass(cpg, config = config) {
 
   override val configFileFilters: List[Path => Boolean] = List(extensionFilter(".plist"), extensionFilter(".xib"))
 

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/passes/ConfigFileCreationPass.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/passes/ConfigFileCreationPass.scala
@@ -1,5 +1,6 @@
 package io.joern.swiftsrc2cpg
 
+import io.joern.swiftsrc2cpg.Config
 import io.joern.x2cpg.passes.frontend.XConfigFileCreationPass
 import io.shiftleft.codepropertygraph.generated.Cpg
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XConfigFileCreationPass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XConfigFileCreationPass.scala
@@ -33,7 +33,7 @@ abstract class XConfigFileCreationPass(cpg: Cpg, private val rootDir: Option[Str
               .walk()
               .filterNot(_ == file)
               .filter(isConfigFile)
-              .filterNot(isExcludedFile(root, _))
+              .filter(isAccepted(root, _))
               .toArray
 
           case Success(file) if isConfigFile(file) => Array(file)
@@ -73,16 +73,14 @@ abstract class XConfigFileCreationPass(cpg: Cpg, private val rootDir: Option[Str
     file.absolutePathAsString.endsWith(pathEnd)
   }
 
-  protected def isExcludedFile(rootPath: String, filePath: Path): Boolean = {
-    val isAcceptedFile = SourceFiles.filterFile(
+  protected def isAccepted(rootPath: String, filePath: Path): Boolean = {
+    SourceFiles.filterFile(
       filePath.toAbsolutePath.toString,
       rootPath,
       Option(config.defaultIgnoredFilesRegex),
       Option(config.ignoredFilesRegex),
       Option(config.ignoredFiles)
     )
-
-    !isAcceptedFile
   }
 
   private def isConfigFile(file: Path): Boolean = {

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XConfigFileCreationPass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XConfigFileCreationPass.scala
@@ -1,5 +1,6 @@
 package io.joern.x2cpg.passes.frontend
 
+import io.joern.x2cpg.{SourceFiles, X2CpgConfig}
 import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.NewConfigFile
@@ -15,7 +16,7 @@ import scala.util.{Failure, Success, Try}
 /** Scans for and inserts configuration files into the CPG. Relies on the MetaData's `ROOT` property to provide the path
   * to scan, but alternatively one can specify a directory on the `rootDir` parameter.
   */
-abstract class XConfigFileCreationPass(cpg: Cpg, private val rootDir: Option[String] = None)
+abstract class XConfigFileCreationPass(cpg: Cpg, private val rootDir: Option[String] = None, config: X2CpgConfig[_])
     extends ForkJoinParallelCpgPass[Path](cpg) {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
@@ -32,6 +33,7 @@ abstract class XConfigFileCreationPass(cpg: Cpg, private val rootDir: Option[Str
               .walk()
               .filterNot(_ == file)
               .filter(isConfigFile)
+              .filterNot(isExcludedFile(root, _))
               .toArray
 
           case Success(file) if isConfigFile(file) => Array(file)
@@ -71,6 +73,18 @@ abstract class XConfigFileCreationPass(cpg: Cpg, private val rootDir: Option[Str
     file.absolutePathAsString.endsWith(pathEnd)
   }
 
+  protected def isExcludedFile(rootPath: String, filePath: Path): Boolean = {
+    val isAcceptedFile = SourceFiles.filterFile(
+      filePath.toAbsolutePath.toString,
+      rootPath,
+      Option(config.defaultIgnoredFilesRegex),
+      Option(config.ignoredFilesRegex),
+      Option(config.ignoredFiles)
+    )
+
+    !isAcceptedFile
+  }
+
   private def isConfigFile(file: Path): Boolean = {
     configFileFilters.exists(predicate => predicate(file))
   }
@@ -79,8 +93,8 @@ abstract class XConfigFileCreationPass(cpg: Cpg, private val rootDir: Option[Str
 /** Parses common Java related configuration files. Multiple frontends cover JVM languages so this is in a single shared
   * spot.
   */
-class JavaConfigFileCreationPass(cpg: Cpg, rootDir: Option[String] = None)
-    extends XConfigFileCreationPass(cpg, rootDir) {
+class JavaConfigFileCreationPass(cpg: Cpg, rootDir: Option[String] = None, config: X2CpgConfig[_])
+    extends XConfigFileCreationPass(cpg, rootDir, config) {
 
   override val configFileFilters: List[Path => Boolean] = List(
     // JAVA_INTERNAL


### PR DESCRIPTION
This PR introduces filtering for config files using the same exclude mechanism we currently use for `SourceFiles`. It's implemented here as an `isExcludedFile` method which can be overridden per-frontend if we want to (either to disable this completely or to use a custom filter), but is enabled by default here (which I'm happy to change if need be).