### PR TITLE
[console] always defer to overridden post-processing impl

### DIFF
--- a/console/src/main/scala/io/joern/console/Console.scala
+++ b/console/src/main/scala/io/joern/console/Console.scala
@@ -409,7 +409,7 @@ class Console[T <: Project](loader: WorkspaceLoader[T], baseDir: Path = FileUtil
   }
 
   def applyPostProcessingPasses(cpg: Cpg): Cpg = {
-    new io.joern.console.cpgcreation.CpgGeneratorFactory(_config).forLanguage(cpg.metaData.language.l.head) match {
+    new io.joern.console.cpgcreation.CpgGeneratorFactory(_config).forLanguage(cpg.metaData.language.head) match {
       case Some(frontend) => frontend.applyPostProcessingPasses(cpg)
       case None           => cpg
     }

--- a/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
@@ -232,7 +232,7 @@ class ImportCode[T <: Project](console: io.joern.console.Console[T])(implicit
         report("""|Code successfully imported. You can now query it using `cpg`.
           |For an overview of all imported code, type `workspace`.""".stripMargin)
         console.applyDefaultOverlays(cpg)
-        generator.applyPostProcessingPasses(cpg)
+        console.applyPostProcessingPasses(cpg)
       }
       .getOrElse(throw new ConsoleException(s"Error creating project for input path: `$inputPath`"))
   }


### PR DESCRIPTION
We already allow downstream console implementations to override which post-processing passes should be running for `importCpg()`, but failed to honor that for `importCode()`. This fixes that.

Nothing changes for direct users of vanilla joern.