### PR TITLE
Deprecate deleteOnExit in switft2cpg and ExcludeTests

### DIFF
--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/io/ExcludeTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/io/ExcludeTests.scala
@@ -48,12 +48,8 @@ class ExcludeTests extends AnyWordSpec with Matchers with TableDrivenPropertyChe
   override def afterAll(): Unit = FileUtil.delete(projectUnderTest, swallowIoExceptions = true)
 
   private def testWithArguments(exclude: Seq[String], excludeRegex: String, expectedFiles: Set[String]): Unit = {
-    val cpgOutFile = FileUtil.newTemporaryFile("c2cpg.bin")
-    FileUtil.deleteOnExit(cpgOutFile)
-
     val config = Config()
       .withInputPath(projectUnderTest.toString)
-      .withOutputPath(cpgOutFile.toString)
       .withIgnoredFiles(exclude)
       .withIgnoredFilesRegex(excludeRegex)
     val c2cpg = new C2Cpg()

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/testfixtures/SwiftSrc2CpgFrontend.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/testfixtures/SwiftSrc2CpgFrontend.scala
@@ -10,13 +10,9 @@ trait SwiftSrc2CpgFrontend extends LanguageFrontend {
   override type ConfigType = Config
 
   def execute(sourceCodePath: java.io.File): Cpg = {
-    val cpgOutFile = FileUtil.newTemporaryFile(suffix = "cpg.bin")
-    FileUtil.deleteOnExit(cpgOutFile)
-
     val config = getConfig()
       .fold(Config())(identity)
       .withInputPath(sourceCodePath.getAbsolutePath)
-      .withOutputPath(cpgOutFile.toString)
 
     val tmp = new SwiftSrc2Cpg().createCpg(config).get
     new PostFrontendValidator(tmp, false).run()


### PR DESCRIPTION
Extension of #5764 , did break swift2cpg tests at some point but seems fine now, think it was a dirty compile directory on my machine rather than a fault of the changes.