### PR TITLE
cpggenerator: only return `Some(frontend)` if it's actually available

### DIFF
--- a/console/src/main/scala/io/joern/console/cpgcreation/CpgGeneratorFactory.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/CpgGeneratorFactory.scala
@@ -31,25 +31,25 @@ object CpgGeneratorFactory {
 
 class CpgGeneratorFactory(config: ConsoleConfig) {
 
-  /** For a given input path, try to guess a suitable generator and return it
-    */
+  /** For a given input path, try to guess a suitable generator and return it if it is available */
   def forCodeAt(inputPath: String): Option[CpgGenerator] =
     for {
       language     <- guessLanguage(inputPath)
       cpgGenerator <- cpgGeneratorForLanguage(language, config.frontend, config.install.rootPath, args = Nil)
+      if cpgGenerator.isAvailable
     } yield {
       report(s"Using generator for language: $language: ${cpgGenerator.getClass.getSimpleName}")
       cpgGenerator
     }
 
-  /** For a language, return the generator
-    */
+  /** For a language, return the generator if it is available */
   def forLanguage(language: String): Option[CpgGenerator] = {
-    Option(language)
-      .filter(languageIsKnown)
-      .flatMap { lang =>
-        cpgGeneratorForLanguage(lang, config.frontend, config.install.rootPath, args = Nil)
-      }
+    for {
+      lang <- Option(language)
+      if languageIsKnown(lang)
+      generator <- cpgGeneratorForLanguage(lang, config.frontend, config.install.rootPath, args = Nil)
+      if generator.isAvailable
+    } yield generator
   }
 
   def languageIsKnown(language: String): Boolean = CpgGeneratorFactory.KNOWN_LANGUAGES.contains(language)

--- a/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
@@ -102,8 +102,9 @@ class ImportCode[T <: Project](console: io.joern.console.Console[T])(implicit
       config: FrontendConfig,
       rootPath: Path,
       args: List[String]
-    ): Option[CpgGenerator] =
+    ): Option[CpgGenerator] = {
       io.joern.console.cpgcreation.cpgGeneratorForLanguage(language, config, rootPath, args)
+    }
 
     def isAvailable: Boolean =
       cpgGeneratorForLanguage(language, config.frontend, config.install.rootPath, args = Nil).exists(_.isAvailable)

--- a/console/src/main/scala/io/joern/console/cpgcreation/LlvmCpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/LlvmCpgGenerator.scala
@@ -17,7 +17,9 @@ case class LlvmCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgG
     runShellCommand(command, arguments).map(_ => outputPath)
   }
 
-  override def isAvailable: Boolean = rootPath.resolve("llvm2cpg.sh").toFile.exists()
+  override def isAvailable: Boolean = {
+    rootPath.resolve("llvm2cpg.sh").toFile.exists()
+  }
 
   override def isJvmBased = false
 }

--- a/console/src/main/scala/io/joern/console/cpgcreation/package.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/package.scala
@@ -10,7 +10,8 @@ import scala.util.Try
 
 package object cpgcreation {
 
-  /** For a given language, return CPG generator script
+  /** For a given language, return CPG generator script Note, this doesn't check if the generator is available, that is
+    * done in the ImportCode class.
     */
   def cpgGeneratorForLanguage(
     language: String,
@@ -19,7 +20,7 @@ package object cpgcreation {
     args: List[String]
   ): Option[CpgGenerator] = {
     lazy val conf = config.withArgs(args)
-    val generator = language match {
+    language match {
       case Languages.CSHARP             => Some(CSharpCpgGenerator(conf, rootPath))
       case Languages.CSHARPSRC          => Some(CSharpSrcCpgGenerator(conf, rootPath))
       case Languages.C | Languages.NEWC => Some(CCpgGenerator(conf, rootPath))
@@ -40,8 +41,6 @@ package object cpgcreation {
       case Languages.SWIFTSRC  => Some(SwiftSrcCpgGenerator(conf, rootPath))
       case _                   => None
     }
-
-    generator.filter(_.isAvailable)
   }
 
   /** Heuristically determines language by inspecting file/dir at path.

--- a/console/src/test/scala/io/joern/console/ConsoleTests.scala
+++ b/console/src/test/scala/io/joern/console/ConsoleTests.scala
@@ -53,9 +53,6 @@ class ConsoleTests extends AnyWordSpec with Matchers {
       intercept[ConsoleException] {
         console.importCode.swiftsrc(nonExistentDir)
       }.getMessage shouldBe s"Input path does not exist: '$nonExistentDir'"
-      intercept[ConsoleException] {
-        console.importCode.java(nonExistentDir)
-      }.getMessage shouldBe s"Input path does not exist: '$nonExistentDir'"
     }
 
     "provide overview of available language modules" in ConsoleFixture() { (console, _) =>

--- a/console/src/test/scala/io/joern/console/testing/ConsoleFixture.scala
+++ b/console/src/test/scala/io/joern/console/testing/ConsoleFixture.scala
@@ -3,7 +3,7 @@ package io.joern.console.testing
 import io.joern.console.cpgcreation.{CCpgGenerator, CpgGenerator, CpgGeneratorFactory, ImportCode}
 import io.joern.console.workspacehandling.{Project, ProjectFile, WorkspaceLoader}
 import io.joern.console.{Console, ConsoleConfig, FrontendConfig, InstallConfig}
-import io.joern.console.cpgcreation.{JsSrcCpgGenerator, SwiftSrcCpgGenerator}
+import io.joern.console.cpgcreation.{JavaSrcCpgGenerator, JsSrcCpgGenerator, SwiftSrcCpgGenerator}
 import io.joern.console.cpgcreation.guessLanguage
 import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Languages
@@ -12,6 +12,7 @@ import io.shiftleft.utils.ProjectRoot
 
 import java.nio.file.{Files, Path, Paths}
 import scala.util.Try
+import io.joern.console.cpgcreation.JavaSrcCpgGenerator
 
 object ConsoleFixture {
   def apply[T <: Console[Project]](constructor: String => T = { x =>
@@ -77,6 +78,19 @@ class TestConsole(workspaceDir: String) extends Console[Project](TestWorkspaceLo
         }
       }
 
+    override def java: SourceBasedFrontend =
+      new SourceBasedFrontend("testJavaSrcFrontend", Languages.JAVASRC, "", "java") {
+        override def cpgGeneratorForLanguage(
+          language: String,
+          config: FrontendConfig,
+          rootPath: Path,
+          args: List[String]
+        ): Option[CpgGenerator] = {
+          val newConfig = new ConsoleConfig(TestConsole.this.config.install, config.withArgs(args))
+          new TestCpgGeneratorFactory(newConfig).forLanguage(language)
+        }
+      }
+
     override def swiftsrc: SourceBasedFrontend =
       new SwiftSrcFrontend("testSwiftSrcFrontend", Languages.SWIFTSRC, "", "swift") {
         override def cpgGeneratorForLanguage(
@@ -107,6 +121,13 @@ class TestCpgGeneratorFactory(config: ConsoleConfig) extends CpgGeneratorFactory
     )
   }
 
+  private def newJavaSrcCpgGenerator(): JavaSrcCpgGenerator = {
+    JavaSrcCpgGenerator(
+      config.frontend,
+      Path.of(ProjectRoot.relativise("joern-cli/frontends/javasrc2cpg/target/universal/stage/bin"))
+    )
+  }
+
   private def newSwiftSrcCpgGenerator(): SwiftSrcCpgGenerator = {
     SwiftSrcCpgGenerator(
       config.frontend,
@@ -118,6 +139,7 @@ class TestCpgGeneratorFactory(config: ConsoleConfig) extends CpgGeneratorFactory
     guessLanguage(inputPath) match
       case Some(Languages.NEWC)     => Option(newCCpgGenerator())
       case Some(Languages.JSSRC)    => Option(newJsSrcCpgGenerator())
+      case Some(Languages.JAVASRC)  => Option(newJavaSrcCpgGenerator())
       case Some(Languages.SWIFTSRC) => Option(newSwiftSrcCpgGenerator())
       case _                        => None // no other languages are tested here
   }


### PR DESCRIPTION
Before this, we'd return the frontend and happily invoke it.
Only to then fail with a slightly different exception and a long and
confusing stacktrace:

```
Caused by: java.lang.AssertionError: assertion failed: CPG generator does not exist at: path/to/js2cpg.sh
	at scala.runtime.Scala3RunTime$.assertFailed(Scala3RunTime.scala:8)
	at io.joern.console.cpgcreation.CpgGenerator.runShellCommand$$anonfun$1(CpgGenerator.scala:30)
	at io.joern.console.cpgcreation.CpgGenerator.runShellCommand$$anonfun$adapted$1(CpgGenerator.scala:47)
	at scala.util.Try$.apply(Try.scala:217)
	at io.joern.console.cpgcreation.CpgGenerator.runShellCommand(CpgGenerator.scala:47)
	at io.joern.console.cpgcreation.JsCpgGenerator.generate(JsCpgGenerator.scala:15)
	at io.joern.console.cpgcreation.CpgGeneratorFactory.runGenerator(CpgGeneratorFactory.scala:59)
	at io.joern.console.cpgcreation.ImportCode.$anonfun$5(ImportCode.scala:212)
	at scala.Option.flatMap(Option.scala:283)
	at io.joern.console.cpgcreation.ImportCode.io$joern$console$cpgcreation$ImportCode$$apply(ImportCode.scala:210)
	at io.joern.console.cpgcreation.ImportCode.apply(ImportCode.scala:45)
```

This changes the above to a more meaningful and helpful:
```
io.joern.console.ConsoleException: No suitable CPG generator found for: /home/mp/testdata/shiftleft-js-demo/src/Controllers/Login.js
To get an overview of all available language modules, try `importCode`.
To choose a specific language, try `importCode.<language>`."
```