### PR TITLE
[frontend] Update astgen URLs to reference monorepo

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/build.sbt
+++ b/joern-cli/frontends/csharpsrc2cpg/build.sbt
@@ -43,7 +43,7 @@ lazy val AstgenMac      = "dotnetastgen-macos"
 lazy val AllPlatforms = Seq(AstgenWin, AstgenLinux, AstgenLinuxArm, AstgenMac)
 
 lazy val astGenDlUrl = settingKey[String]("astgen download url")
-astGenDlUrl := s"https://github.com/joernio/DotNetAstGen/releases/download/v${astGenVersion.value}/"
+astGenDlUrl := s"https://github.com/joernio/astgen-monorepo/releases/download/dotnet-astgen/v${astGenVersion.value}/"
 
 def hasCompatibleAstGenVersion(astGenVersion: String): Boolean = {
   Try("dotnetastgen --version".!!).toOption.map(_.strip()) match {

--- a/joern-cli/frontends/gosrc2cpg/build.sbt
+++ b/joern-cli/frontends/gosrc2cpg/build.sbt
@@ -38,7 +38,7 @@ lazy val GoAstgenMac      = "goastgen-macos"
 lazy val GoAstgenMacArm   = "goastgen-macos-arm64"
 
 lazy val goAstGenDlUrl = settingKey[String]("goastgen download url")
-goAstGenDlUrl := s"https://github.com/joernio/goastgen/releases/download/v${goAstGenVersion.value}/"
+goAstGenDlUrl := s"https://github.com/joernio/astgen-monorepo/releases/download/go-astgen/v${goAstGenVersion.value}/"
 
 def hasCompatibleAstGenVersion(goAstGenVersion: String): Boolean = {
   Try("goastgen -version".!!).toOption.map(_.strip()) match {

--- a/joern-cli/frontends/jssrc2cpg/README.md
+++ b/joern-cli/frontends/jssrc2cpg/README.md
@@ -18,13 +18,13 @@ of the build process. To build jssrc2cpg issue the command `sbt stage`.
 
 ## JS/TS AST Generation
 
-jssrc2cpg uses [joernio/astgen](https://github.com/joernio/astgen) under the hood.
-Native binaries for Linux, macOS, and Windows are generated as described [here](https://github.com/joernio/astgen#building).
+jssrc2cpg uses [joernio/astgen-monorepo](https://github.com/joernio/astgen-monorepo/tree/main/javascript-astgen) under the hood.
+Native binaries for Linux, macOS, and Windows are generated as described [here](https://github.com/joernio/astgen-monorepo/tree/main/javascript-astgen#building).
 To build your own native binaries run the following commands:
 
 ```shell script
-git clone https://github.com/joernio/astgen.git
-cd astgen
+git clone https://github.com/joernio/astgen-monorepo.git
+cd astgen-monorepo/javascript-astgen
 yarn install
 ```
 (requires `yarn`).

--- a/joern-cli/frontends/jssrc2cpg/build.sbt
+++ b/joern-cli/frontends/jssrc2cpg/build.sbt
@@ -42,7 +42,7 @@ lazy val AstgenMacAmd64   = "astgen-macos"
 lazy val AstgenMacArmV8   = "astgen-macos-arm"
 
 lazy val astGenDlUrl = settingKey[String]("astgen download url")
-astGenDlUrl := s"https://github.com/joernio/astgen/releases/download/v${astGenVersion.value}/"
+astGenDlUrl := s"https://github.com/joernio/astgen-monorepo/releases/download/javascript-astgen/v${astGenVersion.value}/"
 
 def hasCompatibleAstGenVersion(astGenVersion: String): Boolean = {
   Try("astgen --version".!!).toOption.map(_.strip()) match {

--- a/joern-cli/frontends/rubysrc2cpg/README.md
+++ b/joern-cli/frontends/rubysrc2cpg/README.md
@@ -2,7 +2,7 @@
 
 A `parser` Gem based parser for Ruby source code that creates code property graphs according to the specification at https://github.com/ShiftLeftSecurity/codepropertygraph .
 
-The `parser` Gem is wrapped around a Ruby application [ruby_ast_gen](https://github.com/joernio/ruby_ast_gen) that is
+The `parser` Gem is wrapped around a Ruby application [ruby_ast_gen](https://github.com/joernio/astgen-monorepo/tree/main/ruby-astgen) that is
 then embedded under `src/main/resources` and executed during runtime using JRuby.
 
 To update this, set the version under `src/main/resources/application.conf` and run `sbt rubysrc2cpg/astGenDlTask`.

--- a/joern-cli/frontends/rubysrc2cpg/build.sbt
+++ b/joern-cli/frontends/rubysrc2cpg/build.sbt
@@ -38,7 +38,7 @@ lazy val astGenVersion = settingKey[String]("`ruby_ast_gen` version")
 astGenVersion := appProperties.value.getString("rubysrc2cpg.ruby_ast_gen_version")
 
 lazy val astGenDlUrl = settingKey[String]("astgen download url")
-astGenDlUrl := s"https://github.com/joernio/ruby_ast_gen/releases/download/v${astGenVersion.value}/"
+astGenDlUrl := s"https://github.com/joernio/astgen-monorepo/releases/download/ruby-astgen/v${astGenVersion.value}/"
 
 def hasCompatibleAstGenVersion(astGenBaseDir: File, astGenVersion: String): Boolean = {
   val versionFile = astGenBaseDir / "lib" / "ruby_ast_gen" / "version.rb"

--- a/joern-cli/frontends/rust2cpg/build.sbt
+++ b/joern-cli/frontends/rust2cpg/build.sbt
@@ -38,7 +38,7 @@ lazy val AstgenMac      = "rust_ast_gen-macos"
 lazy val AstgenMacArm   = "rust_ast_gen-macos-arm"
 
 lazy val astGenDlUrl = settingKey[String]("rust_ast_gen download url")
-astGenDlUrl := s"https://github.com/joernio/rust_ast_gen/releases/download/v${astGenVersion.value}/"
+astGenDlUrl := s"https://github.com/joernio/astgen-monorepo/releases/download/rust-astgen/v${astGenVersion.value}/"
 
 def hasCompatibleAstGenVersion(astGenVersion: String): Boolean = {
   Try("rust_ast_gen --version".!!).toOption.map(_.strip().stripPrefix("rust_ast_gen ")) match {

--- a/joern-cli/frontends/swiftsrc2cpg/README.md
+++ b/joern-cli/frontends/swiftsrc2cpg/README.md
@@ -18,13 +18,13 @@ of the build process. To build swiftsrc2cpg issue the command `sbt stage`.
 
 ## Swift AST Generation
 
-swiftsrc2cpg uses [joernio/swiftastgen](https://github.com/joernio/swiftastgen) under the hood.
-Native binaries for Linux, macOS, and Windows are generated as described [here](https://github.com/joernio/swiftastgen#building).
+swiftsrc2cpg uses [joernio/astgen-monorepo](https://github.com/joernio/astgen-monorepo/tree/main/swift-astgen) under the hood.
+Native binaries for Linux, macOS, and Windows are generated as described [here](https://github.com/joernio/astgen-monorepo/tree/main/swift-astgen#building).
 To build your own native binaries run the following commands:
 
 ```shell script
-git clone https://github.com/joernio/swiftastgen.git
-cd swiftastgen
+git clone https://github.com/joernio/astgen-monorepo.git
+cd astgen-monorepo/swift-astgen
 swift build
 ```
 (requires `swift`).

--- a/joern-cli/frontends/swiftsrc2cpg/build.sbt
+++ b/joern-cli/frontends/swiftsrc2cpg/build.sbt
@@ -46,7 +46,7 @@ lazy val AstgenLinuxArm = "SwiftAstGen-linux-arm64"
 lazy val AstgenMac      = "SwiftAstGen-mac"
 
 lazy val astGenDlUrl = settingKey[String]("astgen download url")
-astGenDlUrl := s"https://github.com/joernio/swiftastgen/releases/download/v${astGenVersion.value}/"
+astGenDlUrl := s"https://github.com/joernio/astgen-monorepo/releases/download/swift-astgen/v${astGenVersion.value}/"
 
 def hasCompatibleAstGenVersion(astGenVersion: String): Boolean = {
   Try("SwiftAstGen -h".!).toOption match {


### PR DESCRIPTION
Migrate from individual astgen repositories to the consolidated astgen-monorepo structure. Updates download URLs in build files and documentation links in READMEs.

- JavaScript: github.com/joernio/astgen → astgen-monorepo/javascript-astgen
- Go: github.com/joernio/goastgen → astgen-monorepo/go-astgen
- Swift: github.com/joernio/swiftastgen → astgen-monorepo/swift-astgen
- Rust: github.com/joernio/rust_ast_gen → astgen-monorepo/rust-astgen
- Ruby: github.com/joernio/ruby_ast_gen → astgen-monorepo/ruby-astgen
- C#/.NET: github.com/joernio/DotNetAstGen → astgen-monorepo/dotnet-astgen