### PR TITLE
Bump lombok

### DIFF
--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -23,7 +23,7 @@ object Versions {
   val jlhttp                 = "3.1"
   val jRuby                  = "9.4.9.0"
   val json4s                 = "4.0.7"
-  val lombok                 = "1.18.32"
+  val lombok                 = "1.18.42"
   val mavenArcheologist      = "0.0.10"
   val phpParser              = "4.15.10"
   val pPrint                 = "0.8.1"


### PR DESCRIPTION
This brings in support for java >= 23. See https://projectlombok.org/changelog for more details

I tested this on my machine with a sample project and, although there were still unresolved types, delombok did not crash