### PR TITLE
bump cpg

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name                     := "joern"
 ThisBuild / organization := "io.joern"
 ThisBuild / scalaVersion := "3.6.4"
 
-val cpgVersion = "1.7.48"
+val cpgVersion = "1.7.49"
 
 lazy val joerncli          = Projects.joerncli
 lazy val querydb           = Projects.querydb


### PR DESCRIPTION
This bumps the codepropertygraph version, in order to make groupByStable available. Follow-up will review all uses of the unstable groupBy.