### PR TITLE
[javasrc2cpg] Use defining type for inherited static call method full names

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForCallExpressionsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/expressions/AstForCallExpressionsCreator.scala
@@ -45,7 +45,7 @@ import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes, Opera
 
 import scala.jdk.CollectionConverters.*
 import scala.jdk.OptionConverters.RichOptional
-import scala.util.{Success, Try}
+import scala.util.{Failure, Success, Try}
 import javassist.compiler.ast.CallExpr
 import io.joern.javasrc2cpg.scope.JavaScopeElement.PartialInit
 import org.slf4j.LoggerFactory
@@ -97,8 +97,21 @@ trait AstForCallExpressionsCreator { this: AstCreator =>
       .getOrElse(codePrefixForMethodCall(call))
     val callCode = s"$codePrefix${call.getNameAsString}($argumentsCode)"
 
-    val callName       = call.getNameAsString
-    val namespace      = receiverType.filter(_ != TypeConstants.Any).getOrElse(Defines.UnresolvedNamespace)
+    val callName = call.getNameAsString
+    val namespace = maybeResolvedCall.toOption
+      .collect {
+        case resolvedCall if resolvedCall.isStatic =>
+          for {
+            packageName <- Option(resolvedCall.getPackageName)
+            className   <- Option(resolvedCall.getClassName)
+          } yield List(packageName, className.replace(".", "$")).filter(_.nonEmpty).mkString(".")
+      }
+      .flatten
+      .getOrElse {
+        // Fall back to the scope type in case it could be resolved when the full call could not
+        receiverType.filter(_ != TypeConstants.Any).getOrElse(Defines.UnresolvedNamespace)
+      }
+
     val signature      = composeSignature(returnType, argumentTypes, argumentAsts.size)
     val methodFullName = composeMethodFullName(namespace, callName, signature)
     val callRoot = NewCall()

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
@@ -599,6 +599,58 @@ class NewCallTests extends JavaSrcCode2CpgFixture {
     }
   }
 
+  "a static call to an inherited method" should {
+    val cpg = code("""
+        |package foo;
+        |
+        |class Foo {
+        |  static String foo() { return "hello"; }
+        |}
+        |
+        |class Bar extends Foo {}
+        |
+        |public class Test {
+        |  public static String test() {
+        |    return Bar.foo();
+        |  }
+        |}
+        |""".stripMargin)
+
+    "use the defining class name for the method full name" in {
+      inside(cpg.call.name("foo").l) { case List(fooCall) =>
+        fooCall.code shouldBe "Bar.foo()"
+        fooCall.methodFullName shouldBe "foo.Foo.foo:java.lang.String()"
+      }
+    }
+  }
+
+  "a static call to a nested inherited method" should {
+    val cpg = code("""
+                     |package foo;
+                     |
+                     |class Outer {
+                     |  static class Foo {
+                     |    static String foo() { return "hello"; }
+                     |  }
+                     |}
+                     |
+                     |class Bar extends Outer.Foo {}
+                     |
+                     |public class Test {
+                     |  public static String test() {
+                     |    return Bar.foo();
+                     |  }
+                     |}
+                     |""".stripMargin)
+
+    "use the defining class name for the method full name" in {
+      inside(cpg.call.name("foo").l) { case List(fooCall) =>
+        fooCall.code shouldBe "Bar.foo()"
+        fooCall.methodFullName shouldBe "foo.Outer$Foo.foo:java.lang.String()"
+      }
+    }
+  }
+
   "call to method in derived class using external package" should {
 
     lazy val cpg = code("""


### PR DESCRIPTION
Since the StaticCallLinker links static calls based only on the `methodFullName`, the mfn for calls to inherited static methods needs to match the mfn for the method in the implementing ancestor type. For languages like php, we set the static_receiver field and fix it in the backend, but since we have better information available from JavaParser (as it includes type information from external dependencies), we now use that and set the correct method full names in javasrc2cpg instead.