### PR TITLE
Upgraded sealed traits in Model.scala to scala3

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/jartypereader/descriptorparser/TypeParser.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/jartypereader/descriptorparser/TypeParser.scala
@@ -1,7 +1,8 @@
 package io.joern.javasrc2cpg.jartypereader.descriptorparser
 
-import io.joern.javasrc2cpg.jartypereader.model.Bound.{BoundAbove, BoundBelow}
 import io.joern.javasrc2cpg.jartypereader.model.*
+import io.joern.javasrc2cpg.jartypereader.model.Bound.{BoundAbove, BoundBelow}
+import io.joern.javasrc2cpg.jartypereader.model.TypeArgument.{BoundWildcard, SimpleTypeArgument, UnboundWildcard}
 import org.slf4j.LoggerFactory
 
 trait TypeParser extends TokenParser {

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/jartypereader/model/Model.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/jartypereader/model/Model.scala
@@ -1,7 +1,5 @@
 package io.joern.javasrc2cpg.jartypereader.model
 
-import Bound.Bound
-
 sealed trait Named {
   def name: String
   def qualifiedName: String
@@ -21,16 +19,16 @@ sealed trait Named {
 
 case class NameWithTypeArgs(name: String, typeArguments: List[TypeArgument])
 
-object Bound {
-  sealed trait Bound
-  case object BoundAbove extends Bound
-  case object BoundBelow extends Bound
+enum Bound {
+  case BoundAbove
+  case BoundBelow
 }
 
-sealed trait TypeArgument
-case class SimpleTypeArgument(typeSignature: ReferenceTypeSignature)          extends TypeArgument
-case class BoundWildcard(bound: Bound, typeSignature: ReferenceTypeSignature) extends TypeArgument
-case object UnboundWildcard                                                   extends TypeArgument
+enum TypeArgument {
+  case SimpleTypeArgument(typeSignature: ReferenceTypeSignature)
+  case BoundWildcard(bound: Bound, typeSignature: ReferenceTypeSignature)
+  case UnboundWildcard
+}
 
 sealed trait JavaTypeSignature extends Named
 case class PrimitiveType(fullName: String) extends JavaTypeSignature {

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/jartypereader/JarTypeReaderTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/jartypereader/JarTypeReaderTests.scala
@@ -1,16 +1,7 @@
 package io.joern.javasrc2cpg.jartypereader
 
-import io.joern.javasrc2cpg.jartypereader.model.{
-  BoundWildcard,
-  ClassSignature,
-  ClassTypeSignature,
-  NameWithTypeArgs,
-  ResolvedTypeDecl,
-  SimpleTypeArgument,
-  TypeParameter,
-  TypeVariableSignature,
-  UnboundWildcard
-}
+import io.joern.javasrc2cpg.jartypereader.model.*
+import io.joern.javasrc2cpg.jartypereader.model.TypeArgument.{BoundWildcard, SimpleTypeArgument, UnboundWildcard}
 import io.joern.javasrc2cpg.jartypereader.JarTypeReader.ObjectTypeSignature
 import io.joern.javasrc2cpg.jartypereader.model.Bound.{BoundAbove, BoundBelow}
 import io.shiftleft.utils.ProjectRoot


### PR DESCRIPTION
Not sure if the following cases should be converted too, inside the same Model.scala file.

- Named defines shared methods and is used as a trait bound
- JavaTypeSignature and ReferenceTypeSignature form a nested inheritance hierarchy, possible, but don't I think idiomatic scala 3 enums would improve the code/usage of these classes.
- ResolvedType includes a non-case class (ResolvedTypeDecl) with mutable state, which isn't suitable for enum conversion. Would require a large amount of changes by separating the types out completely, or changing usage to make use of immutable objects.