### PR TITLE
[swiftsrc2cpg ] Update extension handling to correctly reference the extended type (via its fullName)

### DIFF
--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstCreatorHelper.scala
@@ -391,7 +391,9 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
         TypeInfo(name, cleanedFullName)
       case None =>
         val (_, declFullname) = calcNameAndFullName(name)
-        registerType(declFullname)
+        if (!node.isInstanceOf[ExtensionDeclSyntax]) {
+          registerType(declFullname)
+        }
         TypeInfo(name, declFullname)
     }
   }

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/utils/GsonTypeInfoReader.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/utils/GsonTypeInfoReader.scala
@@ -18,7 +18,7 @@ object GsonTypeInfoReader {
   private val DeclFullNameFieldNames = Set("usr", "decl_usr", "protocol", "superclass_type")
 
   /** Field names that can contain type fullNames in the Swift AST */
-  private val TypeFullNameFieldNames = Set("type", "type_usr", "result", "interface_type")
+  private val TypeFullNameFieldNames = Set("type", "type_usr", "result", "interface_type", "extended_type")
 
   /** AST node kinds that require special handling.
     *
@@ -238,6 +238,7 @@ object GsonTypeInfoReader {
       .orElse(safePropertyValue(obj, "type_usr"))
       .orElse(safePropertyValue(obj, "result"))
       .orElse(safePropertyValue(obj, "interface_type"))
+      .orElse(safePropertyValue(obj, "extended_type"))
   }
 
   private def isInBuildFolder(filename: String): Boolean = {


### PR DESCRIPTION
`self` was referencing the extension fullName and not the fullName of the extended type.
This PR fixes that.