### PR TITLE
[workflows] Skip release creation if already exists

### DIFF
--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -33,7 +33,20 @@ jobs:
       - run: sbt stage createDistribution
       - run: sha512sum target/joern-cli.zip > target/joern-cli.zip.sha512
       - run: sbt "querydb/runMain io.joern.dumpq.Main"
+      - name: Check if release exists
+        id: check_release
+        run: |
+          if gh release view "${{ github.ref_name }}" > /dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Release ${{ github.ref_name }} already exists, will skip creation"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "Release ${{ github.ref_name }} does not exist, will create it"
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Create Release and Upload Assets
+        if: steps.check_release.outputs.exists == 'false'
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}


### PR DESCRIPTION
Make the GitHub release creation step conditional based on the check_release step output. Only creates release when it doesn't already exist for the tag.

softprops/action-gh-release can't do this on its own: https://github.com/softprops/action-gh-release/issues/74