### PR TITLE
[jssrc2cpg] Remove manual order/argumentIndex handling

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreator.scala
@@ -94,15 +94,11 @@ class AstCreator(val config: Config, val global: Global, val parserResult: Parse
     scope.pushNewMethodScope(fullName, name, blockNode, None)
     localAstParentStack.push(blockNode)
 
-    val thisParam =
-      parameterInNode(astNodeInfo, "this", "this", 0, false, EvaluationStrategies.BY_VALUE)
-        .dynamicTypeHintFullName(typeHintForThisExpression())
+    val thisParam = parameterInNode(astNodeInfo, "this", "this", 0, false, EvaluationStrategies.BY_VALUE)
+      .dynamicTypeHintFullName(typeHintForThisExpression())
     scope.addVariable("this", thisParam, Defines.Any, VariableScopeManager.ScopeType.MethodScope)
 
     val methodChildren = astsForFile(astNodeInfo)
-    setArgumentIndices(methodChildren)
-
-    val methodReturn = methodReturnNode(astNodeInfo, Defines.Any)
 
     localAstParentStack.pop()
     scope.popScope()
@@ -113,7 +109,7 @@ class AstCreator(val config: Config, val global: Global, val parserResult: Parse
         programMethod,
         Ast(thisParam) :: Nil,
         blockAst(blockNode, methodChildren),
-        methodReturn,
+        methodReturnNode(astNodeInfo, Defines.Any),
         modifierNode(astNodeInfo, ModifierTypes.MODULE) :: Nil
       )
     )

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForDeclarationsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForDeclarationsCreator.scala
@@ -150,7 +150,6 @@ trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) {
     }
 
     val asts = fromAst +: (specifierAsts ++ declAsts)
-    setArgumentIndices(asts)
     blockAst(blockNode(declaration, declaration.code, Defines.Any), asts)
   }
 
@@ -162,7 +161,6 @@ trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) {
         createExportAssignmentCallAst(name, exportCallAst, assignment, None)
       }
     }
-    setArgumentIndices(declAsts)
     blockAst(blockNode(assignment, assignment.code, Defines.Any), declAsts)
   }
 
@@ -175,7 +173,6 @@ trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) {
         createExportAssignmentCallAst(name, exportCallAst, declaration, None)
       }
     }
-    setArgumentIndices(declAsts)
     blockAst(blockNode(declaration, declaration.code, Defines.Any), declAsts)
   }
 
@@ -192,7 +189,6 @@ trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) {
     val assignmentCallAst = createExportAssignmentCallAst(s"_$name", exportCallAst, declaration, None)
 
     val childrenAsts = List(fromCallAst, assignmentCallAst)
-    setArgumentIndices(childrenAsts)
     blockAst(blockNode(declaration, declaration.code, Defines.Any), childrenAsts)
   }
 
@@ -543,7 +539,6 @@ trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) {
     localAstParentStack.pop()
 
     val blockChildren = assignmentTmpCallAst +: subTreeAsts :+ Ast(returnTmpNode)
-    setArgumentIndices(blockChildren)
     blockAst(blockNode_, blockChildren)
   }
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -138,7 +138,6 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     localAstParentStack.pop()
 
     val blockChildren = List(assignmentTmpAllocCallNode, callAst, tmpAllocReturnNode)
-    setArgumentIndices(blockChildren)
     blockAst(blockNode_, blockChildren)
   }
 
@@ -321,7 +320,6 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     scope.pushNewBlockScope(blockNode_)
     localAstParentStack.push(blockNode_)
     val sequenceExpressionAsts = createBlockStatementAsts(seq.json("expressions"))
-    setArgumentIndices(sequenceExpressionAsts)
     localAstParentStack.pop()
     scope.popScope()
     blockAst(blockNode_, sequenceExpressionAsts)
@@ -398,7 +396,6 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
         val placeholder = literalNode(arrExpr, "<too-many-initializers>", Defines.Any)
         assignmentTmpArrayCallNode +: elementAsts :+ Ast(placeholder) :+ Ast(tmpArrayReturnNode)
       } else { assignmentTmpArrayCallNode +: elementAsts :+ Ast(tmpArrayReturnNode) }
-      setArgumentIndices(blockChildrenAsts)
       blockAst(blockNode_, blockChildrenAsts)
     }
   }
@@ -504,7 +501,6 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     localAstParentStack.pop()
 
     val childrenAsts = propertiesAsts :+ Ast(tmpNode)
-    setArgumentIndices(childrenAsts)
     blockAst(blockNode_, childrenAsts)
   }
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -355,7 +355,6 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
 
     val blockAsts =
       methodBlockContent.constructorContent.flatMap(m => methodBlockContent.typeDecl.map(astForClassMember(m, _)))
-    setArgumentIndices(blockAsts)
 
     val methodReturnNode_ = methodReturnNode(func)
 
@@ -460,9 +459,6 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     val methodBlockChildren = methodBlockContent.constructorContent.flatMap(m =>
       methodBlockContent.typeDecl.map(astForClassMember(m, _))
     ) ++ additionalBlockStatements.toList ++ bodyStmtAsts
-    setArgumentIndices(methodBlockChildren)
-
-    val methodReturnNode_ = methodReturnNode(func)
 
     localAstParentStack.pop()
     scope.popScope()
@@ -483,7 +479,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
         methodNode_,
         (thisNode +: paramNodes).map(Ast(_)),
         blockAst(blockNode_, methodBlockChildren),
-        methodReturnNode_,
+        methodReturnNode(func),
         modifierNodes,
         astsForDecorators(func)
       )

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -42,9 +42,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
 
   protected def createBlockStatementAsts(json: Value): List[Ast] = {
     val blockStmts = sortBlockStatements(json.arr.map(createBabelNodeInfo).toList)
-    val blockAsts  = blockStmts.map(stmt => astForNodeWithFunctionReferenceAndCall(stmt.json))
-    setArgumentIndices(blockAsts)
-    blockAsts
+    blockStmts.map(stmt => astForNodeWithFunctionReferenceAndCall(stmt.json))
   }
 
   protected def astForWithStatement(withStatement: BabelNodeInfo): Ast = {
@@ -58,7 +56,6 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
       case _              => List(astForNodeWithFunctionReferenceAndCall(bodyNodeInfo.json))
     }
     val blockStatementAsts = objectAst +: bodyAsts
-    setArgumentIndices(blockStatementAsts)
     localAstParentStack.pop()
     scope.popScope()
     blockAst(blockNode_, blockStatementAsts)
@@ -69,7 +66,6 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     scope.pushNewBlockScope(blockNode_)
     localAstParentStack.push(blockNode_)
     val blockStatementAsts = createBlockStatementAsts(block.json("body"))
-    setArgumentIndices(blockStatementAsts)
     localAstParentStack.pop()
     scope.popScope()
     blockAst(blockNode_, blockStatementAsts)
@@ -95,7 +91,6 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
       .getOrElse(Ast())
     val bodyAsts           = createBlockStatementAsts(catchClause.json("body")("body"))
     val blockStatementAsts = paramAst +: bodyAsts
-    setArgumentIndices(blockStatementAsts)
     localAstParentStack.pop()
     scope.popScope()
     blockAst(blockNode_, blockStatementAsts)
@@ -207,7 +202,6 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     localAstParentStack.pop()
 
     val labelAsts = List(Ast(labeledNode), bodyAst)
-    setArgumentIndices(labelAsts)
     blockAst(blockNode_, labelAsts)
   }
 
@@ -274,7 +268,6 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     scope.pushNewBlockScope(blockNode_)
     localAstParentStack.push(blockNode_)
     val casesAsts = switchStmt.json("cases").arr.flatMap(c => astsForSwitchCase(createBabelNodeInfo(c)))
-    setArgumentIndices(casesAsts.toList)
     scope.popScope()
     localAstParentStack.pop()
 
@@ -419,8 +412,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     val bodyAst = astForNodeWithFunctionReference(forInOfStmt.json("body"))
 
     val whileLoopBlockChildren = List(loopVariableAssignmentAst, bodyAst)
-    setArgumentIndices(whileLoopBlockChildren)
-    val whileLoopBlockAst = blockAst(whileLoopBlockNode, whileLoopBlockChildren)
+    val whileLoopBlockAst      = blockAst(whileLoopBlockNode, whileLoopBlockChildren)
 
     scope.popScope()
     localAstParentStack.pop()
@@ -431,7 +423,6 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
 
     val blockChildren =
       List(iteratorAssignmentAst, Ast(resultNode), Ast(loopVariableNode), whileLoopAst.withChild(whileLoopBlockAst))
-    setArgumentIndices(blockChildren)
     blockAst(blockNode_, blockChildren)
   }
 
@@ -562,8 +553,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     val bodyAst = astForNodeWithFunctionReference(forInOfStmt.json("body"))
 
     val whileLoopBlockChildren = List(loopVariableAssignmentAst, bodyAst)
-    setArgumentIndices(whileLoopBlockChildren)
-    val whileLoopBlockAst = blockAst(whileLoopBlockNode, whileLoopBlockChildren)
+    val whileLoopBlockAst      = blockAst(whileLoopBlockNode, whileLoopBlockChildren)
 
     scope.popScope()
     localAstParentStack.pop()
@@ -573,7 +563,6 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     localAstParentStack.pop()
 
     val blockChildren = List(iteratorAssignmentAst, Ast(resultNode), whileLoopAst.withChild(whileLoopBlockAst))
-    setArgumentIndices(blockChildren)
     blockAst(blockNode_, blockChildren)
   }
 
@@ -712,8 +701,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     val bodyAst = astForNodeWithFunctionReference(forInOfStmt.json("body"))
 
     val whileLoopBlockChildren = loopVariableAssignmentAsts :+ bodyAst
-    setArgumentIndices(whileLoopBlockChildren)
-    val whileLoopBlockAst = blockAst(whileLoopBlockNode, whileLoopBlockChildren)
+    val whileLoopBlockAst      = blockAst(whileLoopBlockNode, whileLoopBlockChildren)
 
     scope.popScope()
     localAstParentStack.pop()
@@ -726,7 +714,6 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
       List(iteratorAssignmentAst, Ast(resultNode)) ++ loopVariableNodes.map(Ast(_)) :+ whileLoopAst.withChild(
         whileLoopBlockAst
       )
-    setArgumentIndices(blockNodeChildren)
     blockAst(blockNode_, blockNodeChildren)
   }
 
@@ -864,8 +851,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     val bodyAst = astForNodeWithFunctionReference(forInOfStmt.json("body"))
 
     val whileLoopBlockChildren = loopVariableAssignmentAsts :+ bodyAst
-    setArgumentIndices(whileLoopBlockChildren)
-    val whileLoopBlockAst = blockAst(whileLoopBlockNode, whileLoopBlockChildren)
+    val whileLoopBlockAst      = blockAst(whileLoopBlockNode, whileLoopBlockChildren)
 
     scope.popScope()
     localAstParentStack.pop()
@@ -878,7 +864,6 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
       List(iteratorAssignmentAst, Ast(resultNode)) ++ loopVariableNodes.map(Ast(_)) :+ whileLoopAst.withChild(
         whileLoopBlockAst
       )
-    setArgumentIndices(blockNodeChildren)
     blockAst(blockNode_, blockNodeChildren)
   }
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTemplateDomCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTemplateDomCreator.scala
@@ -15,7 +15,6 @@ trait AstForTemplateDomCreator(implicit withSchemaValidation: ValidationMode) { 
       .map(e => astForNodeWithFunctionReference(Obj(e)))
       .getOrElse(Ast())
     val allChildrenAsts = openingAst +: childrenAsts :+ closingAst
-    setArgumentIndices(allChildrenAsts)
     Ast(domNode).withChildren(allChildrenAsts)
   }
 
@@ -23,7 +22,6 @@ trait AstForTemplateDomCreator(implicit withSchemaValidation: ValidationMode) { 
     val name         = jsxFragment.node.toString
     val domNode      = templateDomNode(name, jsxFragment.code, jsxFragment.lineNumber, jsxFragment.columnNumber)
     val childrenAsts = astForNodes(jsxFragment.json("children").arr.toList)
-    setArgumentIndices(childrenAsts)
     Ast(domNode).withChildren(childrenAsts)
   }
 
@@ -47,7 +45,6 @@ trait AstForTemplateDomCreator(implicit withSchemaValidation: ValidationMode) { 
     val valueAst = safeObj(jsxAttr.json, "value")
       .map(e => astForNodeWithFunctionReference(Obj(e)))
       .getOrElse(Ast())
-    setArgumentIndices(List(valueAst))
     Ast(domNode).withChild(valueAst)
   }
 
@@ -59,7 +56,6 @@ trait AstForTemplateDomCreator(implicit withSchemaValidation: ValidationMode) { 
       jsxOpeningElem.columnNumber
     )
     val childrenAsts = astForNodes(jsxOpeningElem.json("attributes").arr.toList)
-    setArgumentIndices(childrenAsts)
     Ast(domNode).withChildren(childrenAsts)
   }
 
@@ -88,7 +84,6 @@ trait AstForTemplateDomCreator(implicit withSchemaValidation: ValidationMode) { 
       case JSXEmptyExpression => Ast()
       case _                  => astForNodeWithFunctionReference(nodeInfo.json)
     }
-    setArgumentIndices(List(exprAst))
     Ast(domNode).withChild(exprAst)
   }
 
@@ -100,7 +95,6 @@ trait AstForTemplateDomCreator(implicit withSchemaValidation: ValidationMode) { 
       jsxSpreadAttr.columnNumber
     )
     val argAst = astForNodeWithFunctionReference(jsxSpreadAttr.json("argument"))
-    setArgumentIndices(List(argAst))
     Ast(domNode).withChild(argAst)
   }
 

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/SimpleAstCreationPassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/SimpleAstCreationPassTests.scala
@@ -249,7 +249,7 @@ class SimpleAstCreationPassTests extends JsSrc2CpgSuite {
       // all other elements are truncated
       val List(literalNode) = pushBlock.astChildren.isLiteral.l
       literalNode.code shouldBe "<too-many-initializers>"
-      literalNode.argumentIndex shouldBe 1002
+      literalNode.order shouldBe 1002
 
       val List(tmpReturn) = pushBlock.astChildren.isIdentifier.l
       tmpReturn.name shouldBe "_tmp_0"
@@ -963,7 +963,7 @@ class SimpleAstCreationPassTests extends JsSrc2CpgSuite {
     }
 
     "have correct structure for empty method with rest parameter" in {
-      val cpg              = code("function method(x, ...args) {}").withConfig(Config(tsTypes = true))
+      val cpg              = code("function method(x, ...args) {}").withConfig(Config())
       val List(method)     = cpg.method.nameExact("method").l
       val List(t, x, args) = method.parameter.l
       t.index shouldBe 0

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsClassesAstCreationPassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsClassesAstCreationPassTests.scala
@@ -393,6 +393,35 @@ class TsClassesAstCreationPassTests extends JsSrc2CpgSuite(".ts") {
       cpg.call.assignment.astParent.isTypeDecl shouldBe empty
     }
 
+    "have stable order for globally defined JS/TS types" in {
+      val cpg = code("""
+          |class FirstClass {}
+          |
+          |declare class DeclaredClass { constructor(); }
+          |
+          |interface FirstInterface {}
+          |
+          |enum FirstEnum { A }
+          |
+          |type FirstAlias = {}
+          |
+          |namespace N {
+          |  class NsClass {}
+          |  interface NsInterface {}
+          |  enum NsEnum { B }
+          |  type NsAlias = {}
+          |}
+          |""".stripMargin)
+      cpg.method.nameExact(":program").block.astChildren.labelNot("LOCAL").order.l shouldBe (1 to 6).toList
+      cpg.namespaceBlock
+        .nameExact("N")
+        .astChildren
+        .isBlock
+        .astChildren
+        .labelNot("LOCAL")
+        .order
+        .l shouldBe (1 to 4).toList
+    }
   }
 
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstCreatorBase.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstCreatorBase.scala
@@ -316,15 +316,10 @@ abstract class AstCreatorBase[Node, NodeProcessor](filename: String)(implicit wi
   }
 
   def setArgumentIndices(arguments: Seq[Ast], start: Int = 1): Unit = {
-    var currIndex = start
-    arguments.foreach { a =>
-      a.root match {
-        case Some(x: ExpressionNew) =>
-          x.argumentIndex = currIndex
-          currIndex = currIndex + 1
-        case None => // do nothing
-        case _ =>
-          currIndex = currIndex + 1
+    arguments.zipWithIndex.foreach { case (ast, i) =>
+      ast.root match {
+        case Some(x: ExpressionNew) => x.argumentIndex = start + i
+        case _                      => // do nothing
       }
     }
   }


### PR DESCRIPTION
This is done by:
- `io.joern.x2cpg.Ast.setOrderWhereNotSet` called by `io.joern.x2cpg.Ast.storeInDiffGraph`, and
- `io.joern.x2cpg.AstCreatorBase.setArgumentIndices` called by all creator functions for all kinds of calls

Helps for: https://github.com/joernio/joern/pull/5816