### PR TITLE
Deprecate FileUtils.deleteOnExit in jimple2cpg

### DIFF
--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/testfixtures/JimpleCodeToCpgFixture.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/testfixtures/JimpleCodeToCpgFixture.scala
@@ -65,10 +65,6 @@ object JimpleCodeToCpgFixture {
           fileManager.getJavaFileObjectsFromFiles(sourceCodeFiles.asJava)
         )
         .call()
-
-      fileManager
-        .list(StandardLocation.CLASS_OUTPUT, "", Collections.singleton(JavaFileObject.Kind.CLASS), true)
-        .forEach(x => new File(x.toUri).deleteOnExit())
     } finally {
       fileManager.close()
     }


### PR DESCRIPTION
https://github.com/ShiftLeftSecurity/codescience/issues/8638

This one is an interesting case, the files should be cleared anyways since the callers should clear the dir, so this call was likely redundant.