### PR TITLE
Fix other jobs w.r.t. Swift

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -23,6 +23,10 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
+      - name: Set up Swift
+        uses: SwiftyLab/setup-swift@latest
+        with:
+          swift-version: "6.1"
       - name: Install Bundler
         run: gem install bundler -v 2.4.22
       - name: Delete `.rustup` directory

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,10 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
+      - name: Set up Swift
+        uses: SwiftyLab/setup-swift@latest
+        with:
+          swift-version: "6.1"
       - name: Install Bundler
         run: gem install bundler -v 2.4.22
       - name: Delete `.rustup` directory

--- a/.github/workflows/upgrade-deps.yml
+++ b/.github/workflows/upgrade-deps.yml
@@ -20,6 +20,10 @@ jobs:
           distribution: temurin
           java-version: 21
           cache: sbt
+      - name: Set up Swift
+        uses: SwiftyLab/setup-swift@latest
+        with:
+          swift-version: "6.1"
       - uses: sbt/setup-sbt@v1
       - name: Upgrade all (internal) dependencies
         run: ./updateDependencies.sh --non-interactive


### PR DESCRIPTION
Ubuntu runners update their Swift version.
We use a fixed version (6.1) now universally.