### PR TITLE
Upgrade the openjdk version in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
 
 # dependencies
-RUN apk update && apk upgrade && apk add --no-cache openjdk17-jdk python3 git curl gnupg bash nss ncurses php
+RUN apk update && apk upgrade && apk add --no-cache openjdk21-jdk python3 git curl gnupg bash nss ncurses php
 RUN ln -sf python3 /usr/bin/python
 
 # sbt


### PR DESCRIPTION
The Java runtime version in the Dockerfile no longer meets Ghidra's requirements; upgrade to openjdk21 according to the instructions for the current version.

links:
- https://github.com/NationalSecurityAgency/ghidra/blob/Ghidra_11.4_build/Ghidra/Configurations/Public_Release/src/global/docs/ChangeHistory.md#new-features-3
- https://github.com/joernio/joern/blob/8cd7d91c73a540bc2cba9d1af85493436e84f8c3/project/Versions.scala#L19

Error output:

[root@bd5cde3533df app]# /opt/joern/joern-cli/ghidra2cpg -J-Xmx15360m ./testBinary --output /root/test/workspace/testBinary/cpg.bin.zip Exception in thread "main" java.lang.UnsupportedClassVersionError: ghidra/util/exception/InvalidInputException has been compiled by a more recent version of the Java Runtime (class file version 65.0), this version of the Java Runtime only recognizes class file versions up to 61.0
        at java.base/java.lang.ClassLoader.defineClass1(Native Method)
        at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1017)
        at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:150)
        at java.base/jdk.internal.loader.BuiltinClassLoader.defineClass(BuiltinClassLoader.java:862)
        at java.base/jdk.internal.loader.BuiltinClassLoader.findClassOnClassPathOrNull(BuiltinClassLoader.java:760)
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:681)
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:639)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
        at io.joern.ghidra2cpg.Main$.<init>(Main.scala:28)
        at io.joern.ghidra2cpg.Main$.<clinit>(Main.scala:28)
        at io.joern.ghidra2cpg.Main.main(Main.scala)
[root@bd5cde3533df app]# java -version
openjdk version "17.0.18" 2026-01-20 LTS
OpenJDK Runtime Environment (Red_Hat-17.0.18.0.8-1) (build 17.0.18+8-LTS) OpenJDK 64-Bit Server VM (Red_Hat-17.0.18.0.8-1) (build 17.0.18+8-LTS, mixed mode, sharing)