### PR TITLE
[x2cpg] Make the scope path separator adjustable

### DIFF
--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstCreator.scala
@@ -5,8 +5,8 @@ import io.joern.swiftsrc2cpg.parser.SwiftJsonParser.ParseResult
 import io.joern.swiftsrc2cpg.parser.SwiftNodeSyntax.*
 import io.joern.swiftsrc2cpg.utils.FullnameProvider
 import io.joern.swiftsrc2cpg.utils.SwiftTypesProvider.SwiftFileLocalTypeMapping
+import io.joern.x2cpg.datastructures.Global
 import io.joern.x2cpg.datastructures.Stack.*
-import io.joern.x2cpg.datastructures.{Global, VariableScopeManager}
 import io.joern.x2cpg.frontendspecific.swiftsrc2cpg.Defines
 import io.joern.x2cpg.{Ast, AstCreatorBase, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.nodes.*
@@ -36,7 +36,7 @@ class AstCreator(
 
   protected val logger: Logger = LoggerFactory.getLogger(classOf[AstCreator])
 
-  protected val scope            = new VariableScopeManager()
+  protected val scope            = new SwiftVariableScopeManager()
   protected val fullnameProvider = new FullnameProvider(typeMap)
 
   protected val methodAstParentStack     = new Stack[NewNode]()

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstCreatorHelper.scala
@@ -174,7 +174,7 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
   protected def scopeLocalUniqueName(targetName: String): String = {
     val name = if (targetName.nonEmpty) { s"<$targetName>" }
     else { "<anonymous>" }
-    val key = s"${scope.computeScopePath}:$name"
+    val key = s"${scope.computeScopePath}.$name"
     val idx = scopeLocalUniqueNames.getOrElseUpdate(key, 0)
     scopeLocalUniqueNames.update(key, idx + 1)
     s"$name$idx"
@@ -312,8 +312,8 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
   }
 
   private def calcNameAndFullName(name: String): (String, String) = {
-    val fullNamePrefix = s"${parserResult.filename}:${scope.computeScopePath.replace(":", ".")}."
-    val fullName       = s"$fullNamePrefix$name"
+    val fullNamePrefix = s"${parserResult.filename}:${scope.computeScopePath}"
+    val fullName       = s"$fullNamePrefix.$name"
     (name, fullName)
   }
 

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/SwiftVariableScopeManager.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/SwiftVariableScopeManager.scala
@@ -1,0 +1,9 @@
+package io.joern.swiftsrc2cpg.astcreation
+
+import io.joern.x2cpg.datastructures.VariableScopeManager
+
+class SwiftVariableScopeManager extends VariableScopeManager {
+
+  override val ScopePathSeparator: String = "."
+
+}

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/datastructures/VariableScopeManager.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/datastructures/VariableScopeManager.scala
@@ -124,13 +124,15 @@ class VariableScopeManager {
   /** The current scope stack, represented as an optional `ScopeElement`. */
   protected var stack: Option[ScopeElement] = Option.empty
 
+  protected val ScopePathSeparator: String = ":"
+
   /** Computes the scope path by concatenating the names of all enclosing method scopes.
     *
     * @return
     *   A string representing the scope path.
     */
   def computeScopePath: String = {
-    getAllEnclosingMethodScopeElements(stack).reverse.map(_.methodName).mkString(":")
+    getAllEnclosingMethodScopeElements(stack).reverse.map(_.methodName).mkString(ScopePathSeparator)
   }
 
   /** Looks up a variable by its identifier in the current scope stack.


### PR DESCRIPTION
The whole `VariableScopeManager` thing was extracted from the old JS frontend implementation where we by default used "`:`" as separator. This does not hold for all frontends.