### PR TITLE
[rubysrc2cpg] feat: use shared JRuby container for tests

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
@@ -4,6 +4,7 @@ import io.joern.rubysrc2cpg.astcreation.AstCreator
 import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.StatementList
 import io.joern.rubysrc2cpg.datastructures.RubyProgramSummary
 import io.joern.rubysrc2cpg.parser.*
+import io.joern.rubysrc2cpg.parser.RubyAstGenRunner.JRubyEnvironment
 import io.joern.rubysrc2cpg.passes.{
   AstCreationPass,
   ConfigFileCreationPass,
@@ -30,7 +31,7 @@ import java.nio.file.{Files, Paths}
 import scala.util.matching.Regex
 import scala.util.{Failure, Success, Try, Using}
 
-class RubySrc2Cpg extends X2CpgFrontend {
+class RubySrc2Cpg(sharedJRubyEnv: Option[JRubyEnvironment] = None) extends X2CpgFrontend {
   override type ConfigType = Config
   override val defaultConfig: Config = Config()
 
@@ -52,7 +53,7 @@ class RubySrc2Cpg extends X2CpgFrontend {
         case Some(astGenRunner) =>
           astGenRunner.execute(tmpDir, config)
         case None =>
-          val astGenRunner = RubyAstGenRunner(config)
+          val astGenRunner = RubyAstGenRunner(config, sharedJRubyEnv)
           rubyAstGenRunner = Option(astGenRunner)
           astGenRunner.execute(tmpDir, config)
       }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyAstGenRunner.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyAstGenRunner.scala
@@ -34,14 +34,7 @@ class RubyAstGenRunner(config: Config, sharedJRubyEnv: Option[JRubyEnvironment] 
 
   override def close(): Unit = {
     if (ownsEnvironment) {
-      val closeContainer = Try(container.terminate())
-      if (closeContainer.isFailure) {
-        logger.error("Error occurred while terminating JRuby scripting container!", closeContainer.failed.get)
-      }
-      val closeEnv = Try(env.close())
-      if (closeEnv.isFailure) {
-        logger.error("Error occurred while cleaning up JRuby execution directory!", closeEnv.failed.get)
-      }
+      jrubyEnv.close()
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyAstGenRunner.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyAstGenRunner.scala
@@ -1,7 +1,7 @@
 package io.joern.rubysrc2cpg.parser
 
 import io.joern.rubysrc2cpg.Config
-import io.joern.rubysrc2cpg.parser.RubyAstGenRunner.{ExecutionEnvironment, astGenMetaData}
+import io.joern.rubysrc2cpg.parser.RubyAstGenRunner.{ExecutionEnvironment, JRubyEnvironment, astGenMetaData}
 import io.joern.x2cpg.SourceFiles
 import io.joern.x2cpg.astgen.AstGenRunner.{AstGenProgramMetaData, AstGenRunnerResult, DefaultAstGenRunnerResult}
 import io.joern.x2cpg.astgen.AstGenRunner
@@ -21,41 +21,27 @@ import scala.util.{Failure, Success, Try, Using}
 /** Creates a JRuby scripting environment using `ruby_ast_gen` within a temporary directory allowing for re-usable
   * execution.
   */
-class RubyAstGenRunner(config: Config)
+class RubyAstGenRunner(config: Config, sharedJRubyEnv: Option[JRubyEnvironment] = None)
     extends AstGenRunner(RubyAstGenRunner.astGenMetaData, config)
     with AutoCloseable {
 
   private val logger = LoggerFactory.getLogger(getClass)
 
-  private val env: ExecutionEnvironment = RubyAstGenRunner.prepareExecutionEnvironment("ruby_ast_gen")
-  // The scripting container is re-used as it persists any previously imported definitions. The cost to import and
-  // construct class and method definitions is quite expensive, so it makes sense to persist and create the container
-  // on-demand.
-  private val container: ScriptingContainer = {
-    val cwd       = env.path.toAbsolutePath.toString
-    val gemPath   = Seq(cwd, "vendor", "bundle", "jruby", "3.1.0").mkString(separator)
-    val container = new ScriptingContainer(LocalContextScope.THREADSAFE, LocalVariableBehavior.TRANSIENT)
-    val config    = container.getProvider.getRubyInstanceConfig
-    container.setCompileMode(RubyInstanceConfig.CompileMode.OFF)
-    container.setNativeEnabled(false)
-    container.setObjectSpaceEnabled(true)
-    container.setCurrentDirectory(cwd)
-    config.setLoadGemfile(true)
-    container.setEnvironment(Map("GEM_PATH" -> gemPath, "GEM_FILE" -> gemPath).asJava)
-    config.setHasShebangLine(true)
-    config.setHardExit(false)
-
-    container
-  }
+  private val ownsEnvironment            = sharedJRubyEnv.isEmpty
+  private val jrubyEnv: JRubyEnvironment = sharedJRubyEnv.getOrElse(JRubyEnvironment())
+  private val env                        = jrubyEnv.env
+  private val container                  = jrubyEnv.container
 
   override def close(): Unit = {
-    val closeContainer = Try(container.terminate())
-    if (closeContainer.isFailure) {
-      logger.error("Error occurred while terminating JRuby scripting container!", closeContainer.failed.get)
-    }
-    val closeEnv = Try(env.close())
-    if (closeEnv.isFailure) {
-      logger.error("Error occurred while cleaning up JRuby execution directory!", closeEnv.failed.get)
+    if (ownsEnvironment) {
+      val closeContainer = Try(container.terminate())
+      if (closeContainer.isFailure) {
+        logger.error("Error occurred while terminating JRuby scripting container!", closeContainer.failed.get)
+      }
+      val closeEnv = Try(env.close())
+      if (closeEnv.isFailure) {
+        logger.error("Error occurred while cleaning up JRuby execution directory!", closeEnv.failed.get)
+      }
     }
   }
 
@@ -214,6 +200,43 @@ object RubyAstGenRunner {
 
   private object astGenMetaData
       extends AstGenProgramMetaData(name = "ruby_ast_gen", configPrefix = "rubysrc2cpg", multiArchitectureBuilds = true)
+
+  /** Encapsulates the expensive JRuby runtime setup (execution environment and scripting container). Can be shared
+    * across multiple RubyAstGenRunner instances to avoid repeated JRuby initialization.
+    */
+  class JRubyEnvironment(val env: ExecutionEnvironment, val container: ScriptingContainer) extends AutoCloseable {
+    private val logger = LoggerFactory.getLogger(getClass)
+
+    override def close(): Unit = {
+      val closeContainer = Try(container.terminate())
+      if (closeContainer.isFailure) {
+        logger.error("Error terminating JRuby scripting container!", closeContainer.failed.get)
+      }
+      val closeEnv = Try(env.close())
+      if (closeEnv.isFailure) {
+        logger.error("Error cleaning up JRuby execution directory!", closeEnv.failed.get)
+      }
+    }
+  }
+
+  object JRubyEnvironment {
+    def apply(): JRubyEnvironment = {
+      val env       = prepareExecutionEnvironment("ruby_ast_gen")
+      val cwd       = env.path.toAbsolutePath.toString
+      val gemPath   = Seq(cwd, "vendor", "bundle", "jruby", "3.1.0").mkString(separator)
+      val container = new ScriptingContainer(LocalContextScope.THREADSAFE, LocalVariableBehavior.TRANSIENT)
+      val config    = container.getProvider.getRubyInstanceConfig
+      container.setCompileMode(RubyInstanceConfig.CompileMode.OFF)
+      container.setNativeEnabled(false)
+      container.setObjectSpaceEnabled(true)
+      container.setCurrentDirectory(cwd)
+      config.setLoadGemfile(true)
+      container.setEnvironment(Map("GEM_PATH" -> gemPath, "GEM_FILE" -> gemPath).asJava)
+      config.setHasShebangLine(true)
+      config.setHardExit(false)
+      new JRubyEnvironment(env, container)
+    }
+  }
 
   sealed trait ExecutionEnvironment extends AutoCloseable {
     def path: Path

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/testfixtures/RubyCode2CpgFixture.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/testfixtures/RubyCode2CpgFixture.scala
@@ -5,6 +5,7 @@ import io.joern.dataflowengineoss.language.Path
 import io.joern.dataflowengineoss.semanticsloader.Semantics
 import io.joern.dataflowengineoss.testfixtures.{SemanticCpgTestFixture, SemanticTestCpg}
 import io.joern.rubysrc2cpg.{Config, RubySrc2Cpg}
+import io.joern.rubysrc2cpg.parser.RubyAstGenRunner.JRubyEnvironment
 import io.joern.x2cpg.ValidationMode
 import io.joern.x2cpg.testfixtures.*
 import io.shiftleft.codepropertygraph.generated.Cpg
@@ -13,12 +14,15 @@ import io.shiftleft.semanticcpg.validation.{PostFrontendValidator, ValidationLev
 import org.scalatest.Inside
 
 import java.io.File
+import java.nio.charset.Charset
 import scala.util.Using
 
 trait RubyFrontend(withDownloadDependencies: Boolean, disableFileContent: Boolean) extends LanguageFrontend {
   override type ConfigType = Config
 
   override val fileSuffix: String = ".rb"
+
+  protected def sharedJRubyEnv: Option[JRubyEnvironment] = None
 
   implicit val config: Config =
     getConfig()
@@ -27,7 +31,10 @@ trait RubyFrontend(withDownloadDependencies: Boolean, disableFileContent: Boolea
       .withDisableFileContent(disableFileContent)
 
   override def execute(sourceCodeFile: File): Cpg = {
-    val tmp = Using.resource(new RubySrc2Cpg())(_.createCpg(config.withInputPath(sourceCodeFile.getAbsolutePath)).get)
+    val tmp =
+      Using.resource(new RubySrc2Cpg(sharedJRubyEnv))(
+        _.createCpg(config.withInputPath(sourceCodeFile.getAbsolutePath)).get
+      )
     new PostFrontendValidator(tmp, ValidationLevel.V0).run()
     tmp
   }
@@ -38,6 +45,15 @@ class DefaultTestCpgWithRuby(downloadDependencies: Boolean = false, disableFileC
     extends DefaultTestCpg
     with RubyFrontend(downloadDependencies, disableFileContent)
     with SemanticTestCpg {
+
+  private var _sharedJRubyEnv: Option[JRubyEnvironment] = None
+
+  def withSharedJRubyEnv(env: JRubyEnvironment): this.type = {
+    _sharedJRubyEnv = Some(env)
+    this
+  }
+
+  override protected def sharedJRubyEnv: Option[JRubyEnvironment] = _sharedJRubyEnv
 
   override protected def applyPasses(): Unit = {
     super.applyPasses()
@@ -63,6 +79,25 @@ class RubyCode2CpgFixture(
     )
     with Inside
     with SemanticCpgTestFixture(semantics) {
+
+  private lazy val _sharedJRubyEnv = JRubyEnvironment()
+
+  override def code(code: String): DefaultTestCpgWithRuby = {
+    super.code(code).withSharedJRubyEnv(_sharedJRubyEnv)
+  }
+
+  override def code(code: String, fileName: String): DefaultTestCpgWithRuby = {
+    super.code(code, fileName).withSharedJRubyEnv(_sharedJRubyEnv)
+  }
+
+  override def code(code: String, fileName: String, charset: Charset): DefaultTestCpgWithRuby = {
+    super.code(code, fileName, charset).withSharedJRubyEnv(_sharedJRubyEnv)
+  }
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    _sharedJRubyEnv.close()
+  }
 
   implicit val resolver: ICallResolver = NoResolve
 


### PR DESCRIPTION
To speed up rubysrc2cpg frontend tests, use a shared JRuby container for each test class. 

Closes https://github.com/ShiftLeftSecurity/codescience/issues/8825