### PR TITLE
fix: use fully qualified fullname for NamespaceBlock

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
@@ -66,13 +66,13 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
       scope.pushNewScope(NamespaceScope(namespaceBlockFullName))
 
       val namespaceBlock =
-        NewNamespaceBlock().name(astParentFullName).fullName(astParentFullName).filename(relativeFileName)
+        NewNamespaceBlock().name(astParentFullName).fullName(namespaceBlockFullName).filename(relativeFileName)
 
       diffGraph.addNode(namespaceBlock)
 
       fileNode.foreach(diffGraph.addEdge(_, namespaceBlock, EdgeTypes.AST))
 
-      typeDecl.astParentFullName(astParentFullName)
+      typeDecl.astParentFullName(namespaceBlockFullName)
       typeDecl.astParentType(NodeTypes.NAMESPACE_BLOCK)
 
       typeDecl.fullName(computeFullName(className))

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
@@ -977,7 +977,7 @@ class ClassTests extends RubyCode2CpgFixture {
         |end
         |""".stripMargin)
 
-    inside(cpg.namespaceBlock.fullNameExact("Api.V1").typeDecl.l) {
+    inside(cpg.namespaceBlock.fullNameExact("Test0.rb:<main>.Api.V1").typeDecl.l) {
       case mobileNamespace :: mobileClassNamespace :: Nil =>
         mobileNamespace.name shouldBe "MobileController"
         mobileNamespace.fullName shouldBe s"Test0.rb:$Main.Api.V1.MobileController"
@@ -991,7 +991,7 @@ class ClassTests extends RubyCode2CpgFixture {
       case mobileTypeDecl :: Nil =>
         mobileTypeDecl.name shouldBe "MobileController"
         mobileTypeDecl.fullName shouldBe s"Test0.rb:$Main.Api.V1.MobileController"
-        mobileTypeDecl.astParentFullName shouldBe "Api.V1"
+        mobileTypeDecl.astParentFullName shouldBe "Test0.rb:<main>.Api.V1"
         mobileTypeDecl.astParentType shouldBe NodeTypes.NAMESPACE_BLOCK
 
         mobileTypeDecl.astParent.isNamespaceBlock shouldBe true

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ModuleTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ModuleTests.scala
@@ -47,7 +47,7 @@ class ModuleTests extends RubyCode2CpgFixture {
         |end
         |""".stripMargin)
 
-    inside(cpg.namespaceBlock.fullNameExact("Api.V1").typeDecl.l) {
+    inside(cpg.namespaceBlock.fullNameExact("Test0.rb:<main>.Api.V1").typeDecl.l) {
       case mobileNamespace :: mobileClassNamespace :: Nil =>
         mobileNamespace.name shouldBe "MobileController"
         mobileNamespace.fullName shouldBe "Test0.rb:<main>.Api.V1.MobileController"
@@ -61,7 +61,7 @@ class ModuleTests extends RubyCode2CpgFixture {
       case mobileTypeDecl :: Nil =>
         mobileTypeDecl.name shouldBe "MobileController"
         mobileTypeDecl.fullName shouldBe "Test0.rb:<main>.Api.V1.MobileController"
-        mobileTypeDecl.astParentFullName shouldBe "Api.V1"
+        mobileTypeDecl.astParentFullName shouldBe "Test0.rb:<main>.Api.V1"
         mobileTypeDecl.astParentType shouldBe NodeTypes.NAMESPACE_BLOCK
 
         mobileTypeDecl.astParent.isNamespaceBlock shouldBe true


### PR DESCRIPTION
This fixes fullname collisions for NamespaceBlock nodes. Fully qualified names are now used, which will guarantee uniqueness.

Fixes https://github.com/ShiftLeftSecurity/codescience/issues/8537