### PR TITLE
[kotlin2cpg] Add missing type-erased binding for generic class methods

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/GenericsTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/GenericsTests.scala
@@ -7,6 +7,81 @@ class GenericsTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
 
   implicit val resolver: ICallResolver = NoResolve
 
+  "CPG for code with class inheriting from generic interface" should {
+    val cpg = code("""
+    |interface Transformer<T, R> {
+    | fun transform(p: T): R
+    |}
+    |
+    |class TransformerImpl: Transformer<Int, Boolean> {
+    | override fun transform(p: Int): Boolean{
+    |   return p == 42
+    | }
+    |}
+    """)
+
+    val typedecls = cpg.typeDecl.name("TransformerImpl").l
+    typedecls.size shouldBe 1
+    val typedecl = typedecls.head
+
+    "transform should contain two bindings" in {
+      val bindings = typedecl.methodBinding.name("transform").l
+      bindings.size shouldBe 2
+    }
+
+    "the transform method bindings should have the correct properties" in {
+      val bindings = typedecl.methodBinding.name("transform").l.sortBy(_.signature)
+
+      val List(full, generic) = bindings
+
+      generic.signature shouldBe "java.lang.Object(java.lang.Object)"
+      generic.methodFullName shouldBe "TransformerImpl.transform:boolean(int)"
+
+      full.signature shouldBe "boolean(int)"
+      full.methodFullName shouldBe "TransformerImpl.transform:boolean(int)"
+    }
+
+  }
+
+  "CPG for code with class inheriting from generic interface with upper bound" should {
+    val cpg = code("""
+    |open class TestClass
+    |
+    |interface Transformer<T: TestClass, R> {
+    | fun transform(p: T): R
+    |}
+    |
+    |class TestClassImpl: TestClass
+    |
+    |class TransformerImpl: Transformer<TestClassImpl, Boolean> {
+    | override fun transform(p: TestClassImpl): Boolean{
+    |   return p is TestClass
+    | }
+    |}
+    """)
+
+    val typedecls = cpg.typeDecl.name("TransformerImpl").l
+    typedecls.size shouldBe 1
+    val typedecl = typedecls.head
+
+    "transform should contain two bindings" in {
+      val bindings = typedecl.methodBinding.name("transform").l
+      bindings.size shouldBe 2
+    }
+
+    "the transform method bindings should have the correct properties" in {
+      val bindings = typedecl.methodBinding.name("transform").l.sortBy(_.signature)
+
+      val List(full, generic) = bindings
+
+      generic.signature shouldBe "java.lang.Object(TestClass)"
+      generic.methodFullName shouldBe "TransformerImpl.transform:boolean(TestClassImpl)"
+
+      full.signature shouldBe "boolean(TestClassImpl)"
+      full.methodFullName shouldBe "TransformerImpl.transform:boolean(TestClassImpl)"
+    }
+  }
+
   "CPG for code with simple user-defined fn using generics" should {
     val cpg = code("""
         |


### PR DESCRIPTION
This is a dependency for #5775 

This PR solves an issue where the dataflow engine is unable to find the correct implementation of methods overridden in a generic superclass. This was because no binding for the type-erased signature was created for the class type declaration.