### PR TITLE
[swiftsrc2cpg] De-sugar tuple patterns in if-case/guard-case conditions

### DIFF
--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForExprSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForExprSyntaxCreator.scala
@@ -722,7 +722,7 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     * identifier/field-identifier nodes so the resulting AST can be safely used as an argument without node-sharing
     * issues.
     */
-  private def createFieldAccessChain(baseName: String, fields: List[String], node: SwiftNode): Ast = {
+  protected def createFieldAccessChain(baseName: String, fields: List[String], node: SwiftNode): Ast = {
     val baseAst = Ast(identifierNode(node, baseName))
     fields.foldLeft(baseAst) { (accAst, field) =>
       createFieldAccessCallAst(node, accAst, fieldIdentifierNode(node, field, field))
@@ -740,7 +740,7 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     * Nested tuples like case ((1, 2), 3): are handled recursively: <subject>.0.0 == 1 && <subject>.0.1 == 2 &&
     * <subject>.1 == 3
     */
-  private def astForExpressionTuplePatternInSwitchContext(
+  protected def astForExpressionTuplePattern(
     tupleExpr: TupleExprSyntax,
     subjectBase: String,
     subjectFieldPath: List[String],
@@ -753,7 +753,7 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
       val subjectAst  = createFieldAccessChain(subjectBase, currentPath, node)
       element.expression match {
         case inner: TupleExprSyntax =>
-          astForExpressionTuplePatternInSwitchContext(inner, subjectBase, currentPath, node)
+          astForExpressionTuplePattern(inner, subjectBase, currentPath, node)
         case _ =>
           val rhsAst = astForNode(element)
           val eqCode = s"$subjectCode == ${code(element.expression)}"
@@ -768,7 +768,7 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     }
   }
 
-  private def isBindingTupleExpr(tupleExpr: TupleExprSyntax): Boolean = {
+  protected def isBindingTupleExpr(tupleExpr: TupleExprSyntax): Boolean = {
     tupleExpr.elements.children.exists { elem =>
       elem.expression.isInstanceOf[PatternExprSyntax]
     }
@@ -782,16 +782,16 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
           case ep: ExpressionPatternSyntax if ep.expression.isInstanceOf[TupleExprSyntax] =>
             val tupleExpr = ep.expression.asInstanceOf[TupleExprSyntax]
             if (isBindingTupleExpr(tupleExpr)) {
-              astsForBindingTupleExprInSwitchContext(tupleExpr, tmpName, List.empty, ep)
+              astsForBindingTupleExpr(tupleExpr, tmpName, List.empty, ep)
             } else {
-              List(astForExpressionTuplePatternInSwitchContext(tupleExpr, tmpName, List.empty, ep))
+              List(astForExpressionTuplePattern(tupleExpr, tmpName, List.empty, ep))
             }
           case vb: ValueBindingPatternSyntax =>
             vb.pattern match {
               case tp: TuplePatternSyntax =>
-                astsForBindingTuplePatternInSwitchContext(tp, tmpName, List.empty, vb)
+                astsForBindingTuplePattern(tp, tmpName, List.empty, vb)
               case ep: ExpressionPatternSyntax if ep.expression.isInstanceOf[TupleExprSyntax] =>
-                astsForBindingTupleExprInSwitchContext(
+                astsForBindingTupleExpr(
                   ep.expression.asInstanceOf[TupleExprSyntax],
                   tmpName,
                   List.empty,
@@ -801,7 +801,7 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
               case _ => List(astForNode(item.pattern))
             }
           case tuple: TuplePatternSyntax =>
-            astsForBindingTuplePatternInSwitchContext(tuple, tmpName, List.empty, tuple)
+            astsForBindingTuplePattern(tuple, tmpName, List.empty, tuple)
           case _ =>
             List(astForNode(item.pattern))
         }
@@ -825,7 +825,7 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     */
 
   /** Creates an instanceOf check for an IsTypePatternSyntax against a subject field access. */
-  private def astForIsTypePatternInTupleContext(
+  protected def astForIsTypePatternInTupleContext(
     isType: IsTypePatternSyntax,
     subjectAst: Ast,
     subjectCode: String,
@@ -842,7 +842,7 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
   }
 
   /** Creates an equality check for an expression pattern against a subject field access. */
-  private def astForExpressionPatternInTupleContext(
+  protected def astForExpressionPatternInTupleContext(
     ep: ExpressionPatternSyntax,
     subjectAst: Ast,
     subjectCode: String,
@@ -855,7 +855,7 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
   }
 
   /** Creates a variable binding assignment for a pattern element against a subject field access. */
-  private def astForBindingInTupleContext(
+  protected def astForBindingInTupleContext(
     varName: String,
     subjectAst: Ast,
     subjectCode: String,
@@ -869,7 +869,7 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     List(createAssignmentCallAst(anchorNode, Ast(lhsNode), subjectAst, assignCode))
   }
 
-  private def astsForBindingTuplePatternInSwitchContext(
+  protected def astsForBindingTuplePattern(
     tuplePat: TuplePatternSyntax,
     subjectBase: String,
     subjectFieldPath: List[String],
@@ -881,7 +881,7 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
       val subjectAst  = createFieldAccessChain(subjectBase, currentPath, node)
       element.pattern match {
         case inner: TuplePatternSyntax =>
-          astsForBindingTuplePatternInSwitchContext(inner, subjectBase, currentPath, node)
+          astsForBindingTuplePattern(inner, subjectBase, currentPath, node)
         case isType: IsTypePatternSyntax =>
           astForIsTypePatternInTupleContext(isType, subjectAst, subjectCode, node)
         case ep: ExpressionPatternSyntax =>
@@ -891,7 +891,7 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
         case vb: ValueBindingPatternSyntax =>
           vb.pattern match {
             case inner: TuplePatternSyntax =>
-              astsForBindingTuplePatternInSwitchContext(inner, subjectBase, currentPath, node)
+              astsForBindingTuplePattern(inner, subjectBase, currentPath, node)
             case _ =>
               astForBindingInTupleContext(code(vb.pattern), subjectAst, subjectCode, tuplePat)
           }
@@ -902,7 +902,7 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
   }
 
   /** Determines whether an expression inside a tuple represents a binding (let/var pattern). */
-  private def isBindingExpression(expr: ExprSyntax): Boolean = expr match {
+  protected def isBindingExpression(expr: ExprSyntax): Boolean = expr match {
     case p: PatternExprSyntax =>
       p.pattern match {
         case _: ValueBindingPatternSyntax => true
@@ -913,7 +913,7 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
   }
 
   /** Dispatches a PatternSyntax inside a tuple context to the appropriate de-sugaring. */
-  private def astsForPatternInTupleContext(
+  protected def astsForPatternInTupleContext(
     pattern: PatternSyntax,
     subjectAst: Ast,
     subjectCode: String,
@@ -932,7 +932,7 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
       List(callAst(eqNode, List(subjectAst, rhsAst)))
   }
 
-  private def astsForBindingTupleExprInSwitchContext(
+  protected def astsForBindingTupleExpr(
     tupleExpr: TupleExprSyntax,
     subjectBase: String,
     subjectFieldPath: List[String],
@@ -945,7 +945,7 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
       val subjectAst  = createFieldAccessChain(subjectBase, currentPath, node)
       element.expression match {
         case inner: TupleExprSyntax =>
-          astsForBindingTupleExprInSwitchContext(inner, subjectBase, currentPath, node, allBindings)
+          astsForBindingTupleExpr(inner, subjectBase, currentPath, node, allBindings)
         case _ if allBindings || isBindingExpression(element.expression) =>
           val varName = extractBindingName(element.expression)
           astForBindingInTupleContext(varName, subjectAst, subjectCode, tupleExpr)
@@ -966,7 +966,7 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     *   - `DeclReferenceExprSyntax` (`a` in `case let (a, b):`)
     *   - `PatternExprSyntax(ValueBindingPatternSyntax(IdentifierPatternSyntax))` (`var a` in `case (var a, var b):`)
     */
-  private def extractBindingName(expr: ExprSyntax): String = {
+  protected def extractBindingName(expr: ExprSyntax): String = {
     expr match {
       case d: DeclReferenceExprSyntax => code(d)
       case p: PatternExprSyntax =>

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForPatternSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForPatternSyntaxCreator.scala
@@ -35,8 +35,9 @@ trait AstForPatternSyntaxCreator(implicit withSchemaValidation: ValidationMode) 
 
   private def astForMissingPatternSyntax(@unused node: MissingPatternSyntax): Ast = Ast()
 
-  // TODO: implement astForTuplePatternSyntax for non-switch contexts (e.g. if-case expressions).
-  // Switch-context handling is done via astsForBindingTuplePatternInSwitchContext in AstForExprSyntaxCreator.
+  // Tuple patterns in switch-case and if-case/guard-case conditions are handled via
+  // astsForBindingTuplePattern / astForExpressionTuplePattern in AstForExprSyntaxCreator.
+  // This handler covers remaining contexts (e.g. bare pattern matching) which are not yet implemented.
   private def astForTuplePatternSyntax(node: TuplePatternSyntax): Ast = notHandledYet(node)
 
   private def localForValueBindingPatternSyntax(

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForSyntaxCreator.scala
@@ -263,14 +263,115 @@ trait AstForSyntaxCreator(implicit withSchemaValidation: ValidationMode) { this:
   private def astForLayoutRequirementSyntax(node: LayoutRequirementSyntax): Ast                 = notHandledYet(node)
 
   private def astForMatchingPatternConditionSyntax(node: MatchingPatternConditionSyntax): Ast = {
-    val lhsAst = astForNode(node.pattern)
-    val rhsAst = astForNode(node.initializer.value)
+    val initValue = node.initializer.value
 
-    val tpe       = Defines.Bool
-    val op        = Operators.equals
-    val callNode_ = createStaticCallNode(node, code(node), op, op, tpe)
-    val argAsts   = List(lhsAst, rhsAst)
-    callAst(callNode_, argAsts)
+    // Detect tuple pattern variants
+    val maybeTuplePattern: Option[TuplePatternSyntax] = node.pattern match {
+      case tp: TuplePatternSyntax => Some(tp)
+      case vb: ValueBindingPatternSyntax =>
+        vb.pattern match {
+          case tp: TuplePatternSyntax => Some(tp)
+          case _                      => None
+        }
+      case _ => None
+    }
+
+    val maybeTupleExpr: Option[TupleExprSyntax] = node.pattern match {
+      case ep: ExpressionPatternSyntax =>
+        ep.expression match {
+          case te: TupleExprSyntax => Some(te)
+          case _                   => None
+        }
+      case vb: ValueBindingPatternSyntax =>
+        vb.pattern match {
+          case ep: ExpressionPatternSyntax =>
+            ep.expression match {
+              case te: TupleExprSyntax => Some(te)
+              case _                   => None
+            }
+          case _ => None
+        }
+      case _ => None
+    }
+
+    (maybeTuplePattern, maybeTupleExpr) match {
+      case (Some(tuplePat), _) =>
+        astForTuplePatternInConditionContext(node, tuplePat, initValue)
+      case (_, Some(tupleExpr)) =>
+        astForTupleExprInConditionContext(node, tupleExpr, initValue)
+      case _ =>
+        // Original behavior for non-tuple patterns
+        val lhsAst    = astForNode(node.pattern)
+        val rhsAst    = astForNode(initValue)
+        val tpe       = Defines.Bool
+        val op        = Operators.equals
+        val callNode_ = createStaticCallNode(node, code(node), op, op, tpe)
+        val argAsts   = List(lhsAst, rhsAst)
+        callAst(callNode_, argAsts)
+    }
+  }
+
+  /** De-sugars a tuple in an if-case / guard-case condition.
+    *
+    * Creates a block: { <tmp> = initValue; ...desugarAsts... } where the de-sugaring is provided by `desugarFn`.
+    *
+    * Locals are added to `localAstParentStack.head`. For `if` conditions this is the IF control structure node. For
+    * `guard` conditions this is the enclosing method/block scope (matching existing `guard let` behavior).
+    */
+  private def astForTupleInConditionContext(
+    node: SwiftNode,
+    initValue: SwiftNode,
+    desugarFn: String => List[Ast]
+  ): Ast = {
+    val blockNode_ = blockNode(node)
+    scope.pushNewBlockScope(blockNode_)
+    localAstParentStack.push(blockNode_)
+
+    val tmpName      = scopeLocalUniqueName("tmp")
+    val tmpLocalNode = localNode(node, tmpName, tmpName, Defines.Any).order(0)
+    diffGraph.addEdge(localAstParentStack.head, tmpLocalNode, EdgeTypes.AST)
+    scope.addVariable(tmpName, tmpLocalNode, Defines.Any, VariableScopeManager.ScopeType.BlockScope)
+
+    val tmpIdentNode = identifierNode(node, tmpName, tmpName, Defines.Any)
+    scope.addVariableReference(tmpName, tmpIdentNode, Defines.Any, EvaluationStrategies.BY_REFERENCE)
+    val initAst   = astForNode(initValue)
+    val assignAst = createAssignmentCallAst(node, Ast(tmpIdentNode), initAst, s"$tmpName = ${code(initValue)}")
+
+    val desugarAsts = desugarFn(tmpName)
+
+    scope.popScope()
+    localAstParentStack.pop()
+
+    blockAst(blockNode_, assignAst +: desugarAsts)
+  }
+
+  private def astForTuplePatternInConditionContext(
+    node: SwiftNode,
+    tuplePat: TuplePatternSyntax,
+    initValue: SwiftNode
+  ): Ast = {
+    astForTupleInConditionContext(
+      node,
+      initValue,
+      tmpName => astsForBindingTuplePattern(tuplePat, tmpName, List.empty, node)
+    )
+  }
+
+  private def astForTupleExprInConditionContext(
+    node: SwiftNode,
+    tupleExpr: TupleExprSyntax,
+    initValue: SwiftNode
+  ): Ast = {
+    astForTupleInConditionContext(
+      node,
+      initValue,
+      tmpName =>
+        if (isBindingTupleExpr(tupleExpr)) {
+          astsForBindingTupleExpr(tupleExpr, tmpName, List.empty, node)
+        } else {
+          List(astForExpressionTuplePattern(tupleExpr, tmpName, List.empty, node))
+        }
+    )
   }
 
   private def astForMemberBlockItemSyntax(node: MemberBlockItemSyntax): Ast = notHandledYet(node)
@@ -305,24 +406,50 @@ trait AstForSyntaxCreator(implicit withSchemaValidation: ValidationMode) { this:
   private def astForOptionalBindingConditionSyntax(node: OptionalBindingConditionSyntax): Ast = {
     val typeFullName = node.typeAnnotation.fold(Defines.Any)(t => AstCreatorHelper.cleanType(code(t.`type`)))
 
-    node.pattern match {
-      case ident: IdentifierPatternSyntax =>
-        val tpeFromTypeMap = fullnameProvider.typeFullname(ident)
-        localForOptionalBindingConditionSyntax(node, code(ident.identifier), tpeFromTypeMap.getOrElse(typeFullName))
-      case _ => // do nothing
+    // Detect tuple pattern: Swift parser may produce TuplePatternSyntax or
+    // ExpressionPatternSyntax wrapping TupleExprSyntax for `if let (a, b) = x`
+    val maybeTupleExpr: Option[TupleExprSyntax] = node.pattern match {
+      case tp: TuplePatternSyntax =>
+        // Direct tuple pattern — use TuplePatternInConditionContext
+        return node.initializer match {
+          case Some(init) => astForTuplePatternInConditionContext(node, tp, init.value)
+          case None       => Ast()
+        }
+      case ep: ExpressionPatternSyntax =>
+        ep.expression match {
+          case te: TupleExprSyntax => Some(te)
+          case _                   => None
+        }
+      case _ => None
     }
 
-    val initAst = node.initializer.map(astForNode)
-    if (initAst.isEmpty) {
-      Ast()
-    } else {
-      val patternAst = astForNode(node.pattern)
-      val tpe        = fullnameProvider.typeFullname(node.pattern).getOrElse(typeFullName)
-      registerType(tpe)
-      patternAst.root
-        .collect { case i: NewIdentifier => i }
-        .foreach(_.typeFullName(tpe))
-      createAssignmentCallAst(node, patternAst, initAst.head, code(node))
+    maybeTupleExpr match {
+      case Some(tupleExpr) =>
+        node.initializer match {
+          case Some(init) => astForTupleExprInConditionContext(node, tupleExpr, init.value)
+          case None       => Ast()
+        }
+      case None =>
+        // Original behavior for non-tuple patterns
+        node.pattern match {
+          case ident: IdentifierPatternSyntax =>
+            val tpeFromTypeMap = fullnameProvider.typeFullname(ident)
+            localForOptionalBindingConditionSyntax(node, code(ident.identifier), tpeFromTypeMap.getOrElse(typeFullName))
+          case _ => // do nothing
+        }
+
+        val initAst = node.initializer.map(astForNode)
+        if (initAst.isEmpty) {
+          Ast()
+        } else {
+          val patternAst = astForNode(node.pattern)
+          val tpe        = fullnameProvider.typeFullname(node.pattern).getOrElse(typeFullName)
+          registerType(tpe)
+          patternAst.root
+            .collect { case i: NewIdentifier => i }
+            .foreach(_.typeFullName(tpe))
+          createAssignmentCallAst(node, patternAst, initAst.head, code(node))
+        }
     }
   }
 

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForSyntaxCreator.scala
@@ -321,6 +321,7 @@ trait AstForSyntaxCreator(implicit withSchemaValidation: ValidationMode) { this:
   private def astForTupleInConditionContext(
     node: SwiftNode,
     initValue: SwiftNode,
+    arity: Int,
     desugarFn: String => List[Ast]
   ): Ast = {
     val blockNode_ = blockNode(node)
@@ -339,10 +340,18 @@ trait AstForSyntaxCreator(implicit withSchemaValidation: ValidationMode) { this:
 
     val desugarAsts = desugarFn(tmpName)
 
+    // Emit an isTupleN check as the final expression in the condition block
+    val op               = Defines.createIsTupleOperator(arity)
+    val isTupleCode      = s"$op($tmpName)"
+    val isTupleNode      = createStaticCallNode(node, isTupleCode, op, op, Defines.Bool)
+    val tmpIdentForCheck = identifierNode(node, tmpName, tmpName, Defines.Any)
+    scope.addVariableReference(tmpName, tmpIdentForCheck, Defines.Any, EvaluationStrategies.BY_REFERENCE)
+    val isTupleAst = callAst(isTupleNode, List(Ast(tmpIdentForCheck)))
+
     scope.popScope()
     localAstParentStack.pop()
 
-    blockAst(blockNode_, assignAst +: desugarAsts)
+    blockAst(blockNode_, (assignAst +: desugarAsts) :+ isTupleAst)
   }
 
   private def astForTuplePatternInConditionContext(
@@ -350,9 +359,11 @@ trait AstForSyntaxCreator(implicit withSchemaValidation: ValidationMode) { this:
     tuplePat: TuplePatternSyntax,
     initValue: SwiftNode
   ): Ast = {
+    val arity = tuplePat.elements.children.size
     astForTupleInConditionContext(
       node,
       initValue,
+      arity,
       tmpName => astsForBindingTuplePattern(tuplePat, tmpName, List.empty, node)
     )
   }
@@ -362,9 +373,11 @@ trait AstForSyntaxCreator(implicit withSchemaValidation: ValidationMode) { this:
     tupleExpr: TupleExprSyntax,
     initValue: SwiftNode
   ): Ast = {
+    val arity = tupleExpr.elements.children.size
     astForTupleInConditionContext(
       node,
       initValue,
+      arity,
       tmpName =>
         if (isBindingTupleExpr(tupleExpr)) {
           astsForBindingTupleExpr(tupleExpr, tmpName, List.empty, node)

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/dataflow/DataFlowTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/dataflow/DataFlowTests.scala
@@ -1402,6 +1402,71 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
     }
   }
 
+  "DataFlowIfCaseTupleBindingLet" should {
+    val cpg = code("""
+      |func source() -> Int { return 42 }
+      |func sink(x: Int) {}
+      |
+      |func testFlow() {
+      |  let t: (Int, Int) = (source(), 0)
+      |  if case let (a, b) = t {
+      |    sink(x: a)
+      |  }
+      |}
+      |""".stripMargin)
+
+    "find flow from source through 'if case let (a, b):' to sink via first component" in {
+      implicit val callResolver: NoResolve.type = NoResolve
+      val source                                = cpg.call.nameExact("source")
+      val sink                                  = cpg.call.nameExact("sink").argument.codeExact("a")
+      val flows                                 = sink.reachableByFlows(source)
+
+      flows.map(flowToResultPairs).toSetMutable shouldBe
+        Set(
+          List(
+            ("source()", 6),
+            ("(source(), 0)", 6),
+            ("let t: (Int, Int) = (source(), 0)", 6),
+            ("<tmp>0 = t", 7),
+            ("a = <tmp>0.0", 7),
+            ("sink(x: a)", 8)
+          )
+        )
+    }
+  }
+
+  "DataFlowGuardCaseTupleBindingLet" should {
+    val cpg = code("""
+      |func source() -> Int { return 42 }
+      |func sink(x: Int) {}
+      |
+      |func testFlow() {
+      |  let t: (Int, Int) = (0, source())
+      |  guard case let (a, b) = t else { return }
+      |  sink(x: b)
+      |}
+      |""".stripMargin)
+
+    "find flow from source through 'guard case let (a, b):' to sink via second component" in {
+      implicit val callResolver: NoResolve.type = NoResolve
+      val source                                = cpg.call.nameExact("source")
+      val sink                                  = cpg.call.nameExact("sink").argument.codeExact("b")
+      val flows                                 = sink.reachableByFlows(source)
+
+      flows.map(flowToResultPairs).toSetMutable shouldBe
+        Set(
+          List(
+            ("source()", 6),
+            ("(0, source())", 6),
+            ("let t: (Int, Int) = (0, source())", 6),
+            ("<tmp>0 = t", 7),
+            ("b = <tmp>0.1", 7),
+            ("sink(x: b)", 8)
+          )
+        )
+    }
+  }
+
 }
 
 class DataFlowTestsWithCallDepth extends DataFlowCodeToCpgSuite {

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/MatchingPatternsTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/MatchingPatternsTests.scala
@@ -3,6 +3,10 @@
 package io.joern.swiftsrc2cpg.passes.ast
 
 import io.joern.swiftsrc2cpg.testfixtures.SwiftSrc2CpgSuite
+import io.joern.x2cpg.frontendspecific.swiftsrc2cpg.Defines
+import io.shiftleft.codepropertygraph.generated.ControlStructureTypes
+import io.shiftleft.codepropertygraph.generated.Operators
+import io.shiftleft.semanticcpg.language.*
 
 class MatchingPatternsTests extends SwiftSrc2CpgSuite {
 
@@ -221,6 +225,160 @@ class MatchingPatternsTests extends SwiftSrc2CpgSuite {
       |}
       |""".stripMargin)
       ???
+    }
+
+    "testIfCaseExpressionTuplePattern" in {
+      val cpg = code("""
+        |func foo(x: (Int, Int)) {
+        |  if case (1, 2) = x {
+        |    print("matched")
+        |  }
+        |}
+        |""".stripMargin)
+      val List(ifNode) = cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).l
+      val condBlock    = ifNode.condition.isBlock.l.head
+      // Temp local
+      val List(tmpLocal) = condBlock.astChildren.isLocal.l
+      val tmpName        = tmpLocal.name
+      // Temp assignment
+      val List(tmpAssign) = condBlock.astChildren.isCall.nameExact(Operators.assignment).l
+      tmpAssign.code shouldBe s"$tmpName = x"
+      // Equality chain
+      val List(andCall) = condBlock.astChildren.isCall.nameExact(Operators.logicalAnd).l
+      andCall.code shouldBe s"$tmpName.0 == 1 && $tmpName.1 == 2"
+      val List(eq1, eq2) = andCall.argument.isCall.nameExact(Operators.equals).l
+      eq1.code shouldBe s"$tmpName.0 == 1"
+      eq2.code shouldBe s"$tmpName.1 == 2"
+    }
+
+    "testIfCaseBindingTuplePattern" in {
+      val cpg = code("""
+        |func foo(x: (Int, Int)) {
+        |  if case let (a, b) = x {
+        |    print(a)
+        |    print(b)
+        |  }
+        |}
+        |""".stripMargin)
+      val List(ifNode) = cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).l
+      val condBlock    = ifNode.condition.isBlock.l.head
+      // Temp local + binding locals
+      val tmpName = condBlock.ast.isLocal.name.filter(_.startsWith("<tmp>")).loneElement
+      condBlock.ast.isLocal.nameExact("a").size shouldBe 1
+      condBlock.ast.isLocal.nameExact("b").size shouldBe 1
+      // Temp assignment
+      val allAssigns = condBlock.astChildren.isCall.nameExact(Operators.assignment).l
+      allAssigns.size shouldBe 3
+      allAssigns.head.code shouldBe s"$tmpName = x"
+      // Binding assignments with field accesses
+      val List(assignA) = condBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact(s"a = $tmpName.0").l
+      val List(assignB) = condBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact(s"b = $tmpName.1").l
+      assignA.order shouldBe 2
+      assignB.order shouldBe 3
+    }
+
+    "testIfCaseMixedTuplePattern" in {
+      val cpg = code("""
+        |func foo(x: (Int, Int)) {
+        |  if case (let a, 1) = x {
+        |    print(a)
+        |  }
+        |}
+        |""".stripMargin)
+      val List(ifNode) = cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).l
+      val condBlock    = ifNode.condition.isBlock.l.head
+      // Temp local + binding local for a
+      val tmpName = condBlock.ast.isLocal.name.filter(_.startsWith("<tmp>")).loneElement
+      condBlock.ast.isLocal.nameExact("a").size shouldBe 1
+      // Temp assignment
+      val allAssigns = condBlock.astChildren.isCall.nameExact(Operators.assignment).l
+      allAssigns.head.code shouldBe s"$tmpName = x"
+      // Binding assignment for a
+      val List(assignA) = condBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact(s"a = $tmpName.0").l
+      assignA.order shouldBe 2
+      // Equality check for second element
+      val List(eqCall) = condBlock.astChildren.isCall.nameExact(Operators.equals).l
+      eqCall.code shouldBe s"$tmpName.1 == 1"
+    }
+
+    "testGuardCaseBindingTuplePattern" in {
+      val cpg = code("""
+        |func foo(x: (Int, Int)) {
+        |  guard case let (a, b) = x else { return }
+        |  print(a)
+        |  print(b)
+        |}
+        |""".stripMargin)
+      val List(methodBlock) = cpg.method.nameExact("foo").block.l
+      // Locals for a and b should be under the enclosing method block (guard scoping)
+      methodBlock.local.nameExact("a").size shouldBe 1
+      methodBlock.local.nameExact("b").size shouldBe 1
+      val List(guardIf) = cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).l
+      val condBlock     = guardIf.condition.isBlock.l.head
+      // Temp local
+      val tmpName = condBlock.astChildren.isLocal.name.filter(_.startsWith("<tmp>")).loneElement
+      // Temp + binding assignments
+      val allAssigns = condBlock.astChildren.isCall.nameExact(Operators.assignment).l
+      allAssigns.size shouldBe 3
+      allAssigns.head.code shouldBe s"$tmpName = x"
+      // Binding assignments with field accesses
+      val List(assignA) = condBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact(s"a = $tmpName.0").l
+      val List(assignB) = condBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact(s"b = $tmpName.1").l
+      assignA.order shouldBe 2
+      assignB.order shouldBe 3
+    }
+
+    "testIfCaseNestedBindingTuplePattern" in {
+      val cpg = code("""
+        |func foo(x: ((Int, Int), Int)) {
+        |  if case let ((a, b), c) = x {
+        |    print(a)
+        |  }
+        |}
+        |""".stripMargin)
+      val List(ifNode) = cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).l
+      val condBlock    = ifNode.condition.isBlock.l.head
+      // Tmp local + binding locals
+      val tmpName = condBlock.ast.isLocal.name.filter(_.startsWith("<tmp>")).loneElement
+      condBlock.ast.isLocal.name.toSet shouldBe Set("a", "b", "c", tmpName)
+      // Temp assignment
+      val allAssigns = condBlock.astChildren.isCall.nameExact(Operators.assignment).l
+      allAssigns.head.code shouldBe s"$tmpName = x"
+      // Nested field access: a = <tmp>.0.0, b = <tmp>.0.1, c = <tmp>.1
+      val List(assignA) =
+        condBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact(s"a = $tmpName.0.0").l
+      val List(assignB) =
+        condBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact(s"b = $tmpName.0.1").l
+      val List(assignC) = condBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact(s"c = $tmpName.1").l
+      assignA.order shouldBe 2
+      assignB.order shouldBe 3
+      assignC.order shouldBe 4
+    }
+
+    "testIfLetTuplePattern" in {
+      val cpg = code("""
+        |func foo(x: (Int, Int)?) {
+        |  if let (a, b) = x {
+        |    print(a)
+        |    print(b)
+        |  }
+        |}
+        |""".stripMargin)
+      val List(ifNode) = cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).l
+      val condBlock    = ifNode.condition.isBlock.l.head
+      // Tmp local + binding locals
+      val tmpName = condBlock.ast.isLocal.name.filter(_.startsWith("<tmp>")).loneElement
+      condBlock.ast.isLocal.nameExact("a").size shouldBe 1
+      condBlock.ast.isLocal.nameExact("b").size shouldBe 1
+      // Temp + binding assignments
+      val allAssigns = condBlock.astChildren.isCall.nameExact(Operators.assignment).l
+      allAssigns.size shouldBe 3
+      allAssigns.head.code shouldBe s"$tmpName = x"
+      // Binding assignments with field accesses
+      val List(assignA) = condBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact(s"a = $tmpName.0").l
+      val List(assignB) = condBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact(s"b = $tmpName.1").l
+      assignA.order shouldBe 2
+      assignB.order shouldBe 3
     }
 
   }

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/MatchingPatternsTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/MatchingPatternsTests.scala
@@ -243,12 +243,19 @@ class MatchingPatternsTests extends SwiftSrc2CpgSuite {
       // Temp assignment
       val List(tmpAssign) = condBlock.astChildren.isCall.nameExact(Operators.assignment).l
       tmpAssign.code shouldBe s"$tmpName = x"
+      tmpAssign.order shouldBe 1
       // Equality chain
       val List(andCall) = condBlock.astChildren.isCall.nameExact(Operators.logicalAnd).l
       andCall.code shouldBe s"$tmpName.0 == 1 && $tmpName.1 == 2"
+      andCall.order shouldBe 2
       val List(eq1, eq2) = andCall.argument.isCall.nameExact(Operators.equals).l
       eq1.code shouldBe s"$tmpName.0 == 1"
       eq2.code shouldBe s"$tmpName.1 == 2"
+      // isTuple check
+      val isTupleOp         = Defines.createIsTupleOperator(2)
+      val List(isTupleCall) = condBlock.astChildren.isCall.nameExact(isTupleOp).l
+      isTupleCall.code shouldBe s"$isTupleOp($tmpName)"
+      isTupleCall.order shouldBe 3
     }
 
     "testIfCaseBindingTuplePattern" in {
@@ -270,11 +277,17 @@ class MatchingPatternsTests extends SwiftSrc2CpgSuite {
       val allAssigns = condBlock.astChildren.isCall.nameExact(Operators.assignment).l
       allAssigns.size shouldBe 3
       allAssigns.head.code shouldBe s"$tmpName = x"
+      allAssigns.head.order shouldBe 1
       // Binding assignments with field accesses
       val List(assignA) = condBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact(s"a = $tmpName.0").l
       val List(assignB) = condBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact(s"b = $tmpName.1").l
       assignA.order shouldBe 2
       assignB.order shouldBe 3
+      // isTuple check
+      val isTupleOp         = Defines.createIsTupleOperator(2)
+      val List(isTupleCall) = condBlock.astChildren.isCall.nameExact(isTupleOp).l
+      isTupleCall.code shouldBe s"$isTupleOp($tmpName)"
+      isTupleCall.order shouldBe 4
     }
 
     "testIfCaseMixedTuplePattern" in {
@@ -293,12 +306,17 @@ class MatchingPatternsTests extends SwiftSrc2CpgSuite {
       // Temp assignment
       val allAssigns = condBlock.astChildren.isCall.nameExact(Operators.assignment).l
       allAssigns.head.code shouldBe s"$tmpName = x"
+      allAssigns.head.order shouldBe 1
       // Binding assignment for a
       val List(assignA) = condBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact(s"a = $tmpName.0").l
       assignA.order shouldBe 2
       // Equality check for second element
       val List(eqCall) = condBlock.astChildren.isCall.nameExact(Operators.equals).l
       eqCall.code shouldBe s"$tmpName.1 == 1"
+      // isTuple check
+      val isTupleOp         = Defines.createIsTupleOperator(2)
+      val List(isTupleCall) = condBlock.astChildren.isCall.nameExact(isTupleOp).l
+      isTupleCall.code shouldBe s"$isTupleOp($tmpName)"
     }
 
     "testGuardCaseBindingTuplePattern" in {
@@ -321,11 +339,19 @@ class MatchingPatternsTests extends SwiftSrc2CpgSuite {
       val allAssigns = condBlock.astChildren.isCall.nameExact(Operators.assignment).l
       allAssigns.size shouldBe 3
       allAssigns.head.code shouldBe s"$tmpName = x"
+      allAssigns.head.order shouldBe 1
       // Binding assignments with field accesses
       val List(assignA) = condBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact(s"a = $tmpName.0").l
       val List(assignB) = condBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact(s"b = $tmpName.1").l
       assignA.order shouldBe 2
       assignB.order shouldBe 3
+      // isTuple check
+      val isTupleOp         = Defines.createIsTupleOperator(2)
+      val List(isTupleCall) = condBlock.astChildren.isCall.nameExact(isTupleOp).l
+      isTupleCall.code shouldBe s"$isTupleOp($tmpName)"
+      isTupleCall.order shouldBe 4
+      // Guard: else branch contains the return
+      guardIf.astChildren.order(3).ast.isReturn.size shouldBe 1
     }
 
     "testIfCaseNestedBindingTuplePattern" in {
@@ -344,6 +370,7 @@ class MatchingPatternsTests extends SwiftSrc2CpgSuite {
       // Temp assignment
       val allAssigns = condBlock.astChildren.isCall.nameExact(Operators.assignment).l
       allAssigns.head.code shouldBe s"$tmpName = x"
+      allAssigns.head.order shouldBe 1
       // Nested field access: a = <tmp>.0.0, b = <tmp>.0.1, c = <tmp>.1
       val List(assignA) =
         condBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact(s"a = $tmpName.0.0").l
@@ -353,6 +380,11 @@ class MatchingPatternsTests extends SwiftSrc2CpgSuite {
       assignA.order shouldBe 2
       assignB.order shouldBe 3
       assignC.order shouldBe 4
+      // isTuple check (outer tuple has 2 elements)
+      val isTupleOp         = Defines.createIsTupleOperator(2)
+      val List(isTupleCall) = condBlock.astChildren.isCall.nameExact(isTupleOp).l
+      isTupleCall.code shouldBe s"$isTupleOp($tmpName)"
+      isTupleCall.order shouldBe 5
     }
 
     "testIfLetTuplePattern" in {
@@ -374,11 +406,17 @@ class MatchingPatternsTests extends SwiftSrc2CpgSuite {
       val allAssigns = condBlock.astChildren.isCall.nameExact(Operators.assignment).l
       allAssigns.size shouldBe 3
       allAssigns.head.code shouldBe s"$tmpName = x"
+      allAssigns.head.order shouldBe 1
       // Binding assignments with field accesses
       val List(assignA) = condBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact(s"a = $tmpName.0").l
       val List(assignB) = condBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact(s"b = $tmpName.1").l
       assignA.order shouldBe 2
       assignB.order shouldBe 3
+      // isTuple check
+      val isTupleOp         = Defines.createIsTupleOperator(2)
+      val List(isTupleCall) = condBlock.astChildren.isCall.nameExact(isTupleOp).l
+      isTupleCall.code shouldBe s"$isTupleOp($tmpName)"
+      isTupleCall.order shouldBe 4
     }
 
   }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/swiftsrc2cpg/Defines.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/swiftsrc2cpg/Defines.scala
@@ -29,6 +29,9 @@ object Defines {
   val GlobalNamespace: String        = NamespaceTraversal.globalNamespaceName
   val ErasedSignature: String        = "<erased>"
 
+  /** Returns `<operator>.isTupleN` for the given arity, e.g. `<operator>.isTuple2`. */
+  def createIsTupleOperator(arity: Int): String = s"<operator>.isTuple$arity"
+
   val SwiftTypes: List[String] =
     List(
       Any,


### PR DESCRIPTION
Extend tuple pattern de-sugaring from switch-case to if-case and guard-case conditions. Rename existing switch-specific helpers to context-agnostic names and promote them to protected visibility for reuse across AST creator traits.

Supported patterns:
- if case (1, 2) = expr (expression tuple, equality chain)
- if case let (a, b) = expr (binding tuple, field access assignments)
- if case (let a, 1) = expr (mixed binding + equality)
- guard case let (a, b) = expr (bindings under enclosing scope)
- if case let ((a, b), c) = expr (nested tuples)
- if let (a, b) = optionalExpr (optional binding with tuple)