### PR TITLE
[swiftsrc2cpg] Refactor GsonTypeInfoReader to streaming with callback API

### DIFF
--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/utils/GsonTypeInfoReader.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/utils/GsonTypeInfoReader.scala
@@ -1,12 +1,11 @@
 package io.joern.swiftsrc2cpg.utils
 
 import com.google.gson.stream.{JsonReader, JsonToken}
-import com.google.gson.{JsonArray, JsonObject, JsonParser, Strictness}
+import com.google.gson.Strictness
 import io.joern.swiftsrc2cpg.utils.SwiftTypesProvider.TypeInfo
 
 import java.io.Reader
 import scala.annotation.tailrec
-import scala.jdk.CollectionConverters.*
 import scala.collection.mutable
 
 /** Utility for reading and extracting type information from Swift AST in JSON format. Parses Swift's JSON
@@ -14,16 +13,10 @@ import scala.collection.mutable
   */
 object GsonTypeInfoReader {
 
-  /** Field names that can contain decl fullNames in the Swift AST */
-  private val DeclFullNameFieldNames = Set("usr", "decl_usr", "protocol", "superclass_type")
-
-  /** Field names that can contain type fullNames in the Swift AST */
-  private val TypeFullNameFieldNames = Set("type", "type_usr", "result", "interface_type", "extended_type")
-
   /** Child object/array field names actually accessed by `extractTypeInfo` and its helpers (`range`,
     * `declFromCallExpr`, `resultFromReturnStmt`, `declFromMemberRefExpr`, `conformancesFromNode`,
     * `superClassesFromNode`). Children with names outside this set are still recursed for side effects but not retained
-    * on the parent `JsonObject`, avoiding retention of large irrelevant subtrees.
+    * on the parent node, avoiding retention of large irrelevant subtrees.
     */
   private val RelevantChildFieldNames =
     Set("range", "fn", "decl", "sub_expr", "result", "inherits", "conformances", "attrs")
@@ -42,226 +35,163 @@ object GsonTypeInfoReader {
     val DotCallExpr            = "dot_syntax_call_expr"
   }
 
-  /** Safely retrieves a string property from a JsonObject.
+  /** Minimal mutable node model used while token-streaming JSON with JsonReader.
     *
-    * @param obj
-    *   The JSON object to extract from
-    * @param propertyName
-    *   The name of the property to extract
-    * @return
-    *   Some(value) if property exists and is a primitive, None otherwise
-    */
-  private def safePropertyValue(obj: JsonObject, propertyName: String): Option[String] = {
-    Option.when(obj.has(propertyName) && obj.get(propertyName).isJsonPrimitive)(obj.get(propertyName).getAsString)
-  }
-
-  /** Safely retrieves a JsonObject property.
+    * This avoids Gson DOM allocations while retaining only fields needed for TypeInfo extraction.
     *
-    * @param obj
-    *   The JSON object to extract from
-    * @param propertyName
-    *   The name of the property to extract
-    * @return
-    *   Some(jsonObject) if property exists and is an object, None otherwise
-    */
-  private def safePropertyObject(obj: JsonObject, propertyName: String): Option[JsonObject] = {
-    Option.when(obj.has(propertyName) && obj.get(propertyName).isJsonObject)(obj.get(propertyName).getAsJsonObject)
-  }
-
-  /** Safely retrieves a JsonArray property.
+    * '''Performance note on nullable fields:''' This class intentionally uses `null` instead of `Option[T]` for
+    * performance reasons. Swift compiler JSON output can be large (hundreds of MB), creating thousands of AstNode
+    * instances during streaming parsing. Using `Option[T]` for ~20 fields per node would:
+    *   - Add ~20 object allocations per AstNode (one `Some`/`None` per field)
+    *   - Increase GC pressure significantly during bulk parsing
+    *   - Add pattern-matching overhead on every field access
     *
-    * @param obj
-    *   The JSON object to extract from
-    * @param propertyName
-    *   The name of the property to extract
-    * @return
-    *   Some(jsonArray) if property exists and is an array, None otherwise
-    */
-  private def safePropertyArray(obj: JsonObject, propertyName: String): Option[JsonArray] = {
-    Option.when(obj.has(propertyName) && obj.get(propertyName).isJsonArray)(obj.get(propertyName).getAsJsonArray)
-  }
-
-  /** Extracts the source range from a JSON object.
+    * Safety is maintained by:
+    *   - This class is `private` to this object - no external access
+    *   - All field access goes through null-safe wrappers (`Option(field)`) or explicit null checks
+    *   - Fields are only set during parsing and read once during `extractTypeInfo`
     *
-    * @param obj
-    *   The JSON object containing a range property
-    * @return
-    *   A tuple of (start, end) positions
+    * This is a conscious trade-off: performance optimization in a hot path at the cost of idiomatic Scala.
     */
-  private def range(obj: JsonObject): (Int, Int) = {
-    val rangeObj = obj.get("range").getAsJsonObject
-    val start    = rangeObj.get("start").getAsInt
-    val end      = rangeObj.get("end").getAsInt
+  private final class AstNode {
+    var kind: String                                = null
+    var start: Int                                  = -1
+    var end: Int                                    = -1
+    var rangeNode: AstNode                          = null
+    var attrs: mutable.ArrayBuffer[AstNode]         = null
+    var fn: AstNode                                 = null
+    var decl: AstNode                               = null
+    var subExpr: AstNode                            = null
+    var resultObj: AstNode                          = null
+    var inheritsObj: AstNode                        = null
+    var inheritsLegacy: mutable.ArrayBuffer[String] = null
+    var conformances: mutable.ArrayBuffer[AstNode]  = null
 
-    // no adjustment needed for zero-length ranges, e.g., for member accesses:
-    if (start == end) return (start, end)
+    var typeValue: String      = null
+    var typeUsr: String        = null
+    var resultValue: String    = null
+    var interfaceType: String  = null
+    var extendedType: String   = null
+    var usr: String            = null
+    var declUsr: String        = null
+    var protocol: String       = null
+    var superclassType: String = null
 
-    val endOffset = astNodeKind(obj) match {
-      case NodeKinds.DotCallExpr => 3 // offsets are off by 2 from SwiftParser for simple dot calls
-      case _                     => 1
+    def hasTypeOrDeclInfo: Boolean = {
+      typeValue != null || typeUsr != null || resultValue != null || interfaceType != null || extendedType != null ||
+      usr != null || declUsr != null || protocol != null || superclassType != null ||
+      // Also check for child objects that contain type/decl info (e.g., resultObj in return_stmt, fn/decl in call_expr)
+      resultObj != null || fn != null || decl != null
     }
-    val startWithModifiers = obj match {
-      case _ if obj.has("attrs") =>
-        /** Handles cases where attributes modify the start position of the range. For example, in the presence of
-          * attributes like `@escaping` or for access modifiers like `static` the start position may need to be adjusted
-          * to account for the attribute's position because swift-parser does include attributes in the range of the
-          * associated declaration while swiftc does not.
-          */
-        val elemWithRange = safePropertyArray(obj, "attrs").flatMap { arr =>
-          arr.asList().asScala.collectFirst {
-            case attrObj if safeRange(attrObj.getAsJsonObject).isDefined => attrObj.getAsJsonObject
+  }
+
+  private def safeRange(node: AstNode): Option[(Int, Int)] = {
+    Option(node.rangeNode)
+      .filter(r => r.start > -1 && r.end > -1)
+      .map { rangeObj =>
+        val start = rangeObj.start
+        val end   = rangeObj.end
+
+        // no adjustment needed for zero-length ranges, e.g., for member accesses:
+        if (start == end) {
+          (start, end)
+        } else {
+          val endOffset = node.kind match {
+            case NodeKinds.DotCallExpr => 3 // offsets are off by 2 from SwiftParser for simple dot calls
+            case _                     => 1
           }
+
+          /** Handles cases where attributes modify the start position of the range. For example, in the presence of
+            * attributes like `@escaping` or for access modifiers like `static` the start position may need to be
+            * adjusted to account for the attribute's position because swift-parser does include attributes in the range
+            * of the associated declaration while swiftc does not.
+            */
+          val startWithModifiers = Option(node.attrs)
+            .flatMap(_.collectFirst(Function.unlift(attr => safeRange(attr))))
+            .map {
+              case (s, _) if s < start => s
+              case _                   => start
+            }
+            .getOrElse(start)
+
+          (startWithModifiers, end + endOffset)
         }
-        elemWithRange.map(range) match {
-          case Some((s, e)) if s < start => s
-          case _                         => start
-        }
-      case _ => start
-    }
-    (startWithModifiers, end + endOffset)
+      }
   }
 
-  /** Safely extracts the source range from a JSON object.
-    *
-    * @param obj
-    *   The JSON object to extract range information from
-    * @return
-    *   Some((start, end)) if the range property exists, None otherwise
-    */
-  private def safeRange(obj: JsonObject): Option[(Int, Int)] = {
-    Option.when(obj.has("range"))(range(obj))
+  private def qualifies(node: AstNode): Boolean = {
+    safeRange(node).isDefined && node.hasTypeOrDeclInfo
   }
 
-  /** Determines if a JSON object contains useful type or decl fullName information.
-    *
-    * @param obj
-    *   The JSON object to check
-    * @return
-    *   true if the object contains type or decl fullName information, false otherwise
-    */
-  private def qualifies(obj: JsonObject): Boolean = {
-    obj.has("range") && (TypeFullNameFieldNames.exists(obj.has) || DeclFullNameFieldNames.exists(obj.has))
+  private def isParameter(node: AstNode): Boolean = {
+    node.kind == "parameter" && node.hasTypeOrDeclInfo
   }
 
-  /** Determines if a JSON object represents a parameter in the Swift AST.
-    *
-    * @param obj
-    *   The JSON object to check
-    * @return
-    *   true if the object is a parameter with type or declaration information, false otherwise
-    */
-  private def isParameter(obj: JsonObject): Boolean = {
-    safePropertyValue(obj, "_kind").contains("parameter") &&
-    (TypeFullNameFieldNames.exists(obj.has) || DeclFullNameFieldNames.exists(obj.has))
-  }
-
-  /** Gets the AST node kind from a JSON object.
-    *
-    * @param obj
-    *   The JSON object representing an AST node
-    * @return
-    *   The kind of the AST node as a string
-    */
-  private def astNodeKind(obj: JsonObject): String = {
-    obj.get("_kind").getAsString
-  }
-
-  /** Recursively traverses a call expression to find its declaration.
-    *
-    * @param obj
-    *   The JSON object representing a call expression
-    * @return
-    *   The JSON object representing the declaration
-    */
   @tailrec
-  private def declFromCallExpr(obj: JsonObject): JsonObject = {
-    safePropertyObject(obj, "fn") match {
-      case Some(fn) =>
-        astNodeKind(fn) match {
-          case NodeKinds.DeclRefExpr            => fn.getAsJsonObject("decl")
-          case NodeKinds.FunctionConversionExpr => fn.getAsJsonObject("sub_expr").getAsJsonObject("decl")
-          case other if other.endsWith("_expr") => declFromCallExpr(fn)
-          case _                                => obj
-        }
-      case None => obj
+  private def declFromCallExpr(node: AstNode): AstNode = {
+    val fn = node.fn
+    if (fn == null) {
+      node
+    } else {
+      fn.kind match {
+        case NodeKinds.DeclRefExpr            => Option(fn.decl).getOrElse(node)
+        case NodeKinds.FunctionConversionExpr => Option(fn.subExpr).flatMap(s => Option(s.decl)).getOrElse(node)
+        case other if other != null && other.endsWith("_expr") =>
+          declFromCallExpr(fn)
+        case _ => node
+      }
     }
   }
 
-  /** Extracts result object from a return statement.
-    *
-    * @param obj
-    *   The JSON object representing a return statement
-    * @return
-    *   The JSON object representing the result or the original object if result not found
-    */
-  private def resultFromReturnStmt(obj: JsonObject): JsonObject = {
-    safePropertyObject(obj, "result") match {
-      case Some(resultObj) => resultObj
-      case None            => obj
-    }
-  }
+  private def resultFromReturnStmt(node: AstNode): AstNode = Option(node.resultObj).getOrElse(node)
 
-  /** Extracts declaration from a member reference expression.
-    *
-    * @param obj
-    *   The JSON object representing a member reference expression
-    * @return
-    *   The JSON object representing the declaration or the original object if result not found
-    */
-  private def declFromMemberRefExpr(obj: JsonObject): JsonObject = {
-    safePropertyObject(obj, "decl") match {
-      case Some(decl) if astNodeKind(decl) == NodeKinds.DeclRef => decl
-      case _                                                    => obj
-    }
+  private def declFromMemberRefExpr(node: AstNode): AstNode = {
+    Option(node.decl).filter(_.kind == NodeKinds.DeclRef).getOrElse(node)
   }
 
   /** Until swiftc 6.1.x `inherits` is a plain JSON array storing the mangled fullNames directly */
-  private def superClassesFromNodeLegacy(obj: JsonObject): Seq[String] = {
-    safePropertyArray(obj, "inherits")
-      .filter(_ != null)
-      .map(_.asList().asScala.toSeq.map(_.getAsString))
-      .getOrElse(Seq.empty)
+  private def superClassesFromNodeLegacy(node: AstNode): Seq[String] = {
+    Option(node.inheritsLegacy).map(_.toSeq).getOrElse(Seq.empty)
   }
 
   /** Starting with swiftc 6.2.x `inherits` is an actual JSON object */
-  private def superClassesFromNode(obj: JsonObject): Seq[String] = {
-    safePropertyObject(obj, "inherits").flatMap(safePropertyValue(_, "superclass_type")).toSeq
+  private def superClassesFromNode(node: AstNode): Seq[String] = {
+    Option(node.inheritsObj).flatMap(n => Option(n.superclassType)).toSeq
   }
 
   /** Starting with swiftc 6.2.x `inherits` is an actual JSON object */
-  private def conformancesFromNode(obj: JsonObject): Seq[String] = {
-    safePropertyObject(obj, "inherits")
-      .flatMap(safePropertyArray(_, "conformances"))
-      .filter(_ != null)
-      .map(_.asList().asScala.toSeq.flatMap(r => safePropertyValue(r.getAsJsonObject, "protocol")))
+  private def conformancesFromNode(node: AstNode): Seq[String] = {
+    Option(node.inheritsObj)
+      .flatMap(inh => Option(inh.conformances))
+      .map(_.flatMap(c => Option(c.protocol)).toSeq)
       .getOrElse(Seq.empty)
   }
 
-  private def declFullNameFromNode(obj: JsonObject, declObj: JsonObject): Option[String] = {
-    safePropertyValue(obj, "usr").orElse(safePropertyValue(declObj, "decl_usr"))
+  private def declFullNameFromNode(node: AstNode, declNode: AstNode): Option[String] = {
+    Option(node.usr).orElse(Option(declNode.declUsr))
   }
 
-  private def typeFullNameFromNode(obj: JsonObject): Option[String] = {
-    safePropertyValue(obj, "type")
-      .orElse(safePropertyValue(obj, "type_usr"))
-      .orElse(safePropertyValue(obj, "result"))
-      .orElse(safePropertyValue(obj, "interface_type"))
-      .orElse(safePropertyValue(obj, "extended_type"))
+  private def typeFullNameFromNode(node: AstNode): Option[String] = {
+    Option(node.typeValue)
+      .orElse(Option(node.typeUsr))
+      .orElse(Option(node.resultValue))
+      .orElse(Option(node.interfaceType))
+      .orElse(Option(node.extendedType))
   }
 
   private def isInBuildFolder(filename: String): Boolean = {
     filename.contains("/.build/") || filename.contains("\\.build\\") || filename.contains("/Build/")
   }
 
-  /** Collects type information from Swift AST JSON.
+  /** Collects type information from Swift AST JSON, emitting each [[TypeInfo]] via the provided callback as it is
+    * discovered during streaming token-by-token parsing. No intermediate collection is built.
     *
     * @param reader
     *   The reader providing the JSON input
-    * @return
-    *   A set of TypeInfo objects extracted from the JSON
+    * @param emit
+    *   Called once for each [[TypeInfo]] extracted from the JSON stream
     */
-  def collectTypeInfo(reader: Reader): Set[TypeInfo] = {
-    val found        = mutable.HashSet.empty[TypeInfo]
+  def collectTypeInfo(reader: Reader, emit: TypeInfo => Unit): Unit = {
     val jsonReader   = new JsonReader(reader)
     var filename     = ""
     var currentRange = Option.empty[(Int, Int)]
@@ -269,8 +199,98 @@ object GsonTypeInfoReader {
     // Configure reader for better performance
     jsonReader.setStrictness(Strictness.LENIENT)
 
-    def parseObject(): JsonObject = {
-      val obj         = new JsonObject
+    def readPrimitiveAsString(): Option[String] = {
+      jsonReader.peek() match {
+        case JsonToken.STRING  => Some(jsonReader.nextString())
+        case JsonToken.NUMBER  => Some(jsonReader.nextString())
+        case JsonToken.BOOLEAN => Some(jsonReader.nextBoolean().toString)
+        case JsonToken.NULL =>
+          jsonReader.nextNull()
+          None
+        case _ =>
+          jsonReader.skipValue()
+          None
+      }
+    }
+
+    def readPrimitiveAsInt(): Option[Int] = {
+      jsonReader.peek() match {
+        case JsonToken.NUMBER =>
+          Some(jsonReader.nextInt())
+        case _ =>
+          jsonReader.skipValue()
+          None
+      }
+    }
+
+    def addChild(parent: AstNode, name: String, child: AstNode): Unit = name match {
+      case "range"    => parent.rangeNode = child
+      case "fn"       => parent.fn = child
+      case "decl"     => parent.decl = child
+      case "sub_expr" => parent.subExpr = child
+      case "result"   => parent.resultObj = child
+      case "inherits" => parent.inheritsObj = child
+      case _          =>
+    }
+
+    def addChildFromArray(parent: AstNode, name: String, child: AstNode): Unit = name match {
+      case "attrs" =>
+        if (parent.attrs == null) parent.attrs = mutable.ArrayBuffer.empty[AstNode]
+        parent.attrs += child
+      case "conformances" =>
+        if (parent.conformances == null) parent.conformances = mutable.ArrayBuffer.empty[AstNode]
+        parent.conformances += child
+      case _ =>
+    }
+
+    def extractTypeInfo(node: AstNode, filename: String, rangeOpt: Option[(Int, Int)]): Unit = {
+      val nodeKind   = node.kind
+      val maybeRange = rangeOpt.orElse(safeRange(node))
+      lazy val declObj = nodeKind match {
+        case kind if kind.endsWith(NodeKinds.CallExpr) => declFromCallExpr(node)
+        case NodeKinds.MemberRefExpr                   => declFromMemberRefExpr(node)
+        case _                                         => node
+      }
+
+      val typeObj = nodeKind match {
+        case NodeKinds.ReturnStmt => resultFromReturnStmt(node)
+        case _                    => node
+      }
+
+      val typeFullName    = typeFullNameFromNode(typeObj)
+      val declFullName    = declFullNameFromNode(node, declObj)
+      val conformances    = conformancesFromNode(node)
+      val superClassTypes = superClassesFromNode(node) ++ superClassesFromNodeLegacy(node)
+
+      maybeRange.foreach { range_ =>
+        emit(TypeInfo(filename, range_, typeFullName, declFullName, superClassTypes ++ conformances, nodeKind))
+      }
+    }
+
+    def parseArray(parent: AstNode, fieldName: String): Unit = {
+      jsonReader.beginArray()
+      while (jsonReader.hasNext) {
+        jsonReader.peek() match {
+          case JsonToken.BEGIN_OBJECT =>
+            val child = parseObject()
+            if (RelevantChildFieldNames.contains(fieldName)) {
+              addChildFromArray(parent, fieldName, child)
+            }
+          case JsonToken.BEGIN_ARRAY =>
+            parseArray(parent, fieldName)
+          case JsonToken.STRING if fieldName == "inherits" =>
+            val value = jsonReader.nextString()
+            if (parent.inheritsLegacy == null) parent.inheritsLegacy = mutable.ArrayBuffer.empty[String]
+            parent.inheritsLegacy += value
+          case _ =>
+            jsonReader.skipValue()
+        }
+      }
+      jsonReader.endArray()
+    }
+
+    def parseObject(): AstNode = {
+      val node        = new AstNode
       var hasKind     = false
       var isFromBuild = false
 
@@ -280,96 +300,66 @@ object GsonTypeInfoReader {
 
         if (name == "_kind") {
           hasKind = true
-          val value = JsonParser.parseReader(jsonReader)
-          obj.add(name, value)
+          node.kind = readPrimitiveAsString().orNull
         } else if (name == "filename") {
-          filename = JsonParser.parseReader(jsonReader).getAsString
-          isFromBuild = isInBuildFolder(filename)
+          filename = readPrimitiveAsString().orNull
+          isFromBuild = filename != null && isInBuildFolder(filename)
         } else {
           jsonReader.peek() match {
             case JsonToken.BEGIN_OBJECT if hasKind && !isFromBuild =>
               val child = parseObject()
-              if (RelevantChildFieldNames.contains(name)) obj.add(name, child)
+              if (RelevantChildFieldNames.contains(name)) {
+                addChild(node, name, child)
+              }
             case JsonToken.BEGIN_OBJECT =>
               // don't descend
               jsonReader.skipValue()
             case JsonToken.BEGIN_ARRAY if hasKind && !isFromBuild =>
-              val child = parseArray()
-              if (RelevantChildFieldNames.contains(name)) obj.add(name, child)
+              parseArray(node, name)
             case JsonToken.BEGIN_ARRAY =>
               // don't descend
               jsonReader.skipValue()
             case _ =>
-              if (
-                name == "start" || name == "end" ||
-                TypeFullNameFieldNames.contains(name) ||
-                DeclFullNameFieldNames.contains(name)
-              ) {
-                val value = JsonParser.parseReader(jsonReader)
-                obj.add(name, value)
-              } else jsonReader.skipValue()
+              name match {
+                case "start" =>
+                  node.start = readPrimitiveAsInt().getOrElse(-1)
+                case "end" =>
+                  node.end = readPrimitiveAsInt().getOrElse(-1)
+                case "type" =>
+                  node.typeValue = readPrimitiveAsString().orNull
+                case "type_usr" =>
+                  node.typeUsr = readPrimitiveAsString().orNull
+                case "result" =>
+                  node.resultValue = readPrimitiveAsString().orNull
+                case "interface_type" =>
+                  node.interfaceType = readPrimitiveAsString().orNull
+                case "extended_type" =>
+                  node.extendedType = readPrimitiveAsString().orNull
+                case "usr" =>
+                  node.usr = readPrimitiveAsString().orNull
+                case "decl_usr" =>
+                  node.declUsr = readPrimitiveAsString().orNull
+                case "protocol" =>
+                  node.protocol = readPrimitiveAsString().orNull
+                case "superclass_type" =>
+                  node.superclassType = readPrimitiveAsString().orNull
+                case _ =>
+                  jsonReader.skipValue()
+              }
           }
-          currentRange = safeRange(obj).orElse(currentRange)
+          currentRange = safeRange(node).orElse(currentRange)
         }
       }
       jsonReader.endObject()
 
-      if (qualifies(obj)) {
-        extractTypeInfo(obj, filename, None)
-      } else if (isParameter(obj)) {
-        extractTypeInfo(obj, filename, currentRange)
-      }
-      obj
-    }
-
-    /** Extracts type information from an AST node and adds it to the result set.
-      *
-      * @param obj
-      *   The JSON object representing an AST node
-      * @param filename
-      *   The source file name
-      */
-    def extractTypeInfo(obj: JsonObject, filename: String, rangeOpt: Option[(Int, Int)]): Unit = {
-      val nodeKind = astNodeKind(obj)
-      val range_   = rangeOpt.getOrElse(range(obj))
-
-      lazy val declObj = nodeKind match {
-        case kind if kind.endsWith(NodeKinds.CallExpr) => declFromCallExpr(obj)
-        case NodeKinds.MemberRefExpr                   => declFromMemberRefExpr(obj)
-        case _                                         => obj
-      }
-
-      val typeObj = nodeKind match {
-        case NodeKinds.ReturnStmt => resultFromReturnStmt(obj)
-        case _                    => obj
-      }
-
-      val typeFullName    = typeFullNameFromNode(typeObj)
-      val declFullName    = declFullNameFromNode(obj, declObj)
-      val conformances    = conformancesFromNode(obj)
-      val superClassTypes = superClassesFromNode(obj) ++ superClassesFromNodeLegacy(obj)
-
-      found.add(TypeInfo(filename, range_, typeFullName, declFullName, superClassTypes ++ conformances, nodeKind))
-    }
-
-    /** Parses a JSON array.
-      *
-      * @return
-      *   The parsed JsonArray
-      */
-    def parseArray(): JsonArray = {
-      val arr = new JsonArray
-      jsonReader.beginArray()
-      while (jsonReader.hasNext) {
-        jsonReader.peek() match {
-          case JsonToken.BEGIN_OBJECT => arr.add(parseObject())
-          case JsonToken.BEGIN_ARRAY  => arr.add(parseArray())
-          case JsonToken.STRING       => arr.add(jsonReader.nextString())
-          case _                      => jsonReader.skipValue()
+      if (!isFromBuild && node.kind != null) {
+        if (qualifies(node)) {
+          extractTypeInfo(node, filename, None)
+        } else if (isParameter(node)) {
+          extractTypeInfo(node, filename, currentRange)
         }
       }
-      jsonReader.endArray()
-      arr
+      node
     }
 
     var shouldTerminate = false
@@ -377,12 +367,13 @@ object GsonTypeInfoReader {
       // Start parsing based on the root element type
       jsonReader.peek() match {
         case JsonToken.BEGIN_OBJECT => parseObject()
-        case JsonToken.BEGIN_ARRAY  => parseArray()
-        case _                      => shouldTerminate = true
+        case JsonToken.BEGIN_ARRAY =>
+          val sinkNode = new AstNode
+          parseArray(sinkNode, "")
+        case _ => shouldTerminate = true
       }
     }
 
     jsonReader.close()
-    found.toSet
   }
 }

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/utils/SwiftTypesProvider.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/utils/SwiftTypesProvider.scala
@@ -790,15 +790,10 @@ case class SwiftTypesProvider(config: Config, parsedSwiftInvocations: Seq[Seq[St
   }
 
   /** Parses Swift compiler JSON output and collects raw type information without demangling.
-    *
-    * @param jsonString
-    *   The JSON string from the Swift compiler
-    * @return
-    *   The set of TypeInfo objects extracted from the JSON
     */
-  private def collectTypeInfoFromJson(jsonString: String): Set[TypeInfo] = {
+  private def collectTypeInfoFromJson(jsonString: String, emit: TypeInfo => Unit): Unit = {
     Using.resource(new StringReader(jsonString)) { reader =>
-      GsonTypeInfoReader.collectTypeInfo(reader)
+      GsonTypeInfoReader.collectTypeInfo(reader, emit)
     }
   }
 
@@ -845,7 +840,9 @@ case class SwiftTypesProvider(config: Config, parsedSwiftInvocations: Seq[Seq[St
     *   The type mapping to update with extracted information
     */
   def mappingFromJson(jsonString: String, result: MutableSwiftTypeMapping): Unit = {
-    collectTypeInfoFromJson(jsonString).foreach(addToMapping(_, result))
+    Using.resource(new StringReader(jsonString)) { reader =>
+      GsonTypeInfoReader.collectTypeInfo(reader, addToMapping(_, result))
+    }
   }
 
   /** Retrieves Swift type mappings by executing Swift compiler commands and processing output.
@@ -875,7 +872,7 @@ case class SwiftTypesProvider(config: Config, parsedSwiftInvocations: Seq[Seq[St
           val reader = use(new InputStreamReader(process.getInputStream))
           val stdOut = use(new BufferedReader(reader))
           ParallelLineProcessor.processLinesParallel(stdOut, pool, _.startsWith("{")) { jsonString =>
-            collectTypeInfoFromJson(jsonString).foreach(allTypeInfos.add)
+            collectTypeInfoFromJson(jsonString, allTypeInfos.add)
           }
         } match {
           case Failure(exception) =>

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/utils/GsonTypeInfoReaderTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/utils/GsonTypeInfoReaderTests.scala
@@ -1,0 +1,218 @@
+package io.joern.swiftsrc2cpg.utils
+
+import io.joern.swiftsrc2cpg.utils.SwiftTypesProvider.TypeInfo
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.io.StringReader
+import scala.collection.mutable
+
+class GsonTypeInfoReaderTests extends AnyWordSpec with Matchers {
+
+  "collectTypeInfo" should {
+    "extract decl/type info for call, return, and member ref expressions" in {
+      val json =
+        """[
+          |  {
+          |    "_kind": "call_expr",
+          |    "filename": "/tmp/F.swift",
+          |    "range": { "start": 10, "end": 20 },
+          |    "type": "Swift.Int",
+          |    "fn": {
+          |      "_kind": "declref_expr",
+          |      "decl": {
+          |        "_kind": "decl_ref",
+          |        "decl_usr": "usr.fn"
+          |      }
+          |    }
+          |  },
+          |  {
+          |    "_kind": "return_stmt",
+          |    "filename": "/tmp/F.swift",
+          |    "range": { "start": 30, "end": 40 },
+          |    "result": {
+          |      "_kind": "integer_literal_expr",
+          |      "type": "Swift.String"
+          |    }
+          |  },
+          |  {
+          |    "_kind": "member_ref_expr",
+          |    "filename": "/tmp/F.swift",
+          |    "range": { "start": 50, "end": 60 },
+          |    "decl": {
+          |      "_kind": "decl_ref",
+          |      "decl_usr": "usr.member"
+          |    }
+          |  }
+          |]""".stripMargin
+
+      val result = mutable.HashSet.empty[TypeInfo]
+      GsonTypeInfoReader.collectTypeInfo(new StringReader(json), result.add)
+      result should contain(
+        TypeInfo("/tmp/F.swift", (10, 21), Some("Swift.Int"), Some("usr.fn"), Seq.empty, "call_expr")
+      )
+      result should contain(TypeInfo("/tmp/F.swift", (30, 41), Some("Swift.String"), None, Seq.empty, "return_stmt"))
+      result should contain(TypeInfo("/tmp/F.swift", (50, 61), None, Some("usr.member"), Seq.empty, "member_ref_expr"))
+    }
+
+    "apply attrs-adjusted ranges for parameters and collect inheritances while filtering build folder files" in {
+      val json =
+        """[
+          |  {
+          |    "_kind": "function_decl",
+          |    "filename": "/tmp/F.swift",
+          |    "range": { "start": 100, "end": 120 },
+          |    "attrs": [{ "_kind": "attribute", "range": { "start": 95, "end": 99 } }],
+          |    "type": "Swift.Void"
+          |  },
+          |  {
+          |    "_kind": "parameter",
+          |    "filename": "/tmp/F.swift",
+          |    "type": "Swift.Int"
+          |  },
+          |  {
+          |    "_kind": "class_decl",
+          |    "filename": "/tmp/F.swift",
+          |    "range": { "start": 1, "end": 2 },
+          |    "type": "Swift.C",
+          |    "inherits": ["Swift.Base"]
+          |  },
+          |  {
+          |    "_kind": "class_decl",
+          |    "filename": "/tmp/F.swift",
+          |    "range": { "start": 3, "end": 4 },
+          |    "type": "Swift.D",
+          |    "inherits": {
+          |      "_kind": "inheritance_clause",
+          |      "superclass_type": "Swift.Parent",
+          |      "conformances": [{ "_kind": "type_expr", "protocol": "Swift.P" }]
+          |    }
+          |  },
+          |  {
+          |    "_kind": "class_decl",
+          |    "filename": "/tmp/.build/generated.swift",
+          |    "range": { "start": 5, "end": 6 },
+          |    "type": "Swift.Skip"
+          |  }
+          |]""".stripMargin
+
+      val result = mutable.HashSet.empty[TypeInfo]
+      GsonTypeInfoReader.collectTypeInfo(new StringReader(json), result.add)
+
+      result should contain(TypeInfo("/tmp/F.swift", (95, 121), Some("Swift.Void"), None, Seq.empty, "function_decl"))
+      result should contain(TypeInfo("/tmp/F.swift", (95, 121), Some("Swift.Int"), None, Seq.empty, "parameter"))
+      result should contain(TypeInfo("/tmp/F.swift", (1, 3), Some("Swift.C"), None, Seq("Swift.Base"), "class_decl"))
+      result should contain(
+        TypeInfo("/tmp/F.swift", (3, 5), Some("Swift.D"), None, Seq("Swift.Parent", "Swift.P"), "class_decl")
+      )
+      result.exists(_.filename.contains("/.build/")) shouldBe false
+    }
+
+    "handle deeply nested structures with multiple levels of child objects" in {
+      val json =
+        """[
+          |  {
+          |    "_kind": "call_expr",
+          |    "filename": "/tmp/Nested.swift",
+          |    "range": { "start": 200, "end": 250 },
+          |    "type": "Swift.Result",
+          |    "fn": {
+          |      "_kind": "function_conversion_expr",
+          |      "sub_expr": {
+          |        "_kind": "declref_expr",
+          |        "type": "Swift.Function",
+          |        "decl": {
+          |          "_kind": "decl_ref",
+          |          "decl_usr": "usr.deeply.nested.function"
+          |        }
+          |      }
+          |    }
+          |  },
+          |  {
+          |    "_kind": "class_decl",
+          |    "filename": "/tmp/Nested.swift",
+          |    "range": { "start": 300, "end": 400 },
+          |    "type": "MyModule.ComplexClass",
+          |    "usr": "usr.MyModule.ComplexClass",
+          |    "attrs": [
+          |      { "_kind": "attribute", "range": { "start": 290, "end": 295 } },
+          |      { "_kind": "attribute", "range": { "start": 285, "end": 289 } }
+          |    ],
+          |    "inherits": {
+          |      "_kind": "inheritance_clause",
+          |      "superclass_type": "MyModule.BaseClass",
+          |      "conformances": [
+          |        { "_kind": "type_expr", "protocol": "Swift.Codable" },
+          |        { "_kind": "type_expr", "protocol": "Swift.Equatable" },
+          |        { "_kind": "type_expr", "protocol": "MyModule.CustomProtocol" }
+          |      ]
+          |    }
+          |  },
+          |  {
+          |    "_kind": "call_expr",
+          |    "filename": "/tmp/Nested.swift",
+          |    "range": { "start": 500, "end": 550 },
+          |    "type": "Swift.Void",
+          |    "fn": {
+          |      "_kind": "declref_expr",
+          |      "decl": {
+          |        "_kind": "decl_ref",
+          |        "decl_usr": "usr.method.chain"
+          |      }
+          |    },
+          |    "irrelevant_field": {
+          |      "_kind": "some_node",
+          |      "deeply": {
+          |        "nested": {
+          |          "structure": {
+          |            "that": {
+          |              "should": {
+          |                "be": {
+          |                  "skipped": "because it's not in RelevantChildFieldNames"
+          |                }
+          |              }
+          |            }
+          |          }
+          |        }
+          |      }
+          |    }
+          |  }
+          |]""".stripMargin
+
+      val result = mutable.HashSet.empty[TypeInfo]
+      GsonTypeInfoReader.collectTypeInfo(new StringReader(json), result.add)
+
+      // Verify deeply nested call_expr with function_conversion_expr -> sub_expr -> decl chain
+      result should contain(
+        TypeInfo(
+          "/tmp/Nested.swift",
+          (200, 251),
+          Some("Swift.Result"),
+          Some("usr.deeply.nested.function"),
+          Seq.empty,
+          "call_expr"
+        )
+      )
+
+      // Verify class with multiple attributes (uses first attribute's start) and multiple conformances
+      result should contain(
+        TypeInfo(
+          "/tmp/Nested.swift",
+          (290, 401),
+          Some("MyModule.ComplexClass"),
+          Some("usr.MyModule.ComplexClass"),
+          Seq("MyModule.BaseClass", "Swift.Codable", "Swift.Equatable", "MyModule.CustomProtocol"),
+          "class_decl"
+        )
+      )
+
+      // Verify nested fn -> declref_expr -> decl chain (tests RelevantChildFieldNames filtering)
+      result should contain(
+        TypeInfo("/tmp/Nested.swift", (500, 551), Some("Swift.Void"), Some("usr.method.chain"), Seq.empty, "call_expr")
+      )
+
+      // Verify we extracted exactly 3 TypeInfo entries (irrelevant nested structure should be skipped)
+      result.size shouldBe 3
+    }
+  }
+}

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/utils/SwiftCompilerFullnameTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/utils/SwiftCompilerFullnameTests.scala
@@ -2,7 +2,6 @@ package io.joern.swiftsrc2cpg.utils
 
 import io.joern.swiftsrc2cpg.testfixtures.SwiftCompilerSrc2CpgSuite
 import io.shiftleft.codepropertygraph.generated.*
-import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.*
 
 class SwiftCompilerFullnameTests extends SwiftCompilerSrc2CpgSuite {


### PR DESCRIPTION
This PR refactors `GsonTypeInfoReader` from DOM-based JSON parsing to token-streaming with a callback-style API for better memory efficiency:

- Replace `JsonParser.parseReader` with `JsonReader` for token streaming
- Introduce minimal mutable `AstNode` class instead of `JsonObject` trees
- Change `collectTypeInfo` to accept emit callback instead of returning `Set`
- Only retain relevant child fields during parsing (`RelevantChildFieldNames`)

Benefits:
- Reduces memory allocations by avoiding full DOM tree construction
- Enables streaming processing of large JSON outputs

Running current master vs. this branch on `shiftleft-swift-demo`:
-  cpu time: ~20% savings
<img width="1697" height="194" alt="cpu-time" src="https://github.com/user-attachments/assets/5a2118d0-5944-49db-867d-883b98301770" />
- memory: ~35% saving
<img width="1697" height="194" alt="mem" src="https://github.com/user-attachments/assets/b9eed8c6-ea50-4571-937e-da9cf2ac9fe5" />

Note: this project is small (~1100 fullnames from the compiler, only 16 Swift source files = 16 mappings from 16 Json). Larger projects with Json files above 100 MB benefit significantly.
