### PR TITLE
[x2cpg] add block to CdgPass

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/codepencegraph/CdgPass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/controlflow/codepencegraph/CdgPass.scala
@@ -3,6 +3,7 @@ package io.joern.x2cpg.passes.controlflow.codepencegraph
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.{
+  Block,
   Call,
   ControlStructure,
   Identifier,
@@ -37,7 +38,7 @@ class CdgPass(cpg: Cpg) extends ForkJoinParallelCpgPass[Method](cpg) {
     postDomFrontiers.foreach { case (node, postDomFrontierNodes) =>
       postDomFrontierNodes.foreach {
         case postDomFrontierNode @ (_: Literal | _: Identifier | _: Call | _: MethodRef | _: Unknown |
-            _: ControlStructure | _: JumpTarget) =>
+            _: ControlStructure | _: JumpTarget | _: Block) =>
           dstGraph.addEdge(postDomFrontierNode, node, EdgeTypes.CDG)
         case postDomFrontierNode =>
           val nodeLabel  = postDomFrontierNode.label


### PR DESCRIPTION
Addendum to https://github.com/joernio/joern/pull/1791 to remove spurious warnings during CdgPass. 

An example where such warnings would occur is inside `try` blocks -- in which the last statement of the try-block is connected to each `case` block and whatever is after the `try` itself -- when the last child of the try-block is another block itself.

As @maltek initially pointed out to me, blocks have been in the CFG since that PR. During private correspondence with @ml86, we confirmed that they are also [allowed in the schema](https://github.com/ShiftLeftSecurity/codepropertygraph/blob/34fa2db754b9212cbf4bf81520e84425302ec838/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Pdg.scala#L111), and thus decided to add them here.

