### PR TITLE
Deprecate FileUtil.deleteOnExit in kotlin2cpg tests

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/io/Kotlin2CpgHTTPServerTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/io/Kotlin2CpgHTTPServerTests.scala
@@ -19,21 +19,20 @@ class Kotlin2CpgHTTPServerTests extends AnyWordSpec with Matchers with BeforeAnd
 
   private var port: Int = -1
 
-  private def newProjectUnderTest(index: Option[Int] = None): Path = {
-    val dir  = Files.createTempDirectory("kotlin2cpgTestsHttpTest")
-    val file = dir / "main.kt"
-    file.createWithParentsIfNotExists(createParents = true)
-    val indexStr = index.map(_.toString).getOrElse("")
-    val content = s"""
-                     |package mypkg
-                     |fun main(args : Array<String>) {
-                     |  println($indexStr)
-                     |}
-                     |""".stripMargin
-    Files.writeString(file, content)
-    FileUtil.deleteOnExit(file)
-    FileUtil.deleteOnExit(dir)
-    dir
+  private def newProjectUnderTest[T](index: Option[Int] = None)(f: Path => T): T = {
+    FileUtil.usingTemporaryDirectory("kotlin2cpgTestsHttpTest") { dir =>
+      val file = dir / "main.kt"
+      file.createWithParentsIfNotExists(createParents = true)
+      val indexStr = index.map(_.toString).getOrElse("")
+      val content = s"""
+                       |package mypkg
+                       |fun main(args : Array<String>) {
+                       |  println($indexStr)
+                       |}
+                       |""".stripMargin
+      Files.writeString(file, content)
+      f(dir)
+    }
   }
 
   override def beforeAll(): Unit = {
@@ -46,39 +45,41 @@ class Kotlin2CpgHTTPServerTests extends AnyWordSpec with Matchers with BeforeAnd
 
   "Using kotlin2cpg in server mode" should {
     "build CPGs correctly (single test)" in {
-      val cpgOutFile = FileUtil.newTemporaryFile("kotlin2cpg.bin")
-      FileUtil.deleteOnExit(cpgOutFile)
-      val projectUnderTest = newProjectUnderTest()
-      val input            = projectUnderTest.absolutePathAsString
-      val output           = cpgOutFile.toString
-      val client           = FrontendHTTPClient(port)
-      val req              = client.buildRequest(Array(s"input=$input", s"output=$output"))
-      client.sendRequest(req) match {
-        case Failure(exception) => fail(exception.getMessage)
-        case Success(out) =>
-          out shouldBe output
-          val cpg = CpgLoader.load(output)
-          cpg.method.name.l should contain("main")
-          cpg.call.code.l shouldBe List("println()")
+      FileUtil.usingTemporaryFile("kotlin2cpg", ".bin") { cpgOutFile =>
+        newProjectUnderTest() { projectUnderTest =>
+          val input  = projectUnderTest.absolutePathAsString
+          val output = cpgOutFile.toString
+          val client = FrontendHTTPClient(port)
+          val req    = client.buildRequest(Array(s"input=$input", s"output=$output"))
+          client.sendRequest(req) match {
+            case Failure(exception) => fail(exception.getMessage)
+            case Success(out) =>
+              out shouldBe output
+              val cpg = CpgLoader.load(output)
+              cpg.method.name.l should contain("main")
+              cpg.call.code.l shouldBe List("println()")
+          }
+        }
       }
     }
 
     "build CPGs correctly (multi-threaded test)" in {
       (0 until 10).par.foreach { index =>
-        val cpgOutFile = FileUtil.newTemporaryFile("kotlin2cpg.bin")
-        FileUtil.deleteOnExit(cpgOutFile)
-        val projectUnderTest = newProjectUnderTest(Some(index))
-        val input            = projectUnderTest.absolutePathAsString
-        val output           = cpgOutFile.toString
-        val client           = FrontendHTTPClient(port)
-        val req              = client.buildRequest(Array(s"input=$input", s"output=$output", "no-default-exclude"))
-        client.sendRequest(req) match {
-          case Failure(exception) => fail(exception.getMessage)
-          case Success(out) =>
-            out shouldBe output
-            val cpg = CpgLoader.load(output)
-            cpg.method.name.l should contain("main")
-            cpg.call.code.l shouldBe List(s"println($index)")
+        FileUtil.usingTemporaryFile("kotlin2cpg", ".bin") { cpgOutFile =>
+          newProjectUnderTest(Some(index)) { projectUnderTest =>
+            val input  = projectUnderTest.absolutePathAsString
+            val output = cpgOutFile.toString
+            val client = FrontendHTTPClient(port)
+            val req    = client.buildRequest(Array(s"input=$input", s"output=$output", "no-default-exclude"))
+            client.sendRequest(req) match {
+              case Failure(exception) => fail(exception.getMessage)
+              case Success(out) =>
+                out shouldBe output
+                val cpg = CpgLoader.load(output)
+                cpg.method.name.l should contain("main")
+                cpg.call.code.l shouldBe List(s"println($index)")
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Note: CompilerAPI.scala still uses raw deleteOnExit() for resource dependencies. This is a more complex case requiring refactoring of the compiler configuration lifecycle. Not sure it would be practical.