### PR TITLE
[swiftsrc2cpg] Update swiftastgen version to 0.3.4

### DIFF
--- a/joern-cli/frontends/swiftsrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 swiftsrc2cpg {
-    astgen_version: "0.3.3"
+    astgen_version: "0.3.4"
 }


### PR DESCRIPTION
Brings in the latest swiftastgen which ignores test paths from all .testTarget paths from Package.swift (if any).

See: https://github.com/joernio/SwiftAstGen/pull/20