### PR TITLE
[php2cpg] Prevent crashes on keyed foreach list destructuring

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForControlStructuresCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForControlStructuresCreator.scala
@@ -173,9 +173,13 @@ trait AstForControlStructuresCreator(implicit withSchemaValidation: ValidationMo
     val iterIdentifier = getTmpIdentifier(stmt, maybeTypeFullName = None, prefix = "iter_")
     val localN         = handleVariableOccurrence(stmt, iterIdentifier.name)
 
+    stmt.keyVar.collect { case PhpVariable(name: PhpNameExpr, _) =>
+      handleVariableOccurrence(stmt, name.name)
+    }
+
     // keep this just used to construct the `code` field
     val assignItemTargetString = stmt.keyVar match {
-      case Some(key) => astForKeyValPair(stmt, key, stmt.valueVar).rootCodeOrEmpty
+      case Some(key) => s"${codeForExpr(key)} => ${codeForExpr(stmt.valueVar)}"
       case None =>
         stmt.valueVar match {
           case x: PhpListExpr => createListExprCodeField(x)

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/ControlStructureTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/ControlStructureTests.scala
@@ -1378,6 +1378,55 @@ class ControlStructureTests extends PhpCode2CpgFixture {
     }
   }
 
+  "foreach statements with key and list destructuring should be represented as a for" in {
+    val cpg = code("""<?php
+      |function foo($arr) {
+      |  foreach ($arr as $key => list($a, $b)) {
+      |    echo $key;
+      |    echo $a;
+      |    echo $b;
+      |  }
+      |}
+      |""".stripMargin)
+
+    val foreachStruct = inside(cpg.method.name("foo").body.astChildren.l) {
+      case List(iterLocal: Local, keyLocal: Local, aLocal: Local, bLocal: Local, foreachStruct: ControlStructure) =>
+        iterLocal.name shouldBe "foo@iter_tmp-0"
+        keyLocal.name shouldBe "key"
+        aLocal.name shouldBe "a"
+        bLocal.name shouldBe "b"
+
+        foreachStruct
+    }
+
+    foreachStruct.code shouldBe "foreach ($arr as $key => list($a, $b))"
+
+    val (initAsts, updateAsts, body) = inside(foreachStruct.astChildren.l) {
+      case List(initAsts: Block, _, updateAsts: Block, body: Block) =>
+        (initAsts, updateAsts, body)
+    }
+
+    inside(initAsts.assignment.l) { case List(_: Call, keyInit: Call, tmpInit: Call, aInit: Call, bInit: Call) =>
+      keyInit.code shouldBe "$key = $foo@iter_tmp-0->key()"
+      tmpInit.code shouldBe "$foo@tmp-1 = $foo@iter_tmp-0->current()"
+      aInit.code shouldBe "$a = $foo@tmp-1[0]"
+      bInit.code shouldBe "$b = $foo@tmp-1[1]"
+    }
+
+    inside(updateAsts.assignment.l) { case List(keyInit: Call, tmpAssign: Call, aAssign: Call, bAssign: Call) =>
+      keyInit.code shouldBe "$key = $foo@iter_tmp-0->key()"
+      tmpAssign.code shouldBe "$foo@tmp-1 = $foo@iter_tmp-0->current()"
+      aAssign.code shouldBe "$a = $foo@tmp-1[0]"
+      bAssign.code shouldBe "$b = $foo@tmp-1[1]"
+    }
+
+    inside(body.astChildren.l) { case List(echoKey: Call, echoA: Call, echoB: Call) =>
+      echoKey.code shouldBe "echo $key"
+      echoA.code shouldBe "echo $a"
+      echoB.code shouldBe "echo $b"
+    }
+  }
+
   "foreach loop with listExpr" should {
     val cpg = code("""<?php
         |function foo($data) {


### PR DESCRIPTION

  ## Summary
  - avoid routing keyed `foreach (... as $key => list(...))` targets through the unimplemented `astForExpr(PhpListExpr)` path when building the `foreach` code field
  - reuse the existing list-expression code rendering for keyed `foreach` destructuring
  - add a regression test in `ControlStructureTests` for keyed `foreach` list destructuring
  - add a small file-backed integration test in `ProjectParseTests`

  ## Error
  `php2cpg` could throw a `scala.NotImplementedError` on input like:

  ```php
  foreach ($arr as $key => list($a, $b)) {
    echo $key;
    echo $a;
    echo $b;
  }
```
Original error message:
```
scala.NotImplementedError: an implementation is missing
  ...
  Caused by: scala.NotImplementedError: unexpected expression 'PhpListExpr(...)' of type class io.joern.php2cpg.parser.Domain$PhpListExpr
  at io.joern.php2cpg.astcreation.AstForExpressionsCreator.astForExpr(AstForExpressionsCreator.scala:55)
  at io.joern.php2cpg.astcreation.AstForExpressionsCreator.astForKeyValPair(AstForExpressionsCreator.scala:715)
  at io.joern.php2cpg.astcreation.AstForControlStructuresCreator.astForForeachStmt(AstForControlStructuresCreator.scala:178)

```

  ## Why this happens

  The keyed foreach code path was constructing the key => value code via astForKeyValPair(...), which calls astForExpr(...) on both sides. PhpListExpr is not implemented in astForExpr, so foreach ($arr as $key => list(...)) failed before the existing
  lowering logic for list destructuring could run.

  ## Fix

  Keep the fix narrow in astForForeachStmt by rendering PhpListExpr targets with the existing list-expression code helper instead of sending them through astForExpr(...).

  ## Test Plan

  - [x] sbt 'project php2cpg' 'scalafmt' 'Test / scalafmt'
  - [x] sbt 'project php2cpg' 'test'

