### PR TITLE
frontend http server: attempt 1 to fix OOM issue

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/server/FrontendHTTPServer.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/server/FrontendHTTPServer.scala
@@ -146,8 +146,10 @@ class FrontendHTTPServer(executor: ExecutorService, handleRequest: Array[String]
     */
   def stop(): Unit = {
     if (isRunning) {
-      executor.shutdown()
       httpServer.stop(0)
+      httpServer = null
+      executor.shutdown()
+      executor.awaitTermination(10, TimeUnit.SECONDS)
       isRunning = false
       logger.debug("Server stopped.")
     }


### PR DESCRIPTION
We're seeing occasional OOM errors, which is likely due to the recent
change in the FrontendHttpServer (930caed). This is an attempt to fix
it. Idea being:

* null out the http server so it can get gc-collected
* shutdown the executorservice