### PR TITLE
Johannes/null variant check

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/files/SourceFilesPicker.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/files/SourceFilesPicker.scala
@@ -47,8 +47,8 @@ object SourceFilesPicker {
   }
 
   private def isGradleFile(fileName: String): Boolean = {
-    val gradleRelatedFiles = Seq("build.gradle", "settings.gradle", "gradle.properties", "build.gradle.kts")
-    gradleRelatedFiles.exists(fileName.endsWith)
+    val gradleRelatedSuffixes = Seq(".gradle", ".gradle.kts", "gradle.properties")
+    gradleRelatedSuffixes.exists(fileName.endsWith)
   }
 
   private def isKotlinScript(fileName: String): Boolean = {

--- a/joern-cli/frontends/x2cpg/src/main/resources/io/joern/x2cpg/utils/dependency/dependency-fetcher-init.gradle
+++ b/joern-cli/frontends/x2cpg/src/main/resources/io/joern/x2cpg/utils/dependency/dependency-fetcher-init.gradle
@@ -40,7 +40,7 @@ abstract class FetchDependencies extends DefaultTask {
         .filter(variant -> variant.getDisplayName() == configurationName)
         .findFirst()
 
-    if (maybeRootVariant.isPresent()) {
+    if (maybeRootVariant.isPresent() && maybeRootVariant.get() != null) {
       def rootVariant = maybeRootVariant.get()
       seen.add(rootVariant)
 
@@ -71,7 +71,9 @@ abstract class FetchDependencies extends DefaultTask {
           if (!dependency.constraint) {
             def toVariant = resolved.resolvedVariant
 
-            if (seen.add(toVariant)) {
+            if (toVariant == null) {
+              System.err.println("Found null toVariant for $dependency")
+            } else if (seen.add(toVariant)) {
               stack.addFirst(new Tuple2(toVariant, resolved.selected))
             }
           }


### PR DESCRIPTION
A customer project ran into the following error when executing the gradle dependency fetcher:

```
2026-03-27T17:12:02.5223527Z > Cannot get property 'owner' on null object
```

I have a few ideas about what could be going wrong, but haven't been able to reproduce it yet. The fix in this PR would stop the crash which stops the whole build though. At worst, we would be missing dependencies for some modules. 

We're also missing some gradle config files that could help with explaining this, so I've also loosened the `isGradleFile` filter.