### PR TITLE
[swiftsrc2cpg] Update swift astgen_version to 0.3.9

### DIFF
--- a/joern-cli/frontends/swiftsrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 swiftsrc2cpg {
-    astgen_version: "0.3.7"
+    astgen_version: "0.3.9"
 }


### PR DESCRIPTION
This brings in https://github.com/joernio/SwiftAstGen/pull/23

That fixes the handling of unknown operators during operator folding so that these operators degrade gracefully instead of failing the entire file.

See the original issue: https://github.com/joernio/SwiftAstGen/issues/21