### PR TITLE
[kotlin2cpg] fix: update kotlin version for JDK 25 support

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/build.sbt
+++ b/joern-cli/frontends/kotlin2cpg/build.sbt
@@ -1,6 +1,6 @@
 name := "kotlin2cpg"
 
-val kotlinVersion = "1.9.23"
+val kotlinVersion = "2.2.20"
 
 dependsOn(
   Projects.dataflowengineoss  % "compile->compile;test->test",


### PR DESCRIPTION
Update kotlin2cpg dependencies for JDK 25 support.

Fixes https://github.com/ShiftLeftSecurity/codescience/issues/8507