### PR TITLE
[javasrc2cpg] use standard forAst method for for-loop

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForForLoopsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForForLoopsCreator.scala
@@ -86,19 +86,9 @@ trait AstForForLoopsCreator { this: AstCreator =>
 
     scope.addLocalsForPatternsToEnclosingBlock(patternPartition.patternsIntroducedByStatement)
 
-    val ast = Ast(forNode)
-      .withChildren(initAsts)
-      .withChildren(compareAsts)
-      .withChildren(updateAsts)
-      .withChild(bodyAst)
+    val ast = forAst(forNode, Nil, initAsts.toSeq, compareAsts, updateAsts, bodyAst)
 
-    val astWithConditionEdge = compareAsts.flatMap(_.root) match {
-      case c :: Nil =>
-        ast.withConditionEdge(forNode, c)
-      case _ => ast
-    }
-
-    patternLocals :+ astWithConditionEdge
+    patternLocals :+ ast
   }
 
   def astForForEach(stmt: ForEachStmt): Seq[Ast] = {

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/PatternExprTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/PatternExprTests.scala
@@ -1475,16 +1475,18 @@ class PatternExprTests extends JavaSrcCode2CpgFixture {
       "lower the init, update, and body correctly" in {
         inside(cpg.method.name("foo").body.astChildren.l) { case List(_: Local, forStmt: ControlStructure) =>
           forStmt.controlStructureType shouldBe ControlStructureTypes.FOR
-          inside(forStmt.astChildren.l) { case List(iLocal: Local, iAssign: Call, _: Call, update: Call, body: Block) =>
-            iLocal.name shouldBe "i"
+          inside(forStmt.astChildren.l) { case List(block: Block, _: Call, update: Call, body: Block) =>
+            inside(block.astChildren.l) { case List(iLocal: Local, iAssign: Call) =>
+              iLocal.name shouldBe "i"
 
-            iAssign.methodFullName shouldBe Operators.assignment
-            iAssign.code shouldBe "int i = 0"
+              iAssign.methodFullName shouldBe Operators.assignment
+              iAssign.code shouldBe "int i = 0"
+            }
 
             update.methodFullName shouldBe Operators.assignmentPlus
             inside(update.argument.l) { case List(iIdentifier: Identifier, lengthCall: Call) =>
               iIdentifier.name shouldBe "i"
-              iIdentifier.refsTo.l shouldBe List(iLocal)
+              iIdentifier.refsTo.l shouldBe block.astChildren.isLocal.l
 
               lengthCall.name shouldBe "length"
               lengthCall.methodFullName shouldBe "java.lang.String.length:int()"


### PR DESCRIPTION
- Instead of manually building up the Ast for for-loops, use the shared `forAst`.
- `forAst` ensures that the newly added control structure edges are present.
- Tests for the new edges will be added in a separate PR.
- Separated from https://github.com/joernio/joern/pull/5939. Will update <- after merging.

