### PR TITLE
[php2cpg] Remove enclosing type from synthetic method type inheritsFrom

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForFunctionsCreator.scala
@@ -198,7 +198,6 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     parameters: List[Ast]
   ): Unit = {
     val methodTypeDecl = typeDeclNode(decl, method.name, method.fullName, method.filename, code = method.name)
-    scope.getEnclosingTypeDeclTypeFullName.foreach(tfn => methodTypeDecl.inheritsFromTypeFullName(tfn :: Nil))
 
     val binding = NewBinding().name(NameConstants.Invoke).signature("")
     val methodTypeDeclAst = Ast(methodTypeDecl)

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/TypeDeclTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/TypeDeclTests.scala
@@ -52,6 +52,12 @@ class TypeDeclTests extends PhpCode2CpgFixture {
         }
       }
     }
+
+    "not inherit from the enclosing type for the synthetic method type decl" in {
+      inside(cpg.typeDecl.name("foo").l) { case List(fooMethodTypeDecl) =>
+        fooMethodTypeDecl.inheritsFromTypeFullName shouldBe empty
+      }
+    }
   }
 
   "class methods" should {
@@ -85,6 +91,12 @@ class TypeDeclTests extends PhpCode2CpgFixture {
           fooMethod.name shouldBe "foo"
           fooMethod.fullName shouldBe "Foo.foo"
         }
+      }
+    }
+
+    "not inherit from the enclosing type for the synthetic method type decl" in {
+      inside(cpg.typeDecl.name("foo").l) { case List(fooMethodTypeDecl) =>
+        fooMethodTypeDecl.inheritsFromTypeFullName shouldBe empty
       }
     }
 


### PR DESCRIPTION
Synthetic type decls for methods should not extend the enclosing class and is contributing to slow-downs in the dataflow engine as it tracks nonsense paths.