### PR TITLE
[php2cpg] fix: slice file content bytes instead of string

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
@@ -32,23 +32,17 @@ class AstCreator(
     with AstForFunctionsCreator
     with AstForTypesCreator {
 
-  protected val logger: Logger            = LoggerFactory.getLogger(AstCreator.getClass)
-  protected val scope                     = new Scope(summary)
-  protected var fileContentBytes          = Array.empty[Byte]
-  protected val fileContentString: String = getFileContents
-  protected var fileContent               = Option.empty[String]
-  protected var fileCharset: Charset      = StandardCharsets.UTF_8
-
-  private def getFileContents: String = {
-    val filePath = Path.of(fileName)
-    fileContentBytes = Files.readAllBytes(filePath)
-    fileCharset = Try(Charset.forName(UniversalDetector.detectCharset(filePath))).getOrElse(StandardCharsets.UTF_8)
-    new String(fileContentBytes, fileCharset)
-  }
+  protected val logger: Logger   = LoggerFactory.getLogger(AstCreator.getClass)
+  protected val scope            = new Scope(summary)
+  protected val filePath         = Path.of(fileName)
+  protected val fileContentBytes = Files.readAllBytes(filePath)
+  protected val fileCharset: Charset =
+    Try(Charset.forName(UniversalDetector.detectCharset(filePath))).getOrElse(StandardCharsets.UTF_8)
+  protected var fileContent = Option.empty[String]
 
   override def createAst(): DiffGraphBuilder = {
     if (!disableFileContent) {
-      fileContent = Option(fileContentString)
+      fileContent = Option(new String(fileContentBytes, fileCharset))
     }
 
     val ast = astForPhpFile(phpAst)

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreatorHelper.scala
@@ -111,7 +111,7 @@ trait AstCreatorHelper(disableFileContent: Boolean)(implicit withSchemaValidatio
   }
 
   protected def codeForExpr(expr: PhpExpr): String = {
-    fileContentString.substring(expr.attributes.startFilePos, expr.attributes.endFilePos)
+    new String(fileContentBytes.slice(expr.attributes.startFilePos, expr.attributes.endFilePos), fileCharset)
   }
 
   protected def codeForSingleArrayTmpElemAssign(targetName: String, key: Option[PhpExpr], value: PhpExpr): String = {

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/OffsetTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/OffsetTests.scala
@@ -2,7 +2,7 @@ package io.joern.php2cpg.querying
 
 import io.joern.php2cpg.Config
 import io.joern.php2cpg.testfixtures.PhpCode2CpgFixture
-import io.shiftleft.codepropertygraph.generated.nodes.Call
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, ControlStructure}
 import io.shiftleft.semanticcpg.language.*
 
 import java.nio.charset.StandardCharsets
@@ -16,28 +16,23 @@ class OffsetTests extends PhpCode2CpgFixture {
         |
         |// ääú
         |
-        |print("hello");
+        |foreach ($arr as $key => $val) {};
         |""".stripMargin,
       "test.php",
       StandardCharsets.ISO_8859_1
     ).withConfig(contentEnabled)
 
     "have correct offsets" in {
-      inside(cpg.call.name("print").l) {
-        case (printCall: Call) :: Nil =>
-          printCall.offset shouldBe Some(15)
-          printCall.offsetEnd shouldBe Some(29)
-        case xs =>
-          fail(s"Expected a single 'print' call, instead got ${xs.count}")
+      inside(cpg.controlStructure.l) { case (forEach: ControlStructure) :: Nil =>
+        forEach.code shouldBe "foreach ($arr as $key => $val)"
+        forEach.offset shouldBe Some(15)
+        forEach.offsetEnd shouldBe Some(48)
       }
     }
 
     "contain the correct symbol for the print call" in {
-      inside(cpg.call.name("print").l) {
-        case (printCall: Call) :: Nil =>
-          printCall.location.symbol shouldBe """print("hello")"""
-        case xs =>
-          fail(s"Expected a single 'print' call, instead got ${xs.count}")
+      inside(cpg.controlStructure.l) { case (forEach: ControlStructure) :: Nil =>
+        forEach.location.symbol shouldBe """foreach ($arr as $key => $val) {}"""
       }
     }
   }
@@ -48,28 +43,23 @@ class OffsetTests extends PhpCode2CpgFixture {
         |
         |// ääú
         |
-        |print("hello");
+        |foreach ($arr as $key => $val) {};
         |""".stripMargin,
       "test.php",
       StandardCharsets.UTF_8
     ).withConfig(contentEnabled)
 
     "have correct offsets" in {
-      inside(cpg.call.name("print").l) {
-        case (printCall: Call) :: Nil =>
-          printCall.offset shouldBe Some(15)
-          printCall.offsetEnd shouldBe Some(29)
-        case xs =>
-          fail(s"Expected a single 'print' call, instead got ${xs.count}")
+      inside(cpg.controlStructure.l) { case (forEach: ControlStructure) :: Nil =>
+        forEach.code shouldBe "foreach ($arr as $key => $val)"
+        forEach.offset shouldBe Some(15)
+        forEach.offsetEnd shouldBe Some(48)
       }
     }
 
     "contain the correct symbol for the print call" in {
-      inside(cpg.call.name("print").l) {
-        case (printCall: Call) :: Nil =>
-          printCall.location.symbol shouldBe """print("hello")"""
-        case xs =>
-          fail(s"Expected a single 'print' call, instead got ${xs.count}")
+      inside(cpg.controlStructure.l) { case (forEach: ControlStructure) :: Nil =>
+        forEach.location.symbol shouldBe """foreach ($arr as $key => $val) {}"""
       }
     }
   }


### PR DESCRIPTION
- `codeForExpr` slices `fileContentString` using the byte offsets. This is incorrect and leads to crashes (and potentially incorrect output) when the expression passed to `codeForExpr` has `startFilePos` and `endFilePos` exceeding the size of the string.
- The correct approach is to first slice the byte array then decode after. 