### PR TITLE
[javasrc2cpg] Fix null type handling in TypeInferencePass

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/TypeInferencePass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/TypeInferencePass.scala
@@ -12,7 +12,7 @@ import org.slf4j.LoggerFactory
 import scala.jdk.OptionConverters.RichOptional
 import io.joern.x2cpg.Defines.UnresolvedNamespace
 import io.shiftleft.codepropertygraph.generated.PropertyNames
-import io.joern.javasrc2cpg.typesolvers.TypeInfoCalculator.TypeConstants
+import io.joern.javasrc2cpg.typesolvers.TypeInfoCalculator.{PrimitiveTypes, TypeConstants}
 
 class TypeInferencePass(cpg: Cpg) extends ForkJoinParallelCpgPass[Call](cpg) {
 
@@ -55,7 +55,9 @@ class TypeInferencePass(cpg: Cpg) extends ForkJoinParallelCpgPass[Call](cpg) {
 
     val hasDifferingArg = method.parameter.zip(callArgs).exists { case (parameter, argument) =>
       val maybeArgumentType = argument.propertyOption(Properties.TypeFullName).getOrElse(TypeConstants.Any)
-      val argMatches        = maybeArgumentType == TypeConstants.Any || maybeArgumentType == parameter.typeFullName
+      val argMatches =
+        maybeArgumentType == TypeConstants.Any || maybeArgumentType == parameter.typeFullName || (maybeArgumentType == TypeConstants.Null && !PrimitiveTypes
+          .contains(parameter.typeFullName))
 
       !argMatches
     }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/TypeInfoCalculator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/TypeInfoCalculator.scala
@@ -264,6 +264,7 @@ object TypeInfoCalculator {
     val Record: String   = "java.lang.Record"
     val Void: String     = "void"
     val Any: String      = "ANY"
+    val Null: String     = "null"
   }
 
   object TypeNameConstants {
@@ -288,15 +289,9 @@ object TypeInfoCalculator {
     "registerNatives()"
   )
 
-  val NumericTypes: Set[String] = Set(
-    "byte",
-    "short",
-    "int",
-    "long",
-    "float",
-    "double",
-    "char",
-    "boolean",
+  val PrimitiveTypes: Set[String] = Set("byte", "short", "int", "long", "float", "double", "char", "boolean")
+
+  val NumericTypes: Set[String] = PrimitiveTypes ++ Set(
     "java.lang.Byte",
     "java.lang.Short",
     "java.lang.Integer",

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/TypeInferenceTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/TypeInferenceTests.scala
@@ -44,6 +44,41 @@ class NewTypeInferenceTests extends JavaSrcCode2CpgFixture {
       )
     }
 
+    "a call with an unresolved argument with a null type" when {
+      "there is only one matching method should be resolved" in {
+        val cpg = code(
+          """
+            |package foo;
+            |
+            |import a.b.Bar;
+            |
+            |public class Foo {
+            |  public static Bar test(String s) {
+            |    return new Bar(s);
+            |  }
+            |
+            |  public void sink(Bar b) {}
+            |}
+            |""".stripMargin,
+          fileName = "Foo.java"
+        ).moreCode("""
+            |import foo.Foo;
+            |
+            |import baz.Baz;
+            |
+            |class Test {
+            |  public static Bar stringCall() {
+            |    sink(Foo.test(null));
+            |  }
+            |}
+            |""".stripMargin)
+
+        cpg.method.name("stringCall").call.name("test").methodFullName.l shouldBe List(
+          "foo.Foo.test:a.b.Bar(java.lang.String)"
+        )
+      }
+    }
+
     "there are multiple matching methods should not be resolved" in {
       val cpg = code(
         """


### PR DESCRIPTION
Fixes https://github.com/joernio/joern/issues/5676

Just setting the type of `null` to any isn't quite correct, since this would incorrectly match parameters with primitive types. We'll probably need to handle this in the back-end as well. 