### PR TITLE
[javasrc2cpg] Add support for getting type information from modules jimage archive

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -25,6 +25,7 @@ class JavaSrc2Cpg extends X2CpgFrontend {
       astCreationPass.createAndApply()
       astCreationPass.sourceParser.cleanupDelombokOutput()
       astCreationPass.clearJavaParserCaches()
+      astCreationPass.closeTypeSolvers()
       new OuterClassRefPass(cpg).createAndApply()
       JavaConfigFileCreationPass(cpg, config = config).createAndApply()
       if (!config.skipTypeInfPass) {

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
@@ -44,7 +44,7 @@ class AstCreationPass(config: Config, cpg: Cpg, sourcesOverride: Option[List[Str
 
   def usedTypes(): Set[String] = _usedTypes
 
-  val (sourceParser, symbolSolver) = initParserAndUtils(config)
+  val (sourceParser, symbolSolver, combinedTypeSolver) = initParserAndUtils(config)
 
   override def createAccumulator(): AstCreationPass.Accumulator = AstCreationPass.Accumulator()
 
@@ -92,11 +92,16 @@ class AstCreationPass(config: Config, cpg: Cpg, sourcesOverride: Option[List[Str
     JavaParserFacade.clearInstances()
   }
 
-  private def initParserAndUtils(config: Config): (SourceParser, JavaSymbolSolver) = {
-    val dependencies = getDependencyList(config.inputPath)
-    val sourceParser = SourceParser(config, sourcesOverride)
-    val symbolSolver = createSymbolSolver(config, dependencies, sourceParser)
-    (sourceParser, symbolSolver)
+  /** Close type solver resources (open JAR files, jrt: file systems). Should be called after all AST creation is done
+    * and [[clearJavaParserCaches]] has been called.
+    */
+  def closeTypeSolvers(): Unit = combinedTypeSolver.close()
+
+  private def initParserAndUtils(config: Config): (SourceParser, JavaSymbolSolver, SimpleCombinedTypeSolver) = {
+    val dependencies                   = getDependencyList(config.inputPath)
+    val sourceParser                   = SourceParser(config, sourcesOverride)
+    val (symbolSolver, combinedSolver) = createSymbolSolver(config, dependencies, sourceParser)
+    (sourceParser, symbolSolver, combinedSolver)
   }
 
   private def getDependencyList(inputPath: String): List[String] = {
@@ -131,7 +136,7 @@ class AstCreationPass(config: Config, cpg: Cpg, sourcesOverride: Option[List[Str
     config: Config,
     dependencies: List[String],
     sourceParser: SourceParser
-  ): JavaSymbolSolver = {
+  ): (JavaSymbolSolver, SimpleCombinedTypeSolver) = {
     val verboseDebugLoggingEnvVarValue = Option(System.getenv(JavaSrcEnvVar.EnableVerboseTypeLogging.name))
     val enableVerboseTypeLogging       = verboseDebugLoggingEnvVarValue.isDefined || config.enableVerboseTypeLogging
     if (enableVerboseTypeLogging) {
@@ -191,7 +196,7 @@ class AstCreationPass(config: Config, cpg: Cpg, sourcesOverride: Option[List[Str
         }
       }
 
-    symbolSolver
+    (symbolSolver, combinedTypeSolver)
   }
 
   private def recursiveJarsFromPath(path: String): List[String] = {

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/BytecodeIndexedClassPath.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/BytecodeIndexedClassPath.scala
@@ -22,7 +22,7 @@ object BytecodeIndexedClassPath {
   * their path within the archive. This handles non-standard archive structures (e.g., fat JARs, repackaged JARs, JMODs)
   * where the entry path may not match the class's declared package.
   */
-class BytecodeIndexedClassPath(archivePath: String) extends ClassPath {
+class BytecodeIndexedClassPath(archivePath: String) extends ClassPath with AutoCloseable {
 
   private val logger     = LoggerFactory.getLogger(this.getClass)
   private val jarFile    = new JarFile(archivePath)
@@ -64,4 +64,6 @@ class BytecodeIndexedClassPath(archivePath: String) extends ClassPath {
   override def openClassfile(classname: String): InputStream = {
     classNameToEntry.get(classname).map(jarFile.getInputStream).orNull
   }
+
+  override def close(): Unit = jarFile.close()
 }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/BytecodeIndexedClassPath.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/BytecodeIndexedClassPath.scala
@@ -11,6 +11,13 @@ import java.util.jar.{JarEntry, JarFile}
 import scala.jdk.CollectionConverters.*
 import scala.util.{Try, Using}
 
+object BytecodeIndexedClassPath {
+
+  /** Read the declared class name from an open `.class` file stream using javassist. */
+  def readClassNameFrom(inputStream: InputStream): String =
+    new ClassFile(new DataInputStream(inputStream)).getName
+}
+
 /** A ClassPath implementation that resolves classes by their actual package declaration in bytecode rather than by
   * their path within the archive. This handles non-standard archive structures (e.g., fat JARs, repackaged JARs, JMODs)
   * where the entry path may not match the class's declared package.
@@ -42,14 +49,8 @@ class BytecodeIndexedClassPath(archivePath: String) extends ClassPath {
       .toMap
   }
 
-  private def readClassName(entry: JarEntry): Option[String] = {
-    Try {
-      Using.resource(jarFile.getInputStream(entry)) { inputStream =>
-        val classFile = new ClassFile(new DataInputStream(inputStream))
-        classFile.getName
-      }
-    }.toOption
-  }
+  private def readClassName(entry: JarEntry): Option[String] =
+    Try(Using.resource(jarFile.getInputStream(entry))(BytecodeIndexedClassPath.readClassNameFrom)).toOption
 
   override def find(classname: String): URL = {
     classNameToEntry

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/JrtRuntimeImageClassPath.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/JrtRuntimeImageClassPath.scala
@@ -114,7 +114,7 @@ object JrtRuntimeImageClassPath {
   /** Max directory depth (in terms of file depth from the search root) when searching under findRuntimeImage. Since
     * `lib/modules` sits 2 levels below a java.home, a maxDepth of 6 allows java.home directories up to 4 levels deep.
     */
-  val DefaultRuntimeImageSearchMaxDepth: Int = 4
+  val DefaultRuntimeImageSearchMaxDepth: Int = 10
 
   /** Find the shallowest `<java.home>/lib/modules` layout under searchRoot. maxDepth limits how deep the `modules` file
     * itself can be. Does not follow symbolic links (avoids symlink loops, consistent with jar discovery).

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/JrtRuntimeImageClassPath.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/JrtRuntimeImageClassPath.scala
@@ -29,11 +29,7 @@ class JrtRuntimeImageClassPath(javaHome: Path) extends ClassPath with AutoClosea
       logger.warn(s"jrt: file system has no /modules root for java.home=$javaHome")
       (Map.empty[String, Path], Map.empty[String, List[String]])
     } else {
-      val exports = buildExports(modulesRoot)
-
-      val index = buildIndex(modulesRoot)
-
-      (index, exports)
+      buildExportsAndIndex(modulesRoot)
     }
   }
 
@@ -42,52 +38,51 @@ class JrtRuntimeImageClassPath(javaHome: Path) extends ClassPath with AutoClosea
   /** Module name to exported package names (for JarTypeSolver.tryToSolveTypeInModule). */
   val moduleExportsMap: Map[String, List[String]] = moduleExports
 
-  private def buildExports(modulesRoot: Path): Map[String, List[String]] = {
+  private def buildExportsAndIndex(modulesRoot: Path): (Map[String, Path], Map[String, List[String]]) = {
     val exportsBuilder = Map.newBuilder[String, List[String]]
-    Using.resource(Files.walk(modulesRoot)) { recursiveFiles =>
-      recursiveFiles.iterator().asScala.foreach { moduleDir =>
-        if (Files.isDirectory(moduleDir)) {
-          val moduleInfo = moduleDir.resolve("module-info.class")
-          if (Files.isRegularFile(moduleInfo)) {
-            Try(Using.resource(Files.newInputStream(moduleInfo)) { in =>
-              val (moduleName, exportPkgs) = JrtRuntimeImageClassPath.readModuleExports(in)
-              exportsBuilder += moduleName -> exportPkgs
-            }).recover(e => logger.debug(s"Could not read module descriptor at $moduleInfo", e))
-          }
-        }
-      }
-    }
-    exportsBuilder.result()
-  }
-
-  private def buildIndex(modulesRoot: Path): Map[String, Path] = {
-    val indexMutable = mutable.Map.empty[String, Path]
+    val indexMutable   = mutable.Map.empty[String, Path]
     var duplicateCount = 0
+
     Using.resource(Files.walk(modulesRoot)) { recursiveFiles =>
       recursiveFiles.iterator().asScala.foreach { path =>
         if (Files.isRegularFile(path) && path.getFileName.toString.endsWith(".class")) {
-          if (path.getFileName.toString != "module-info.class") {
-            Try(
-              Using.resource(Files.newInputStream(path))(BytecodeIndexedClassPath.readClassNameFrom)
-            ).toOption match {
-              case Some(className) =>
-                if (!indexMutable.contains(className)) {
-                  indexMutable(className) = path
-                } else {
-                  duplicateCount += 1
-                }
-              case None =>
-                logger.debug(s"Could not read class name from $path")
+          Try(Using.resource(Files.newInputStream(path)) { recursiveFiles =>
+            if (path.getFileName.toString == "module-info.class") {
+              handleModuleInfo(recursiveFiles, exportsBuilder)
+            } else {
+              if (handleClassFile(recursiveFiles, path, indexMutable)) {
+                duplicateCount += 1
+              }
             }
-          }
+          }).recover { case e => logger.debug(s"Could not read class files at $path", e) }
         }
       }
     }
+
     if (duplicateCount > 0) {
       logger.debug(s"JRT index: $duplicateCount duplicate class names across modules (first module wins)")
     }
 
-    indexMutable.toMap
+    (indexMutable.toMap, exportsBuilder.result())
+  }
+
+  private def handleModuleInfo(
+    in: InputStream,
+    exportsBuilder: mutable.Builder[(String, List[String]), Map[String, List[String]]]
+  ): Unit = {
+    val (moduleName, exportPkgs) = JrtRuntimeImageClassPath.readModuleExports(in)
+    exportsBuilder += moduleName -> exportPkgs
+  }
+
+  /** Returns true if the class name was a duplicate. */
+  private def handleClassFile(in: InputStream, path: Path, indexMutable: mutable.Map[String, Path]): Boolean = {
+    val className = BytecodeIndexedClassPath.readClassNameFrom(in)
+    if (!indexMutable.contains(className)) {
+      indexMutable(className) = path
+      false
+    } else {
+      true
+    }
   }
 
   override def find(classname: String): URL = {
@@ -125,10 +120,7 @@ object JrtRuntimeImageClassPath {
   /** Find the shallowest `<java.home>/lib/modules` layout under searchRoot. maxDepth limits how deep the `modules` file
     * itself can be. Does not follow symbolic links (avoids symlink loops, consistent with jar discovery).
     */
-  def findRuntimeImage(
-    searchRoot: Path,
-    maxDepth: Int = DefaultRuntimeImageRootSearchMaxDepth
-  ): Option[Path] = {
+  def findRuntimeImage(searchRoot: Path, maxDepth: Int = DefaultRuntimeImageRootSearchMaxDepth): Option[Path] = {
     if (!Files.exists(searchRoot)) {
       None
     } else {

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/JrtRuntimeImageClassPath.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/JrtRuntimeImageClassPath.scala
@@ -18,7 +18,7 @@ import scala.util.{Failure, Success, Try, Using}
   * The FileSystem is kept open for the lifetime of this instance (same lifecycle as BytecodeIndexedClassPath holding a
   * JarFile).
   */
-class JrtRuntimeImageClassPath(javaHome: Path) extends ClassPath {
+class JrtRuntimeImageClassPath(javaHome: Path) extends ClassPath with AutoCloseable {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
 
@@ -95,6 +95,8 @@ class JrtRuntimeImageClassPath(javaHome: Path) extends ClassPath {
   override def openClassfile(classname: String): InputStream = {
     classNameToPath.get(classname).map(p => Files.newInputStream(p)).orNull
   }
+
+  override def close(): Unit = jrtFileSystem.close()
 }
 
 object JrtRuntimeImageClassPath {
@@ -109,7 +111,7 @@ object JrtRuntimeImageClassPath {
   }
 
   /** Max directory depth when searching under findRuntimeImage (avoids scanning huge trees). */
-  val DefaultRuntimeImageSearchMaxDepth: Int = 48
+  val DefaultRuntimeImageSearchMaxDepth: Int = 4
 
   /** Walk searchRoot once; return java.home and the modules file path used for jrt (no second tree walk). */
   def findRuntimeImage(

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/JrtRuntimeImageClassPath.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/JrtRuntimeImageClassPath.scala
@@ -66,10 +66,11 @@ class JrtRuntimeImageClassPath(javaHome: Path) extends ClassPath with AutoClosea
                 Using.resource(Files.newInputStream(path))(BytecodeIndexedClassPath.readClassNameFrom)
               ).toOption match {
                 case Some(className) =>
-                  if (indexMutable.contains(className)) {
+                  if (!indexMutable.contains(className)) {
+                    indexMutable(className) = path
+                  } else {
                     duplicateCount += 1
                   }
-                  indexMutable(className) = path
                 case None =>
                   logger.debug(s"Could not read class name from $path")
               }
@@ -78,7 +79,7 @@ class JrtRuntimeImageClassPath(javaHome: Path) extends ClassPath with AutoClosea
         }
       }
       if (duplicateCount > 0) {
-        logger.debug(s"JRT index: $duplicateCount duplicate internal class names (last path wins)")
+        logger.debug(s"JRT index: $duplicateCount duplicate class names across modules (first module wins)")
       }
 
       (indexMutable.toMap, exports)
@@ -110,10 +111,14 @@ object JrtRuntimeImageClassPath {
     (descriptor.name(), descriptor.exports().asScala.map(_.source()).toList)
   }
 
-  /** Max directory depth when searching under findRuntimeImage (avoids scanning huge trees). */
-  val DefaultRuntimeImageSearchMaxDepth: Int = 4
+  /** Max directory depth (in terms of file depth from the search root) when searching under findRuntimeImage. Since
+    * `lib/modules` sits 2 levels below a java.home, a maxDepth of 6 allows java.home directories up to 4 levels deep.
+    */
+  val DefaultRuntimeImageSearchMaxDepth: Int = 6
 
-  /** Walk searchRoot once; return java.home and the modules file path used for jrt (no second tree walk). */
+  /** Find the shallowest `<java.home>/lib/modules` layout under searchRoot. maxDepth limits how deep the `modules` file
+    * itself can be. Does not follow symbolic links (avoids symlink loops, consistent with jar discovery).
+    */
   def findRuntimeImage(
     searchRoot: Path,
     maxDepth: Int = DefaultRuntimeImageSearchMaxDepth
@@ -121,31 +126,20 @@ object JrtRuntimeImageClassPath {
     if (!Files.exists(searchRoot)) {
       None
     } else {
-      val root       = searchRoot.toAbsolutePath.normalize()
-      val candidates = mutable.ArrayBuffer.empty[RuntimeImageLayout]
-      // Two-arg walk does not follow symbolic links (consistent with jar discovery; avoids symlink loops).
+      val root = searchRoot.toAbsolutePath.normalize()
       Using.resource(Files.walk(root, maxDepth)) { stream =>
-        stream.iterator().asScala.foreach { p =>
-          if (Files.isRegularFile(p) && !Files.isSymbolicLink(p) && p.getFileName.toString == "modules") {
-            val lib = p.getParent
-            if (
-              lib != null && lib.getFileName != null && lib.getFileName.toString == "lib" && !Files.isSymbolicLink(lib)
-            ) {
-              val javaHome = lib.getParent
-              if (javaHome != null) {
-                candidates += RuntimeImageLayout(javaHome, p)
-              }
-            }
+        stream
+          .iterator()
+          .asScala
+          .filter(p => Files.isRegularFile(p) && !Files.isSymbolicLink(p) && p.getFileName.toString == "modules")
+          .flatMap { p =>
+            for {
+              lib <- Option(p.getParent)
+              if lib.getFileName != null && lib.getFileName.toString == "lib" && !Files.isSymbolicLink(lib)
+              javaHome <- Option(lib.getParent)
+            } yield RuntimeImageLayout(javaHome, p)
           }
-        }
-      }
-      if (candidates.isEmpty) None
-      else {
-        // Prefer the shallowest match (e.g. jdkRoot/lib/modules over jdkRoot/extra/nested/lib/modules).
-        Some(candidates.minBy { layout =>
-          val rel = root.relativize(layout.javaHome)
-          (rel.getNameCount, rel.toString)
-        })
+          .minByOption(layout => root.relativize(layout.javaHome).getNameCount)
       }
     }
   }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/JrtRuntimeImageClassPath.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/JrtRuntimeImageClassPath.scala
@@ -114,7 +114,7 @@ object JrtRuntimeImageClassPath {
   /** Max directory depth (in terms of file depth from the search root) when searching under findRuntimeImage. Since
     * `lib/modules` sits 2 levels below a java.home, a maxDepth of 6 allows java.home directories up to 4 levels deep.
     */
-  val DefaultRuntimeImageSearchMaxDepth: Int = 6
+  val DefaultRuntimeImageSearchMaxDepth: Int = 4
 
   /** Find the shallowest `<java.home>/lib/modules` layout under searchRoot. maxDepth limits how deep the `modules` file
     * itself can be. Does not follow symbolic links (avoids symlink loops, consistent with jar discovery).

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/JrtRuntimeImageClassPath.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/JrtRuntimeImageClassPath.scala
@@ -1,5 +1,6 @@
 package io.joern.javasrc2cpg.typesolvers
 
+import io.joern.javasrc2cpg.typesolvers.JrtRuntimeImageClassPath.logger
 import javassist.ClassPath
 import org.slf4j.LoggerFactory
 
@@ -20,8 +21,6 @@ import scala.util.{Failure, Success, Try, Using}
   */
 class JrtRuntimeImageClassPath(javaHome: Path) extends ClassPath with AutoCloseable {
 
-  private val logger = LoggerFactory.getLogger(this.getClass)
-
   private val jrtFileSystem = JrtRuntimeImageClassPath.openJrtFileSystem(javaHome)
 
   private val (classNameToPath: Map[String, Path], moduleExports: Map[String, List[String]]) = buildIndexAndExports()
@@ -30,6 +29,8 @@ class JrtRuntimeImageClassPath(javaHome: Path) extends ClassPath with AutoClosea
 
   /** Module name to exported package names (for JarTypeSolver.tryToSolveTypeInModule). */
   val moduleExportsMap: Map[String, List[String]] = moduleExports
+
+  private def buildExports(): Map[String, List[String]] = {}
 
   private def buildIndexAndExports(): (Map[String, Path], Map[String, List[String]]) = {
     val modulesRoot = jrtFileSystem.getPath("/modules")
@@ -89,18 +90,20 @@ class JrtRuntimeImageClassPath(javaHome: Path) extends ClassPath with AutoClosea
   override def find(classname: String): URL = {
     classNameToPath
       .get(classname)
-      .flatMap(p => Try(p.toUri.toURL).toOption)
+      .flatMap(path => Try(path.toUri.toURL).toOption)
       .orNull
   }
 
   override def openClassfile(classname: String): InputStream = {
-    classNameToPath.get(classname).map(p => Files.newInputStream(p)).orNull
+    classNameToPath.get(classname).map(path => Files.newInputStream(path)).orNull
   }
 
   override def close(): Unit = jrtFileSystem.close()
 }
 
 object JrtRuntimeImageClassPath {
+
+  private val logger = LoggerFactory.getLogger(this.getClass)
 
   /** Result of a single filesystem walk: the jrt java.home directory and the exact lib/modules jimage path. */
   final case class RuntimeImageLayout(javaHome: Path, modulesImageFile: Path)
@@ -122,31 +125,40 @@ object JrtRuntimeImageClassPath {
   def findRuntimeImage(
     searchRoot: Path,
     maxDepth: Int = DefaultRuntimeImageSearchMaxDepth
-  ): Option[RuntimeImageLayout] = {
+  ): Option[Path] = {
     if (!Files.exists(searchRoot)) {
       None
     } else {
       val root = searchRoot.toAbsolutePath.normalize()
-      Using.resource(Files.walk(root, maxDepth)) { stream =>
-        stream
+      Using.resource(Files.walk(root, maxDepth)) { fileStream =>
+        fileStream
           .iterator()
           .asScala
           .filter(p => Files.isRegularFile(p) && !Files.isSymbolicLink(p) && p.getFileName.toString == "modules")
-          .flatMap { p =>
+          .flatMap { path =>
             for {
-              lib <- Option(p.getParent)
-              if lib.getFileName != null && lib.getFileName.toString == "lib" && !Files.isSymbolicLink(lib)
+              lib <- Option(path.getParent)
+              if (lib.getFileName != null && lib.getFileName.toString == "lib" && !Files.isSymbolicLink(lib))
               javaHome <- Option(lib.getParent)
-            } yield RuntimeImageLayout(javaHome, p)
+            } yield javaHome
           }
-          .minByOption(layout => root.relativize(layout.javaHome).getNameCount)
+          .toList
+          .match {
+            case Nil =>
+              logger.debug("No modules runtime image found")
+              None
+
+            case singleResult :: Nil =>
+              Some(singleResult)
+
+            case firstResult :: _ =>
+              logger.warn(s"Found multiple modules runtime images. Using the first found at ${firstResult}")
+              Some(firstResult)
+
+          }
       }
     }
   }
-
-  /** Directory layout root for a JDK / jlink image (java.home); see findRuntimeImage for the modules file path. */
-  def findRuntimeImageRoot(searchRoot: Path, maxDepth: Int = DefaultRuntimeImageSearchMaxDepth): Option[Path] =
-    findRuntimeImage(searchRoot, maxDepth).map(_.javaHome)
 
   private def openJrtFileSystem(javaHome: Path) = {
     val env = new java.util.HashMap[String, String]()

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/JrtRuntimeImageClassPath.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/JrtRuntimeImageClassPath.scala
@@ -21,6 +21,8 @@ import scala.util.{Failure, Success, Try, Using}
   */
 class JrtRuntimeImageClassPath(javaHome: Path) extends ClassPath with AutoCloseable {
 
+  // The jrtFileSystem needs to stay open for the entire javasrc2cpg lifetime since all paths indexed
+  // and used here are paths within the jrtfs, so it is kept as a private member here.
   private val jrtFileSystem = JrtRuntimeImageClassPath.openJrtFileSystem(javaHome)
 
   private val (classNameToPath: Map[String, Path], moduleExports: Map[String, List[String]]) = {

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/JrtRuntimeImageClassPath.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/JrtRuntimeImageClassPath.scala
@@ -1,0 +1,160 @@
+package io.joern.javasrc2cpg.typesolvers
+
+import javassist.ClassPath
+import org.slf4j.LoggerFactory
+
+import java.io.InputStream
+import java.lang.module.ModuleDescriptor
+import java.net.{URI, URL}
+import java.nio.file.{FileSystems, Files, Path}
+import scala.collection.mutable
+import scala.jdk.CollectionConverters.*
+import scala.util.{Failure, Success, Try, Using}
+
+/** ClassPath over the JDK modular runtime image (JEP 220, lib/modules jimage), exposed via the jrt file system. Used
+  * when the configured JDK path has no jar/jmod archives to index (e.g. minimal jlink images). When a full JDK is
+  * present, BytecodeIndexedClassPath on jmods and other archives is preferred instead (see JarTypeSolver.fromPath).
+  *
+  * The FileSystem is kept open for the lifetime of this instance (same lifecycle as BytecodeIndexedClassPath holding a
+  * JarFile).
+  */
+class JrtRuntimeImageClassPath(javaHome: Path) extends ClassPath {
+
+  private val logger = LoggerFactory.getLogger(this.getClass)
+
+  private val jrtFileSystem = JrtRuntimeImageClassPath.openJrtFileSystem(javaHome)
+
+  private val (classNameToPath: Map[String, Path], moduleExports: Map[String, List[String]]) = buildIndexAndExports()
+
+  val knownClassNames: Set[String] = classNameToPath.keySet
+
+  /** Module name to exported package names (for JarTypeSolver.tryToSolveTypeInModule). */
+  val moduleExportsMap: Map[String, List[String]] = moduleExports
+
+  private def buildIndexAndExports(): (Map[String, Path], Map[String, List[String]]) = {
+    val modulesRoot = jrtFileSystem.getPath("/modules")
+    if (!Files.exists(modulesRoot)) {
+      logger.warn(s"jrt: file system has no /modules root for java.home=$javaHome")
+      (Map.empty, Map.empty)
+    } else {
+      val exportsBuilder = Map.newBuilder[String, List[String]]
+      Using.resource(Files.list(modulesRoot)) { stream =>
+        stream.iterator().asScala.foreach { moduleDir =>
+          if (Files.isDirectory(moduleDir)) {
+            val moduleInfo = moduleDir.resolve("module-info.class")
+            if (Files.isRegularFile(moduleInfo)) {
+              Try(Using.resource(Files.newInputStream(moduleInfo)) { in =>
+                val (moduleName, exportPkgs) = JrtRuntimeImageClassPath.readModuleExports(in)
+                exportsBuilder += moduleName -> exportPkgs
+              }) match {
+                case Failure(e) => logger.debug(s"Could not read module descriptor at $moduleInfo", e)
+                case Success(_) =>
+              }
+            }
+          }
+        }
+      }
+      val exports = exportsBuilder.result()
+
+      val indexMutable   = mutable.Map.empty[String, Path]
+      var duplicateCount = 0
+      Using.resource(Files.walk(modulesRoot)) { stream =>
+        stream.iterator().asScala.foreach { path =>
+          if (Files.isRegularFile(path) && path.getFileName.toString.endsWith(".class")) {
+            if (path.getFileName.toString != "module-info.class") {
+              Try(
+                Using.resource(Files.newInputStream(path))(BytecodeIndexedClassPath.readClassNameFrom)
+              ).toOption match {
+                case Some(className) =>
+                  if (indexMutable.contains(className)) {
+                    duplicateCount += 1
+                  }
+                  indexMutable(className) = path
+                case None =>
+                  logger.debug(s"Could not read class name from $path")
+              }
+            }
+          }
+        }
+      }
+      if (duplicateCount > 0) {
+        logger.debug(s"JRT index: $duplicateCount duplicate internal class names (last path wins)")
+      }
+
+      (indexMutable.toMap, exports)
+    }
+  }
+
+  override def find(classname: String): URL = {
+    classNameToPath
+      .get(classname)
+      .flatMap(p => Try(p.toUri.toURL).toOption)
+      .orNull
+  }
+
+  override def openClassfile(classname: String): InputStream = {
+    classNameToPath.get(classname).map(p => Files.newInputStream(p)).orNull
+  }
+}
+
+object JrtRuntimeImageClassPath {
+
+  /** Result of a single filesystem walk: the jrt java.home directory and the exact lib/modules jimage path. */
+  final case class RuntimeImageLayout(javaHome: Path, modulesImageFile: Path)
+
+  /** Parse a `module-info.class` stream and return the module name with its exported package names. */
+  def readModuleExports(inputStream: InputStream): (String, List[String]) = {
+    val descriptor = ModuleDescriptor.read(inputStream)
+    (descriptor.name(), descriptor.exports().asScala.map(_.source()).toList)
+  }
+
+  /** Max directory depth when searching under findRuntimeImage (avoids scanning huge trees). */
+  val DefaultRuntimeImageSearchMaxDepth: Int = 48
+
+  /** Walk searchRoot once; return java.home and the modules file path used for jrt (no second tree walk). */
+  def findRuntimeImage(
+    searchRoot: Path,
+    maxDepth: Int = DefaultRuntimeImageSearchMaxDepth
+  ): Option[RuntimeImageLayout] = {
+    if (!Files.exists(searchRoot)) {
+      None
+    } else {
+      val root       = searchRoot.toAbsolutePath.normalize()
+      val candidates = mutable.ArrayBuffer.empty[RuntimeImageLayout]
+      // Two-arg walk does not follow symbolic links (consistent with jar discovery; avoids symlink loops).
+      Using.resource(Files.walk(root, maxDepth)) { stream =>
+        stream.iterator().asScala.foreach { p =>
+          if (Files.isRegularFile(p) && !Files.isSymbolicLink(p) && p.getFileName.toString == "modules") {
+            val lib = p.getParent
+            if (
+              lib != null && lib.getFileName != null && lib.getFileName.toString == "lib" && !Files.isSymbolicLink(lib)
+            ) {
+              val javaHome = lib.getParent
+              if (javaHome != null) {
+                candidates += RuntimeImageLayout(javaHome, p)
+              }
+            }
+          }
+        }
+      }
+      if (candidates.isEmpty) None
+      else {
+        // Prefer the shallowest match (e.g. jdkRoot/lib/modules over jdkRoot/extra/nested/lib/modules).
+        Some(candidates.minBy { layout =>
+          val rel = root.relativize(layout.javaHome)
+          (rel.getNameCount, rel.toString)
+        })
+      }
+    }
+  }
+
+  /** Directory layout root for a JDK / jlink image (java.home); see findRuntimeImage for the modules file path. */
+  def findRuntimeImageRoot(searchRoot: Path, maxDepth: Int = DefaultRuntimeImageSearchMaxDepth): Option[Path] =
+    findRuntimeImage(searchRoot, maxDepth).map(_.javaHome)
+
+  private def openJrtFileSystem(javaHome: Path) = {
+    val env = new java.util.HashMap[String, String]()
+    env.put("java.home", javaHome.toAbsolutePath.normalize().toString)
+    FileSystems.newFileSystem(URI.create("jrt:/"), env)
+  }
+}

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/JrtRuntimeImageClassPath.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/JrtRuntimeImageClassPath.scala
@@ -23,68 +23,71 @@ class JrtRuntimeImageClassPath(javaHome: Path) extends ClassPath with AutoClosea
 
   private val jrtFileSystem = JrtRuntimeImageClassPath.openJrtFileSystem(javaHome)
 
-  private val (classNameToPath: Map[String, Path], moduleExports: Map[String, List[String]]) = buildIndexAndExports()
+  private val (classNameToPath: Map[String, Path], moduleExports: Map[String, List[String]]) = {
+    val modulesRoot = jrtFileSystem.getPath("/modules")
+    if (!Files.exists(modulesRoot)) {
+      logger.warn(s"jrt: file system has no /modules root for java.home=$javaHome")
+      (Map.empty[String, Path], Map.empty[String, List[String]])
+    } else {
+      val exports = buildExports(modulesRoot)
+
+      val index = buildIndex(modulesRoot)
+
+      (index, exports)
+    }
+  }
 
   val knownClassNames: Set[String] = classNameToPath.keySet
 
   /** Module name to exported package names (for JarTypeSolver.tryToSolveTypeInModule). */
   val moduleExportsMap: Map[String, List[String]] = moduleExports
 
-  private def buildExports(): Map[String, List[String]] = {}
-
-  private def buildIndexAndExports(): (Map[String, Path], Map[String, List[String]]) = {
-    val modulesRoot = jrtFileSystem.getPath("/modules")
-    if (!Files.exists(modulesRoot)) {
-      logger.warn(s"jrt: file system has no /modules root for java.home=$javaHome")
-      (Map.empty, Map.empty)
-    } else {
-      val exportsBuilder = Map.newBuilder[String, List[String]]
-      Using.resource(Files.list(modulesRoot)) { stream =>
-        stream.iterator().asScala.foreach { moduleDir =>
-          if (Files.isDirectory(moduleDir)) {
-            val moduleInfo = moduleDir.resolve("module-info.class")
-            if (Files.isRegularFile(moduleInfo)) {
-              Try(Using.resource(Files.newInputStream(moduleInfo)) { in =>
-                val (moduleName, exportPkgs) = JrtRuntimeImageClassPath.readModuleExports(in)
-                exportsBuilder += moduleName -> exportPkgs
-              }) match {
-                case Failure(e) => logger.debug(s"Could not read module descriptor at $moduleInfo", e)
-                case Success(_) =>
-              }
-            }
+  private def buildExports(modulesRoot: Path): Map[String, List[String]] = {
+    val exportsBuilder = Map.newBuilder[String, List[String]]
+    Using.resource(Files.walk(modulesRoot)) { recursiveFiles =>
+      recursiveFiles.iterator().asScala.foreach { moduleDir =>
+        if (Files.isDirectory(moduleDir)) {
+          val moduleInfo = moduleDir.resolve("module-info.class")
+          if (Files.isRegularFile(moduleInfo)) {
+            Try(Using.resource(Files.newInputStream(moduleInfo)) { in =>
+              val (moduleName, exportPkgs) = JrtRuntimeImageClassPath.readModuleExports(in)
+              exportsBuilder += moduleName -> exportPkgs
+            }).recover(e => logger.debug(s"Could not read module descriptor at $moduleInfo", e))
           }
         }
       }
-      val exports = exportsBuilder.result()
-
-      val indexMutable   = mutable.Map.empty[String, Path]
-      var duplicateCount = 0
-      Using.resource(Files.walk(modulesRoot)) { stream =>
-        stream.iterator().asScala.foreach { path =>
-          if (Files.isRegularFile(path) && path.getFileName.toString.endsWith(".class")) {
-            if (path.getFileName.toString != "module-info.class") {
-              Try(
-                Using.resource(Files.newInputStream(path))(BytecodeIndexedClassPath.readClassNameFrom)
-              ).toOption match {
-                case Some(className) =>
-                  if (!indexMutable.contains(className)) {
-                    indexMutable(className) = path
-                  } else {
-                    duplicateCount += 1
-                  }
-                case None =>
-                  logger.debug(s"Could not read class name from $path")
-              }
-            }
-          }
-        }
-      }
-      if (duplicateCount > 0) {
-        logger.debug(s"JRT index: $duplicateCount duplicate class names across modules (first module wins)")
-      }
-
-      (indexMutable.toMap, exports)
     }
+    exportsBuilder.result()
+  }
+
+  private def buildIndex(modulesRoot: Path): Map[String, Path] = {
+    val indexMutable = mutable.Map.empty[String, Path]
+    var duplicateCount = 0
+    Using.resource(Files.walk(modulesRoot)) { recursiveFiles =>
+      recursiveFiles.iterator().asScala.foreach { path =>
+        if (Files.isRegularFile(path) && path.getFileName.toString.endsWith(".class")) {
+          if (path.getFileName.toString != "module-info.class") {
+            Try(
+              Using.resource(Files.newInputStream(path))(BytecodeIndexedClassPath.readClassNameFrom)
+            ).toOption match {
+              case Some(className) =>
+                if (!indexMutable.contains(className)) {
+                  indexMutable(className) = path
+                } else {
+                  duplicateCount += 1
+                }
+              case None =>
+                logger.debug(s"Could not read class name from $path")
+            }
+          }
+        }
+      }
+    }
+    if (duplicateCount > 0) {
+      logger.debug(s"JRT index: $duplicateCount duplicate class names across modules (first module wins)")
+    }
+
+    indexMutable.toMap
   }
 
   override def find(classname: String): URL = {
@@ -117,21 +120,21 @@ object JrtRuntimeImageClassPath {
   /** Max directory depth (in terms of file depth from the search root) when searching under findRuntimeImage. Since
     * `lib/modules` sits 2 levels below a java.home, a maxDepth of 6 allows java.home directories up to 4 levels deep.
     */
-  val DefaultRuntimeImageSearchMaxDepth: Int = 10
+  val DefaultRuntimeImageRootSearchMaxDepth: Int = 10
 
   /** Find the shallowest `<java.home>/lib/modules` layout under searchRoot. maxDepth limits how deep the `modules` file
     * itself can be. Does not follow symbolic links (avoids symlink loops, consistent with jar discovery).
     */
   def findRuntimeImage(
     searchRoot: Path,
-    maxDepth: Int = DefaultRuntimeImageSearchMaxDepth
+    maxDepth: Int = DefaultRuntimeImageRootSearchMaxDepth
   ): Option[Path] = {
     if (!Files.exists(searchRoot)) {
       None
     } else {
       val root = searchRoot.toAbsolutePath.normalize()
-      Using.resource(Files.walk(root, maxDepth)) { fileStream =>
-        fileStream
+      Using.resource(Files.walk(root, maxDepth)) { recursiveFiles =>
+        recursiveFiles
           .iterator()
           .asScala
           .filter(p => Files.isRegularFile(p) && !Files.isSymbolicLink(p) && p.getFileName.toString == "modules")

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/SimpleCombinedTypeSolver.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/SimpleCombinedTypeSolver.scala
@@ -11,11 +11,12 @@ import org.slf4j.LoggerFactory
 import java.util.concurrent.ConcurrentHashMap
 import scala.collection.mutable
 import scala.jdk.OptionConverters.RichOptional
+import scala.util.Try
 
 type TypeCacheKey         = String | (String, String)
 private type TypeLookupFn = TypeSolver => SymbolReference[ResolvedReferenceTypeDeclaration]
 
-class SimpleCombinedTypeSolver(enableVerboseTypeLogging: Boolean) extends TypeSolver {
+class SimpleCombinedTypeSolver(enableVerboseTypeLogging: Boolean) extends TypeSolver with AutoCloseable {
 
   private val logger             = LoggerFactory.getLogger(this.getClass)
   private var parent: TypeSolver = scala.compiletime.uninitialized
@@ -116,6 +117,12 @@ class SimpleCombinedTypeSolver(enableVerboseTypeLogging: Boolean) extends TypeSo
       this.parent = parent
     }
   }
+
+  override def close(): Unit =
+    (cachingTypeSolvers ++ nonCachingTypeSolvers).foreach {
+      case c: AutoCloseable => Try(c.close())
+      case _                =>
+    }
 
   override def tryToSolveTypeInModule(
     qualifiedModuleName: String,

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/noncaching/JarTypeSolver.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/noncaching/JarTypeSolver.scala
@@ -10,7 +10,7 @@ import javassist.CtClass
 import org.slf4j.LoggerFactory
 
 import java.io.IOException
-import java.lang.module.ModuleDescriptor
+import java.nio.file.{Path, Paths}
 import java.util.jar.JarFile
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
@@ -121,7 +121,11 @@ class JarTypeSolverBuilder(enableVerboseTypeLogging: Boolean) {
     archivePaths.foreach { archivePath =>
       addPathToClassPool(archivePath) match {
         case Success(classPath) =>
-          registerPackagesFromClassNames(archivePath, classPath.knownClassNames)
+          registerPackagesFromClassNames(
+            archivePath,
+            classPath.knownClassNames,
+            jarExportArchivePath = Some(archivePath)
+          )
 
         case Failure(e) =>
           logger.warn(s"Could not load jar at path $archivePath", e.getMessage())
@@ -129,30 +133,42 @@ class JarTypeSolverBuilder(enableVerboseTypeLogging: Boolean) {
     }
   }
 
+  /** Load the `jrt:` runtime image (`lib/modules`) for a minimal JDK/jlink layout. */
+  def addRuntimeImage(jdkRoot: Path): Try[Unit] = {
+    Try {
+      val jrt = new JrtRuntimeImageClassPath(jdkRoot)
+      classPool.appendClassPath(jrt)
+      registerPackagesFromClassNames(jdkRoot.toString, jrt.knownClassNames, jarExportArchivePath = None)
+      exportedPackages ++= jrt.moduleExportsMap
+    }
+  }
+
   private def registerExportedPackages(jarFile: JarFile): Unit = {
     jarFile.entries().asScala.filter(_.getName.endsWith("module-info.class")).foreach { moduleInfoEntry =>
       Using(jarFile.getInputStream(moduleInfoEntry)) { inputStream =>
         // TODO: Handle qualified exports if the JavaParser type solver adds support for that
-        val descriptor = ModuleDescriptor.read(inputStream)
-        val moduleName = descriptor.name()
-        val exports    = descriptor.exports().asScala.map(_.source()).toList
-
+        val (moduleName, exports) = JrtRuntimeImageClassPath.readModuleExports(inputStream)
         exportedPackages.put(moduleName, exports)
       }
     }
   }
 
   /** Register package prefixes from actual class names read from bytecode. Used for JAR files where the entry path may
-    * not match the declared package.
+    * not match the declared package. When `jarExportArchivePath` is set, also reads `module-info.class` from that JAR;
+    * for the `jrt:` runtime image, exports are registered separately in [[addRuntimeImage]].
     */
-  private def registerPackagesFromClassNames(archivePath: String, classNames: Set[String]): Unit = {
+  private def registerPackagesFromClassNames(
+    sourceLabel: String,
+    classNames: Set[String],
+    jarExportArchivePath: Option[String]
+  ): Unit = {
     if (enableVerboseTypeLogging) {
-      logger.debug(s"Adding jar to JarTypeSolver: $archivePath")
+      logger.debug(s"Adding types to JarTypeSolver: $sourceLabel")
       classNames.foreach(name => logger.debug(s" - $name"))
     }
     val newPrefixes = classNames.map(packagePrefixForJavaParserName)
     knownPackagePrefixes ++= newPrefixes
-    registerExportedPackagesForArchive(archivePath)
+    jarExportArchivePath.foreach(registerExportedPackagesForArchive)
   }
 
   private def registerExportedPackagesForArchive(archivePath: String): Unit = {
@@ -171,20 +187,20 @@ object JarTypeSolver {
   val JarExtension: String                                     = ".jar"
   val JmodExtension: String                                    = ".jmod"
   private val cache: mutable.Map[String, JarTypeSolverBuilder] = mutable.Map.empty
+  private val logger                                           = LoggerFactory.getLogger(classOf[JarTypeSolver])
 
   extension (path: String) {
     def isJarPath: Boolean  = path.endsWith(JarExtension)
     def isJmodPath: Boolean = path.endsWith(JmodExtension)
   }
 
-  private def determineJarPaths(inputPath: String): List[String] = {
+  /** All `.jar` / `.jmod` paths under `inputPath`, or empty if none (may still use `lib/modules` via
+    * [[JrtRuntimeImageClassPath]]).
+    */
+  private def determineJarPathsAllowEmpty(inputPath: String): List[String] = {
     // not following symlinks, because some setups might have a loop, e.g. AWS's Corretto
     // see https://github.com/joernio/joern/pull/3871
-    val jarPaths = SourceFiles.determine(inputPath, Set(JarExtension, JmodExtension))(Seq.empty)
-    if (jarPaths.isEmpty) {
-      throw new IllegalArgumentException(s"No .jar or .jmod files found at path: ${inputPath}")
-    }
-    jarPaths
+    SourceFiles.determine(inputPath, Set(JarExtension, JmodExtension))(Seq.empty)
   }
 
   def fromPath(
@@ -192,7 +208,35 @@ object JarTypeSolver {
     useCache: Boolean = false,
     enableVerboseTypeLogging: Boolean = false
   ): JarTypeSolver = {
-    def createBuilder = new JarTypeSolverBuilder(enableVerboseTypeLogging).withJars(determineJarPaths(inputPath))
+    def createBuilder: JarTypeSolverBuilder = {
+      val jarPaths = determineJarPathsAllowEmpty(inputPath)
+      val builder  = new JarTypeSolverBuilder(enableVerboseTypeLogging)
+      if (jarPaths.nonEmpty) {
+        logger.info(s"JDK type solver: using ${jarPaths.size} jar/jmod archive(s) under $inputPath")
+        builder.withJars(jarPaths)
+      } else {
+        JrtRuntimeImageClassPath.findRuntimeImage(Paths.get(inputPath)) match {
+          case Some(layout) =>
+            logger.info(
+              s"JDK type solver: using runtime image at ${layout.javaHome} (modules file: ${layout.modulesImageFile}; search root: $inputPath)"
+            )
+            builder
+              .addRuntimeImage(layout.javaHome)
+              .fold(
+                e =>
+                  throw new IllegalArgumentException(
+                    s"Could not load JDK runtime image (jrt:) for java.home=${layout.javaHome}",
+                    e
+                  ),
+                _ => builder
+              )
+          case None =>
+            throw new IllegalArgumentException(
+              s"No .jar or .jmod files found under $inputPath, and no runtime image file at .../lib/modules beneath that path (see JrtRuntimeImageClassPath.findRuntimeImage)"
+            )
+        }
+      }
+    }
     if (useCache) {
       cache.getOrElseUpdate(inputPath, createBuilder).build
     } else {

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/noncaching/JarTypeSolver.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/noncaching/JarTypeSolver.scala
@@ -245,7 +245,7 @@ object JarTypeSolver {
               )
           case None =>
             throw new IllegalArgumentException(
-              s"No .jar or .jmod files found under $inputPath, and no runtime image file at .../lib/modules beneath that path (see JrtRuntimeImageClassPath.findRuntimeImage)"
+              s"No .jar or .jmod files found under $inputPath, and no runtime image file at .../lib/modules beneath that path"
             )
         }
       }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/noncaching/JarTypeSolver.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/noncaching/JarTypeSolver.scala
@@ -230,9 +230,7 @@ object JarTypeSolver {
       } else {
         JrtRuntimeImageClassPath.findRuntimeImage(Paths.get(inputPath)) match {
           case Some(imageRootPath) =>
-            logger.info(
-              s"JDK type solver: using runtime image at $imageRootPath; search root: $inputPath)"
-            )
+            logger.info(s"JDK type solver: using runtime image at $imageRootPath; search root: $inputPath)")
             builder.addRuntimeImage(imageRootPath) match {
               case Success(_) => builder
               case Failure(exception) =>

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/noncaching/JarTypeSolver.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/noncaching/JarTypeSolver.scala
@@ -229,20 +229,18 @@ object JarTypeSolver {
         builder.withJars(jarPaths)
       } else {
         JrtRuntimeImageClassPath.findRuntimeImage(Paths.get(inputPath)) match {
-          case Some(layout) =>
+          case Some(imageRootPath) =>
             logger.info(
-              s"JDK type solver: using runtime image at ${layout.javaHome} (modules file: ${layout.modulesImageFile}; search root: $inputPath)"
+              s"JDK type solver: using runtime image at $imageRootPath; search root: $inputPath)"
             )
-            builder
-              .addRuntimeImage(layout.javaHome)
-              .fold(
-                e =>
-                  throw new IllegalArgumentException(
-                    s"Could not load JDK runtime image (jrt:) for java.home=${layout.javaHome}",
-                    e
-                  ),
-                _ => builder
-              )
+            builder.addRuntimeImage(imageRootPath) match {
+              case Success(_) => builder
+              case Failure(exception) =>
+                throw new IllegalArgumentException(
+                  s"Could not load JDK runtime image (jrt:) for image root path=$imageRootPath",
+                  exception
+                )
+            }
           case None =>
             throw new IllegalArgumentException(
               s"No .jar or .jmod files found under $inputPath, and no runtime image file at .../lib/modules beneath that path"

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/noncaching/JarTypeSolver.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/noncaching/JarTypeSolver.scala
@@ -146,7 +146,7 @@ class JarTypeSolverBuilder(enableVerboseTypeLogging: Boolean) {
   }
 
   /** Load the `jrt:` runtime image (`lib/modules`) for a minimal JDK/jlink layout. */
-  def addRuntimeImage(jdkRoot: Path): Try[Unit] = {
+  private[typesolvers] def addRuntimeImage(jdkRoot: Path): Try[Unit] = {
     Try {
       val jrt = new JrtRuntimeImageClassPath(jdkRoot)
       classPool.appendClassPath(jrt)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/noncaching/JarTypeSolver.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/noncaching/JarTypeSolver.scala
@@ -146,13 +146,14 @@ class JarTypeSolverBuilder(enableVerboseTypeLogging: Boolean) {
   }
 
   /** Load the `jrt:` runtime image (`lib/modules`) for a minimal JDK/jlink layout. */
-  private[typesolvers] def addRuntimeImage(jdkRoot: Path): Try[Unit] = {
+  private[typesolvers] def addRuntimeImage(jdkRoot: Path): Try[JarTypeSolverBuilder] = {
     Try {
       val jrt = new JrtRuntimeImageClassPath(jdkRoot)
       classPool.appendClassPath(jrt)
       ownedCloseables += jrt
       registerPackagesFromClassNames(jdkRoot.toString, jrt.knownClassNames, jarExportArchivePath = None)
       exportedPackages ++= jrt.moduleExportsMap
+      this
     }
   }
 
@@ -231,14 +232,15 @@ object JarTypeSolver {
         JrtRuntimeImageClassPath.findRuntimeImage(Paths.get(inputPath)) match {
           case Some(imageRootPath) =>
             logger.info(s"JDK type solver: using runtime image at $imageRootPath; search root: $inputPath)")
-            builder.addRuntimeImage(imageRootPath) match {
-              case Success(_) => builder
-              case Failure(exception) =>
+            builder
+              .addRuntimeImage(imageRootPath)
+              .recover(exception =>
                 throw new IllegalArgumentException(
-                  s"Could not load JDK runtime image (jrt:) for image root path=$imageRootPath",
+                  s"Could not load JDK runtime image (jrt:) for the image root path=$imageRootPath",
                   exception
                 )
-            }
+              )
+              .get
           case None =>
             throw new IllegalArgumentException(
               s"No .jar or .jmod files found under $inputPath, and no runtime image file at .../lib/modules beneath that path"

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/noncaching/JarTypeSolver.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/noncaching/JarTypeSolver.scala
@@ -19,8 +19,10 @@ import scala.util.{Failure, Success, Try, Using}
 class JarTypeSolver(
   classPool: NonCachingClassPool,
   knownPackagePrefixes: Set[String],
-  exportedPackages: Map[String, List[String]]
-) extends TypeSolver {
+  exportedPackages: Map[String, List[String]],
+  private val closeables: Seq[AutoCloseable] = Seq.empty
+) extends TypeSolver
+    with AutoCloseable {
 
   private var parent: Option[TypeSolver] = None
 
@@ -74,6 +76,8 @@ class JarTypeSolver(
     SymbolReference.solved[RefType, RefType](refType)
   }
 
+  override def close(): Unit = closeables.foreach(c => Try(c.close()))
+
   override def tryToSolveTypeInModule(qualifiedModuleName: String, simpleTypeName: String): SymbolReference[RefType] = {
     exportedPackages
       .get(qualifiedModuleName)
@@ -95,16 +99,24 @@ class JarTypeSolverBuilder(enableVerboseTypeLogging: Boolean) {
   private val knownPackagePrefixes: mutable.Set[String] = mutable.Set.empty
   // A map of module name -> exported package names
   private val exportedPackages: mutable.Map[String, List[String]] = mutable.Map.empty
+  private val ownedCloseables: mutable.ArrayBuffer[AutoCloseable] = mutable.ArrayBuffer.empty
 
-  def build: JarTypeSolver = {
+  /** Build a solver that owns its classpath resources and closes them when [[JarTypeSolver.close]] is called. */
+  def build: JarTypeSolver =
+    new JarTypeSolver(classPool, knownPackagePrefixes.toSet, exportedPackages.toMap, ownedCloseables.toSeq)
+
+  /** Build a solver that does NOT own the classpath resources (used for cached builders whose resources must outlive
+    * any single solver instance).
+    */
+  private[typesolvers] def buildShared: JarTypeSolver =
     new JarTypeSolver(classPool, knownPackagePrefixes.toSet, exportedPackages.toMap)
-  }
 
   private def addPathToClassPool(archivePath: String): Try[BytecodeIndexedClassPath] = {
     if (archivePath.isJarPath || archivePath.isJmodPath) {
       Try {
         val classPath = new BytecodeIndexedClassPath(archivePath)
         classPool.appendClassPath(classPath)
+        ownedCloseables += classPath
         classPath
       }
     } else {
@@ -138,6 +150,7 @@ class JarTypeSolverBuilder(enableVerboseTypeLogging: Boolean) {
     Try {
       val jrt = new JrtRuntimeImageClassPath(jdkRoot)
       classPool.appendClassPath(jrt)
+      ownedCloseables += jrt
       registerPackagesFromClassNames(jdkRoot.toString, jrt.knownClassNames, jarExportArchivePath = None)
       exportedPackages ++= jrt.moduleExportsMap
     }
@@ -238,7 +251,7 @@ object JarTypeSolver {
       }
     }
     if (useCache) {
-      cache.getOrElseUpdate(inputPath, createBuilder).build
+      cache.getOrElseUpdate(inputPath, createBuilder).buildShared
     } else {
       createBuilder.build
     }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/typesolvers/JrtRuntimeImageClassPathTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/typesolvers/JrtRuntimeImageClassPathTests.scala
@@ -20,13 +20,6 @@ class JrtRuntimeImageClassPathTests extends AnyWordSpec with Matchers with Befor
     super.afterAll()
   }
 
-  private def assumeRuntimeImage(): Unit = {
-    assume(
-      JrtRuntimeImageClassPath.findRuntimeImage(javaHome).isDefined,
-      s"Skipping: no lib/modules at $javaHome (not a modular JDK layout)"
-    )
-  }
-
   "findRuntimeImageRoot" should {
 
     "find lib/modules nested under the search root (single walk returns java.home and modules path)" in {
@@ -43,7 +36,6 @@ class JrtRuntimeImageClassPathTests extends AnyWordSpec with Matchers with Befor
   "JrtRuntimeImageClassPath" should {
 
     "index and open java.lang.String from the running JDK's runtime image" in {
-      assumeRuntimeImage()
       cp.knownClassNames should contain("java.lang.String")
       Using.resource(cp.openClassfile("java.lang.String")) { stringClassFile =>
         stringClassFile should not be null
@@ -53,7 +45,6 @@ class JrtRuntimeImageClassPathTests extends AnyWordSpec with Matchers with Befor
     }
 
     "expose module exports for java.base" in {
-      assumeRuntimeImage()
       cp.moduleExportsMap.get("java.base") should not be empty
       cp.moduleExportsMap("java.base") should contain("java.lang")
     }
@@ -62,9 +53,8 @@ class JrtRuntimeImageClassPathTests extends AnyWordSpec with Matchers with Befor
   "JarTypeSolver with runtime image only" should {
 
     "resolve java.lang.String via tryToSolveTypeInModule" in {
-      assumeRuntimeImage()
       val builder = new JarTypeSolverBuilder(enableVerboseTypeLogging = false)
-      builder.addRuntimeImage(javaHome) shouldEqual Success(())
+      builder.addRuntimeImage(javaHome).isSuccess shouldBe true
       val jarTypeSolver  = builder.build
       val combinedSolver = new SimpleCombinedTypeSolver(enableVerboseTypeLogging = false)
       combinedSolver.addNonCachingTypeSolver(jarTypeSolver)

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/typesolvers/JrtRuntimeImageClassPathTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/typesolvers/JrtRuntimeImageClassPathTests.scala
@@ -1,0 +1,84 @@
+package io.joern.javasrc2cpg.typesolvers
+
+import io.shiftleft.semanticcpg.utils.FileUtil
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.nio.file.{Files, Paths}
+import scala.util.{Success, Using}
+
+class JrtRuntimeImageClassPathTests extends AnyFreeSpec with Matchers {
+
+  private def javaHome = Paths.get(System.getProperty("java.home"))
+
+  private def assumeRuntimeImage(): Unit = {
+    assume(
+      JrtRuntimeImageClassPath.findRuntimeImageRoot(javaHome).isDefined,
+      s"Skipping: no lib/modules at $javaHome (not a modular JDK layout)"
+    )
+  }
+
+  "findRuntimeImageRoot" - {
+
+    "should find lib/modules nested under the search root (single walk returns java.home and modules path)" in {
+      FileUtil.usingTemporaryDirectory("jrt-nested-modules") { tmp =>
+        val imageRoot   = tmp.resolve("vendor").resolve("my-jlink")
+        val modulesFile = imageRoot.resolve("lib").resolve("modules")
+        Files.createDirectories(imageRoot.resolve("lib"))
+        Files.createFile(modulesFile)
+        val layout = JrtRuntimeImageClassPath.findRuntimeImage(tmp).get
+        layout.javaHome shouldEqual imageRoot
+        layout.modulesImageFile shouldEqual modulesFile
+      }
+    }
+
+    "should prefer the shallowest runtime image when several exist" in {
+      FileUtil.usingTemporaryDirectory("jrt-shallow-wins") { tmp =>
+        val deep = tmp.resolve("a").resolve("b").resolve("c")
+        Files.createDirectories(deep.resolve("lib"))
+        Files.createFile(deep.resolve("lib").resolve("modules"))
+        val shallow = tmp.resolve("z")
+        Files.createDirectories(shallow.resolve("lib"))
+        Files.createFile(shallow.resolve("lib").resolve("modules"))
+        JrtRuntimeImageClassPath.findRuntimeImageRoot(tmp) shouldEqual Some(shallow)
+      }
+    }
+  }
+
+  "JrtRuntimeImageClassPath" - {
+
+    "should index and open java.lang.String from the running JDK's runtime image" in {
+      assumeRuntimeImage()
+      val cp = new JrtRuntimeImageClassPath(javaHome)
+      cp.knownClassNames should contain("java.lang.String")
+      Using.resource(cp.openClassfile("java.lang.String")) { in =>
+        in should not be null
+        in.available() should be > 0
+      }
+      cp.find("java.lang.String") should not be null
+    }
+
+    "should expose module exports for java.base" in {
+      assumeRuntimeImage()
+      val cp = new JrtRuntimeImageClassPath(javaHome)
+      cp.moduleExportsMap.get("java.base") should not be empty
+      cp.moduleExportsMap("java.base") should contain("java.lang")
+    }
+  }
+
+  "JarTypeSolver with runtime image only" - {
+
+    "should resolve java.lang.String via tryToSolveTypeInModule" in {
+      assumeRuntimeImage()
+      val builder = new JarTypeSolverBuilder(enableVerboseTypeLogging = false)
+      builder.addRuntimeImage(javaHome) shouldEqual Success(())
+      val jarTypeSolver  = builder.build
+      val combinedSolver = new SimpleCombinedTypeSolver(enableVerboseTypeLogging = false)
+      combinedSolver.addNonCachingTypeSolver(jarTypeSolver)
+
+      val r = combinedSolver.tryToSolveTypeInModule("java.base", "String")
+      r.isSolved shouldBe true
+      r.getCorrespondingDeclaration.getQualifiedName shouldBe "java.lang.String"
+    }
+  }
+}

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/typesolvers/JrtRuntimeImageClassPathTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/typesolvers/JrtRuntimeImageClassPathTests.scala
@@ -1,15 +1,24 @@
 package io.joern.javasrc2cpg.typesolvers
 
 import io.shiftleft.semanticcpg.utils.FileUtil
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
 import java.nio.file.{Files, Paths}
-import scala.util.{Success, Using}
+import scala.util.{Success, Try, Using}
 
-class JrtRuntimeImageClassPathTests extends AnyFreeSpec with Matchers {
+class JrtRuntimeImageClassPathTests extends AnyFreeSpec with Matchers with BeforeAndAfterAll {
 
   private def javaHome = Paths.get(System.getProperty("java.home"))
+
+  /** Shared instance — only constructed if a test actually needs it (lazy), and closed after all tests run. */
+  private lazy val cp = new JrtRuntimeImageClassPath(javaHome)
+
+  override def afterAll(): Unit = {
+    Try(cp.close())
+    super.afterAll()
+  }
 
   private def assumeRuntimeImage(): Unit = {
     assume(
@@ -49,7 +58,6 @@ class JrtRuntimeImageClassPathTests extends AnyFreeSpec with Matchers {
 
     "should index and open java.lang.String from the running JDK's runtime image" in {
       assumeRuntimeImage()
-      val cp = new JrtRuntimeImageClassPath(javaHome)
       cp.knownClassNames should contain("java.lang.String")
       Using.resource(cp.openClassfile("java.lang.String")) { in =>
         in should not be null
@@ -60,7 +68,6 @@ class JrtRuntimeImageClassPathTests extends AnyFreeSpec with Matchers {
 
     "should expose module exports for java.base" in {
       assumeRuntimeImage()
-      val cp = new JrtRuntimeImageClassPath(javaHome)
       cp.moduleExportsMap.get("java.base") should not be empty
       cp.moduleExportsMap("java.base") should contain("java.lang")
     }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/typesolvers/JrtRuntimeImageClassPathTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/typesolvers/JrtRuntimeImageClassPathTests.scala
@@ -45,9 +45,9 @@ class JrtRuntimeImageClassPathTests extends AnyWordSpec with Matchers with Befor
     "index and open java.lang.String from the running JDK's runtime image" in {
       assumeRuntimeImage()
       cp.knownClassNames should contain("java.lang.String")
-      Using.resource(cp.openClassfile("java.lang.String")) { in =>
-        in should not be null
-        in.available() should be > 0
+      Using.resource(cp.openClassfile("java.lang.String")) { stringClassFile =>
+        stringClassFile should not be null
+        stringClassFile.available() should be > 0
       }
       cp.find("java.lang.String") should not be null
     }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/typesolvers/JrtRuntimeImageClassPathTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/typesolvers/JrtRuntimeImageClassPathTests.scala
@@ -81,4 +81,17 @@ class JrtRuntimeImageClassPathTests extends AnyFreeSpec with Matchers {
       r.getCorrespondingDeclaration.getQualifiedName shouldBe "java.lang.String"
     }
   }
+
+  "JarTypeSolver.fromPath" - {
+
+    "should throw IllegalArgumentException when no jars and no runtime image are found" in {
+      FileUtil.usingTemporaryDirectory("jrt-no-jars-no-modules") { tmp =>
+        val exception = the[IllegalArgumentException] thrownBy {
+          JarTypeSolver.fromPath(tmp.toString)
+        }
+        exception.getMessage should include("No .jar or .jmod files found")
+        exception.getMessage should include("no runtime image file")
+      }
+    }
+  }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/typesolvers/JrtRuntimeImageClassPathTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/typesolvers/JrtRuntimeImageClassPathTests.scala
@@ -2,13 +2,13 @@ package io.joern.javasrc2cpg.typesolvers
 
 import io.shiftleft.semanticcpg.utils.FileUtil
 import org.scalatest.BeforeAndAfterAll
-import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 import java.nio.file.{Files, Paths}
 import scala.util.{Success, Try, Using}
 
-class JrtRuntimeImageClassPathTests extends AnyFreeSpec with Matchers with BeforeAndAfterAll {
+class JrtRuntimeImageClassPathTests extends AnyWordSpec with Matchers with BeforeAndAfterAll {
 
   private def javaHome = Paths.get(System.getProperty("java.home"))
 
@@ -22,41 +22,27 @@ class JrtRuntimeImageClassPathTests extends AnyFreeSpec with Matchers with Befor
 
   private def assumeRuntimeImage(): Unit = {
     assume(
-      JrtRuntimeImageClassPath.findRuntimeImageRoot(javaHome).isDefined,
+      JrtRuntimeImageClassPath.findRuntimeImage(javaHome).isDefined,
       s"Skipping: no lib/modules at $javaHome (not a modular JDK layout)"
     )
   }
 
-  "findRuntimeImageRoot" - {
+  "findRuntimeImageRoot" should {
 
-    "should find lib/modules nested under the search root (single walk returns java.home and modules path)" in {
+    "find lib/modules nested under the search root (single walk returns java.home and modules path)" in {
       FileUtil.usingTemporaryDirectory("jrt-nested-modules") { tmp =>
         val imageRoot   = tmp.resolve("vendor").resolve("my-jlink")
         val modulesFile = imageRoot.resolve("lib").resolve("modules")
         Files.createDirectories(imageRoot.resolve("lib"))
         Files.createFile(modulesFile)
-        val layout = JrtRuntimeImageClassPath.findRuntimeImage(tmp).get
-        layout.javaHome shouldEqual imageRoot
-        layout.modulesImageFile shouldEqual modulesFile
-      }
-    }
-
-    "should prefer the shallowest runtime image when several exist" in {
-      FileUtil.usingTemporaryDirectory("jrt-shallow-wins") { tmp =>
-        val deep = tmp.resolve("a").resolve("b").resolve("c")
-        Files.createDirectories(deep.resolve("lib"))
-        Files.createFile(deep.resolve("lib").resolve("modules"))
-        val shallow = tmp.resolve("z")
-        Files.createDirectories(shallow.resolve("lib"))
-        Files.createFile(shallow.resolve("lib").resolve("modules"))
-        JrtRuntimeImageClassPath.findRuntimeImageRoot(tmp) shouldEqual Some(shallow)
+        JrtRuntimeImageClassPath.findRuntimeImage(tmp) shouldEqual Some(imageRoot)
       }
     }
   }
 
-  "JrtRuntimeImageClassPath" - {
+  "JrtRuntimeImageClassPath" should {
 
-    "should index and open java.lang.String from the running JDK's runtime image" in {
+    "index and open java.lang.String from the running JDK's runtime image" in {
       assumeRuntimeImage()
       cp.knownClassNames should contain("java.lang.String")
       Using.resource(cp.openClassfile("java.lang.String")) { in =>
@@ -66,16 +52,16 @@ class JrtRuntimeImageClassPathTests extends AnyFreeSpec with Matchers with Befor
       cp.find("java.lang.String") should not be null
     }
 
-    "should expose module exports for java.base" in {
+    "expose module exports for java.base" in {
       assumeRuntimeImage()
       cp.moduleExportsMap.get("java.base") should not be empty
       cp.moduleExportsMap("java.base") should contain("java.lang")
     }
   }
 
-  "JarTypeSolver with runtime image only" - {
+  "JarTypeSolver with runtime image only" should {
 
-    "should resolve java.lang.String via tryToSolveTypeInModule" in {
+    "resolve java.lang.String via tryToSolveTypeInModule" in {
       assumeRuntimeImage()
       val builder = new JarTypeSolverBuilder(enableVerboseTypeLogging = false)
       builder.addRuntimeImage(javaHome) shouldEqual Success(())
@@ -89,9 +75,9 @@ class JrtRuntimeImageClassPathTests extends AnyFreeSpec with Matchers with Befor
     }
   }
 
-  "JarTypeSolver.fromPath" - {
+  "JarTypeSolver.fromPath" should {
 
-    "should throw IllegalArgumentException when no jars and no runtime image are found" in {
+    "throw IllegalArgumentException when no jars and no runtime image are found" in {
       FileUtil.usingTemporaryDirectory("jrt-no-jars-no-modules") { tmp =>
         val exception = the[IllegalArgumentException] thrownBy {
           JarTypeSolver.fromPath(tmp.toString)

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/GradleDependencies.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/GradleDependencies.scala
@@ -158,7 +158,7 @@ object GradleDependencies {
           logger.info(s"Task $taskName resolved `$dependencyCount` dependency files.")
           result
         case Failure(ex) =>
-          logger.warn(s"Caught exception while executing Gradle task: ${ex.getMessage}")
+          logger.warn(s"Caught exception while executing Gradle task: ${ex.getMessage}", ex)
           val androidSdkError = "Define a valid SDK location with an ANDROID_HOME environment variable"
           if (stderrStream.toString.contains(androidSdkError)) {
             logger.warn(


### PR DESCRIPTION
One of the sources of type information used by javasrc2cpg is java itself. While we originally used the `ReflectionTypeSolver` included in JavaParser for this, we decided at some point to start using the JDK jars/jmods instead to decouple the java version used for type inference from that used for running javasrc2cpg. In the original implementation of that, I didn't consider the `modules` jimage archive containing the necessary runtime libs built by `jlink`, however.

This PR introduces support for that as well, which means we can get type information both from the JDK and the bundled JRE (with the jmods taking preference over the `modules` archive)