### PR TITLE
eclipse cdt 9.2.100

### DIFF
--- a/joern-cli/frontends/c2cpg/eclipse-cdt/eclipse-cdt-core-publish.sh
+++ b/joern-cli/frontends/c2cpg/eclipse-cdt/eclipse-cdt-core-publish.sh
@@ -7,7 +7,11 @@ set -o pipefail
 # sonatype, so that we can promote it to maven central.
 # note: we also swap the original CCorePlugin.java for a simplified one
 # context: eclipse uses their own repository format called p2 tycho,
-# but tooling is limited
+# but tooling is limited.
+
+# Prerequisite: your ~/.m2/settings.xml must contain joern-io credentials for a
+# `sonatype-central-joern` server entry, which is referenced in the `pom.xml.template`
+
 # Some related links:
 # https://ci.eclipse.org/cdt/job/cdt/job/main
 # https://ci.eclipse.org/cdt/job/cdt/job/main/353/artifact/releng/org.eclipse.cdt.repo/target/repository/plugins/org.eclipse.cdt.core_8.4.0.202401242025.jar
@@ -18,8 +22,8 @@ set -o pipefail
 # https://github.com/digimead/sbt-osgi-manager/blob/master/src/main/scala/sbt/osgi/manager/tycho/ResolveP2.scala
 
 # adapt for every release
-JAR_URL='https://ci.eclipse.org/cdt/job/cdt/job/main/452/artifact/releng/org.eclipse.cdt.repo/target/repository/plugins/org.eclipse.cdt.core_8.5.0.202410191453.jar'
-CUSTOM_RELEASE_VERSION='8.5.0.202410191453+3'
+JAR_URL='https://ci.eclipse.org/cdt/job/cdt/job/main/614/artifact/releng/org.eclipse.cdt.repo/target/repository/plugins/org.eclipse.cdt.core_9.2.100.202507101054.jar'
+CUSTOM_RELEASE_VERSION='9.2.100.202507101054+1'
 
 LOCAL_JAR="org.eclipse.cdt.core-$CUSTOM_RELEASE_VERSION.jar"
 echo "downloading jar from $JAR_URL to $LOCAL_JAR"


### PR DESCRIPTION
Already ran this - looks good: 

```
[INFO] Created bundle successfully /home/mp/Projects/shiftleft/joern/joern-cli/frontends/c2cpg/eclipse-cdt/build/target/central-staging/central-bundle.zip
[INFO] Going to upload /home/mp/Projects/shiftleft/joern/joern-cli/frontends/c2cpg/eclipse-cdt/build/target/central-publishing/central-bundle.zip
[INFO] Uploaded bundle successfully, deployment name: cdt-9.2.100.202507101054+1, deploymentId: 12183697-c871-4bf8-8c4e-2477978b3ad3. Deployment will publish automatically
[INFO] Waiting until Deployment 12183697-c871-4bf8-8c4e-2477978b3ad3 is validated
[INFO] Deployment 12183697-c871-4bf8-8c4e-2477978b3ad3 has been validated. To finish publishing visit https://central.sonatype.com/publishing/deployments
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  27.946 s
[INFO] Finished at: 2025-09-30T13:27:21+02:00
[INFO] ------------------------------------------------------------------------
~/Projects/shiftleft/joern/joern-cli/frontends/c2cpg/eclipse-cdt
release is now published to sonatype central and should get promoted to maven central automatically. For more context go to https://central.sonatype.com/publishing/deployments
once it's synchronised to maven central (https://repo1.maven.org/maven2/io/joern/eclipse-cdt-core/), update the cdt-core version in 'joern/joern-cli/frontends/c2cpg/build.sbt' to 9.2.100.202507101054+1
```