### PR TITLE
[pysrc2cpg] Avoid tmp variable creation in for non complex receivers.

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
@@ -12,6 +12,7 @@ import io.shiftleft.codepropertygraph.generated.nodes.{NewCall, NewIdentifier, N
 import org.slf4j.LoggerFactory
 import io.shiftleft.codepropertygraph.generated.DiffGraphBuilder
 
+import scala.annotation.tailrec
 import scala.collection.mutable
 
 object MethodParameters {
@@ -1836,6 +1837,18 @@ class PythonAstVisitor(
     ("and", Operators.logicalAnd)
   }
 
+  @tailrec
+  private def mayHaveSideEffects(expr: ast.iexpr): Boolean = {
+    expr match {
+      case attr: ast.Attribute =>
+        mayHaveSideEffects(attr.value)
+      case attr: ast.Name =>
+        false
+      case _ =>
+        true
+    }
+  }
+
   /** TODO For now this function compromises on the correctness of the lowering in order to get some data flow tracking
     * going.
     *   1. For constructs like x.func() we assume x to be the instance which is passed into func. This is not true since
@@ -1862,7 +1875,7 @@ class PythonAstVisitor(
         createXDotYCall(
           () => convert(attribute.value),
           attribute.attr,
-          xMayHaveSideEffects = !attribute.value.isInstanceOf[ast.Name],
+          xMayHaveSideEffects = mayHaveSideEffects(attribute.value),
           lineAndColOf(call),
           argumentNodes,
           keywordArgNodes,


### PR DESCRIPTION
So far the python frontend emitted tmp variables in the context of call
site lowering if the `<x>` in a `<x>.y()` call was anything other than
an identifier/name. Now we also avoid emitting tmp variables if `<x>` is
a member access chain. E.g. `x.y.z()`. This leads to less clutter and
better alias handling.
