### PR TITLE
[swiftsrc2cpg] Update swiftastgen to 0.3.3

### DIFF
--- a/joern-cli/frontends/swiftsrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 swiftsrc2cpg {
-    astgen_version: "0.3.2"
+    astgen_version: "0.3.3"
 }


### PR DESCRIPTION
Brings in https://github.com/joernio/SwiftAstGen/pull/18 so we can finally run it on larger projects on certain Linux distributions where the small default musl stack size resulted in seg faults.

See: https://wiki.musl-libc.org/functional-differences-from-glibc.html#Thread-stack-size