### PR TITLE
[php2cpg] fix parser out-of-memory issue

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/PhpParser.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/PhpParser.scala
@@ -218,20 +218,13 @@ object PhpParser {
 
         f(parserOption)
       case _ =>
-        Try {
-          FileUtil.usingTemporaryFile(suffix = "-php.ini") { tmpIni =>
-            val iniContents = Using(Source.fromResource("php.ini"))(_.getLines().mkString(System.lineSeparator()))
-              .getOrElse("")
-            Files.writeString(tmpIni, iniContents)
-            val parserOption = getParser(config, tmpIni.absolutePathAsString)
+        FileUtil.usingTemporaryFile(suffix = "-php.ini") { tmpIni =>
+          val iniContents = Using(Source.fromResource("php.ini"))(_.getLines().mkString(System.lineSeparator()))
+            .getOrElse("")
+          Files.writeString(tmpIni, iniContents)
+          val parserOption = getParser(config, tmpIni.absolutePathAsString)
 
-            f(parserOption)
-          }
-        } match {
-          case Success(result) => result
-          case Failure(exception) =>
-            logger.error(s"Failed to set up temporary php.ini: ${exception.getMessage}")
-            f(None)
+          f(parserOption)
         }
     }
   }


### PR DESCRIPTION
Fixed sptest out-of-memory issue caused by the `php.ini` file needed by the parser being deleted before it is used. It contains a config to remove the memory limit, hence the out-of-memory issue we're now seeing.

sptests running successfully :+1: 

Fixes https://github.com/ShiftLeftSecurity/codescience/issues/8712