### PR TITLE
[x2cpg] Use File.pathSeparator to split maven dependencies output path

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/MavenDependencies.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/MavenDependencies.scala
@@ -3,6 +3,7 @@ package io.joern.x2cpg.utils.dependency
 import io.shiftleft.semanticcpg.utils.ExternalCommand
 import org.slf4j.LoggerFactory
 
+import java.io.File
 import java.nio.file.Path
 import scala.util.{Failure, Success}
 import scala.util.Properties.isWin
@@ -68,7 +69,7 @@ object MavenDependencies {
       val isClassPathNow = classPathNext
       classPathNext = line.endsWith("Dependencies classpath:")
 
-      if (isClassPathNow) line.split(':') else Array.empty[String]
+      if (isClassPathNow) line.split(File.pathSeparatorChar) else Array.empty[String]
     }.distinct
 
     logger.info("got {} Maven dependencies", deps.size)


### PR DESCRIPTION
This fixes an error where Windows path output was still split with the Linux path separator `:`, leading to depenency output like:
```
- C
- \path\to\dependency;C
- \path\to\other\dependency
```