### PR TITLE
Deprecate FileUtil.deleteOnExit in jimple2cpg tests

### DIFF
--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/io/Jimple2CpgHTTPServerTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/io/Jimple2CpgHTTPServerTests.scala
@@ -19,23 +19,22 @@ class Jimple2CpgHTTPServerTests extends JimpleCode2CpgFixture with BeforeAndAfte
 
   private var port: Int = -1
 
-  private def newProjectUnderTest(index: Option[Int] = None): Path = {
-    val dir  = Files.createTempDirectory("jimple2cpgTestsHttpTest")
-    val file = dir / "main.java"
-    file.createWithParentsIfNotExists(createParents = true)
-    val indexStr = index.map(_.toString).getOrElse("")
-    val content = s"""
-                     |class Foo {
-                     |  static void main$indexStr(int argc, char argv) {
-                     |    System.out.println("Hello World!");
-                     |  }
-                     |}
-                     |""".stripMargin
-    Files.writeString(file, content)
-    JimpleCodeToCpgFixture.compileJava(dir, List(file.toFile))
-    FileUtil.deleteOnExit(file)
-    FileUtil.deleteOnExit(dir)
-    dir
+  private def newProjectUnderTest[T](index: Option[Int] = None)(f: Path => T): T = {
+    FileUtil.usingTemporaryDirectory("jimple2cpgTestsHttpTest") { dir =>
+      val file = dir / "main.java"
+      file.createWithParentsIfNotExists(createParents = true)
+      val indexStr = index.map(_.toString).getOrElse("")
+      val content = s"""
+                       |class Foo {
+                       |  static void main$indexStr(int argc, char argv) {
+                       |    System.out.println("Hello World!");
+                       |  }
+                       |}
+                       |""".stripMargin
+      Files.writeString(file, content)
+      JimpleCodeToCpgFixture.compileJava(dir, List(file.toFile))
+      f(dir)
+    }
   }
 
   override def beforeAll(): Unit = {
@@ -48,39 +47,41 @@ class Jimple2CpgHTTPServerTests extends JimpleCode2CpgFixture with BeforeAndAfte
 
   "Using jimple2cpg in server mode" should {
     "build CPGs correctly (single test)" in {
-      val cpgOutFile = FileUtil.newTemporaryFile("jimple2cpg.bin")
-      FileUtil.deleteOnExit(cpgOutFile)
-      val projectUnderTest = newProjectUnderTest()
-      val input            = projectUnderTest.toAbsolutePath.toString
-      val output           = cpgOutFile.toString
-      val client           = FrontendHTTPClient(port)
-      val req              = client.buildRequest(Array(s"input=$input", s"output=$output"))
-      client.sendRequest(req) match {
-        case Failure(exception) => fail(exception.getMessage)
-        case Success(out) =>
-          out shouldBe output
-          val cpg = CpgLoader.load(output)
-          cpg.method.name.l should contain("main")
-          cpg.call.code.l should contain("""$stack2.println("Hello World!")""")
+      FileUtil.usingTemporaryFile("jimple2cpg", ".bin") { cpgOutFile =>
+        newProjectUnderTest() { projectUnderTest =>
+          val input  = projectUnderTest.toAbsolutePath.toString
+          val output = cpgOutFile.toString
+          val client = FrontendHTTPClient(port)
+          val req    = client.buildRequest(Array(s"input=$input", s"output=$output"))
+          client.sendRequest(req) match {
+            case Failure(exception) => fail(exception.getMessage)
+            case Success(out) =>
+              out shouldBe output
+              val cpg = CpgLoader.load(output)
+              cpg.method.name.l should contain("main")
+              cpg.call.code.l should contain("""$stack2.println("Hello World!")""")
+          }
+        }
       }
     }
 
     "build CPGs correctly (multi-threaded test)" in {
       (0 until 10).par.foreach { index =>
-        val cpgOutFile = FileUtil.newTemporaryFile("jimple2cpg.bin")
-        FileUtil.deleteOnExit(cpgOutFile)
-        val projectUnderTest = newProjectUnderTest(Some(index))
-        val input            = projectUnderTest.toAbsolutePath.toString
-        val output           = cpgOutFile.toString
-        val client           = FrontendHTTPClient(port)
-        val req              = client.buildRequest(Array(s"input=$input", s"output=$output"))
-        client.sendRequest(req) match {
-          case Failure(exception) => fail(exception.getMessage)
-          case Success(out) =>
-            out shouldBe output
-            val cpg = CpgLoader.load(output)
-            cpg.method.name.l should contain(s"main$index")
-            cpg.call.code.l should contain("""$stack2.println("Hello World!")""")
+        FileUtil.usingTemporaryFile("jimple2cpg", ".bin") { cpgOutFile =>
+          newProjectUnderTest(Some(index)) { projectUnderTest =>
+            val input  = projectUnderTest.toAbsolutePath.toString
+            val output = cpgOutFile.toString
+            val client = FrontendHTTPClient(port)
+            val req    = client.buildRequest(Array(s"input=$input", s"output=$output"))
+            client.sendRequest(req) match {
+              case Failure(exception) => fail(exception.getMessage)
+              case Success(out) =>
+                out shouldBe output
+                val cpg = CpgLoader.load(output)
+                cpg.method.name.l should contain(s"main$index")
+                cpg.call.code.l should contain("""$stack2.println("Hello World!")""")
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Note: There is still an instance in `JimpleCodeToCpgFixture.scala`. This would require some larger changes to remove.