### PR TITLE
[rust2cpg] setup rust_ast_gen

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -29,12 +29,8 @@ jobs:
           swift-version: "6.1"
       - name: Install Bundler
         run: gem install bundler -v 2.4.22
-      - name: Delete `.rustup` directory
-        run: rm -rf /home/runner/.rustup # to save disk space
-        if: runner.os == 'Linux'
-      - name: Delete `.cargo` directory # to save disk space
-        run: rm -rf /home/runner/.cargo
-        if: runner.os == 'Linux'
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
       - run: sbt scalafmtCheck test
       - name: Test distribution
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,12 +29,8 @@ jobs:
         uses: SwiftyLab/setup-swift@latest
         with:
           swift-version: "6.1"
-      - name: Delete `.rustup` directory
-        run: rm -rf /home/runner/.rustup # to save disk space
-        if: runner.os == 'Linux'
-      - name: Delete `.cargo` directory # to save disk space
-        run: rm -rf /home/runner/.cargo
-        if: runner.os == 'Linux'
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
       - name: Run tests
         run: sbt clean test
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,12 +33,8 @@ jobs:
           swift-version: "6.1"
       - name: Install Bundler
         run: gem install bundler -v 2.4.22
-      - name: Delete `.rustup` directory
-        run: rm -rf /home/runner/.rustup # to save disk space
-        if: runner.os == 'Linux'
-      - name: Delete `.cargo` directory # to save disk space
-        run: rm -rf /home/runner/.cargo
-        if: runner.os == 'Linux'
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
       - run: sbt scalafmtCheck test
       - name: Test distribution
         run: |

--- a/.github/workflows/upgrade-deps.yml
+++ b/.github/workflows/upgrade-deps.yml
@@ -24,6 +24,8 @@ jobs:
         uses: SwiftyLab/setup-swift@latest
         with:
           swift-version: "6.1"
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
       - uses: sbt/setup-sbt@v1
       - name: Upgrade all (internal) dependencies
         run: ./updateDependencies.sh --non-interactive

--- a/joern-cli/frontends/rust2cpg/build.sbt
+++ b/joern-cli/frontends/rust2cpg/build.sbt
@@ -1,14 +1,111 @@
+import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.sbt.packager.Keys.stagingDirectory
+
+import scala.sys.process.stringToProcess
+import scala.util.Try
+
 name := "rust2cpg"
 
 dependsOn(
   Projects.dataflowengineoss % "test->test",
   Projects.x2cpg             % "compile->compile;test->test",
-  Projects.linterRules % ScalafixConfig
+  Projects.linterRules       % ScalafixConfig
 )
+
+lazy val appProperties = settingKey[Config]("App Properties")
+appProperties := {
+  val path            = (Compile / resourceDirectory).value / "application.conf"
+  val applicationConf = ConfigFactory.parseFile(path).resolve()
+  applicationConf
+}
+
+lazy val astGenVersion = settingKey[String]("rust_ast_gen version")
+astGenVersion := appProperties.value.getString("rust2cpg.rust_ast_gen_version")
 
 libraryDependencies ++= Seq(
   "io.shiftleft"  %% "codepropertygraph" % Versions.cpg,
+  "com.lihaoyi"   %% "upickle"           % Versions.upickle,
   "org.scalatest" %% "scalatest"         % Versions.scalatest % Test
 )
 
 enablePlugins(JavaAppPackaging, LauncherJarPlugin)
+
+lazy val AstgenWin      = "rust_ast_gen-win.exe"
+lazy val AstgenWinArm   = "rust_ast_gen-win-arm.exe"
+lazy val AstgenLinux    = "rust_ast_gen-linux"
+lazy val AstgenLinuxArm = "rust_ast_gen-linux-arm"
+lazy val AstgenMac      = "rust_ast_gen-macos"
+lazy val AstgenMacArm   = "rust_ast_gen-macos-arm"
+
+lazy val astGenDlUrl = settingKey[String]("rust_ast_gen download url")
+astGenDlUrl := s"https://github.com/joernio/rust_ast_gen/releases/download/v${astGenVersion.value}/"
+
+def hasCompatibleAstGenVersion(astGenVersion: String): Boolean = {
+  Try("rust_ast_gen --version".!!).toOption.map(_.strip().stripPrefix("rust_ast_gen ")) match {
+    case Some(installedVersion) if installedVersion.nonEmpty =>
+      versionsort.VersionHelper.compare(installedVersion, astGenVersion) >= 0
+    case _ => false
+  }
+}
+
+lazy val astGenBinaryNames = taskKey[Seq[String]]("rust_ast_gen binary names")
+astGenBinaryNames := {
+  if (hasCompatibleAstGenVersion(astGenVersion.value)) {
+    Seq.empty
+  } else if (sys.props.get("ALL_PLATFORMS").contains("TRUE")) {
+    Seq(AstgenWin, AstgenWinArm, AstgenLinux, AstgenLinuxArm, AstgenMac, AstgenMacArm)
+  } else {
+    Environment.operatingSystem match {
+      case Environment.OperatingSystemType.Windows =>
+        Environment.architecture match {
+          case Environment.ArchitectureType.X86   => Seq(AstgenWin)
+          case Environment.ArchitectureType.ARMv8 => Seq(AstgenWinArm)
+        }
+      case Environment.OperatingSystemType.Linux =>
+        Environment.architecture match {
+          case Environment.ArchitectureType.X86   => Seq(AstgenLinux)
+          case Environment.ArchitectureType.ARMv8 => Seq(AstgenLinuxArm)
+        }
+      case Environment.OperatingSystemType.Mac =>
+        Environment.architecture match {
+          case Environment.ArchitectureType.X86   => Seq(AstgenMac)
+          case Environment.ArchitectureType.ARMv8 => Seq(AstgenMacArm)
+        }
+      case Environment.OperatingSystemType.Unknown =>
+        Seq(AstgenWin, AstgenWinArm, AstgenLinux, AstgenLinuxArm, AstgenMac, AstgenMacArm)
+    }
+  }
+}
+
+lazy val astGenDlTask = taskKey[Unit](s"Download rust_ast_gen binaries")
+astGenDlTask := {
+  val astGenDir = baseDirectory.value / "bin" / "astgen"
+
+  astGenBinaryNames.value.foreach { fileName =>
+    val file = astGenDir / fileName
+    DownloadHelper.ensureIsAvailable(s"${astGenDlUrl.value}$fileName", file)
+    // permissions are lost during the download; need to set them manually
+    file.setExecutable(true, false)
+  }
+
+  val distDir = (Universal / stagingDirectory).value / "bin" / "astgen"
+  distDir.mkdirs()
+  IO.copyDirectory(astGenDir, distDir, preserveExecutable = true)
+}
+
+Compile / compile := ((Compile / compile) dependsOn astGenDlTask).value
+
+lazy val astGenSetAllPlatforms = taskKey[Unit](s"Set ALL_PLATFORMS")
+astGenSetAllPlatforms := { System.setProperty("ALL_PLATFORMS", "TRUE") }
+
+stage := Def
+  .sequential(astGenSetAllPlatforms, Universal / stage)
+  .andFinally(System.setProperty("ALL_PLATFORMS", "FALSE"))
+  .value
+
+Universal / packageName       := name.value
+Universal / topLevelDirectory := None
+
+/** write the astgen version to the manifest for downstream usage */
+Compile / packageBin / packageOptions +=
+  Package.ManifestAttributes(new java.util.jar.Attributes.Name("Rust-AstGen-Version") -> astGenVersion.value)

--- a/joern-cli/frontends/rust2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/rust2cpg/src/main/resources/application.conf
@@ -1,0 +1,3 @@
+rust2cpg {
+    rust_ast_gen_version: "0.3.0"
+}

--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/Rust2Cpg.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/Rust2Cpg.scala
@@ -1,10 +1,14 @@
 package io.joern.rust2cpg
 
+import io.joern.rust2cpg.astgen.RustAstGenRunner
 import io.joern.x2cpg.X2Cpg.withNewEmptyCpg
 import io.joern.x2cpg.X2CpgFrontend
 import io.joern.x2cpg.passes.frontend.MetaDataPass
+import io.joern.x2cpg.utils.HashUtil
 import io.shiftleft.codepropertygraph.generated.{Cpg, Languages}
+import io.shiftleft.semanticcpg.utils.FileUtil
 
+import java.nio.file.Paths
 import scala.util.Try
 
 class Rust2Cpg extends X2CpgFrontend {
@@ -13,7 +17,11 @@ class Rust2Cpg extends X2CpgFrontend {
 
   def createCpg(config: Config): Try[Cpg] = {
     withNewEmptyCpg(config.outputPath, config) { (cpg, config) =>
-      MetaDataPass(cpg, Languages.RUST, config.inputPath).createAndApply()
+      FileUtil.usingTemporaryDirectory("rust2cpgOut") { tmpDir =>
+        val astGenResult = new RustAstGenRunner(config).execute(tmpDir)
+        val hash         = HashUtil.sha256(astGenResult.parsedFiles.map(Paths.get(_)))
+        MetaDataPass(cpg, Languages.RUST, config.inputPath, Option(hash)).createAndApply()
+      }
     }
   }
 }

--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astgen/RustAstGenRunner.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astgen/RustAstGenRunner.scala
@@ -1,0 +1,32 @@
+package io.joern.rust2cpg.astgen
+
+import io.joern.rust2cpg.Config
+import io.joern.x2cpg.astgen.AstGenRunner
+import io.joern.x2cpg.astgen.AstGenRunner.AstGenProgramMetaData
+import io.shiftleft.semanticcpg.utils.ExternalCommand
+import org.slf4j.LoggerFactory
+
+import java.nio.file.Path
+import scala.util.Try
+
+object RustAstGenRunner {
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  private object astGenMetaData extends AstGenProgramMetaData(name = "rust_ast_gen", configPrefix = "rust2cpg")
+}
+
+class RustAstGenRunner(config: Config) extends AstGenRunner(RustAstGenRunner.astGenMetaData, config) {
+
+  override def skippedFiles(in: Path, astGenOut: List[String]): List[String] = {
+    // 1. rust_ast_gen does not support skipping files yet.
+    // 2. output is controlled by RUST_LOG which can be noisy.
+    // TODO: (on rust_ast_gen side) explicitly print success/failure of each file
+    List.empty
+  }
+
+  override def runAstGenNative(in: String, out: Path, exclude: String, include: String): Try[Seq[String]] = {
+    ExternalCommand
+      .run(Seq(astGenCommand, "-i", in, "-o", out.toString))
+      .toTry
+  }
+}

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/astgen/RustAstGenRunnerTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/astgen/RustAstGenRunnerTests.scala
@@ -1,0 +1,205 @@
+package io.joern.rust2cpg.astgen
+
+import io.joern.rust2cpg.Config
+import io.shiftleft.semanticcpg.utils.FileUtil
+import io.shiftleft.semanticcpg.utils.FileUtil.*
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.BeforeAndAfterAll
+
+import java.nio.file.{Files, Path}
+
+class RustAstGenRunnerTests extends AnyWordSpec with Matchers with BeforeAndAfterAll {
+
+  private def writeFile(file: Path, content: String): Unit = {
+    file.createWithParentsIfNotExists(createParents = true)
+    Files.writeString(file, content)
+  }
+
+  "RustAstGenRunner" should {
+
+    "parse a single-crate project" in {
+      FileUtil.usingTemporaryDirectory("rust2cpgTestInput") { inputDir =>
+        writeFile(
+          inputDir / "Cargo.toml",
+          """[package]
+            |name = "simple"
+            |version = "0.1.0"
+            |edition = "2021"
+            |""".stripMargin
+        )
+        writeFile(inputDir / "src" / "main.rs", "fn main() { println!(\"hello\"); }")
+        writeFile(inputDir / "src" / "lib.rs", "pub fn add(a: i32, b: i32) -> i32 { a + b }")
+        writeFile(inputDir / "src" / "utils" / "mod.rs", "pub fn greet() {}")
+
+        FileUtil.usingTemporaryDirectory("rust2cpgTestOut") { outputDir =>
+          val config = Config().withInputPath(inputDir.toString).withOutputPath(outputDir.toString)
+          val result = new RustAstGenRunner(config).execute(outputDir)
+          result.parsedFiles.sorted should contain theSameElementsAs Seq(
+            outputDir / "src" / "lib.rs.json",
+            outputDir / "src" / "main.rs.json",
+            outputDir / "src" / "utils" / "mod.rs.json"
+          ).map(_.toString)
+        }
+      }
+    }
+
+    "parse a workspace project with crates/" in {
+      FileUtil.usingTemporaryDirectory("rust2cpgTestInput") { inputDir =>
+        writeFile(
+          inputDir / "Cargo.toml",
+          """[workspace]
+            |members = ["crates/core", "crates/cli"]
+            |""".stripMargin
+        )
+        writeFile(
+          inputDir / "crates" / "core" / "Cargo.toml",
+          """[package]
+            |name = "core"
+            |version = "0.1.0"
+            |edition = "2021"
+            |""".stripMargin
+        )
+        writeFile(inputDir / "crates" / "core" / "src" / "lib.rs", "pub fn core_fn() -> u32 { 42 }")
+        writeFile(
+          inputDir / "crates" / "cli" / "Cargo.toml",
+          """[package]
+            |name = "cli"
+            |version = "0.1.0"
+            |edition = "2021"
+            |
+            |[dependencies]
+            |core = { path = "../core" }
+            |""".stripMargin
+        )
+        writeFile(inputDir / "crates" / "cli" / "src" / "main.rs", "fn main() { println!(\"{}\", core::core_fn()); }")
+
+        FileUtil.usingTemporaryDirectory("rust2cpgTestOut") { outputDir =>
+          val config = Config().withInputPath(inputDir.toString).withOutputPath(outputDir.toString)
+          val result = new RustAstGenRunner(config).execute(outputDir)
+          result.parsedFiles.sorted should contain theSameElementsAs Seq(
+            outputDir / "crates" / "cli" / "src" / "main.rs.json",
+            outputDir / "crates" / "core" / "src" / "lib.rs.json"
+          ).map(_.toString)
+        }
+      }
+
+    }
+
+    "parse a library project with tests, examples, and benches" in {
+      FileUtil.usingTemporaryDirectory("rust2cpgTestInput") { inputDir =>
+        writeFile(
+          inputDir / "Cargo.toml",
+          """[package]
+            |name = "mylib"
+            |version = "0.1.0"
+            |edition = "2021"
+            |""".stripMargin
+        )
+        writeFile(inputDir / "src" / "lib.rs", "pub fn lib_fn() -> bool { true }")
+        writeFile(inputDir / "tests" / "integration.rs", "#[test] fn it_works() { assert!(mylib::lib_fn()); }")
+        writeFile(inputDir / "examples" / "demo.rs", "fn main() { println!(\"demo\"); }")
+        writeFile(inputDir / "benches" / "bench.rs", "fn main() {}")
+
+        FileUtil.usingTemporaryDirectory("rust2cpgTestOut") { outputDir =>
+          val config = Config().withInputPath(inputDir.toString).withOutputPath(outputDir.toString)
+          val result = new RustAstGenRunner(config).execute(outputDir)
+          result.parsedFiles.sorted should contain theSameElementsAs Seq(
+            outputDir / "benches" / "bench.rs.json",
+            outputDir / "examples" / "demo.rs.json",
+            outputDir / "src" / "lib.rs.json",
+            outputDir / "tests" / "integration.rs.json"
+          ).map(_.toString)
+        }
+      }
+
+    }
+
+    "respect ignored files configuration" in {
+      FileUtil.usingTemporaryDirectory("rust2cpgTestInput") { inputDir =>
+        writeFile(
+          inputDir / "Cargo.toml",
+          """[package]
+            |name = "simple"
+            |version = "0.1.0"
+            |edition = "2021"
+            |""".stripMargin
+        )
+        writeFile(inputDir / "src" / "main.rs", "fn main() {}")
+        writeFile(inputDir / "src" / "lib.rs", "pub fn add(a: i32, b: i32) -> i32 { a + b }")
+        writeFile(inputDir / "src" / "utils" / "mod.rs", "pub fn greet() {}")
+
+        FileUtil.usingTemporaryDirectory("rust2cpgTestOut") { outputDir =>
+          val ignoredFile = (inputDir / "src" / "lib.rs").toString
+          val config = Config()
+            .withInputPath(inputDir.toString)
+            .withOutputPath(outputDir.toString)
+            .withIgnoredFiles(Seq(ignoredFile))
+          val result = new RustAstGenRunner(config).execute(outputDir)
+          result.parsedFiles.sorted should contain theSameElementsAs Seq(
+            outputDir / "src" / "main.rs.json",
+            outputDir / "src" / "utils" / "mod.rs.json"
+          ).map(_.toString)
+        }
+      }
+    }
+
+    "respect ignored files regex configuration" in {
+      FileUtil.usingTemporaryDirectory("rust2cpgTestInput") { inputDir =>
+        writeFile(
+          inputDir / "Cargo.toml",
+          """[package]
+            |name = "mylib"
+            |version = "0.1.0"
+            |edition = "2021"
+            |""".stripMargin
+        )
+        writeFile(inputDir / "src" / "lib.rs", "pub fn lib_fn() -> bool { true }")
+        writeFile(inputDir / "tests" / "integration.rs", "#[test] fn it_works() { assert!(mylib::lib_fn()); }")
+        writeFile(inputDir / "examples" / "demo.rs", "fn main() { println!(\"demo\"); }")
+        writeFile(inputDir / "benches" / "bench.rs", "fn main() {}")
+
+        FileUtil.usingTemporaryDirectory("rust2cpgTestOut") { outputDir =>
+          val config = Config()
+            .withInputPath(inputDir.toString)
+            .withOutputPath(outputDir.toString)
+            .withIgnoredFilesRegex(".*bench.*")
+          val result = new RustAstGenRunner(config).execute(outputDir)
+          result.parsedFiles.sorted should contain theSameElementsAs Seq(
+            outputDir / "examples" / "demo.rs.json",
+            outputDir / "src" / "lib.rs.json",
+            outputDir / "tests" / "integration.rs.json"
+          ).map(_.toString)
+        }
+      }
+    }
+
+    "parse a project with a non-standard layout" in {
+      FileUtil.usingTemporaryDirectory("rust2cpgTestInput") { inputDir =>
+        writeFile(
+          inputDir / "Cargo.toml",
+          """[package]
+            |name = "custom_layout"
+            |version = "0.1.0"
+            |edition = "2021"
+            |
+            |[[bin]]
+            |name = "app"
+            |path = "bin/app.rs"
+            |""".stripMargin
+        )
+        writeFile(inputDir / "bin" / "app.rs", "fn main() { println!(\"app\"); }")
+        writeFile(inputDir / "src" / "lib.rs", "pub fn lib_fn() {}")
+
+        FileUtil.usingTemporaryDirectory("rust2cpgTestOut") { outputDir =>
+          val config = Config().withInputPath(inputDir.toString).withOutputPath(outputDir.toString)
+          val result = new RustAstGenRunner(config).execute(outputDir)
+          result.parsedFiles.sorted should contain theSameElementsAs Seq(
+            outputDir / "bin" / "app.rs.json",
+            outputDir / "src" / "lib.rs.json"
+          ).map(_.toString)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
* integrates `rust_ast_gen`
* ci: installs rust, since `rust_ast_gen` relies on `cargo` to understand the project being scanned -- added to workflows that run `sbt test` at some point.