### PR TITLE
[kotlin2cpg] Use unique namespace fullNames for imports and for packages

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstCreator.scala
@@ -346,12 +346,6 @@ class AstCreator(
 
     val importDirectives = ktFile.getImportList.getImports.asScala
     val importAsts       = importDirectives.toList.map(astForImportDirective)
-    val namespaceBlocksForImports =
-      for {
-        node <- importAsts.flatMap(_.root.collectAll[NewImport])
-        name     = getName(node)
-        fullName = s"$relativizedPath:$name"
-      } yield Ast(namespaceBlockNode(fileWithMeta.f, name, fullName, relativizedPath))
 
     val packageName = ktFile.getPackageFqName.toString
     val node =
@@ -363,9 +357,8 @@ class AstCreator(
           relativizedPath
         )
       } else {
-        val name     = packageName.split("\\.").lastOption.getOrElse("")
         val fullName = s"$relativizedPath:$packageName"
-        namespaceBlockNode(fileWithMeta.f, name, fullName, relativizedPath)
+        namespaceBlockNode(fileWithMeta.f, packageName, fullName, relativizedPath)
       }
     methodAstParentStack.push(node)
 
@@ -411,7 +404,7 @@ class AstCreator(
         )
     val namespaceBlockAst =
       Ast(node).withChildren(importAsts).withChild(fakeTypeDeclAst)
-    Ast(fileNode).withChildren(namespaceBlockAst :: namespaceBlocksForImports)
+    Ast(fileNode).withChildren(Seq(namespaceBlockAst))
   }
 
   def astsForDeclaration(decl: KtDeclaration): Seq[Ast] = {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/FileTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/FileTests.scala
@@ -30,7 +30,7 @@ class FileTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
     }
 
     "should allow traversing from file to its namespace blocks" in {
-      cpg.file.nameNot(FileTraversal.UNKNOWN).namespaceBlock.name.toSet shouldBe Set("bar")
+      cpg.file.nameNot(FileTraversal.UNKNOWN).namespaceBlock.name.toSet shouldBe Set("mypkg.bar")
     }
 
     "should allow traversing from file to its methods" in {

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/NamespaceBlockTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/NamespaceBlockTests.scala
@@ -19,21 +19,21 @@ class NamespaceBlockTests extends KotlinCode2CpgFixture(withOssDataflow = false)
         |}
         |""".stripMargin)
 
-    "should contain two namespace blocks in total (<global>, PackageFoo)" in {
+    "should contain two namespace blocks in total (<global>, com.test.PackageFoo)" in {
       cpg.namespaceBlock.size shouldBe 2
-      cpg.namespaceBlock.name.l.toSet shouldBe Set("<global>", "PackageFoo")
+      cpg.namespaceBlock.name.l.toSet shouldBe Set("<global>", "com.test.PackageFoo")
     }
 
     "should contain correct namespace block for known file" in {
       val List(x) = cpg.namespaceBlock.filename(".*.kt").l
-      x.name shouldBe "PackageFoo"
+      x.name shouldBe "com.test.PackageFoo"
       x.filename should not be ""
       x.fullName shouldBe s"Test0.kt:com.test.PackageFoo"
       x.order shouldBe 1
     }
 
     "should allow traversing from namespace block to namespace" in {
-      cpg.namespaceBlock.filename(".*kt").namespace.name.l shouldBe List("PackageFoo")
+      cpg.namespaceBlock.filename(".*kt").namespace.name.l shouldBe List("com.test.PackageFoo")
     }
 
     "should allow traversing from namespace block to type declaration" in {
@@ -65,15 +65,10 @@ class NamespaceBlockTests extends KotlinCode2CpgFixture(withOssDataflow = false)
        |}
        | """.stripMargin)
 
-    "should contain a NAMESPACE_BLOCK for the `import android.app.Activity` with the correct props set" in {
-      val List(nsb) = cpg.namespaceBlock.name(".*Activity.*").l
-      nsb.fullName shouldBe "Test0.kt:android.app.Activity"
+    "should not contain a NAMESPACE_BLOCK for the `import android.*` statements" in {
+      cpg.namespaceBlock.name(".*android.*").size shouldBe 0
     }
 
-    "should contain a NAMESPACE_BLOCK for the `import android.webkit.WebView` with the correct props set" in {
-      val List(nsb) = cpg.namespaceBlock.name(".*WebView.*").l
-      nsb.fullName shouldBe "Test0.kt:android.webkit.WebView"
-    }
   }
 
   "CPG for multiple Kotlin files in the same package" should {
@@ -125,11 +120,11 @@ class NamespaceBlockTests extends KotlinCode2CpgFixture(withOssDataflow = false)
       "Second.kt"
     )
 
-    "should keep import namespace block full names unique across files" in {
-      val importNamespaceFullNames = cpg.namespaceBlock.nameExact("android.app.Activity").filename(".*\\.kt").fullName.l
-      importNamespaceFullNames.size shouldBe 2
+    "should keep namespace block full names unique across files" in {
+      val namespaceFullNames = cpg.namespaceBlock.nameExact("mypkg").filename(".*\\.kt").fullName.l
+      namespaceFullNames.size shouldBe 2
       // Should be distinct too
-      importNamespaceFullNames.size shouldBe importNamespaceFullNames.distinct.size
+      namespaceFullNames.size shouldBe namespaceFullNames.distinct.size
     }
   }
 }


### PR DESCRIPTION
This solves the policylinker issue, but not sure that imports are being represented correctly. From what I can tell javasrc does not create namespace blocks for imports.

https://github.com/joernio/joern/blob/master/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala#L236-L259