### PR TITLE
[pysrc2cpg] Fixed code field for CALL nodes

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/CallCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/CallCpgTests.scala
@@ -47,6 +47,30 @@ class CallCpgTests extends PySrc2CpgFixture(withOssDataflow = false) {
     }
   }
 
+  "call on member call-chain" should {
+    lazy val cpg = code("""x.y.func(a, b, **args)""".stripMargin, "test.py")
+
+    "test call node properties" in {
+      val callNode = cpg.call.codeExact("x.y.func(a, b, **args)").head
+      callNode.name shouldBe "func"
+      callNode.signature shouldBe ""
+      callNode.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
+      callNode.lineNumber shouldBe Some(1)
+    }
+  }
+
+  "call on complex call-chain" should {
+    lazy val cpg = code("""x.foo(1, 2).y.func(a, b, **args)""".stripMargin, "test.py")
+
+    "test call node properties" in {
+      val callNode = cpg.call.codeExact("x.foo(1, 2).y.func(a, b, **args)").head
+      callNode.name shouldBe "func"
+      callNode.signature shouldBe ""
+      callNode.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
+      callNode.lineNumber shouldBe Some(1)
+    }
+  }
+
   "call on identifier with named argument" should {
     lazy val cpg = code("""func(a, b, namedPar = c)""".stripMargin, "test.py")
 

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/TypeRecoveryPassTests.scala
@@ -2,8 +2,7 @@ package io.joern.pysrc2cpg.passes
 
 import io.joern.pysrc2cpg.testfixtures.PySrc2CpgFixture
 import io.joern.x2cpg.passes.frontend.XTypeHintCallLinker
-import io.shiftleft.codepropertygraph.generated.Operators
-import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, Member}
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier}
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.language.importresolver.*
 
@@ -350,7 +349,7 @@ class TypeRecoveryPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
         .where(_.parentBlock.ast.isIdentifier.typeFullName("flask_sqlalchemy.py:<module>.SQLAlchemy"))
         .where(_.parentBlock.ast.isFieldIdentifier.canonicalName("session"))
         .headOption
-        .map(_.code) shouldBe Some("tmp0.add(user)")
+        .map(_.code) shouldBe Some("db.session.add(user)")
     }
 
     "provide a dummy type to a member if the member type is not known" in {


### PR DESCRIPTION
This PR sets the actual call AST node code instead of the lowered representation.
Note: this only affects code fields for "true" calls, i.e., calls in the actual source code.
Synthetic calls (from lowering) still use their repective lowered call code.

For: https://github.com/joernio/joern/issues/5674