### PR TITLE
[javasrc2cpg] Add verbose type logging behind a flag/envvar for debugging

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -67,5 +67,10 @@ object JavaSrc2Cpg {
           "JAVASRC_FETCH_DEPENDENCIES",
           "If set, javasrc2cpg will fetch dependencies regardless of the --fetch-dependencies flag."
         )
+    case EnableVerboseTypeLogging
+        extends JavaSrcEnvVar(
+          "JAVASRC_ENABLE_VERBOSE_TYPE_LOGGING",
+          "If set, javasrc2cpg will log all types found across JarTypeSolvers. THIS WILL IMPACT PERFORMANCE AND LOG SIZE AND SHOULD ONLY BE USED FOR DEBUGGING SPECIFIC ISSUES!"
+        )
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
@@ -28,6 +28,7 @@ final case class Config(
   cacheJdkTypeSolver: Boolean = false,
   keepTypeArguments: Boolean = false,
   disableTypeFallback: Boolean = false,
+  enableVerboseTypeLogging: Boolean = false,
   override val genericConfig: X2CpgConfig.GenericConfig =
     X2CpgConfig.GenericConfig(defaultIgnoredFilesRegex = JavaSrc2Cpg.DefaultIgnoredFilesRegex),
   override val typeRecoveryParserConfig: TypeRecoveryParserConfig.Config = TypeRecoveryParserConfig.Config()
@@ -91,6 +92,10 @@ final case class Config(
   def withDisableTypeFallback(value: Boolean): Config = {
     copy(disableTypeFallback = value)
   }
+
+  def withEnableVerboseTypeLogging(value: Boolean): Config = {
+    copy(enableVerboseTypeLogging = value)
+  }
 }
 
 private object Frontend {
@@ -153,6 +158,11 @@ private object Frontend {
         .action((_, c) => c.withDisableTypeFallback(true))
         .text(
           "Disables fallback to wildcard imports, unsound type inferences and the Any type (except where no better information is available)."
+        ),
+      opt[Unit]("enable-verbose-type-logging")
+        .action((_, c) => c.withEnableVerboseTypeLogging(true))
+        .text(
+          "Enable extra verbose type logging. THIS WILL IMPACT PERFORMANCE AND LOG SIZE AND SHOULD ONLY BE USED FOR DEBUGGING SPECIFIC ISSUES!"
         )
     )
   }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/DependencyResolver.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/DependencyResolver.scala
@@ -75,7 +75,10 @@ object DependencyResolver {
       }
     }.flatten
 
-    Option.when(dependencies.nonEmpty)(dependencies)
+    Option.when(dependencies.nonEmpty) {
+      logger.debug(("Dependency jars fetched:" :: dependencies).mkString(s"${System.lineSeparator()} - "))
+      dependencies
+    }
   }
 
   private def getDepsForGradleProject(


### PR DESCRIPTION
I've been having trouble debugging a customer issue where many, many calls are unresolved, despite dependencies apparently being fetched. I thought I'd reproduced it, but the issue I ran into was lombok-related which isn't relevant for the customer one (although merits investigation as well).

This PR adds an `enable-verbose-type-logging` flag and corresponding envvar to enable the following logs:
* All classes discovered by the `EagerSourceTypeSolver`
* All classes discovered by the `JdkJarTypeSolver`
* All classes discovered by all of the `JarTypeSolvers` (which are created from fetched dependencies and jars specified with the `inferenec-jar-paths` option)
* The first instance of each resolution result for a given name in `SimpleCombinedTypeSolver`

In addition to this, we also always log the paths of fetched dependency jars at a debug level, regardless of whether `enable-verbose-type-logging` is set.

Enabling this option results in some performance impact and fairly large log files, so a warning is logged if it is enabled and the option and envvar descriptions also say this should only be enabled for specific issues. I tested it with `elasticsearch` which is the largest test project I usually use and the log size was around 30MB, so not disastrously large.