### PR TITLE
Adjust TrackedAlias to store the aliasing argument expression directly.

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/accesspath/TrackedBase.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/accesspath/TrackedBase.scala
@@ -44,9 +44,9 @@ case class TrackedTypeRef(typeRef: TypeRef) extends TrackedMethodOrTypeRef {
   }
 }
 
-case class TrackedAlias(argIndex: Int) extends TrackedBase {
+case class TrackedAlias(alias: Expression) extends TrackedBase {
   override def toString: String = {
-    s"TrackedAlias($argIndex)"
+    s"TrackedAlias(${alias.code})"
   }
 }
 


### PR DESCRIPTION
Store aliasing argument expression directly instead of its index. That
way we can also handle named arguments.
