### PR TITLE
[x2cpg] Add retryable assertion scalatest util with timeout and exponential backoff support

### DIFF
--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/RetryableAssertionTests.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/RetryableAssertionTests.scala
@@ -2,54 +2,36 @@ package io.joern.x2cpg.utils
 
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
-import RetryableAssertion._
-import scala.concurrent.duration._
+import RetryableAssertion.*
+import org.scalatest.Assertion
+
+import scala.concurrent.duration.*
 
 class RetryableAssertionTests extends AnyWordSpec with Matchers {
 
   "Eventually assertion" should {
 
-    // Example 1: Basic usage with default config
     "retry until condition is met" in {
       var counter = 0
 
-      eventually {
+      eventually[Assertion, Throwable] {
         counter += 1
         counter should be > 2
       }
     }
 
-    // Example 2: Custom configuration
     "work with custom retry config" in {
       var attempts = 0
 
       implicit val customConfig: RetryConfig =
         RetryConfig(maxRetries = 5, retryDelay = 50.millis, timeout = 2.seconds, backoffMultiplier = 1.5)
 
-      eventually {
+      eventually[Assertion, Throwable] {
         attempts += 1
         attempts should be > 3
       }
     }
 
-    // Example 3: Using shouldEventually syntax
-    "work with shouldEventually syntax" in {
-      var state = "initializing"
-
-      // Simulate async state change
-      new Thread(() => {
-        Thread.sleep(300)
-        state = "ready"
-      }).start()
-
-      implicit val config: RetryConfig = RetryConfig(maxRetries = 10, retryDelay = 100.millis, timeout = 3.seconds)
-
-      state shouldEventually { s =>
-        s should be("ready")
-      }
-    }
-
-    // Example 4: Testing API responses with retry
     // intentionally ignored to avoid flaky test runs
     "retry flaky API calls" ignore {
       def flakyApiCall(): String = {
@@ -61,12 +43,11 @@ class RetryableAssertionTests extends AnyWordSpec with Matchers {
       implicit val apiConfig: RetryConfig =
         RetryConfig(maxRetries = 10, retryDelay = 200.millis, timeout = 5.seconds, backoffMultiplier = 1.2)
 
-      eventually {
+      eventually[Assertion, RuntimeException] {
         flakyApiCall() shouldBe "success"
       }
     }
 
-    // Example 5: Eventually with complex assertions
     "support complex ScalaTest matchers" in {
       var items = List.empty[Int]
 
@@ -80,10 +61,28 @@ class RetryableAssertionTests extends AnyWordSpec with Matchers {
 
       implicit val config: RetryConfig = RetryConfig(maxRetries = 20, retryDelay = 100.millis, timeout = 3.seconds)
 
-      eventually {
+      eventually[Assertion, Throwable] {
         items should have length 5
         items should contain allOf (1, 2, 3, 4, 5)
       }
+    }
+
+    "only specified exception type triggers retries" in {
+      // retry on IllegalStateException, shows that only specified exception type triggers retries
+      var attempts = 0
+      eventually[Assertion, IllegalStateException] {
+        attempts += 1
+        if (attempts < 3) throw new IllegalStateException("retry-me")
+        attempts shouldBe 3
+      }
+
+      // other exception types should be rethrown immediately
+      val ex = intercept[IllegalArgumentException] {
+        eventually[Assertion, IllegalStateException] {
+          throw new IllegalArgumentException("do-not-retry")
+        }
+      }
+      ex.getMessage should include("do-not-retry")
     }
   }
 }


### PR DESCRIPTION
I have seen a lot of 403s and timeouts while downloading stuff during tests for frontends (especially during wacky Cloudflare things in the last weeks). Some frontend tests rely on downloading dependencies (e.g., kotlin2cpg for resolving types, csharpsrc2cpg) during tests and fail hard if some resource is affected.

We could gradually fix/adjust the tests affected in these frontends over time.