### PR TITLE
[console] fix line splitting in --runBefore

### DIFF
--- a/console/src/main/scala/io/joern/console/BridgeBase.scala
+++ b/console/src/main/scala/io/joern/console/BridgeBase.scala
@@ -79,7 +79,7 @@ trait BridgeBase extends InteractiveShell with ScriptExecution with PluginHandli
         .valueName("'import Int.MaxValue'")
         .unbounded()
         .optional()
-        .action((x, c) => c.copy(runBefore = c.runBefore :+ x))
+        .action((x, c) => c.copy(runBefore = c.runBefore ++ x.linesIterator.toIndexedSeq))
         .text("given code will be executed on startup - this may be passed multiple times")
 
       opt[String]("runAfter")


### PR DESCRIPTION
before

    ./joern --runBefore '//> using dep org.apache.commons:commons-exec:1.5.0
    //> using dep io.methvin:directory-watcher:0.19.1'

would fail because the version number for commons-exec would not end at "1.5.0", but instead also include the whole second line.