### PR TITLE
[kotlin2cpg] Filter generated bin Kotlin sources

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/files/SourceFilesPicker.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/files/SourceFilesPicker.scala
@@ -10,6 +10,7 @@ object SourceFilesPicker {
   private val SubstringsToFilterFor = List(
     ".idea",
     "target",
+    "bin",
     "build",
     "integrationTest",
     "integrationtest",

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/io/SourceFilesPickerTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/io/SourceFilesPickerTests.scala
@@ -12,6 +12,21 @@ class SourceFilesPickerTests extends AnyFreeSpec with Matchers with BeforeAndAft
       val inFileName = "/path/does/not/exist/build.gradle"
       SourceFilesPicker.shouldFilter(inFileName) shouldBe false
     }
+
+    "should filter generated Kotlin sources in `build` paths" in {
+      val inFileName = "artifact/build/generated/ksp/main/kotlin/com/example/HelloWorld.kt"
+      SourceFilesPicker.shouldFilter(inFileName) shouldBe true
+    }
+
+    "should filter generated Kotlin sources in `bin` paths" in {
+      val inFileName = "artifact/bin/main/com/example/HelloWorld.kt"
+      SourceFilesPicker.shouldFilter(inFileName) shouldBe true
+    }
+
+    "should not filter regular `src/main` Kotlin sources" in {
+      val inFileName = "artifact/src/main/kotlin/com/example/HelloWorld.kt"
+      SourceFilesPicker.shouldFilter(inFileName) shouldBe false
+    }
   }
 
 }


### PR DESCRIPTION
Resolves part of: https://github.com/ShiftLeftSecurity/codescience/issues/8701

Some projects include generated/compiled Kotlin copies in `bin` alongside canonical `src/main/...` sources.

This change filters generated Kotlin sources under bin from frontend input selection to avoid analyzing duplicate source copies.
