### PR TITLE
Fix wexpect dependency 

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -107,6 +107,7 @@ jobs:
       - name: Install Python dependencies for distribution test (Windows)
         if: matrix.os == 'windows-latest'
         run: |
+          python -m pip install setuptools<81
           python -m pip install requests wexpect
       - name: Test distribution
         run: |


### PR DESCRIPTION
Out of date and most likely abandoned and will make problems very soon:
```
C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\wexpect\__init__.py:4: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources
...
```

We may have to find an actual replacement for it in the near future but this PR unblocks other PRs for now.