### PR TITLE
go 1.25

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,7 +21,7 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: brew install php
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           cache: false
           go-version: 1.25


### PR DESCRIPTION
context: go 1.18 isn't available for download any longer, and that blocks other PRs:
    ```
    Setup go version spec 1.18
    Attempting to download 1.18...
    matching 1.18...
    Not found in manifest.  Falling back to download directly from Go
    Install from dist
    Acquiring go1.18.10 from https://storage.googleapis.com/golang/go1.18.10.darwin-arm64.tar.gz
    Error: Failed to download version 1.18: Error: Unexpected HTTP response: 403
    ```
https://github.com/joernio/joern/actions/runs/19851681566/job/56879725873?pr=5711