### PR TITLE
[kotlin2cpg] Handle null pointer graceful and log.

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstCreator.scala
@@ -240,9 +240,14 @@ class AstCreator(
     }
   }
 
-  private def logDebugWithTestAndStackTrace(message: String): Unit = {
+  protected def logDebugWithTestAndStackTrace(message: String): Unit = {
     val declString = debugScope.headOption.map(_.getText).getOrElse("Declaration scope empty")
     logger.debug(message + "\nIn declaration:\n" + declString + "\nStack trace to declaration:" + getStackTrace)
+  }
+
+  protected def logWarnWithTestAndStackTrace(message: String): Unit = {
+    val declString = debugScope.headOption.map(_.getText).getOrElse("Declaration scope empty")
+    logger.warn(message + "\nIn declaration:\n" + declString + "\nStack trace to declaration:" + getStackTrace)
   }
 
   private def getStackTrace: String = {


### PR DESCRIPTION
Handle a null pointer return from getDispatchReceiverParameter
gracefully so that not the hole file is dropped. When this happens we
log an error with some debug information. Hopefully enough to fix this
if the customer resubmits.

Issue which caused this: https://shiftleftinc.atlassian.net/browse/SEN-4407
