### PR TITLE
[javasrc2cpg] Remove duplicate REF edge added in constructor invocation on blocks

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForCallExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForCallExpressionsCreator.scala
@@ -178,7 +178,7 @@ trait AstForCallExpressionsCreator { this: AstCreator =>
     val returnedIdentifierAst = Ast(returnedIdentifier).withRefEdge(returnedIdentifier, tmpLocal)
 
     Ast(blockNode(expr).typeFullName(returnedIdentifier.typeFullName))
-      .withChild(Ast(tmpLocal).withRefEdge(assignTarget, tmpLocal))
+      .withChild(Ast(tmpLocal))
       .withChild(allocAssignAst)
       .withChild(allocAndInitAst.initAst)
       .withChild(returnedIdentifierAst)


### PR DESCRIPTION
This fixes a fairly common graph validation failure for the duplicate ref edges