### PR TITLE
Deprecate deleteOnExit in c2cpg

### DIFF
--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/AstC2CpgFrontend.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/AstC2CpgFrontend.scala
@@ -18,14 +18,11 @@ trait AstC2CpgFrontend extends LanguageFrontend {
   override type ConfigType = Config
 
   def execute(sourceCodePath: java.io.File): Cpg = {
-    val cpgOutFile = FileUtil.newTemporaryFile(suffix = "cpg.bin")
-    FileUtil.deleteOnExit(cpgOutFile)
-    val cpg          = newEmptyCpg(Option(cpgOutFile.toString))
+    val cpg          = newEmptyCpg()
     val pathAsString = sourceCodePath.getAbsolutePath
     val config = getConfig()
       .fold(Config())(_.asInstanceOf[Config])
       .withInputPath(pathAsString)
-      .withOutputPath(pathAsString)
       .withSchemaValidation(ValidationMode.Enabled)
     val global = new CGlobal()
 

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/C2CpgFrontend.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/C2CpgFrontend.scala
@@ -11,13 +11,10 @@ trait C2CpgFrontend extends LanguageFrontend {
   override type ConfigType = Config
 
   def execute(sourceCodePath: java.io.File): Cpg = {
-    val cpgOutFile = FileUtil.newTemporaryFile(suffix = "cpg.bin")
-    FileUtil.deleteOnExit(cpgOutFile)
     val c2cpg = new C2Cpg()
     val config = getConfig()
       .fold(Config())(_.asInstanceOf[Config])
       .withInputPath(sourceCodePath.getAbsolutePath)
-      .withOutputPath(cpgOutFile.toString)
     val res = c2cpg.createCpg(config).get
     new PostFrontendValidator(res, false).run()
     res

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
@@ -17,7 +17,7 @@ import scala.util.matching.Regex
 import scala.util.{Failure, Success, Try}
 
 object X2CpgConfig {
-  def defaultOutputPath: String = "cpg.bin"
+  def defaultOutputPath: String = ""
 
   final case class GenericConfig(
     inputPath: String = "",


### PR DESCRIPTION
This is a 'duplicate' PR, but with a slightly different approach to #5754.

This removes the default behavior where if a path is not specified for cpg serialization, a default path of "cpg.bin" is used, and adapts c2cpg tests to accommodate.