### PR TITLE
[swiftsrc2cpg] Refactor Swift type mapping to use ConcurrentHashMap

### DIFF
--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/utils/FullnameProvider.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/utils/FullnameProvider.scala
@@ -6,7 +6,6 @@ import io.joern.swiftsrc2cpg.utils.FullnameProvider.NodeKindMapping
 import io.joern.swiftsrc2cpg.utils.SwiftTypesProvider.{ResolvedTypeInfo, SwiftFileLocalTypeMapping}
 
 import scala.annotation.tailrec
-import scala.collection.mutable
 
 /** Companion object for the FullnameProvider class. Contains helper types and constants used by the FullnameProvider.
   */
@@ -41,7 +40,7 @@ class FullnameProvider(typeMap: SwiftFileLocalTypeMapping) {
     * @return
     *   An optional resolved type information that matches the node kind
     */
-  private def filterForNodeKind(in: mutable.HashSet[ResolvedTypeInfo], nodeKind: String): Option[ResolvedTypeInfo] = {
+  private def filterForNodeKind(in: Set[ResolvedTypeInfo], nodeKind: String): Option[ResolvedTypeInfo] = {
     if (in.isEmpty) return None
     if (in.size == 1) return in.headOption
     NodeKindMapping.get(nodeKind).flatMap(mappedNodeKind => in.find(_.nodeKind == mappedNodeKind)).orElse(in.headOption)

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/utils/GsonTypeInfoReader.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/utils/GsonTypeInfoReader.scala
@@ -262,7 +262,7 @@ object GsonTypeInfoReader {
 
       val declFullname = safePropertyValue(obj, "usr").orElse(safePropertyValue(declObj, "decl_usr"))
 
-      found.addOne(TypeInfo(filename, range_, typeFullname, declFullname, nodeKind))
+      found.add(TypeInfo(filename, range_, typeFullname, declFullname, nodeKind))
     }
 
     /** Parses a JSON array.

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/utils/FullnameProviderTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/utils/FullnameProviderTests.scala
@@ -22,57 +22,49 @@ class FullnameProviderTests extends AnyFlatSpec with Matchers {
   val typeInfoNoFullName = ResolvedTypeInfo(Some("type.fullname.D"), None, "DKind")
 
   "typeFullname" should "return the type when available in the map" in {
-    val mockTypeMap = new SwiftFileLocalTypeMapping()
-    mockTypeMap.put((10, 20), mutable.HashSet(typeInfo1))
+    val mockTypeMap = Map((10, 20) -> Set(typeInfo1))
 
     val provider = new MockFullNameProvider(mockTypeMap)
     provider.typeFullname((10, 20), "nodeKind") shouldBe Some("type.fullname.A")
   }
 
   it should "return None when type is not available" in {
-    val mockTypeMap = new SwiftFileLocalTypeMapping()
-    mockTypeMap.put((10, 20), mutable.HashSet(typeInfoNoType))
+    val mockTypeMap = Map((10, 20) -> Set(typeInfoNoType))
 
     val provider = new MockFullNameProvider(mockTypeMap)
     provider.typeFullname((10, 20), "nodeKind") shouldBe None
   }
 
   it should "try with a single-point range when original range is not found" in {
-    val mockTypeMap = new SwiftFileLocalTypeMapping()
-    mockTypeMap.put((10, 10), mutable.HashSet(typeInfo2))
+    val mockTypeMap = Map((10, 10) -> Set(typeInfo2))
 
     val provider = new MockFullNameProvider(mockTypeMap)
     provider.typeFullname((10, 20), "nodeKind") shouldBe Some("type.fullname.B")
   }
 
   it should "handle empty sets in the type map" in {
-    val mockTypeMap = new SwiftFileLocalTypeMapping()
-    mockTypeMap.put((10, 20), mutable.HashSet())
-    mockTypeMap.put((10, 10), mutable.HashSet())
+    val mockTypeMap = Map((10, 20) -> Set.empty[ResolvedTypeInfo], (10, 10) -> Set.empty[ResolvedTypeInfo])
 
     val provider = new MockFullNameProvider(mockTypeMap)
     provider.typeFullname((10, 20), "nodeKind") shouldBe None
   }
 
   "declFullname" should "return the fullName when available in the map" in {
-    val mockTypeMap = new SwiftFileLocalTypeMapping()
-    mockTypeMap.put((30, 40), mutable.HashSet(typeInfo1))
+    val mockTypeMap = Map((30, 40) -> Set(typeInfo1))
 
     val provider = new MockFullNameProvider(mockTypeMap)
     provider.declFullname((30, 40), "nodeKind") shouldBe Some("decl.fullname.A")
   }
 
   it should "return None when fullName is not available" in {
-    val mockTypeMap = new SwiftFileLocalTypeMapping()
-    mockTypeMap.put((30, 40), mutable.HashSet(typeInfoNoFullName))
+    val mockTypeMap = Map((30, 40) -> Set(typeInfoNoFullName))
 
     val provider = new MockFullNameProvider(mockTypeMap)
     provider.declFullname((30, 40), "nodeKind") shouldBe None
   }
 
   it should "try with a +-1 range when original range is not found" in {
-    val mockTypeMap = new SwiftFileLocalTypeMapping()
-    mockTypeMap.put((30, 30), mutable.HashSet(typeInfo2))
+    val mockTypeMap = Map((30, 30) -> Set(typeInfo2))
 
     val provider = new MockFullNameProvider(mockTypeMap)
     provider.declFullname((31, 29), "nodeKind") shouldBe Some("decl.fullname.B")
@@ -80,8 +72,7 @@ class FullnameProviderTests extends AnyFlatSpec with Matchers {
   }
 
   it should "try with a single-point range when original range is not found" in {
-    val mockTypeMap = new SwiftFileLocalTypeMapping()
-    mockTypeMap.put((30, 30), mutable.HashSet(typeInfo2))
+    val mockTypeMap = Map((30, 30) -> Set(typeInfo2))
 
     val provider = new MockFullNameProvider(mockTypeMap)
     provider.declFullname((30, 40), "nodeKind") shouldBe Some("decl.fullname.B")
@@ -89,9 +80,7 @@ class FullnameProviderTests extends AnyFlatSpec with Matchers {
   }
 
   it should "handle multiple type infos for the same range" in {
-    val mockTypeMap = new SwiftFileLocalTypeMapping()
-    val multiSet    = mutable.HashSet(typeInfo1, typeInfo2)
-    mockTypeMap.put((50, 60), multiSet)
+    val mockTypeMap = Map((50, 60) -> Set(typeInfo1, typeInfo2))
 
     val provider = new MockFullNameProvider(mockTypeMap)
     // Since filterForNodeKind just returns headOption at the moment, this would pick the first one
@@ -100,7 +89,7 @@ class FullnameProviderTests extends AnyFlatSpec with Matchers {
   }
 
   it should "return None when range is not available at all" in {
-    val mockTypeMap = new SwiftFileLocalTypeMapping()
+    val mockTypeMap = Map.empty[(Int, Int), Set[ResolvedTypeInfo]]
 
     val provider = new MockFullNameProvider(mockTypeMap)
     provider.declFullname((30, 40), "nodeKind") shouldBe None


### PR DESCRIPTION
Even if the compute function looks more complicated now this ensures that multiple concurrent updates to the inner Map are not lost and computed at most once (TrieMap actually uses a retry mechanic which results in additional performance overhead as we call the swift-demangle binary externally).