### PR TITLE
ArtifactFetcher: fix for systems with multiple partitions

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/ArtifactFetcher.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/ArtifactFetcher.scala
@@ -136,13 +136,7 @@ class ArtifactFetcher(val cacheDir: Path) {
               throw new RuntimeException(s"Hash mismatch: expected ${artifact.sha256}, got $downloadedHash")
             }
 
-            try {
-              Files.move(tmpFile, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
-            } catch {
-              case _: java.nio.file.AtomicMoveNotSupportedException =>
-                // if the repo and tmp are on different partitions, atomic move isn't supported
-                Files.move(tmpFile, target, StandardCopyOption.REPLACE_EXISTING)
-            }
+            Files.move(tmpFile, target, StandardCopyOption.REPLACE_EXISTING)
             logger.debug(s"Cached ${artifact.url} at $target")
             target
           } match {


### PR DESCRIPTION
if the repo and tmp are on different partitions, atomic move isn't supported