### PR TITLE
[javasrc2cpg] Fix missing modifiers for Java class declarations along with code fields

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForTypeDeclsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/declarations/AstForTypeDeclsCreator.scala
@@ -1,5 +1,6 @@
 package io.joern.javasrc2cpg.astcreation.declarations
 
+import com.github.javaparser.ast.Modifier.Keyword
 import com.github.javaparser.ast.body.{
   AnnotationDeclaration,
   AnnotationMemberDeclaration,
@@ -43,7 +44,7 @@ import com.github.javaparser.resolution.declarations.{
 }
 import io.joern.javasrc2cpg.astcreation.{AstCreator, ExpectedType}
 import io.joern.javasrc2cpg.typesolvers.TypeInfoCalculator.TypeConstants
-import io.joern.javasrc2cpg.util.{BindingTable, BindingTableEntry, NameConstants, Util}
+import io.joern.javasrc2cpg.util.{BindingTable, BindingTableEntry, JavaModifierTypes, NameConstants, Util}
 import io.joern.x2cpg.{Ast, Defines}
 import io.shiftleft.codepropertygraph.generated.nodes.{
   NewArrayInitializer,
@@ -61,7 +62,7 @@ import scala.util.{Success, Try}
 import com.github.javaparser.ast.expr.ObjectCreationExpr
 import com.github.javaparser.ast.stmt.LocalClassDeclarationStmt
 import io.joern.javasrc2cpg.scope.Scope.ScopeVariable
-import com.github.javaparser.ast.Node
+import com.github.javaparser.ast.{Modifier, Node}
 import com.github.javaparser.resolution.types.ResolvedReferenceType
 import com.github.javaparser.resolution.types.parametrization.ResolvedTypeParametersMap
 import io.shiftleft.codepropertygraph.generated.nodes.NewCall
@@ -654,21 +655,38 @@ private[declarations] trait AstForTypeDeclsCreator { this: AstCreator =>
   }
 
   private def modifiersForTypeDecl(typ: TypeDeclaration[?], isInterface: Boolean): List[NewModifier] = {
-    val accessModifierType = if (typ.isPublic) {
-      Some(ModifierTypes.PUBLIC)
-    } else if (typ.isPrivate) {
-      Some(ModifierTypes.PRIVATE)
-    } else if (typ.isProtected) {
-      Some(ModifierTypes.PROTECTED)
-    } else {
-      None
+    val modifiers = typ.getModifiers.asScala.toList
+    // Interfaces are implicitly abstract, so add the abstract modifier if it hasn't been explicitly added
+    val implicitInterfaceAbstractModifier = Option.when(
+      isInterface && !modifiers.exists(_.getKeyword == Keyword.ABSTRACT)
+    )(modifierNode(typ, ModifierTypes.ABSTRACT))
+
+    val explicitModifiers = typ.getModifiers.asScala
+      .collect {
+        case modifier if modifier.getKeyword == Keyword.PUBLIC     => (modifier, ModifierTypes.PUBLIC)
+        case modifier if modifier.getKeyword == Keyword.PROTECTED  => (modifier, ModifierTypes.PROTECTED)
+        case modifier if modifier.getKeyword == Keyword.PRIVATE    => (modifier, ModifierTypes.PRIVATE)
+        case modifier if modifier.getKeyword == Keyword.ABSTRACT   => (modifier, ModifierTypes.ABSTRACT)
+        case modifier if modifier.getKeyword == Keyword.STATIC     => (modifier, ModifierTypes.STATIC)
+        case modifier if modifier.getKeyword == Keyword.FINAL      => (modifier, ModifierTypes.FINAL)
+        case modifier if modifier.getKeyword == Keyword.SEALED     => (modifier, JavaModifierTypes.Sealed)
+        case modifier if modifier.getKeyword == Keyword.NON_SEALED => (modifier, JavaModifierTypes.NonSealed)
+        case modifier if modifier.getKeyword == Keyword.STRICTFP   => (modifier, JavaModifierTypes.Strictfp)
+        // This should never be reached since the above list was taken directly from the Java Language Specification
+        case unhandled => logger.warn(s"BUG! Encountered unhandled class modifier $unhandled")
+      }
+      .map { case (node, modifierType) => modifierNode(node, modifierType) }
+      .toList
+
+    // This isn't technically necessary, but ensures that the implicit abstract modifier for interfaces is inserted
+    // in the standard order, provided the explicit modifiers follow this order.
+    val accessModifiers = Set(ModifierTypes.PUBLIC, ModifierTypes.PRIVATE, ModifierTypes.PROTECTED)
+    explicitModifiers match {
+      case Nil => implicitInterfaceAbstractModifier.toList
+      case maybeAccess :: rest if accessModifiers.contains(maybeAccess.modifierType) =>
+        maybeAccess :: implicitInterfaceAbstractModifier.toList ++ rest
+      case _ => implicitInterfaceAbstractModifier.toList ++ explicitModifiers
     }
-    val accessModifier = accessModifierType.map(modifierNode(typ, _))
-
-    val abstractModifier =
-      Option.when(isInterface || typ.getMethods.asScala.exists(_.isAbstract))(modifierNode(typ, ModifierTypes.ABSTRACT))
-
-    List(accessModifier, abstractModifier).flatten
   }
 
   private def astForFieldVariable(v: VariableDeclarator, fieldDeclaration: FieldDeclaration): Ast = {
@@ -772,17 +790,12 @@ private[declarations] trait AstForTypeDeclsCreator { this: AstCreator =>
 
   private def codeForTypeDecl(typ: TypeDeclaration[?], isInterface: Boolean): String = {
     val codeBuilder = new mutable.StringBuilder()
-    if (typ.isPublic) {
-      codeBuilder.append("public ")
-    } else if (typ.isPrivate) {
-      codeBuilder.append("private ")
-    } else if (typ.isProtected) {
-      codeBuilder.append("protected ")
-    }
 
-    if (typ.isStatic) {
-      codeBuilder.append("static ")
-    }
+    typ.getModifiers.asScala
+      .foreach { modifier =>
+        codeBuilder.append(modifier.getKeyword.asString())
+        codeBuilder.append(" ")
+      }
 
     val classPrefix =
       if (isInterface)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/JavaModifierTypes.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/JavaModifierTypes.scala
@@ -1,0 +1,9 @@
+package io.joern.javasrc2cpg.util
+
+/** Used for Java-specific modifiers that aren't used by other languages
+  */
+object JavaModifierTypes {
+  val Sealed: String    = "SEALED"
+  val NonSealed: String = "NON_SEALED"
+  val Strictfp: String  = "STRICTFP"
+}

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/TypeDeclTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/TypeDeclTests.scala
@@ -106,7 +106,127 @@ class NewTypeDeclTests extends JavaSrcCode2CpgFixture {
     }
   }
 
+  "a package-private class" should {
+    val cpg = code("class Foo {}")
+
+    "have no modifier" in {
+      cpg.typeDecl.name("Foo").modifier.modifierType.toSet shouldBe Set()
+    }
+
+    "have the correct code field" in {
+      cpg.typeDecl.name("Foo").code.l shouldBe List("class Foo")
+    }
+  }
+
+  "a public class" should {
+    val cpg = code("public class Foo {}")
+
+    "have the correct modifier" in {
+      cpg.typeDecl.name("Foo").modifier.modifierType.toSet shouldBe Set("PUBLIC")
+    }
+
+    "have the correct code field" in {
+      cpg.typeDecl.name("Foo").code.l shouldBe List("public class Foo")
+    }
+  }
+
+  "a protected class" should {
+    val cpg = code("class Outer { protected class Foo {} }")
+
+    "have the correct modifier" in {
+      cpg.typeDecl.name(".*Foo").modifier.modifierType.toSet shouldBe Set("PROTECTED")
+    }
+
+    "have the correct code field" in {
+      cpg.typeDecl.name(".*Foo").code.l shouldBe List("protected class Foo")
+    }
+  }
+
+  "a private class" should {
+    val cpg = code("class Outer { private class Foo {} }")
+
+    "have the correct modifier" in {
+      cpg.typeDecl.name(".*Foo").modifier.modifierType.toSet shouldBe Set("PRIVATE")
+    }
+
+    "have the correct code field" in {
+      cpg.typeDecl.name(".*Foo").code.l shouldBe List("private class Foo")
+    }
+  }
+
+  "an abstract class" should {
+    val cpg = code("abstract class Foo {}")
+
+    "have the correct modifier" in {
+      cpg.typeDecl.name("Foo").modifier.modifierType.toSet shouldBe Set("ABSTRACT")
+    }
+
+    "have the correct code field" in {
+      cpg.typeDecl.name("Foo").code.l shouldBe List("abstract class Foo")
+    }
+  }
+
+  "a static class" should {
+    val cpg = code("class Outer { static class Foo {} }")
+
+    "have the correct modifier" in {
+      cpg.typeDecl.name(".*Foo").modifier.modifierType.toSet shouldBe Set("STATIC")
+    }
+
+    "have the correct code field" in {
+      cpg.typeDecl.name(".*Foo").code.l shouldBe List("static class Foo")
+    }
+  }
+
+  "a final class" should {
+    val cpg = code("final class Foo {}")
+
+    "have the correct modifier" in {
+      cpg.typeDecl.name("Foo").modifier.modifierType.toSet shouldBe Set("FINAL")
+    }
+
+    "have the correct code field" in {
+      cpg.typeDecl.name("Foo").code.l shouldBe List("final class Foo")
+    }
+  }
+
+  "a sealed class" should {
+    val cpg = code("sealed class Foo {}")
+
+    "have the correct modifier" in {
+      cpg.typeDecl.name("Foo").modifier.modifierType.toSet shouldBe Set("SEALED")
+    }
+
+    "have the correct code field" in {
+      cpg.typeDecl.name("Foo").code.l shouldBe List("sealed class Foo")
+    }
+  }
+
+  "a non-sealed class" should {
+    val cpg = code("non-sealed class Foo {}")
+
+    "have the correct modifier" in {
+      cpg.typeDecl.name("Foo").modifier.modifierType.toSet shouldBe Set("NON_SEALED")
+    }
+
+    "have the correct code field" in {
+      cpg.typeDecl.name("Foo").code.l shouldBe List("non-sealed class Foo")
+    }
+  }
+
+  "a strictfp class" should {
+    val cpg = code("strictfp class Foo {}")
+
+    "have the correct modifier" in {
+      cpg.typeDecl.name("Foo").modifier.modifierType.toSet shouldBe Set("STRICTFP")
+    }
+
+    "have the correct code field" in {
+      cpg.typeDecl.name("Foo").code.l shouldBe List("strictfp class Foo")
+    }
+  }
 }
+
 class TypeDeclTests extends JavaSrcCode2CpgFixture {
 
   val cpg = code(


### PR DESCRIPTION
https://github.com/joernio/joern/issues/5726 revealed an issue where javasrc type declarations were missing the `abstract` modifier. When investigating, I found many other modifiers were also missing. This PR adds support for the missing modifiers and relies more on modifiers returned by JavaParser, hence reducing duplicated work (since this is already handled well in JP)