### PR TITLE
[php2cpg] feat: support scope resolution operators

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
@@ -288,17 +288,20 @@ object AstCreator {
   }
 
   object NameConstants {
-    val Default: String      = "default"
-    val HaltCompiler: String = "__halt_compiler"
-    val This: String         = "this"
-    val Self: String         = "self"
-    val Unknown: String      = "UNKNOWN"
-    val Closure: String      = "__closure"
-    val Class: String        = "class"
-    val True: String         = "true"
-    val False: String        = "false"
-    val NullName: String     = "null"
-    val Invoke: String       = "__invoke"
+    val Default: String        = "default"
+    val HaltCompiler: String   = "__halt_compiler"
+    val This: String           = "this"
+    val Self: String           = "self"
+    val Unknown: String        = "UNKNOWN"
+    val Closure: String        = "__closure"
+    val Class: String          = "class"
+    val True: String           = "true"
+    val False: String          = "false"
+    val NullName: String       = "null"
+    val Invoke: String         = "__invoke"
+    val Static: String         = "static"
+    val Parent: String         = "parent"
+    val StaticReceiver: String = "<staticReceiver>"
 
     def isBoolean(name: String): Boolean = {
       List(True, False).contains(name)

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreatorHelper.scala
@@ -90,6 +90,9 @@ trait AstCreatorHelper(disableFileContent: Boolean)(implicit withSchemaValidatio
   protected def getTypeDeclPrefix: Option[String] =
     scope.getEnclosingTypeDeclTypeName.filterNot(_ == NamespaceTraversal.globalNamespaceName)
 
+  protected def getInheritedTypeFullName: Option[String] =
+    scope.getEnclosingTypeDecl.flatMap(_.inheritsFromTypeFullName.headOption)
+
   protected def codeForMethodCall(call: PhpCallExpr, targetAst: Ast, name: String): String = {
     val callOperator = if (call.isNullSafe) s"?$InstanceMethodDelimiter" else InstanceMethodDelimiter
     s"${targetAst.rootCodeOrEmpty}$callOperator$name"
@@ -278,9 +281,17 @@ trait AstCreatorHelper(disableFileContent: Boolean)(implicit withSchemaValidatio
   }
 
   protected def getMfn(call: PhpCallExpr, name: String): String = {
-    lazy val default               = s"$UnresolvedNamespace$MethodDelimiter$name"
-    lazy val maybeResolvedFunction = scope.resolveFunctionIdentifier(name)
+    lazy val default                    = s"$UnresolvedNamespace$MethodDelimiter$name"
+    lazy val maybeResolvedFunction      = scope.resolveFunctionIdentifier(name)
+    lazy val maybeInheritedTypeFullName = getInheritedTypeFullName
     call.target match {
+      case Some(nameExpr: PhpNameExpr) if call.isStatic && nameExpr.name == NameConstants.Static =>
+        // static:: late static binding call handled separately as we consider it a dynamic call
+        composeMethodFullNameForCall(name)
+      case Some(nameExpr: PhpNameExpr)
+          if call.isStatic && nameExpr.name == NameConstants.Parent && maybeInheritedTypeFullName.isDefined =>
+        // Static parent:: method call
+        s"${maybeInheritedTypeFullName.get}$MethodDelimiter$name"
       case Some(nameExpr: PhpNameExpr) if call.isStatic =>
         // Static method call with a simple receiver
         if (nameExpr.name == NameConstants.Self)

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreatorHelper.scala
@@ -280,6 +280,8 @@ trait AstCreatorHelper(disableFileContent: Boolean)(implicit withSchemaValidatio
       .last
   }
 
+  protected def getSimpleName(fullName: String): String = fullName.split("\\\\").last
+
   protected def getMfn(call: PhpCallExpr, name: String): String = {
     lazy val default                    = s"$UnresolvedNamespace$MethodDelimiter$name"
     lazy val maybeResolvedFunction      = scope.resolveFunctionIdentifier(name)

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
@@ -153,10 +153,6 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
   }
 
   private def astForStaticCall(call: PhpCallExpr, name: String, arguments: Seq[Ast]): Ast = {
-    val isParentCall = call.target match {
-      case Some(expr: PhpNameExpr) => expr.name == NameConstants.Parent
-      case _                       => false
-    }
     val argsCode   = getArgsCode(call, arguments)
     val codePrefix = codeForStaticMethodCall(call, name)
     val code       = s"$codePrefix($argsCode)"
@@ -170,7 +166,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     }
 
     val targetArgument = call.target.collect {
-      case nameExpr: PhpNameExpr if nameExpr.name == NameConstants.Parent || nameExpr.name == NameConstants.Self =>
+      case nameExpr: PhpNameExpr if Set(NameConstants.Parent, NameConstants.Self).contains(nameExpr.name) =>
         astForClassScopeResolutionTarget(nameExpr)
       case nameExpr: PhpNameExpr =>
         val typ = typeRefNode(nameExpr, getSimpleName(nameExpr.name), nameExpr.name)
@@ -178,7 +174,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     }.flatten
 
     val staticReceiver = call.target.collect {
-      case nameExpr: PhpNameExpr if isParentCall =>
+      case nameExpr: PhpNameExpr if nameExpr.name == NameConstants.Parent =>
         getInheritedTypeFullName
       case nameExpr: PhpNameExpr if nameExpr.name == NameConstants.Self =>
         getTypeDeclPrefix
@@ -190,7 +186,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
 
     val allArgs            = List(targetArgument, arguments).flatten
     val startArgumentIndex = Option.when(targetArgument.isDefined)(0)
-    staticCallAst(callRoot, List(targetArgument, arguments).flatten, startArgumentIndex = startArgumentIndex)
+    staticCallAst(callRoot, allArgs, startArgumentIndex = startArgumentIndex)
   }
 
   protected def simpleAssignAst(origin: PhpNode, target: Ast, source: Ast): Ast = {

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
@@ -101,16 +101,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
   ): Ast = {
     val argsCode = getArgsCode(call, arguments)
     val targetAst = if (isLateStaticBindingCall) {
-      maybeTarget match {
-        case Some(t: PhpNameExpr) =>
-          scope.surroundingMethodReceiver.map { recv =>
-            val target = t.copy(name = recv)
-            astForNameExpr(target, Some(NameConstants.Static))
-          }
-        case t =>
-          logger.warn(s"Expected a PhpNameExpr target but got $t.")
-          None
-      }
+      maybeTarget.flatMap(astForClassScopeResolutionTarget)
     } else {
       maybeTarget.map(astForExpr)
     }
@@ -148,6 +139,19 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
 
   }
 
+  private def astForClassScopeResolutionTarget(expr: PhpExpr): Option[Ast] = {
+    expr match {
+      case t: PhpNameExpr =>
+        scope.surroundingMethodReceiver.map { recv =>
+          val target = t.copy(name = recv)
+          astForNameExpr(target, code = Some(recv))
+        }
+      case t =>
+        logger.warn(s"Expected a PhpNameExpr target but got $t.")
+        None
+    }
+  }
+
   private def astForStaticCall(call: PhpCallExpr, name: String, arguments: Seq[Ast]): Ast = {
     val isParentCall = call.target match {
       case Some(expr: PhpNameExpr) => expr.name == NameConstants.Parent
@@ -165,6 +169,14 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
       case _                                             => getMfn(call, name)
     }
 
+    val targetArgument = call.target.collect {
+      case nameExpr: PhpNameExpr if nameExpr.name == NameConstants.Parent || nameExpr.name == NameConstants.Self =>
+        astForClassScopeResolutionTarget(nameExpr)
+      case nameExpr: PhpNameExpr =>
+        val typ = typeRefNode(nameExpr, getSimpleName(nameExpr.name), nameExpr.name)
+        Some(Ast(typ))
+    }.flatten
+
     val staticReceiver = call.target.collect {
       case nameExpr: PhpNameExpr if isParentCall =>
         getInheritedTypeFullName
@@ -176,7 +188,9 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
 
     val callRoot = callNode(call, code, name, fullName, dispatchType, None, Some(Defines.Any), staticReceiver)
 
-    callAst(callRoot, arguments)
+    val allArgs            = List(targetArgument, arguments).flatten
+    val startArgumentIndex = Option.when(targetArgument.isDefined)(0)
+    staticCallAst(callRoot, List(targetArgument, arguments).flatten, startArgumentIndex = startArgumentIndex)
   }
 
   protected def simpleAssignAst(origin: PhpNode, target: Ast, source: Ast): Ast = {

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
@@ -85,6 +85,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
       case None if isCallOnVariable(call) => astForDynamicCall(call, name, arguments, None)
       case None                           => astForStaticCall(call, name, arguments)
       case maybeTarget @ Some(expr: PhpNameExpr) if call.isStatic && expr.name == NameConstants.Static =>
+        // Late static binding calls (static::foo()) are dynamic calls resolved at runtime.
         astForDynamicCall(call, name, arguments, maybeTarget, isLateStaticBindingCall = true)
       case _ if call.isStatic => astForStaticCall(call, name, arguments)
       case maybeTarget        => astForDynamicCall(call, name, arguments, maybeTarget)
@@ -102,16 +103,12 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     val targetAst = if (isLateStaticBindingCall) {
       maybeTarget match {
         case Some(t: PhpNameExpr) =>
-          scope.surroundingMethodReceiver match {
-            case Some(recv) =>
-              val target = t.copy(name = recv)
-              Some(astForNameExpr(target, Some(NameConstants.Static)))
-            case _ =>
-              logger.warn(s"Expected method surround call $call to have parameter 0 as `static` or `<staticReceiver>")
-              None
+          scope.surroundingMethodReceiver.map { recv =>
+            val target = t.copy(name = recv)
+            astForNameExpr(target, Some(NameConstants.Static))
           }
         case t =>
-          logger.warn(s"Expected a PhpNameExpr target for call on static receiver but got $t.")
+          logger.warn(s"Expected a PhpNameExpr target but got $t.")
           None
       }
     } else {

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
@@ -84,8 +84,10 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     call.target match {
       case None if isCallOnVariable(call) => astForDynamicCall(call, name, arguments, None)
       case None                           => astForStaticCall(call, name, arguments)
-      case _ if call.isStatic             => astForStaticCall(call, name, arguments)
-      case maybeTarget                    => astForDynamicCall(call, name, arguments, maybeTarget)
+      case maybeTarget @ Some(expr: PhpNameExpr) if call.isStatic && expr.name == NameConstants.Static =>
+        astForDynamicCall(call, name, arguments, maybeTarget, isLateStaticBindingCall = true)
+      case _ if call.isStatic => astForStaticCall(call, name, arguments)
+      case maybeTarget        => astForDynamicCall(call, name, arguments, maybeTarget)
     }
   }
 
@@ -93,12 +95,35 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     call: PhpCallExpr,
     name: String,
     arguments: Seq[Ast],
-    maybeTarget: Option[PhpExpr]
+    maybeTarget: Option[PhpExpr],
+    isLateStaticBindingCall: Boolean = false
   ): Ast = {
-    val argsCode   = getArgsCode(call, arguments)
-    val targetAst  = maybeTarget.map(astForExpr)
-    val codePrefix = targetAst.map(codeForMethodCall(call, _, name)).getOrElse(name)
-    val code       = s"$codePrefix($argsCode)"
+    val argsCode = getArgsCode(call, arguments)
+    val targetAst = if (isLateStaticBindingCall) {
+      maybeTarget match {
+        case Some(t: PhpNameExpr) =>
+          scope.surroundingMethodReceiver match {
+            case Some(recv) =>
+              val target = t.copy(name = recv)
+              Some(astForNameExpr(target, Some(NameConstants.Static)))
+            case _ =>
+              logger.warn(s"Expected method surround call $call to have parameter 0 as `static` or `<staticReceiver>")
+              None
+          }
+        case t =>
+          logger.warn(s"Expected a PhpNameExpr target for call on static receiver but got $t.")
+          None
+      }
+    } else {
+      maybeTarget.map(astForExpr)
+    }
+
+    val codePrefix = if (isLateStaticBindingCall && targetAst.isDefined) {
+      s"${NameConstants.Static}::$name"
+    } else {
+      targetAst.map(codeForMethodCall(call, _, name)).getOrElse(name)
+    }
+    val code = s"$codePrefix($argsCode)"
 
     val dispatchType = DispatchTypes.DYNAMIC_DISPATCH
 
@@ -127,6 +152,10 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
   }
 
   private def astForStaticCall(call: PhpCallExpr, name: String, arguments: Seq[Ast]): Ast = {
+    val isParentCall = call.target match {
+      case Some(expr: PhpNameExpr) => expr.name == NameConstants.Parent
+      case _                       => false
+    }
     val argsCode   = getArgsCode(call, arguments)
     val codePrefix = codeForStaticMethodCall(call, name)
     val code       = s"$codePrefix($argsCode)"
@@ -140,6 +169,8 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     }
 
     val staticReceiver = call.target.collect {
+      case nameExpr: PhpNameExpr if isParentCall =>
+        getInheritedTypeFullName
       case nameExpr: PhpNameExpr if nameExpr.name == NameConstants.Self =>
         getTypeDeclPrefix
       case nameExpr: PhpNameExpr =>
@@ -697,8 +728,8 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     valueAst
   }
 
-  private def astForNameExpr(expr: PhpNameExpr): Ast = {
-    val identifier = identifierNode(expr, expr.name, expr.name, Defines.Any)
+  private def astForNameExpr(expr: PhpNameExpr, code: Option[String] = None): Ast = {
+    val identifier = identifierNode(expr, expr.name, code.getOrElse(expr.name), Defines.Any)
 
     val declaringNode = handleVariableOccurrence(expr, identifier.name)
 

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
@@ -146,8 +146,8 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
           val target = t.copy(name = recv)
           astForNameExpr(target, code = Some(recv))
         }
-      case t =>
-        logger.warn(s"Expected a PhpNameExpr target but got $t.")
+      case expr =>
+        logger.warn(s"Expected a PhpNameExpr target but got $expr.")
         None
     }
   }

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForFunctionsCreator.scala
@@ -158,9 +158,13 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
       MethodScope(method, methodBodyNode, method.fullName, decl.params.map(_.name), methodRef, isArrowClosure)
     )
 
+    val staticReceiver = Option.when(decl.isClassMethod && isStatic) {
+      staticReceiverAstForMethod(decl)
+    }
+
     val thisParam =
       if (!isAnonymousMethod && decl.isClassMethod && !isStatic) Option(thisParamAstForMethod(decl)) else None
-    val parameters = thisParam.toList ++ decl.params.zipWithIndex.map { case (param, idx) =>
+    val parameters = thisParam.toList ++ staticReceiver.toList ++ decl.params.zipWithIndex.map { case (param, idx) =>
       astForParam(param, idx + 1)
     }
     parameters.flatMap(_.root).foreach {
@@ -172,19 +176,6 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
       case _               =>
     }
     scope.useFunctionDecl(methodName, fullName)
-
-    val thisParam = if (!isAnonymousMethod && decl.isClassMethod && !isStatic) {
-      Option(thisParamAstForMethod(decl))
-    } else {
-      None
-    }
-    val staticReceiver = Option.when(decl.isClassMethod && isStatic) {
-      staticReceiverAstForMethod(decl)
-    }
-
-    val parameters = thisParam.toList ++ staticReceiver.toList ++ decl.params.zipWithIndex.map { case (param, idx) =>
-      astForParam(param, idx + 1)
-    }
 
     val returnType = decl.returnType.map(_.name).getOrElse(Defines.Any)
 

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForFunctionsCreator.scala
@@ -124,7 +124,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     val fullName   = fullNameOverride.getOrElse(composeMethodFullName(methodName))
 
     val constructorModifier   = Option.when(isConstructor)(ModifierTypes.CONSTRUCTOR)
-    val virtualModifier       = Option.unless(isStatic || isConstructor)(ModifierTypes.VIRTUAL)
+    val virtualModifier       = Option.unless(isConstructor)(ModifierTypes.VIRTUAL)
     val defaultAccessModifier = Option.unless(containsAccessModifier(decl.modifiers))(ModifierTypes.PUBLIC)
 
     val allModifiers      = virtualModifier ++: constructorModifier ++: defaultAccessModifier ++: decl.modifiers
@@ -267,7 +267,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
       isVariadic = false,
       evaluationStrategy = EvaluationStrategies.BY_SHARING,
       typeFullName = typeFullName
-    ).dynamicTypeHintFullName(typeFullName :: Nil)
+    )
     // TODO Add dynamicTypeHintFullName to parameterInNode param list
 
     Ast(thisNode)
@@ -284,7 +284,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
       isVariadic = false,
       evaluationStrategy = EvaluationStrategies.BY_SHARING,
       typeFullName = typeFullName
-    ).dynamicTypeHintFullName(typeFullName :: Nil)
+    )
     // TODO Add dynamicTypeHintFullName to parameterInNode param list
 
     scope.addToScope(NameConstants.StaticReceiver, node)

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForFunctionsCreator.scala
@@ -268,7 +268,6 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
       evaluationStrategy = EvaluationStrategies.BY_SHARING,
       typeFullName = typeFullName
     )
-    // TODO Add dynamicTypeHintFullName to parameterInNode param list
 
     Ast(thisNode)
   }
@@ -285,7 +284,6 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
       evaluationStrategy = EvaluationStrategies.BY_SHARING,
       typeFullName = typeFullName
     )
-    // TODO Add dynamicTypeHintFullName to parameterInNode param list
 
     scope.addToScope(NameConstants.StaticReceiver, node)
 

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForFunctionsCreator.scala
@@ -173,6 +173,19 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     }
     scope.useFunctionDecl(methodName, fullName)
 
+    val thisParam = if (!isAnonymousMethod && decl.isClassMethod && !isStatic) {
+      Option(thisParamAstForMethod(decl))
+    } else {
+      None
+    }
+    val staticReceiver = Option.when(decl.isClassMethod && isStatic) {
+      staticReceiverAstForMethod(decl)
+    }
+
+    val parameters = thisParam.toList ++ staticReceiver.toList ++ decl.params.zipWithIndex.map { case (param, idx) =>
+      astForParam(param, idx + 1)
+    }
+
     val returnType = decl.returnType.map(_.name).getOrElse(Defines.Any)
 
     val fieldInitAsts = scope.getFieldInits.map { fieldInit =>
@@ -260,6 +273,25 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     Ast(thisNode)
   }
 
+  private def staticReceiverAstForMethod(originNode: PhpNode): Ast = {
+    val typeFullName = scope.getEnclosingTypeDeclTypeFullName.getOrElse(Defines.Any)
+
+    val node = parameterInNode(
+      originNode,
+      name = NameConstants.StaticReceiver,
+      code = NameConstants.StaticReceiver,
+      index = 0,
+      isVariadic = false,
+      evaluationStrategy = EvaluationStrategies.BY_SHARING,
+      typeFullName = typeFullName
+    ).dynamicTypeHintFullName(typeFullName :: Nil)
+    // TODO Add dynamicTypeHintFullName to parameterInNode param list
+
+    scope.addToScope(NameConstants.StaticReceiver, node)
+
+    Ast(node)
+  }
+
   protected def thisIdentifier(originNode: PhpNode): NewIdentifier = {
     val typ = scope.getEnclosingTypeDeclTypeName
     identifierNode(originNode, NameConstants.This, s"$$${NameConstants.This}", typ.getOrElse(Defines.Any), typ.toList)
@@ -309,12 +341,16 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
 
     val typeFullName = param.paramType.map(_.name).getOrElse(Defines.Any)
 
-    val byRefCodePrefix = if (param.byRef) "&" else ""
-    val code            = s"$byRefCodePrefix$$${param.name}"
+    val code      = getParamCode(param)
     val paramNode = parameterInNode(param, param.name, code, index, param.isVariadic, evaluationStrategy, typeFullName)
     val attributeAsts = param.attributeGroups.flatMap(astForAttributeGroup)
 
     Ast(paramNode).withChildren(attributeAsts)
+  }
+
+  private def getParamCode(param: PhpParam): String = {
+    val byRefCodePrefix = if (param.byRef) "&" else ""
+    s"$byRefCodePrefix$$${param.name}"
   }
 
   protected def astForStaticAndConstInits(node: PhpNode): Option[Ast] = {

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/utils/Scope.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/utils/Scope.scala
@@ -248,6 +248,12 @@ class Scope(summary: Map[String, Seq[SymbolSummary]] = Map.empty)
   def surroundingMethodParams: List[String] =
     stack.map(_.scopeNode).collectFirst { case ms: MethodScope => ms }.map(_.parameterNames.toList).get
 
+  def surroundingMethodReceiver: Option[String] =
+    stack
+      .collectFirst { case scopeEl @ ScopeElement(_: MethodScope, vars) => vars.headOption.map(_.head) }
+      .flatten
+      .filter(v => Set(NameConstants.StaticReceiver, NameConstants.This).contains(v))
+
   def getConstAndStaticInits: List[PhpInit] = {
     getInits(constAndStaticInits)
   }

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/utils/Scope.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/utils/Scope.scala
@@ -252,7 +252,7 @@ class Scope(summary: Map[String, Seq[SymbolSummary]] = Map.empty)
     stack
       .collectFirst { case scopeEl @ ScopeElement(_: MethodScope, vars) => vars.headOption.map(_.head) }
       .flatten
-      .filter(v => Set(NameConstants.StaticReceiver, NameConstants.This).contains(v))
+      .filter(el => Set(NameConstants.StaticReceiver, NameConstants.This).contains(el))
 
   def getConstAndStaticInits: List[PhpInit] = {
     getInits(constAndStaticInits)

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/CallTests.scala
@@ -1,11 +1,11 @@
 package io.joern.php2cpg.querying
 
 import io.joern.php2cpg.astcreation.AstCreator.NameConstants
-import io.joern.php2cpg.testfixtures.PhpCode2CpgFixture
 import io.joern.php2cpg.parser.Domain
+import io.joern.php2cpg.testfixtures.PhpCode2CpgFixture
 import io.joern.x2cpg.Defines
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, Literal, Method}
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
-import io.shiftleft.codepropertygraph.generated.nodes.{Call, FieldIdentifier, Identifier, Literal}
 import io.shiftleft.semanticcpg.language.*
 
 class CallTests extends PhpCode2CpgFixture {
@@ -416,5 +416,256 @@ class CallTests extends PhpCode2CpgFixture {
     construct.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
     construct.typeFullName shouldBe Defines.Any
     construct.dynamicTypeHintFullName shouldBe Seq.empty
+  }
+
+  "late static binding call in static method" should {
+    val cpg = code("""<?php
+        |class Foo {
+        |  public static function foo($test) {
+        |    static::bar();
+        |  }
+        |
+        |  private static function bar() {}
+        |}
+        |""".stripMargin)
+
+    "contain a dynamically dispatched call" in {
+      inside(cpg.call("bar").l) { case (call: Call) :: Nil =>
+        call.methodFullName shouldBe "Foo.bar"
+        call.code shouldBe "static::bar()"
+        call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
+
+        inside(call.receiver.isIdentifier.l) { case (identifier: Identifier) :: Nil =>
+          identifier.name shouldBe NameConstants.StaticReceiver
+          identifier.code shouldBe NameConstants.Static
+        }
+      }
+    }
+
+    "contain <staticReceiver> as argument 0 of static functions" in {
+      inside(cpg.method.isStatic.l) { case (fooMethod: Method) :: (barMethod: Method) :: _ :: Nil =>
+        fooMethod.name shouldBe "foo"
+        fooMethod.parameter.headOption.map(_.name) shouldBe Some(NameConstants.StaticReceiver)
+
+        barMethod.name shouldBe "bar"
+        barMethod.parameter.headOption.map(_.name) shouldBe Some(NameConstants.StaticReceiver)
+      }
+    }
+  }
+
+  "late static binding call in a non-static method" should {
+    val cpg = code("""<?php
+        |class Foo {
+        |  public function foo($test) {
+        |    static::bar();
+        |  }
+        |
+        |  private static function bar() {}
+        |}
+        |""".stripMargin)
+
+    "contain a dynamically dispatched call" in {
+      inside(cpg.call("bar").l) { case (call: Call) :: Nil =>
+        call.methodFullName shouldBe "Foo.bar"
+        call.code shouldBe "static::bar()"
+        call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
+      }
+    }
+
+    "have 'this' as the call receiver" in {
+      inside(cpg.call("bar").receiver.isIdentifier.l) { case (identifier: Identifier) :: Nil =>
+        identifier.name shouldBe "this"
+      }
+    }
+  }
+
+  "self call to a static function within a static function" should {
+    val cpg = code("""<?php
+        |class Foo {
+        |  static function foo() {
+        |    self::bar();
+        |  }
+        |
+        |  static function bar() {}
+        |}
+        |""".stripMargin)
+
+    "be a statically dispatched call" in {
+      inside(cpg.call("bar").l) { case (call: Call) :: Nil =>
+        call.methodFullName shouldBe "Foo.bar"
+        call.code shouldBe "self::bar()"
+        call.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+      }
+    }
+
+    "have the correct receivers" in {
+      inside(cpg.call("bar").l) { case (call: Call) :: Nil =>
+        call.staticReceiver shouldBe Some("Foo")
+      }
+    }
+  }
+
+  "self call to a static function within a non-static function" should {
+    val cpg = code("""<?php
+        |class Foo {
+        |  function foo() {
+        |    self::bar();
+        |  }
+        |
+        |  static function bar() {}
+        |}
+        |""".stripMargin)
+
+    "be a statically dispatched call" in {
+      inside(cpg.call("bar").l) { case (call: Call) :: Nil =>
+        call.methodFullName shouldBe "Foo.bar"
+        call.code shouldBe "self::bar()"
+        call.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+      }
+    }
+
+    "have the correct receivers" in {
+      inside(cpg.call("bar").l) { case (call: Call) :: Nil =>
+        call.staticReceiver shouldBe Some("Foo")
+      }
+    }
+  }
+
+  "self call to a non-static function within a non-static function" should {
+    val cpg = code("""<?php
+        |class Foo {
+        |  function foo() {
+        |    self::bar();
+        |  }
+        |
+        |  function bar() {}
+        |}
+        |""".stripMargin)
+
+    "be a statically dispatched call" in {
+      inside(cpg.call("bar").l) { case (call: Call) :: Nil =>
+        call.methodFullName shouldBe "Foo.bar"
+        call.code shouldBe "self::bar()"
+        call.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+      }
+    }
+
+    "have the correct receivers" in {
+      inside(cpg.call("bar").l) { case (call: Call) :: Nil =>
+        call.staticReceiver shouldBe Some("Foo")
+      }
+    }
+  }
+
+  "parent call to a static function from a static function" should {
+    val cpg = code("""<?php
+        |class Base {
+        |  static function bar() {}
+        |}
+        |
+        |class Foo extends Base {
+        |  static function foo() {
+        |    parent::bar();
+        |  }
+        |}
+        |""".stripMargin)
+
+    "be a statically dispatched call to the base class" in {
+      inside(cpg.call("bar").l) { case (call: Call) :: Nil =>
+        call.methodFullName shouldBe "Base.bar"
+        call.code shouldBe "parent::bar()"
+        call.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+      }
+    }
+
+    "have the correct receivers" in {
+      inside(cpg.call("bar").l) { case (call: Call) :: Nil =>
+        call.staticReceiver shouldBe Some("Base")
+      }
+    }
+  }
+
+  "parent call to a static function from a non-static function" should {
+    val cpg = code("""<?php
+        |class Base {
+        |  static function bar() {}
+        |}
+        |
+        |class Foo extends Base {
+        |  function foo() {
+        |    parent::bar();
+        |  }
+        |}
+        |""".stripMargin)
+
+    "be a statically dispatched call to the base class" in {
+      inside(cpg.call("bar").l) { case (call: Call) :: Nil =>
+        call.methodFullName shouldBe "Base.bar"
+        call.code shouldBe "parent::bar()"
+        call.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+      }
+    }
+
+    "have the correct receivers" in {
+      inside(cpg.call("bar").l) { case (call: Call) :: Nil =>
+        call.staticReceiver shouldBe Some("Base")
+      }
+    }
+  }
+
+  "parent call to a non-static function from a non-static function" should {
+    val cpg = code("""<?php
+        |class Base {
+        |  function bar() {}
+        |}
+        |
+        |class Foo extends Base {
+        |  function foo() {
+        |    parent::bar();
+        |  }
+        |}
+        |""".stripMargin)
+
+    "be a statically dispatched call to the base class" in {
+      inside(cpg.call("bar").l) { case (call: Call) :: Nil =>
+        call.methodFullName shouldBe "Base.bar"
+        call.code shouldBe "parent::bar()"
+        call.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+      }
+    }
+
+    "have the correct receivers" in {
+      inside(cpg.call("bar").l) { case (call: Call) :: Nil =>
+        call.staticReceiver shouldBe Some("Base")
+      }
+    }
+  }
+
+  "parent call to a non-static function from a static function" should {
+    val cpg = code("""<?php
+        |class Base {
+        |  function bar() {}
+        |}
+        |
+        |class Foo extends Base {
+        |  static function foo() {
+        |    parent::bar();
+        |  }
+        |}
+        |""".stripMargin)
+
+    "be a statically dispatched call to the base class" in {
+      inside(cpg.call("bar").l) { case (call: Call) :: Nil =>
+        call.methodFullName shouldBe "Base.bar"
+        call.code shouldBe "parent::bar()"
+        call.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+      }
+    }
+
+    "have the correct receivers" in {
+      inside(cpg.call("bar").l) { case (call: Call) :: Nil =>
+        call.staticReceiver shouldBe Some("Base")
+      }
+    }
   }
 }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/CallTests.scala
@@ -4,7 +4,15 @@ import io.joern.php2cpg.astcreation.AstCreator.NameConstants
 import io.joern.php2cpg.parser.Domain
 import io.joern.php2cpg.testfixtures.PhpCode2CpgFixture
 import io.joern.x2cpg.Defines
-import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, Literal, Method}
+import io.shiftleft.codepropertygraph.generated.nodes.{
+  Call,
+  Identifier,
+  Literal,
+  Local,
+  MethodParameterIn,
+  Type,
+  TypeRef
+}
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
 import io.shiftleft.semanticcpg.language.*
 
@@ -103,14 +111,18 @@ class CallTests extends PhpCode2CpgFixture {
     }
 
     "have the correct arguments" in {
-      inside(cpg.call.argument.l) { case List(xArg: Identifier) =>
+      inside(cpg.call.argument.l) { case List(fooTypeRef: TypeRef, xArg: Identifier) =>
+        fooTypeRef.typeFullName shouldBe "Foo"
+        fooTypeRef.code shouldBe "Foo"
         xArg.name shouldBe "x"
         xArg.code shouldBe "$x"
       }
     }
 
     "have the correct child nodes" in {
-      inside(cpg.call.astChildren.l) { case List(arg: Identifier) =>
+      inside(cpg.call.astChildren.l) { case List(fooTypeRef: TypeRef, arg: Identifier) =>
+        fooTypeRef.typeFullName shouldBe "Foo"
+        fooTypeRef.code shouldBe "Foo"
         arg.name shouldBe "x"
       }
     }
@@ -337,6 +349,18 @@ class CallTests extends PhpCode2CpgFixture {
       test1.staticReceiver shouldBe Some("Foo\\Bar\\baz")
     }
 
+    "have typeRef 'baz' as argument 0 of the test1 call" in {
+      inside(cpg.call.name("test1").argument(0).l) { case (typeRef: TypeRef) :: Nil =>
+        typeRef.code shouldBe "baz"
+
+        inside(typeRef.typ.l) { case (typ: Type) :: Nil =>
+          typ.fullName shouldBe """Foo\Bar\baz"""
+          typ.name shouldBe """Foo\Bar\baz"""
+          typ.typeDeclFullName shouldBe """Foo\Bar\baz"""
+        }
+      }
+    }
+
     "be unknown in the case of dynamic calls" in {
       val test2 = cpg.call("test2").head
       test2.name shouldBe "test2"
@@ -418,14 +442,14 @@ class CallTests extends PhpCode2CpgFixture {
     construct.dynamicTypeHintFullName shouldBe Seq.empty
   }
 
-  "late static binding call in static method" should {
+  "late static binding call in static method to a static method" should {
     val cpg = code("""<?php
         |class Foo {
-        |  public static function foo($test) {
+        |  static function foo($test) {
         |    static::bar();
         |  }
         |
-        |  private static function bar() {}
+        |  static function bar() {}
         |}
         |""".stripMargin)
 
@@ -434,33 +458,30 @@ class CallTests extends PhpCode2CpgFixture {
         call.methodFullName shouldBe "Foo.bar"
         call.code shouldBe "static::bar()"
         call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
-
-        inside(call.receiver.isIdentifier.l) { case (identifier: Identifier) :: Nil =>
-          identifier.name shouldBe NameConstants.StaticReceiver
-          identifier.code shouldBe NameConstants.Static
-        }
       }
     }
 
-    "contain <staticReceiver> as argument 0 of static functions" in {
-      inside(cpg.method.isStatic.l) { case (fooMethod: Method) :: (barMethod: Method) :: _ :: Nil =>
-        fooMethod.name shouldBe "foo"
-        fooMethod.parameter.headOption.map(_.name) shouldBe Some(NameConstants.StaticReceiver)
+    "have '<staticReceiver>' as the call receiver" in {
+      inside(cpg.call("bar").receiver.isIdentifier.l) { case (identifier: Identifier) :: Nil =>
+        identifier.name shouldBe NameConstants.StaticReceiver
+        identifier.code shouldBe NameConstants.StaticReceiver
 
-        barMethod.name shouldBe "bar"
-        barMethod.parameter.headOption.map(_.name) shouldBe Some(NameConstants.StaticReceiver)
+        inside(identifier.refOut.l) { case (param: MethodParameterIn) :: Nil =>
+          param.code shouldBe NameConstants.StaticReceiver
+          param.name shouldBe NameConstants.StaticReceiver
+        }
       }
     }
   }
 
-  "late static binding call in a non-static method" should {
+  "late static binding call in a non-static method to a static method" should {
     val cpg = code("""<?php
         |class Foo {
-        |  public function foo($test) {
+        |  function foo() {
         |    static::bar();
         |  }
         |
-        |  private static function bar() {}
+        |  static function bar() {}
         |}
         |""".stripMargin)
 
@@ -474,7 +495,45 @@ class CallTests extends PhpCode2CpgFixture {
 
     "have 'this' as the call receiver" in {
       inside(cpg.call("bar").receiver.isIdentifier.l) { case (identifier: Identifier) :: Nil =>
-        identifier.name shouldBe "this"
+        identifier.name shouldBe NameConstants.This
+        identifier.code shouldBe NameConstants.This
+
+        inside(identifier.refOut.l) { case (param: MethodParameterIn) :: Nil =>
+          param.code shouldBe NameConstants.This
+          param.name shouldBe NameConstants.This
+        }
+      }
+    }
+  }
+
+  "late static binding call in a non-static method to a non-static method" should {
+    val cpg = code("""<?php
+        |class Foo {
+        |  function foo() {
+        |    static::bar();
+        |  }
+        |
+        |  function bar() {}
+        |}
+        |""".stripMargin)
+
+    "contain a dynamically dispatched call" in {
+      inside(cpg.call("bar").l) { case (call: Call) :: Nil =>
+        call.methodFullName shouldBe "Foo.bar"
+        call.code shouldBe "static::bar()"
+        call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
+      }
+    }
+
+    "have 'this' as the call receiver" in {
+      inside(cpg.call("bar").receiver.isIdentifier.l) { case (identifier: Identifier) :: Nil =>
+        identifier.name shouldBe NameConstants.This
+        identifier.code shouldBe NameConstants.This
+
+        inside(identifier.refOut.l) { case (param: MethodParameterIn) :: Nil =>
+          param.code shouldBe NameConstants.This
+          param.name shouldBe NameConstants.This
+        }
       }
     }
   }
@@ -498,9 +557,21 @@ class CallTests extends PhpCode2CpgFixture {
       }
     }
 
-    "have the correct receivers" in {
+    "have the correct staticReceiver property" in {
       inside(cpg.call("bar").l) { case (call: Call) :: Nil =>
         call.staticReceiver shouldBe Some("Foo")
+      }
+    }
+
+    "have <staticReceiver> as argument 0 of the call" in {
+      inside(cpg.call("bar").argument(0).l) { case (identifier: Identifier) :: Nil =>
+        identifier.name shouldBe NameConstants.StaticReceiver
+        identifier.code shouldBe NameConstants.StaticReceiver
+
+        inside(identifier.refOut.isParameter.l) { case (param: MethodParameterIn) :: Nil =>
+          param.code shouldBe NameConstants.StaticReceiver
+          param.name shouldBe NameConstants.StaticReceiver
+        }
       }
     }
   }
@@ -524,9 +595,21 @@ class CallTests extends PhpCode2CpgFixture {
       }
     }
 
-    "have the correct receivers" in {
+    "have the correct staticReceiver property." in {
       inside(cpg.call("bar").l) { case (call: Call) :: Nil =>
         call.staticReceiver shouldBe Some("Foo")
+      }
+    }
+
+    "have 'this' as argument 0 to the 'bar' call" in {
+      inside(cpg.call("bar").argument(0).l) { case (identifier: Identifier) :: Nil =>
+        identifier.name shouldBe NameConstants.This
+        identifier.code shouldBe NameConstants.This
+
+        inside(identifier.refOut.l) { case (param: MethodParameterIn) :: Nil =>
+          param.code shouldBe NameConstants.This
+          param.name shouldBe NameConstants.This
+        }
       }
     }
   }
@@ -550,9 +633,21 @@ class CallTests extends PhpCode2CpgFixture {
       }
     }
 
-    "have the correct receivers" in {
+    "have the correct staticReceiver property." in {
       inside(cpg.call("bar").l) { case (call: Call) :: Nil =>
         call.staticReceiver shouldBe Some("Foo")
+      }
+    }
+
+    "have 'this' as argument 0 to the 'bar' call" in {
+      inside(cpg.call("bar").argument(0).l) { case (identifier: Identifier) :: Nil =>
+        identifier.name shouldBe NameConstants.This
+        identifier.code shouldBe NameConstants.This
+
+        inside(identifier.refOut.l) { case (param: MethodParameterIn) :: Nil =>
+          param.code shouldBe NameConstants.This
+          param.name shouldBe NameConstants.This
+        }
       }
     }
   }
@@ -578,9 +673,21 @@ class CallTests extends PhpCode2CpgFixture {
       }
     }
 
-    "have the correct receivers" in {
+    "have the correct staticReceiver property." in {
       inside(cpg.call("bar").l) { case (call: Call) :: Nil =>
         call.staticReceiver shouldBe Some("Base")
+      }
+    }
+
+    "have '<staticReceiver>' as argument 0 to the 'bar' call" in {
+      inside(cpg.call("bar").argument(0).l) { case (identifier: Identifier) :: Nil =>
+        identifier.name shouldBe NameConstants.StaticReceiver
+        identifier.code shouldBe NameConstants.StaticReceiver
+
+        inside(identifier.refOut.l) { case (param: MethodParameterIn) :: Nil =>
+          param.code shouldBe NameConstants.StaticReceiver
+          param.name shouldBe NameConstants.StaticReceiver
+        }
       }
     }
   }
@@ -606,9 +713,21 @@ class CallTests extends PhpCode2CpgFixture {
       }
     }
 
-    "have the correct receivers" in {
+    "have the correct staticReceiver property." in {
       inside(cpg.call("bar").l) { case (call: Call) :: Nil =>
         call.staticReceiver shouldBe Some("Base")
+      }
+    }
+
+    "have 'this' as argument 0 to the 'bar' call" in {
+      inside(cpg.call("bar").argument(0).l) { case (identifier: Identifier) :: Nil =>
+        identifier.name shouldBe NameConstants.This
+        identifier.code shouldBe NameConstants.This
+
+        inside(identifier.refOut.l) { case (param: MethodParameterIn) :: Nil =>
+          param.code shouldBe NameConstants.This
+          param.name shouldBe NameConstants.This
+        }
       }
     }
   }
@@ -634,37 +753,67 @@ class CallTests extends PhpCode2CpgFixture {
       }
     }
 
-    "have the correct receivers" in {
+    "have the correct staticReceiver property." in {
       inside(cpg.call("bar").l) { case (call: Call) :: Nil =>
         call.staticReceiver shouldBe Some("Base")
+      }
+    }
+
+    "have 'this' as argument 0 to the 'bar' call" in {
+      inside(cpg.call("bar").argument(0).l) { case (identifier: Identifier) :: Nil =>
+        identifier.name shouldBe NameConstants.This
+        identifier.code shouldBe NameConstants.This
+
+        inside(identifier.refOut.l) { case (param: MethodParameterIn) :: Nil =>
+          param.code shouldBe NameConstants.This
+          param.name shouldBe NameConstants.This
+        }
       }
     }
   }
 
-  "parent call to a non-static function from a static function" should {
+  "call to a class instance function" should {
     val cpg = code("""<?php
-        |class Base {
-        |  function bar() {}
+        |class Foo {
+        |  function foo() {}
         |}
-        |
-        |class Foo extends Base {
-        |  static function foo() {
-        |    parent::bar();
-        |  }
-        |}
+        |$a = new Foo();
+        |$a->foo();
         |""".stripMargin)
 
-    "be a statically dispatched call to the base class" in {
-      inside(cpg.call("bar").l) { case (call: Call) :: Nil =>
-        call.methodFullName shouldBe "Base.bar"
-        call.code shouldBe "parent::bar()"
-        call.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+    "have '$a' as argument 0 of the 'foo' call" in {
+      inside(cpg.call.name("foo").argument(0).l) { case (identifier: Identifier) :: Nil =>
+        identifier.code shouldBe "$a"
+        identifier.name shouldBe "a"
+        identifier.argumentIndex shouldBe 0
+
+        inside(identifier.refOut.l) { case (local: Local) :: Nil =>
+          local.code shouldBe "$a"
+          local.name shouldBe "a"
+          local.lineNumber shouldBe Some(5)
+        }
       }
     }
+  }
 
-    "have the correct receivers" in {
-      inside(cpg.call("bar").l) { case (call: Call) :: Nil =>
-        call.staticReceiver shouldBe Some("Base")
+  "call to a static class function" should {
+    val cpg = code("""<?php
+        |class Foo {
+        |  static function foo() {}
+        |}
+        |Foo::foo();
+        |""".stripMargin)
+
+    "have typeRef 'A' as argument 0 of the 'foo' call" in {
+      inside(cpg.call.name("foo").argument(0).l) { case (typeRef: TypeRef) :: Nil =>
+        typeRef.code shouldBe "Foo"
+        typeRef.argumentIndex shouldBe 0
+
+        inside(typeRef.typ.l) { case (typ: Type) :: Nil =>
+          typ.fullName shouldBe "Foo"
+          typ.name shouldBe "Foo"
+          typ.typeDeclFullName shouldBe "Foo"
+        }
       }
     }
   }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/MethodTests.scala
@@ -1,10 +1,19 @@
 package io.joern.php2cpg.querying
 
 import io.joern.php2cpg.Config
+import io.joern.php2cpg.astcreation.AstCreator.NameConstants
 import io.joern.php2cpg.testfixtures.PhpCode2CpgFixture
 import io.joern.x2cpg.Defines
 import io.shiftleft.codepropertygraph.generated.{ModifierTypes, Operators}
-import io.shiftleft.codepropertygraph.generated.nodes.{Call, ClosureBinding, Identifier, Literal, Local, MethodRef}
+import io.shiftleft.codepropertygraph.generated.nodes.{
+  Call,
+  ClosureBinding,
+  Identifier,
+  Literal,
+  Local,
+  Method,
+  MethodRef
+}
 import io.shiftleft.semanticcpg.language.*
 
 import scala.util.Try
@@ -299,6 +308,38 @@ class MethodTests extends PhpCode2CpgFixture {
 
         barDedupTwoTwo.name shouldBe "bar"
         barDedupTwoTwo.fullName shouldBe "Foo.__construct.foo<duplicate>0.bar<duplicate>1"
+    }
+  }
+
+  "static class functions" should {
+    val cpg = code("""<?php
+        |class Foo {
+        |  static function foo() {}
+        |}
+        |""".stripMargin)
+
+    "have parameter 0 as <staticReceiver>" in {
+      inside(cpg.method.name("foo").l) { case (fooMethod: Method) :: Nil =>
+        val List(fooParam) = fooMethod.parameter.order(0).l
+        fooParam.name shouldBe NameConstants.StaticReceiver
+        fooParam.code shouldBe NameConstants.StaticReceiver
+      }
+    }
+  }
+
+  "non-static class functions" should {
+    val cpg = code("""<?php
+        |class Foo {
+        |  function foo() {}
+        |}
+        |""".stripMargin)
+
+    "have parameter 0 as <staticReceiver>" in {
+      inside(cpg.method.name("foo").l) { case (fooMethod: Method) :: Nil =>
+        val List(fooParam) = fooMethod.parameter.order(0).l
+        fooParam.name shouldBe NameConstants.This
+        fooParam.code shouldBe NameConstants.This
+      }
     }
   }
 }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/TypeDeclTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/TypeDeclTests.scala
@@ -613,13 +613,12 @@ class TypeDeclTests extends PhpCode2CpgFixture {
     }
 
     "contain static methods" in {
-      inside(cpg.typeDecl.name(s"Foo").method.name("bar").l) {
-        case barMethod :: Nil =>
-          barMethod.modifier.modifierType.sorted.l shouldBe List(
-            ModifierTypes.PUBLIC,
-            ModifierTypes.STATIC,
-            ModifierTypes.VIRTUAL
-          )
+      inside(cpg.typeDecl.name(s"Foo").method.name("bar").l) { case barMethod :: Nil =>
+        barMethod.modifier.modifierType.sorted.l shouldBe List(
+          ModifierTypes.PUBLIC,
+          ModifierTypes.STATIC,
+          ModifierTypes.VIRTUAL
+        )
       }
     }
 

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/TypeDeclTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/TypeDeclTests.scala
@@ -114,7 +114,7 @@ class TypeDeclTests extends PhpCode2CpgFixture {
         inside(fooMethod.parameter.l) { case List(thisParam, xParam) =>
           thisParam.name shouldBe "this"
           thisParam.code shouldBe "this"
-          thisParam.dynamicTypeHintFullName should contain("Foo")
+          thisParam.dynamicTypeHintFullName shouldBe empty
           thisParam.typeFullName shouldBe "Foo"
           thisParam.index shouldBe 0
 
@@ -613,8 +613,13 @@ class TypeDeclTests extends PhpCode2CpgFixture {
     }
 
     "contain static methods" in {
-      inside(cpg.typeDecl.name(s"Foo").method.name("bar").l) { case barMethod :: Nil =>
-        barMethod.modifier.modifierType.sorted.l shouldBe List(ModifierTypes.PUBLIC, ModifierTypes.STATIC)
+      inside(cpg.typeDecl.name(s"Foo").method.name("bar").l) {
+        case barMethod :: Nil =>
+          barMethod.modifier.modifierType.sorted.l shouldBe List(
+            ModifierTypes.PUBLIC,
+            ModifierTypes.STATIC,
+            ModifierTypes.VIRTUAL
+          )
       }
     }
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/internal/CallAstBuilder.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/internal/CallAstBuilder.scala
@@ -61,6 +61,29 @@ private[x2cpg] trait CallAstBuilder[Node, NodeProcessor] {
       .withReceiverEdges(callNode, receiverRoot)
   }
 
+  /** Create an abstract syntax tree for a static call, i.e. a call without a base or receiver.
+    *
+    * This is a simplified variant of [[callAst]] for calls that are statically dispatched and do not require a `this`
+    * instance or receiver object (e.g. static method calls, top-level function calls, scope-resolution calls).
+    *
+    * @param callNode
+    *   the node that represents the entire call
+    * @param arguments
+    *   arguments to the call
+    * @param startArgumentIndex
+    *   optionally override the starting argument index (defaults to 1 when not provided)
+    */
+  def staticCallAst(callNode: NewCall, arguments: Seq[Ast] = List(), startArgumentIndex: Option[Int] = None): Ast = {
+    if (startArgumentIndex.nonEmpty)
+      setArgumentIndices(arguments, startArgumentIndex.get)
+    else
+      setArgumentIndices(arguments)
+
+    Ast(callNode)
+      .withChildren(arguments)
+      .withArgEdges(callNode, arguments.flatMap(_.root))
+  }
+
   /** Creates an AST for a field-access expression (`base.fieldName`).
     *
     * Emits a [[io.shiftleft.codepropertygraph.generated.Operators.fieldAccess]] call node with `base` as the first


### PR DESCRIPTION
Add support for `static` and `parent` class scope resolution operators. 

Relates to https://github.com/ShiftLeftSecurity/codescience/issues/8640