### PR TITLE
[CI Docker] Update base images and OpenJDK version

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,18 +77,18 @@ python -u ./testDistro.py
 ## Docker based execution
 
 ```
-docker run --rm -it -v /tmp:/tmp -v $(pwd):/app:rw -w /app -t ghcr.io/joernio/joern joern
+docker run --rm -it -v /tmp:/tmp -v $(pwd):/app:rw -w /app -t ghcr.io/joernio/joern:nightly joern
 ```
 
 To run joern in server mode:
 
 ```
-docker run --rm -it -v /tmp:/tmp -v $(pwd):/app:rw -w /app -t ghcr.io/joernio/joern joern --server
+docker run --rm -it -v /tmp:/tmp -v $(pwd):/app:rw -w /app -t ghcr.io/joernio/joern:nightly joern --server
 ```
 
 Almalinux 9 requires the CPU to support SSE4.2. For kvm64 VM use the Almalinux 8 version instead.
 ```
-docker run --rm -it -v /tmp:/tmp -v $(pwd):/app:rw -w /app -t ghcr.io/joernio/joern-alma8 joern
+docker run --rm -it -v /tmp:/tmp -v $(pwd):/app:rw -w /app -t ghcr.io/joernio/joern-alma8:nightly joern
 ```
 
 ## Releases

--- a/ci/Dockerfile.alma
+++ b/ci/Dockerfile.alma
@@ -1,4 +1,4 @@
-FROM almalinux/9-minimal:latest
+FROM almalinux:minimal
 
 LABEL maintainer="joern" \
       org.opencontainers.image.authors="Team Joern" \
@@ -9,20 +9,20 @@ LABEL maintainer="joern" \
       org.opencontainers.image.licenses="Apache-2.0" \
       org.opencontainers.image.title="joern" \
       org.opencontainers.image.description="Joern is a platform for analyzing source code, bytecode, and binary executables" \
-      org.opencontainers.docker.cmd="docker run --rm -it -v /tmp:/tmp -v $(pwd):/app:rw -w /app -t ghcr.io/joernio/joern joern"
+      org.opencontainers.docker.cmd="docker run --rm -it -v /tmp:/tmp -v $(pwd):/app:rw -w /app -t ghcr.io/joernio/joern:nightly joern"
 
 ENV JOERN_HOME=/opt/joern/joern-cli \
     LC_ALL=en_US.UTF-8 \
     LANG=en_US.UTF-8 \
     LANGUAGE=en_US.UTF-8 \
-    JAVA_HOME="/etc/alternatives/jre_17" \
-    JAVA_17_HOME="/etc/alternatives/jre_17" \
+    JAVA_HOME="/etc/alternatives/jre_21" \
+    JAVA_21_HOME="/etc/alternatives/jre_21" \
     JOERN_DATAFLOW_TRACKED_WIDTH=128 \
     CLASSPATH=$CLASSPATH:/usr/local/bin: \
     PATH=${PATH}:/opt/joern/joern-cli:/opt/joern/joern-cli/bin:${GOPATH}/bin:/usr/local/go/bin:/usr/local/bin:/root/.local/bin:${JAVA_HOME}/bin:
 
 RUN microdnf install -y gcc git-core php php-cli python3 python3-devel pcre2 which tar zip unzip sudo \
-        java-17-openjdk-headless ncurses jq zlib graphviz glibc-common glibc-all-langpacks \
+        java-21-openjdk-headless ncurses jq zlib graphviz glibc-common glibc-all-langpacks \
     && curl -LO https://github.com/joernio/joern/releases/latest/download/joern-install.sh \
     && chmod +x ./joern-install.sh \
     && ./joern-install.sh \

--- a/ci/Dockerfile.slim
+++ b/ci/Dockerfile.slim
@@ -1,4 +1,4 @@
-FROM almalinux/9-minimal:latest
+FROM almalinux:minimal
 
 LABEL maintainer="joern" \
       org.opencontainers.image.authors="Team Joern" \
@@ -9,20 +9,20 @@ LABEL maintainer="joern" \
       org.opencontainers.image.licenses="Apache-2.0" \
       org.opencontainers.image.title="joern" \
       org.opencontainers.image.description="Joern is a platform for analyzing source code, bytecode, and binary executables" \
-      org.opencontainers.docker.cmd="docker run --rm -it -v /tmp:/tmp -v $(pwd):/app:rw -w /app -t ghcr.io/joernio/joern-slim joern"
+      org.opencontainers.docker.cmd="docker run --rm -it -v /tmp:/tmp -v $(pwd):/app:rw -w /app -t ghcr.io/joernio/joern-slim:nightly joern"
 
 ENV JOERN_HOME=/opt/joern/joern-cli \
     LC_ALL=en_US.UTF-8 \
     LANG=en_US.UTF-8 \
     LANGUAGE=en_US.UTF-8 \
-    JAVA_HOME="/etc/alternatives/jre_17" \
-    JAVA_17_HOME="/etc/alternatives/jre_17" \
+    JAVA_HOME="/etc/alternatives/jre_21" \
+    JAVA_21_HOME="/etc/alternatives/jre_21" \
     JOERN_DATAFLOW_TRACKED_WIDTH=128 \
     CLASSPATH=$CLASSPATH:/usr/local/bin:/opt/joern/joern-cli/lib: \
     PATH=${PATH}:/opt/joern/joern-cli:/opt/joern/joern-cli/bin:${GOPATH}/bin:/usr/local/go/bin:/usr/local/bin:/root/.local/bin:${JAVA_HOME}/bin:
 
 RUN microdnf install -y php php-cli which tar zip unzip sudo shadow-utils \
-        java-17-openjdk-headless ncurses zlib graphviz glibc-common glibc-all-langpacks \
+        java-21-openjdk-headless ncurses zlib graphviz glibc-common glibc-all-langpacks \
     && curl -LO https://github.com/joernio/joern/releases/latest/download/joern-install.sh \
     && chmod +x ./joern-install.sh \
     && ./joern-install.sh --without-plugins \


### PR DESCRIPTION
# [CI Dockerfile] Update base images & openjdk version.

1. Update JDK version to 21 for Ghidra 11.4.
2. Update almalinux version to 10.1:minimal for decompiler of Ghidra 11.4.


Error output:

```
/root/.config/ghidra/ghidra_11.4_F331B5BBEA-202504251242/jar.resource.copied.files/decompile: /lib64/libc.so.6: version `GLIBC_2.38' not found (required by /root/.config/ghidra/ghidra_11.4_F331B5BBEA-202504251242/jar.resource.copied.files/decompile) /root/.config/ghidra/ghidra_11.4_F331B5BBEA-202504251242/jar.resource.copied.files/decompile: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.32' not found (required by /root/.config/ghidra/ghidra_11.4_F331B5BBEA-202504251242/jar.resource.copied.files/decompile)
```

```
[root@bd5cde3533df app]# /opt/joern/joern-cli/ghidra2cpg -J-Xmx15360m ./gateway --output /root/test/workspace/gateway/cpg.bin.zip
Exception in thread "main" java.lang.UnsupportedClassVersionError: ghidra/util/exception/InvalidInputException has been compiled by a more recent version of the Java Runtime (class file version 65.0), this version of the Java Runtime only recognizes class file versions up to 61.0
at java.base/java.lang.ClassLoader.defineClass1(Native Method)
at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1017)
at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:150)
at java.base/jdk.internal.loader.BuiltinClassLoader.defineClass(BuiltinClassLoader.java:862)
at java.base/jdk.internal.loader.BuiltinClassLoader.findClassOnClassPathOrNull(BuiltinClassLoader.java:760)
at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:681)
at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:639)
at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
at io.joern.ghidra2cpg.Main$.<init>(Main.scala:28)
at io.joern.ghidra2cpg.Main$.<clinit>(Main.scala:28)
at io.joern.ghidra2cpg.Main.main(Main.scala)
```


# [README.md] Specify the image tag in README.md

- Specify the image tags to nightly.

Error output:

```
$ docker pull ghcr.io/joernio/joern
Using default tag: latest
Error response from daemon: manifest unknown
```