### PR TITLE
[c2cpg] Fix NONLOCAL_REF validation errors for static members and extern C operators

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForTypesCreator.scala
@@ -62,6 +62,11 @@ trait AstForTypesCreator { this: AstCreator =>
         Ast(memberNode(declarator, name, code(declarator), tpe))
       case d if isAssignmentFromBrokenMacro(d, declarator) && scope.lookupVariable(name).nonEmpty =>
         Ast()
+      case _ if declarator.getName.isInstanceOf[ICPPASTQualifiedName] =>
+        // Out-of-class static member definition (e.g. `int Foo::bar[N]`).
+        // The member already exists in the class; creating a local here
+        // would pollute the enclosing scope and cause cross-method REF edges.
+        Ast()
       case _ =>
         val tpe  = typeForIASTDeclarator(declaration, declarator, index)
         val code = codeForDeclarator(declaration, declarator)
@@ -310,6 +315,11 @@ trait AstForTypesCreator { this: AstCreator =>
       case a: ICPPASTStaticAssertDeclaration => true
       case declaration: IASTSimpleDeclaration if declaration.getDeclarators.nonEmpty =>
         declaration.getDeclarators.exists {
+          // Out-of-class static member definitions (qualified names like `Foo::bar[N]`) must
+          // not be treated as having an initializer. Processing them would create identifier
+          // nodes at namespace scope via astForConstructorCall, polluting the shared scope
+          // chain and causing cross-method REF edges (NONLOCAL_REF validation errors).
+          case d: IASTDeclarator if d.getName.isInstanceOf[ICPPASTQualifiedName]               => false
           case d: ICPPASTDeclarator if d.getInitializer == null && isCPPClassLike(declaration) => true
           case d: IASTDeclarator if d.getInitializer != null                                   => true
           case arrayDecl: IASTArrayDeclarator                                                  => true
@@ -328,6 +338,9 @@ trait AstForTypesCreator { this: AstCreator =>
       case a: ICPPASTStaticAssertDeclaration => Seq(astForStaticAssert(a))
       case declaration: IASTSimpleDeclaration if declaration.getDeclarators.nonEmpty =>
         declaration.getDeclarators.toList.map {
+          // Skip out-of-class static member definitions; see comment in declHasInit.
+          case d: IASTDeclarator if d.getName.isInstanceOf[ICPPASTQualifiedName] =>
+            Ast()
           case d: ICPPASTDeclarator if d.getInitializer == null && isCPPClassLike(declaration) =>
             astForConstructorCall(d)
           case d: IASTDeclarator if d.getInitializer != null =>

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/FullNameProvider.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/FullNameProvider.scala
@@ -343,7 +343,11 @@ trait FullNameProvider { this: AstCreator =>
             Option(fn)
           case Some(function: ICPPFunction) =>
             val fullNameNoSig = replaceQualifiedNameSeparator(replaceOperator(function.getQualifiedName.mkString(".")))
-            val fn = if (function.isExternC) {
+            // For plain extern "C" free functions, use just the unqualified name (C linkage,
+            // no mangling). However, class methods inside extern "C" blocks (ICPPMethod) must
+            // retain their qualified name and signature. Otherwise overloaded operators like
+            // operator[](int) and operator[](const char*) collapse to the same fullName "[]".
+            val fn = if (function.isExternC && !function.isInstanceOf[ICPPMethod]) {
               replaceOperator(function.getName)
             } else {
               val returnTpe = declarator.getParent match {

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/MethodTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/MethodTests.scala
@@ -539,5 +539,64 @@ class MethodTests extends C2CpgSuite {
       memberCall.argument.isIdentifier.typeFullName.l shouldBe List("Outer.Inner*")
       memberCall.argument.isFieldIdentifier.code.l shouldBe List("member")
     }
+
+    "have distinct fullNames for extern C class operator overloads" in {
+      val cpg = code(
+        """extern "C" {
+          |  typedef struct _json_value {
+          |    int type;
+          |    inline const struct _json_value &operator [] (int index) const {
+          |      return *this;
+          |    }
+          |    inline const struct _json_value &operator [] (const char * index) const {
+          |      return *this;
+          |    }
+          |  } json_value;
+          |}
+          |""".stripMargin,
+        "test.cpp"
+      )
+      val ops = cpg.method.name("\\[\\].*").fullName.sorted.l
+      ops shouldBe List("_json_value.[]:_json_value&(char*)<const>", "_json_value.[]:_json_value&(int)<const>")
+    }
+
+    "not produce cross-method refs for static members with external definitions" in {
+      val cpg = code(
+        """namespace Opm {
+          |template <class S, unsigned d, unsigned t> class Geom;
+          |template <class S> class Geom<S, 1, 0> {
+          |  enum { numScv = 2 };
+          |public:
+          |  static void init() { for (unsigned i = 0; i < numScv; ++i) scvGeoms_[i] = 0; }
+          |private:
+          |  static int scvGeoms_[numScv];
+          |};
+          |template <class S> int Geom<S, 1, 0>::scvGeoms_[Geom<S, 1, 0>::numScv];
+          |template <class S> class Geom<S, 2, 0> {
+          |  enum { numScv = 3 };
+          |public:
+          |  static void init() { for (unsigned i = 0; i < numScv; ++i) scvGeoms_[i] = 0; }
+          |private:
+          |  static int scvGeoms_[numScv];
+          |};
+          |template <class S> int Geom<S, 2, 0>::scvGeoms_[Geom<S, 2, 0>::numScv];
+          |template <class S> class Geom<S, 3, 0> {
+          |  enum { numScv = 4 };
+          |public:
+          |  static void init() { for (unsigned i = 0; i < numScv; ++i) scvGeoms_[i] = 0; }
+          |private:
+          |  static int scvGeoms_[numScv];
+          |};
+          |template <class S> int Geom<S, 3, 0>::scvGeoms_[Geom<S, 3, 0>::numScv];
+          |}
+          |""".stripMargin,
+        "test.hh"
+      )
+      val initMethods = cpg.method.fullName(".*\\.init.*:void\\(\\)").l
+      initMethods.size shouldBe 3
+      initMethods.foreach { method =>
+        method.block.astChildren.isLocal.nameExact("scvGeoms_").size shouldBe 1
+      }
+    }
   }
 }


### PR DESCRIPTION
Fix two sources of cross-method REF edges that caused PostFrontendValidator NONLOCAL_REF violations:

1. Out-of-class static member definitions (e.g. `int Foo::bar[N]`) were creating local nodes at namespace scope, polluting the shared scope chain so that all template specialization methods resolved to a single local instead of each getting their own.

2. Class method operator overloads inside `extern "C"` blocks (e.g. two `operator[]` with different parameter types) collapsed to the same fullName because the isExternC path dropped the class qualifier and signature.