### PR TITLE
[semanticcpg] check for `order` collisions between CFG nodes 

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/validation/validation.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/validation/validation.scala
@@ -120,7 +120,7 @@ class PostFrontendValidator(cpg: Cpg, throwOnError: Boolean) extends AbstractVal
           }
           .groupBy(_.order)
           .foreach { case (order, nodes) =>
-            if (order > -1 && nodes.size > 1) {
+            if (nodes.size > 1) {
               registerViolation(DUPLICATE_ORDER, s"Nodes $nodes have same order $order inside node $astNode")
             }
           }


### PR DESCRIPTION
Adds a check to ensure that CFG nodes have no `order` collisions, as CfgCreatorPass processes its child nodes according to their `order` (and having collisions makes it ambiguous which statement is processed first.)

To prevent warnings on benign collisions, such as between LOCAL and CALL, we whitelist Declaration nodes.