### PR TITLE
[rubysrc2cpg] Remove fail(...) usage in tests

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/RubyTypeRecoveryTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/passes/RubyTypeRecoveryTests.scala
@@ -86,19 +86,15 @@ class RubyInternalTypeRecoveryTests extends RubyCode2CpgFixture(withPostProcessi
                      |""".stripMargin)
 
     "propagate function return types" in {
-      inside(cpg.method.name("func2?").l) {
-        case func :: func2 :: Nil =>
-          func.methodReturn.typeFullName shouldBe Defines.prefixAsCoreType("String")
-          func2.methodReturn.typeFullName shouldBe Defines.prefixAsCoreType("String")
-        case xs => fail(s"Expected 2 functions, got [${xs.name.mkString(",")}]")
+      inside(cpg.method.name("func2?").l) { case func :: func2 :: Nil =>
+        func.methodReturn.typeFullName shouldBe Defines.prefixAsCoreType("String")
+        func2.methodReturn.typeFullName shouldBe Defines.prefixAsCoreType("String")
       }
     }
 
     "propagate return type to identifier c" in {
-      inside(cpg.identifier.name("c").l) {
-        case cIdent :: Nil =>
-          cIdent.typeFullName shouldBe Defines.prefixAsCoreType("String")
-        case xs => fail(s"Expected one identifier for c, got [${xs.name.mkString(",")}]")
+      inside(cpg.identifier.name("c").l) { case cIdent :: Nil =>
+        cIdent.typeFullName shouldBe Defines.prefixAsCoreType("String")
       }
     }
   }
@@ -133,18 +129,13 @@ class RubyInternalTypeRecoveryTests extends RubyCode2CpgFixture(withPostProcessi
     "propagate to assigned variable" ignore {
       inside(cpg.file("test1.rb").method.name(":program").call.nameExact("<operator>.assignment").l) {
         case funcAssignment :: constructAssignment :: tmpAssignment :: Nil =>
-          inside(funcAssignment.argument.l) {
-            case (lhs: Identifier) :: rhs :: Nil =>
-              lhs.typeFullName shouldBe Defines.prefixAsCoreType("String")
-            case xs => fail(s"Expected lhs and rhs, got [${xs.code.mkString(",")}] ")
+          inside(funcAssignment.argument.l) { case (lhs: Identifier) :: rhs :: Nil =>
+            lhs.typeFullName shouldBe Defines.prefixAsCoreType("String")
           }
 
-          inside(constructAssignment.argument.l) {
-            case (lhs: Identifier) :: rhs :: Nil =>
-              lhs.typeFullName shouldBe s"test2.rb:$Main.Test2A"
-            case xs => fail(s"Expected lhs and rhs, got [${xs.code.mkString(",")}]")
+          inside(constructAssignment.argument.l) { case (lhs: Identifier) :: rhs :: Nil =>
+            lhs.typeFullName shouldBe s"test2.rb:$Main.Test2A"
           }
-        case xs => fail(s"Expected lhs and rhs, got [${xs.code.mkString(",")}]")
       }
     }
   }
@@ -165,11 +156,9 @@ class RubyInternalTypeRecoveryTests extends RubyCode2CpgFixture(withPostProcessi
 
     // TODO: Revisit
     "propagate to identifier" ignore {
-      inside(cpg.identifier.name("(a|b)").l) {
-        case aIdent :: bIdent :: Nil =>
-          aIdent.typeFullName shouldBe s"Test0.rb:$Main.A"
-          bIdent.typeFullName shouldBe s"Test0.rb:$Main.A"
-        case xs => fail(s"Expected one identifier, got [${xs.name.mkString(",")}]")
+      inside(cpg.identifier.name("(a|b)").l) { case aIdent :: bIdent :: Nil =>
+        aIdent.typeFullName shouldBe s"Test0.rb:$Main.A"
+        bIdent.typeFullName shouldBe s"Test0.rb:$Main.A"
       }
     }
   }
@@ -200,21 +189,17 @@ class RubyExternalTypeRecoveryTests
     }
 
     "resolve correct imports via tag nodes" in {
-      inside(cpg.call.where(_.referencedImports).l) {
-        case sendgridImport :: Nil =>
-          inside(
-            sendgridImport.tag._toEvaluatedImport
-              .filter(_.label == EvaluatedImport.RESOLVED_METHOD)
-              .map(_.asInstanceOf[ResolvedMethod])
-              .filter(_.fullName.startsWith("sendgrid-ruby.SendGrid.API"))
-              .l
-          ) {
-            case apiClassInit :: apiInit :: Nil =>
-              apiInit.fullName shouldBe s"sendgrid-ruby.SendGrid.API.${Defines.Initialize}"
-              apiClassInit.fullName shouldBe s"sendgrid-ruby.SendGrid.API<class>.${Defines.Initialize}"
-            case xs => fail(s"Two ResolvedMethods expected, got [${xs.mkString(",")}]")
-          }
-        case xs => fail(s"Only sendgrid-ruby should be referenced, got [${xs.name.mkString}]")
+      inside(cpg.call.where(_.referencedImports).l) { case sendgridImport :: Nil =>
+        inside(
+          sendgridImport.tag._toEvaluatedImport
+            .filter(_.label == EvaluatedImport.RESOLVED_METHOD)
+            .map(_.asInstanceOf[ResolvedMethod])
+            .filter(_.fullName.startsWith("sendgrid-ruby.SendGrid.API"))
+            .l
+        ) { case apiClassInit :: apiInit :: Nil =>
+          apiInit.fullName shouldBe s"sendgrid-ruby.SendGrid.API.${Defines.Initialize}"
+          apiClassInit.fullName shouldBe s"sendgrid-ruby.SendGrid.API<class>.${Defines.Initialize}"
+        }
       }
     }
 
@@ -320,20 +305,16 @@ class RubyExternalTypeRecoveryTests
       .moreCode(RubyExternalTypeRecoveryTests.LOGGER_GEMFILE, "Gemfile")
 
     "resolve correct imports via tag nodes" in {
-      inside(cpg.call.where(_.referencedImports).l) {
-        case loggerImport :: Nil =>
-          inside(
-            loggerImport.tag._toEvaluatedImport
-              .filter(_.label == EvaluatedImport.RESOLVED_METHOD)
-              .map(_.asInstanceOf[ResolvedMethod])
-              .filter(_.fullName == s"logger.Logger.${Defines.Initialize}")
-              .l
-          ) {
-            case loggerInit :: Nil =>
-              loggerInit.fullName shouldBe s"logger.Logger.${Defines.Initialize}"
-            case xs => fail(s"Two ResolvedMethods expected, got [${xs.mkString(",")}]")
-          }
-        case xs => fail(s"Only logger library should be referenced, got [${xs.name.mkString}]")
+      inside(cpg.call.where(_.referencedImports).l) { case loggerImport :: Nil =>
+        inside(
+          loggerImport.tag._toEvaluatedImport
+            .filter(_.label == EvaluatedImport.RESOLVED_METHOD)
+            .map(_.asInstanceOf[ResolvedMethod])
+            .filter(_.fullName == s"logger.Logger.${Defines.Initialize}")
+            .l
+        ) { case loggerInit :: Nil =>
+          loggerInit.fullName shouldBe s"logger.Logger.${Defines.Initialize}"
+        }
       }
     }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ArrayTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ArrayTests.scala
@@ -217,14 +217,12 @@ class ArrayTests extends RubyCode2CpgFixture {
   "shift-left operator interpreted as a call (append)" in {
     val cpg = code("[1, 2, 3] << 4")
 
-    inside(cpg.call("<<").headOption) {
-      case Some(append) =>
-        append.name shouldBe "<<"
-        append.methodFullName shouldBe XDefines.DynamicCallUnknownFullName
-        append.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
-        append.argument(0).code shouldBe "[1, 2, 3]"
-        append.argument(1).code shouldBe "4"
-      case None => fail(s"Expected call `<<`")
+    inside(cpg.call("<<").headOption) { case Some(append) =>
+      append.name shouldBe "<<"
+      append.methodFullName shouldBe XDefines.DynamicCallUnknownFullName
+      append.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
+      append.argument(0).code shouldBe "[1, 2, 3]"
+      append.argument(1).code shouldBe "4"
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ArrayTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ArrayTests.scala
@@ -171,20 +171,16 @@ class ArrayTests extends RubyCode2CpgFixture {
         |x = Array [1, 2, 3]
         |""".stripMargin)
 
-    inside(cpg.call.nameExact("[]").l) {
-      case bracketCall :: Nil =>
-        bracketCall.name shouldBe "[]"
-        bracketCall.methodFullName shouldBe s"${Defines.prefixAsCoreType("Array")}.[]"
-        bracketCall.typeFullName shouldBe Defines.prefixAsCoreType("Array")
+    inside(cpg.call.nameExact("[]").l) { case bracketCall :: Nil =>
+      bracketCall.name shouldBe "[]"
+      bracketCall.methodFullName shouldBe s"${Defines.prefixAsCoreType("Array")}.[]"
+      bracketCall.typeFullName shouldBe Defines.prefixAsCoreType("Array")
 
-        inside(bracketCall.argument.l) {
-          case _ :: one :: two :: three :: Nil =>
-            one.code shouldBe "1"
-            two.code shouldBe "2"
-            three.code shouldBe "3"
-          case xs => fail(s"Expected 3 literals under the array initializer, instead got [${xs.code.mkString(", ")}]")
-        }
-      case xs => fail(s"Expected a single array initializer call ([]), instead got [${xs.code.mkString(", ")}]")
+      inside(bracketCall.argument.l) { case _ :: one :: two :: three :: Nil =>
+        one.code shouldBe "1"
+        two.code shouldBe "2"
+        three.code shouldBe "3"
+      }
     }
 
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/AttributeAccessorTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/AttributeAccessorTests.scala
@@ -13,25 +13,21 @@ class AttributeAccessorTests extends RubyCode2CpgFixture {
                      |x.y = 1
                      |""".stripMargin)
 
-    inside(cpg.assignment.where(_.source.isLiteral.codeExact("1")).l) {
-      case xyAssign :: Nil =>
-        xyAssign.lineNumber shouldBe Some(2)
-        xyAssign.code shouldBe "x.y = 1"
+    inside(cpg.assignment.where(_.source.isLiteral.codeExact("1")).l) { case xyAssign :: Nil =>
+      xyAssign.lineNumber shouldBe Some(2)
+      xyAssign.code shouldBe "x.y = 1"
 
-        val fieldTarget = xyAssign.target.asInstanceOf[Call]
-        fieldTarget.code shouldBe "x.y"
-        fieldTarget.name shouldBe Operators.fieldAccess
-        fieldTarget.methodFullName shouldBe Operators.fieldAccess
-        fieldTarget.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+      val fieldTarget = xyAssign.target.asInstanceOf[Call]
+      fieldTarget.code shouldBe "x.y"
+      fieldTarget.name shouldBe Operators.fieldAccess
+      fieldTarget.methodFullName shouldBe Operators.fieldAccess
+      fieldTarget.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
 
-        inside(fieldTarget.argument.l) {
-          case (base: Identifier) :: (field: FieldIdentifier) :: Nil =>
-            base.name shouldBe "x"
-            field.canonicalName shouldBe "@y"
-            field.code shouldBe "y"
-          case xs => fail("Expected field access to have two targets")
-        }
-      case xs => fail("Expected a single assignment to the literal `1`")
+      inside(fieldTarget.argument.l) { case (base: Identifier) :: (field: FieldIdentifier) :: Nil =>
+        base.name shouldBe "x"
+        field.canonicalName shouldBe "@y"
+        field.code shouldBe "y"
+      }
     }
   }
 
@@ -41,22 +37,18 @@ class AttributeAccessorTests extends RubyCode2CpgFixture {
                      |b = x.z()
                      |""".stripMargin)
     // Test the field access
-    inside(cpg.fieldAccess.lineNumber(2).codeExact("x.y").l) {
-      case xyCall :: Nil =>
-        xyCall.lineNumber shouldBe Some(2)
-        xyCall.code shouldBe "x.y"
-        xyCall.methodFullName shouldBe Operators.fieldAccess
-        xyCall.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-      case xs => fail("Expected a single field access for `x.y`")
+    inside(cpg.fieldAccess.lineNumber(2).codeExact("x.y").l) { case xyCall :: Nil =>
+      xyCall.lineNumber shouldBe Some(2)
+      xyCall.code shouldBe "x.y"
+      xyCall.methodFullName shouldBe Operators.fieldAccess
+      xyCall.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
     }
     // Test an explicit call with parenthesis
-    inside(cpg.call("z").lineNumber(3).l) {
-      case xzCall :: Nil =>
-        xzCall.lineNumber shouldBe Some(3)
-        xzCall.code shouldBe "x.z()"
-        xzCall.methodFullName shouldBe Defines.DynamicCallUnknownFullName
-        xzCall.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
-      case xs => fail("Expected a single call for `x.z()`")
+    inside(cpg.call("z").lineNumber(3).l) { case xzCall :: Nil =>
+      xzCall.lineNumber shouldBe Some(3)
+      xzCall.code shouldBe "x.z()"
+      xzCall.methodFullName shouldBe Defines.DynamicCallUnknownFullName
+      xzCall.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CallTests.scala
@@ -147,7 +147,6 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true) {
           baz.code shouldBe "\"baz\""
           baz.argumentIndex shouldBe 2
           baz.argumentName shouldBe Option("bar")
-        case xs => fail(s"Invalid call arguments! Got [${xs.code.mkString(", ")}]")
       }
     }
   }
@@ -166,57 +165,46 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true) {
       inside(cpg.method.isModule.assignment.and(_.target.isIdentifier.name("a"), _.source.isBlock).l) {
         case assignment :: Nil =>
           assignment.code shouldBe "a = A.new 1, 2"
-          inside(assignment.argument.l) {
-            case (a: Identifier) :: (_: Block) :: Nil =>
-              a.name shouldBe "a"
-              a.dynamicTypeHintFullName should contain(s"Test0.rb:$Main.A")
-            case xs => fail(s"Expected one identifier and one call argument, got [${xs.code.mkString(",")}]")
+          inside(assignment.argument.l) { case (a: Identifier) :: (_: Block) :: Nil =>
+            a.name shouldBe "a"
+            a.dynamicTypeHintFullName should contain(s"Test0.rb:$Main.A")
           }
-        case xs => fail(s"Expected a single assignment, got [${xs.code.mkString(",")}]")
       }
     }
 
     "create an assignment from a temp variable to the alloc call" in {
-      inside(cpg.method.isModule.assignment.where(_.target.isIdentifier.name("<tmp-1>")).l) {
-        case assignment :: Nil =>
-          inside(assignment.argument.l) {
-            case (a: Identifier) :: (alloc: Call) :: Nil =>
-              a.name shouldBe "<tmp-1>"
+      inside(cpg.method.isModule.assignment.where(_.target.isIdentifier.name("<tmp-1>")).l) { case assignment :: Nil =>
+        inside(assignment.argument.l) { case (a: Identifier) :: (alloc: Call) :: Nil =>
+          a.name shouldBe "<tmp-1>"
 
-              alloc.name shouldBe Operators.alloc
-              alloc.methodFullName shouldBe Operators.alloc
-              alloc.code shouldBe "A.new 1, 2"
-              alloc.argument.size shouldBe 0
-            case xs => fail(s"Expected one identifier and one call argument, got [${xs.code.mkString(",")}]")
-          }
-        case xs => fail(s"Expected a single assignment, got [${xs.code.mkString(",")}]")
+          alloc.name shouldBe Operators.alloc
+          alloc.methodFullName shouldBe Operators.alloc
+          alloc.code shouldBe "A.new 1, 2"
+          alloc.argument.size shouldBe 0
+        }
       }
     }
 
     "create a call to the object's constructor, with the temp variable receiver" in {
-      inside(cpg.call.nameExact(RubyDefines.Initialize).l) {
-        case constructor :: Nil =>
-          inside(constructor.argument.l) {
-            case (a: Identifier) :: (one: Literal) :: (two: Literal) :: Nil =>
-              a.name shouldBe "<tmp-1>"
-              a.typeFullName shouldBe s"Test0.rb:$Main.A"
-              a.argumentIndex shouldBe 0
+      inside(cpg.call.nameExact(RubyDefines.Initialize).l) { case constructor :: Nil =>
+        inside(constructor.argument.l) { case (a: Identifier) :: (one: Literal) :: (two: Literal) :: Nil =>
+          a.name shouldBe "<tmp-1>"
+          a.typeFullName shouldBe s"Test0.rb:$Main.A"
+          a.argumentIndex shouldBe 0
 
-              one.code shouldBe "1"
-              two.code shouldBe "2"
-            case xs => fail(s"Expected one identifier and one call argument, got [${xs.code.mkString(",")}]")
-          }
+          one.code shouldBe "1"
+          two.code shouldBe "2"
+        }
 
-          val recv = constructor.receiver.head.asInstanceOf[Call]
-          recv.methodFullName shouldBe Operators.fieldAccess
-          recv.name shouldBe Operators.fieldAccess
-          recv.code shouldBe s"A.${RubyDefines.Initialize}"
+        val recv = constructor.receiver.head.asInstanceOf[Call]
+        recv.methodFullName shouldBe Operators.fieldAccess
+        recv.name shouldBe Operators.fieldAccess
+        recv.code shouldBe s"A.${RubyDefines.Initialize}"
 
-          recv.argument(1).label shouldBe NodeTypes.CALL
-          recv.argument(1).code shouldBe "self.A"
-          recv.argument(2).label shouldBe NodeTypes.FIELD_IDENTIFIER
-          recv.argument(2).code shouldBe RubyDefines.Initialize
-        case xs => fail(s"Expected a single alloc, got [${xs.code.mkString(",")}]")
+        recv.argument(1).label shouldBe NodeTypes.CALL
+        recv.argument(1).code shouldBe "self.A"
+        recv.argument(2).label shouldBe NodeTypes.FIELD_IDENTIFIER
+        recv.argument(2).code shouldBe RubyDefines.Initialize
       }
     }
   }
@@ -228,38 +216,34 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true) {
         |""".stripMargin)
 
     "create a call node on the receiver end of the constructor lowering" in {
-      inside(cpg.call.nameExact(RubyDefines.Initialize).l) {
-        case constructor :: Nil =>
-          inside(constructor.argument.l) {
-            case (a: Identifier) :: (selfPath: Call) :: Nil =>
-              a.name shouldBe "<tmp-0>"
-              a.typeFullName shouldBe Defines.Any
-              a.argumentIndex shouldBe 0
+      inside(cpg.call.nameExact(RubyDefines.Initialize).l) { case constructor :: Nil =>
+        inside(constructor.argument.l) { case (a: Identifier) :: (selfPath: Call) :: Nil =>
+          a.name shouldBe "<tmp-0>"
+          a.typeFullName shouldBe Defines.Any
+          a.argumentIndex shouldBe 0
 
-              selfPath.code shouldBe "self.path"
-            case xs => fail(s"Expected one identifier and one call argument, got [${xs.code.mkString(",")}]")
-          }
+          selfPath.code shouldBe "self.path"
+        }
 
-          val recv = constructor.receiver.head.asInstanceOf[Call]
-          recv.methodFullName shouldBe Operators.fieldAccess
-          recv.name shouldBe Operators.fieldAccess
-          recv.code shouldBe s"(<tmp-2> = params[:type].constantize).${RubyDefines.Initialize}"
+        val recv = constructor.receiver.head.asInstanceOf[Call]
+        recv.methodFullName shouldBe Operators.fieldAccess
+        recv.name shouldBe Operators.fieldAccess
+        recv.code shouldBe s"(<tmp-2> = params[:type].constantize).${RubyDefines.Initialize}"
 
-          recv.argument(2).asInstanceOf[FieldIdentifier].canonicalName shouldBe RubyDefines.Initialize
+        recv.argument(2).asInstanceOf[FieldIdentifier].canonicalName shouldBe RubyDefines.Initialize
 
-          inside(recv.argument(1).start.isCall.argument(2).isCall.argument.l) {
-            case (paramsAssign: Call) :: (constantize: FieldIdentifier) :: Nil =>
-              paramsAssign.code shouldBe "<tmp-1> = params[:type]"
-              inside(paramsAssign.argument.l) { case (tmpIdent: Identifier) :: (indexAccess: Call) :: Nil =>
-                tmpIdent.name shouldBe "<tmp-1>"
+        inside(recv.argument(1).start.isCall.argument(2).isCall.argument.l) {
+          case (paramsAssign: Call) :: (constantize: FieldIdentifier) :: Nil =>
+            paramsAssign.code shouldBe "<tmp-1> = params[:type]"
+            inside(paramsAssign.argument.l) { case (tmpIdent: Identifier) :: (indexAccess: Call) :: Nil =>
+              tmpIdent.name shouldBe "<tmp-1>"
 
-                indexAccess.name shouldBe Operators.indexAccess
-                indexAccess.code shouldBe "params[:type]"
-              }
+              indexAccess.name shouldBe Operators.indexAccess
+              indexAccess.code shouldBe "params[:type]"
+            }
 
-              constantize.canonicalName shouldBe "constantize"
-          }
-        case xs => fail(s"Expected a single alloc, got [${xs.code.mkString(",")}]")
+            constantize.canonicalName shouldBe "constantize"
+        }
       }
     }
   }
@@ -274,11 +258,9 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true) {
         |""".stripMargin)
 
     "correctly create a `src` call instead of identifier" in {
-      inside(cpg.call("src").l) {
-        case src :: Nil =>
-          src.name shouldBe "src"
-          src.methodFullName shouldBe s"Test0.rb:$Main.src"
-        case xs => fail(s"Expected exactly one `src` call, instead got [${xs.code.mkString(",")}]")
+      inside(cpg.call("src").l) { case src :: Nil =>
+        src.name shouldBe "src"
+        src.methodFullName shouldBe s"Test0.rb:$Main.src"
       }
     }
   }
@@ -293,11 +275,9 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true) {
         |""".stripMargin)
 
     "correctly create a `src` call instead of identifier" in {
-      inside(cpg.call("src").l) {
-        case src :: Nil =>
-          src.name shouldBe "src"
-          src.methodFullName shouldBe s"Test0.rb:$Main.src"
-        case xs => fail(s"Expected exactly one `src` call, instead got [${xs.code.mkString(",")}]")
+      inside(cpg.call("src").l) { case src :: Nil =>
+        src.name shouldBe "src"
+        src.methodFullName shouldBe s"Test0.rb:$Main.src"
       }
     }
   }
@@ -322,12 +302,10 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true) {
         |foo(*args)
         |""".stripMargin)
 
-    inside(cpg.call("foo").argument.l) {
-      case _ :: (args: Call) :: Nil =>
-        args.methodFullName shouldBe RubyOperators.splat
-        args.code shouldBe "*args"
-        args.lineNumber shouldBe Some(3)
-      case xs => fail(s"Expected a single `*args` argument under `foo`, got [${xs.code.mkString(",")}]")
+    inside(cpg.call("foo").argument.l) { case _ :: (args: Call) :: Nil =>
+      args.methodFullName shouldBe RubyOperators.splat
+      args.code shouldBe "*args"
+      args.lineNumber shouldBe Some(3)
     }
   }
 
@@ -387,10 +365,8 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true) {
   "Object initialize calls should be DynamicUnknown" in {
     val cpg = code("""Date.new(2013, 19, 20)""")
 
-    inside(cpg.call.name(RubyDefines.Initialize).l) {
-      case initCall :: Nil =>
-        initCall.methodFullName shouldBe Defines.DynamicCallUnknownFullName
-      case xs => fail(s"Expected one call to initialize, got ${xs.code.mkString}")
+    inside(cpg.call.name(RubyDefines.Initialize).l) { case initCall :: Nil =>
+      initCall.methodFullName shouldBe Defines.DynamicCallUnknownFullName
     }
   }
 
@@ -433,25 +409,19 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true) {
         |foo([:b, :c => 1])
         |""".stripMargin)
 
-    inside(cpg.call.name("foo").l) {
-      case fooCall :: Nil =>
-        inside(fooCall.argument.l) {
-          case _ :: (arrayArg: Block) :: Nil =>
-            arrayArg.code shouldBe "[:b, :c => 1]"
+    inside(cpg.call.name("foo").l) { case fooCall :: Nil =>
+      inside(fooCall.argument.l) { case _ :: (arrayArg: Block) :: Nil =>
+        arrayArg.code shouldBe "[:b, :c => 1]"
 
-            inside(arrayArg.astChildren.l) {
-              case (_: Call) :: (elem1: Call) :: (elem2: Call) :: (_: Identifier) :: Nil =>
-                elem1.code shouldBe "<tmp-1>[0] = :b"
-                elem2.code shouldBe "<tmp-1>[1] = :c => 1"
+        inside(arrayArg.astChildren.l) { case (_: Call) :: (elem1: Call) :: (elem2: Call) :: (_: Identifier) :: Nil =>
+          elem1.code shouldBe "<tmp-1>[0] = :b"
+          elem2.code shouldBe "<tmp-1>[1] = :c => 1"
 
-                elem1.methodFullName shouldBe Operators.assignment
-                elem2.methodFullName shouldBe Operators.assignment
-                elem2.argument(2).asInstanceOf[Call].methodFullName shouldBe RubyOperators.association
-              case xs => fail(s"Expected two args for elements, got ${xs.code.mkString(",")}")
-            }
-          case xs => fail(s"Expected two args, got ${xs.map(x => x.label -> x.code).mkString(",")}")
+          elem1.methodFullName shouldBe Operators.assignment
+          elem2.methodFullName shouldBe Operators.assignment
+          elem2.argument(2).asInstanceOf[Call].methodFullName shouldBe RubyOperators.association
         }
-      case xs => fail(s"Expected one call for foo, got ${xs.code.mkString}")
+      }
     }
   }
 
@@ -494,7 +464,6 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true) {
         registryScopeSplat.code shouldBe "*::Gitlab::Auth::REGISTRY_SCOPES"
         registryScopeSplat.methodFullName shouldBe RubyOperators.splat
 
-      case xs => fail(s"Expected 5 arguments for call, got [${xs.code.mkString(",")}]")
     }
   }
 
@@ -520,7 +489,6 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true) {
 
         numericLiteral.code shouldBe "10"
         numericLiteral.typeFullName shouldBe RubyDefines.prefixAsCoreType(RubyDefines.Integer)
-      case xs => fail(s"Expected 6 parameters for call, got [${xs.code.mkString(", ")}]")
     }
   }
 
@@ -529,20 +497,16 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true) {
         |foo(bar[:baz] => nil)
         |""".stripMargin)
 
-    inside(cpg.call.name("foo").argument.l) {
-      case _ :: (assocParam: Call) :: Nil =>
-        assocParam.methodFullName shouldBe RubyOperators.association
-        assocParam.code shouldBe "bar[:baz] => nil"
+    inside(cpg.call.name("foo").argument.l) { case _ :: (assocParam: Call) :: Nil =>
+      assocParam.methodFullName shouldBe RubyOperators.association
+      assocParam.code shouldBe "bar[:baz] => nil"
 
-        inside(assocParam.argument.l) {
-          case (lhs: Call) :: (rhs: Literal) :: Nil =>
-            lhs.methodFullName shouldBe Operators.indexAccess
-            lhs.code shouldBe "bar[:baz]"
+      inside(assocParam.argument.l) { case (lhs: Call) :: (rhs: Literal) :: Nil =>
+        lhs.methodFullName shouldBe Operators.indexAccess
+        lhs.code shouldBe "bar[:baz]"
 
-            rhs.code shouldBe "nil"
-          case xs => fail(s"Expected lhs and rhs for association, got [${xs.code.mkString(",")}]")
-        }
-      case xs => fail(s"Expected two params, got [${xs.code.mkString(",")}]")
+        rhs.code shouldBe "nil"
+      }
     }
   }
 
@@ -551,20 +515,16 @@ class CallTests extends RubyCode2CpgFixture(withPostProcessing = true) {
         |foo(bar.baz => nil)
         |""".stripMargin)
 
-    inside(cpg.call.name("foo").argument.l) {
-      case _ :: (assocParam: Call) :: Nil =>
-        assocParam.methodFullName shouldBe RubyOperators.association
-        assocParam.code shouldBe "bar.baz => nil"
+    inside(cpg.call.name("foo").argument.l) { case _ :: (assocParam: Call) :: Nil =>
+      assocParam.methodFullName shouldBe RubyOperators.association
+      assocParam.code shouldBe "bar.baz => nil"
 
-        inside(assocParam.argument.l) {
-          case (lhs: Call) :: (rhs: Literal) :: Nil =>
-            lhs.methodFullName shouldBe Operators.fieldAccess
-            lhs.code shouldBe "bar.baz"
+      inside(assocParam.argument.l) { case (lhs: Call) :: (rhs: Literal) :: Nil =>
+        lhs.methodFullName shouldBe Operators.fieldAccess
+        lhs.code shouldBe "bar.baz"
 
-            rhs.code shouldBe "nil"
-          case xs => fail(s"Expected lhs and rhs for association, got [${xs.code.mkString(",")}]")
-        }
-      case xs => fail(s"Expected two params, got [${xs.code.mkString(",")}]")
+        rhs.code shouldBe "nil"
+      }
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CaseTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CaseTests.scala
@@ -200,24 +200,19 @@ class CaseTests extends RubyCode2CpgFixture {
 
     inside(ifStmts.whenTrue.isBlock.astChildren.isCall.name(Operators.assignment).l) {
       case resultMatchAssignment :: notResultMatchAssignment :: Nil =>
-        inside(resultMatchAssignment.argument.l) {
-          case (lhs: Identifier) :: (rhs: Call) :: Nil =>
-            lhs.name shouldBe "result"
+        inside(resultMatchAssignment.argument.l) { case (lhs: Identifier) :: (rhs: Call) :: Nil =>
+          lhs.name shouldBe "result"
 
-            rhs.methodFullName shouldBe Operators.indexAccess
-            rhs.code shouldBe s"<tmp-0>[1]"
-          case xs => fail(s"Expected lhs and rhs, got [${xs.code.mkString(",")}]")
+          rhs.methodFullName shouldBe Operators.indexAccess
+          rhs.code shouldBe s"<tmp-0>[1]"
         }
 
-        inside(notResultMatchAssignment.argument.l) {
-          case (lhs: Identifier) :: (rhs: Call) :: Nil =>
-            lhs.name shouldBe "notResult"
+        inside(notResultMatchAssignment.argument.l) { case (lhs: Identifier) :: (rhs: Call) :: Nil =>
+          lhs.name shouldBe "notResult"
 
-            rhs.methodFullName shouldBe Operators.indexAccess
-            rhs.code shouldBe s"<tmp-0>[1]"
-          case xs => fail(s"Expected lhs and rhs, got [${xs.code.mkString(",")}]")
+          rhs.methodFullName shouldBe Operators.indexAccess
+          rhs.code shouldBe s"<tmp-0>[1]"
         }
-      case _ => fail(s"Expected two true branches")
     }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
@@ -363,32 +363,26 @@ class ClassTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "generate a type decl with the associated members" in {
-      inside(cpg.typeDecl.nameExact(s"Test0.rb:$Main.<anon-class-0>").l) {
-        case anonClass :: Nil =>
-          anonClass.name shouldBe s"Test0.rb:$Main.<anon-class-0>"
-          anonClass.fullName shouldBe s"Test0.rb:$Main.<anon-class-0>"
-          inside(anonClass.method.l) {
-            case hello :: defaultConstructor :: Nil =>
-              defaultConstructor.name shouldBe RubyDefines.Initialize
-              defaultConstructor.fullName shouldBe s"Test0.rb:$Main.<anon-class-0>.${RubyDefines.Initialize}"
+      inside(cpg.typeDecl.nameExact(s"Test0.rb:$Main.<anon-class-0>").l) { case anonClass :: Nil =>
+        anonClass.name shouldBe s"Test0.rb:$Main.<anon-class-0>"
+        anonClass.fullName shouldBe s"Test0.rb:$Main.<anon-class-0>"
+        inside(anonClass.method.l) { case hello :: defaultConstructor :: Nil =>
+          defaultConstructor.name shouldBe RubyDefines.Initialize
+          defaultConstructor.fullName shouldBe s"Test0.rb:$Main.<anon-class-0>.${RubyDefines.Initialize}"
 
-              hello.name shouldBe "hello"
-              hello.fullName shouldBe s"Test0.rb:$Main.<anon-class-0>.hello"
-            case xs => fail(s"Expected a single method, but got [${xs.map(x => x.label -> x.code).mkString(",")}]")
-          }
-        case xs => fail(s"Expected a single anonymous class, but got [${xs.map(x => x.label -> x.code).mkString(",")}]")
+          hello.name shouldBe "hello"
+          hello.fullName shouldBe s"Test0.rb:$Main.<anon-class-0>.hello"
+        }
       }
     }
 
     "generate an assignment to the variable `a` with the source being a constructor invocation of the class" in {
-      inside(cpg.method.isModule.assignment.l) {
-        case aAssignment :: tmpAssign :: Nil =>
-          aAssignment.target.code shouldBe "a"
-          aAssignment.source.code shouldBe s"(<tmp-0> = Class.new Test0.rb:$Main.<anon-class-0> (...)).new"
+      inside(cpg.method.isModule.assignment.l) { case aAssignment :: tmpAssign :: Nil =>
+        aAssignment.target.code shouldBe "a"
+        aAssignment.source.code shouldBe s"(<tmp-0> = Class.new Test0.rb:$Main.<anon-class-0> (...)).new"
 
-          tmpAssign.target.code shouldBe "<tmp-0>"
-          tmpAssign.source.code shouldBe s"self.Class.new Test0.rb:$Main.<anon-class-0> (...)"
-        case xs => fail(s"Expected a single assignment, but got [${xs.map(x => x.label -> x.code).mkString(",")}]")
+        tmpAssign.target.code shouldBe "<tmp-0>"
+        tmpAssign.source.code shouldBe s"self.Class.new Test0.rb:$Main.<anon-class-0> (...)"
       }
     }
 
@@ -412,37 +406,29 @@ class ClassTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "Create assignments to method refs for methods on singleton object" in {
-      inside(cpg.method.isModule.block.assignment.l) {
-        case _ :: _ :: _ :: barkAssignment :: legsAssignment :: Nil =>
-          inside(barkAssignment.argument.l) {
-            case (lhs: Call) :: (rhs: TypeRef) :: Nil =>
-              val List(identifier, fieldIdentifier) = lhs.argument.l: @unchecked
-              identifier.code shouldBe "animal"
-              fieldIdentifier.code shouldBe "bark"
+      inside(cpg.method.isModule.block.assignment.l) { case _ :: _ :: _ :: barkAssignment :: legsAssignment :: Nil =>
+        inside(barkAssignment.argument.l) { case (lhs: Call) :: (rhs: TypeRef) :: Nil =>
+          val List(identifier, fieldIdentifier) = lhs.argument.l: @unchecked
+          identifier.code shouldBe "animal"
+          fieldIdentifier.code shouldBe "bark"
 
-              rhs.typeFullName shouldBe s"Test0.rb:$Main.class<<animal.bark"
-            case xs => fail(s"Expected two arguments for assignment, got [${xs.code.mkString(",")}]")
-          }
+          rhs.typeFullName shouldBe s"Test0.rb:$Main.class<<animal.bark"
+        }
 
-          inside(legsAssignment.argument.l) {
-            case (lhs: Call) :: (rhs: TypeRef) :: Nil =>
-              val List(identifier, fieldIdentifier) = lhs.argument.l: @unchecked
-              identifier.code shouldBe "animal"
-              fieldIdentifier.code shouldBe "legs"
+        inside(legsAssignment.argument.l) { case (lhs: Call) :: (rhs: TypeRef) :: Nil =>
+          val List(identifier, fieldIdentifier) = lhs.argument.l: @unchecked
+          identifier.code shouldBe "animal"
+          fieldIdentifier.code shouldBe "legs"
 
-              rhs.typeFullName shouldBe s"Test0.rb:$Main.class<<animal.legs"
-            case xs => fail(s"Expected two arguments for assignment, got [${xs.code.mkString(",")}]")
-          }
-        case xs => fail(s"Expected five assignments, got [${xs.code.mkString(",")}]")
+          rhs.typeFullName shouldBe s"Test0.rb:$Main.class<<animal.legs"
+        }
       }
     }
 
     "Create TYPE_DECL nodes for two singleton methods" in {
-      inside(cpg.typeDecl.name("(bark|legs)").l) {
-        case barkTypeDecl :: legsTypeDecl :: Nil =>
-          barkTypeDecl.fullName shouldBe s"Test0.rb:$Main.class<<animal.bark"
-          legsTypeDecl.fullName shouldBe s"Test0.rb:$Main.class<<animal.legs"
-        case xs => fail(s"Expected two type_decls, got [${xs.code.mkString(",")}]")
+      inside(cpg.typeDecl.name("(bark|legs)").l) { case barkTypeDecl :: legsTypeDecl :: Nil =>
+        barkTypeDecl.fullName shouldBe s"Test0.rb:$Main.class<<animal.bark"
+        legsTypeDecl.fullName shouldBe s"Test0.rb:$Main.class<<animal.legs"
       }
     }
   }
@@ -458,28 +444,21 @@ class ClassTests extends RubyCode2CpgFixture {
           |                        if: :password
           |  end
           |""".stripMargin)
-      inside(cpg.typeDecl.name("User").l) {
-        case userType :: Nil =>
-          inside(userType.method.name(RubyDefines.TypeDeclBody).l) {
-            case constructor :: Nil =>
-              inside(constructor.astChildren.isBlock.l) {
-                case methodBlock :: Nil =>
-                  val List(validateCall: Call) = methodBlock.astChildren.isCall.l: @unchecked
+      inside(cpg.typeDecl.name("User").l) { case userType :: Nil =>
+        inside(userType.method.name(RubyDefines.TypeDeclBody).l) { case constructor :: Nil =>
+          inside(constructor.astChildren.isBlock.l) { case methodBlock :: Nil =>
+            val List(validateCall: Call) = methodBlock.astChildren.isCall.l: @unchecked
 
-                  inside(validateCall.argument.l) {
-                    case (identArg: Identifier) :: (passwordArg: Literal) :: (presenceArg: Literal) :: (confirmationArg: Literal) :: (_: Block) :: (onArg: Literal) :: (ifArg: Literal) :: Nil =>
-                      passwordArg.code shouldBe ":password"
-                      presenceArg.code shouldBe "true"
-                      confirmationArg.code shouldBe "true"
-                      onArg.code shouldBe ":create"
-                      ifArg.code shouldBe ":password"
-                    case xs => fail(s"Expected 7 arguments, got ${xs.code.mkString(", ")} instead")
-                  }
-                case xs => fail(s"Expected one block for method body, got ${xs.code.mkString(", ")} instead")
-              }
-            case xs => fail(s"Expected one constructor method, got ${xs.name.mkString(", ")} instead")
+            inside(validateCall.argument.l) {
+              case (identArg: Identifier) :: (passwordArg: Literal) :: (presenceArg: Literal) :: (confirmationArg: Literal) :: (_: Block) :: (onArg: Literal) :: (ifArg: Literal) :: Nil =>
+                passwordArg.code shouldBe ":password"
+                presenceArg.code shouldBe "true"
+                confirmationArg.code shouldBe "true"
+                onArg.code shouldBe ":create"
+                ifArg.code shouldBe ":password"
+            }
           }
-        case _ => fail("Expected typeDecl for user, none found instead")
+        }
       }
     }
 
@@ -492,29 +471,20 @@ class ClassTests extends RubyCode2CpgFixture {
           | end
           |""".stripMargin)
 
-      inside(cpg.typeDecl.name("AdminController").l) {
-        case adminTypeDecl :: Nil =>
-          inside(adminTypeDecl.method.name(RubyDefines.TypeDeclBody).l) {
-            case constructor :: Nil =>
-              inside(constructor.astChildren.isBlock.l) {
-                case methodBlock :: Nil =>
-                  inside(methodBlock.astChildren.isCall.l) {
-                    case beforeActionCall :: skipBeforeActionCall :: layoutCall :: Nil =>
-                      inside(beforeActionCall.argument.l) {
-                        case identArg :: adminArg :: ifArg :: exceptArg :: Nil =>
-                          adminArg.code shouldBe ":administrative"
-                          ifArg.code shouldBe ":admin_param"
-                          exceptArg.code shouldBe "[:get_user]"
-                        case xs => fail(s"Expected 4 args, instead found ${xs.code.mkString(", ")}")
-                      }
-                    case xs => fail(s"Expected 3 calls, instead found ${xs.code.mkString(", ")}")
-                  }
-                case xs => fail(s"Expected one block for method body, got ${xs.code.mkString(", ")} instead")
-              }
-            case xs => fail(s"Expected one constructor method, got ${xs.name.mkString(", ")} instead")
+      inside(cpg.typeDecl.name("AdminController").l) { case adminTypeDecl :: Nil =>
+        inside(adminTypeDecl.method.name(RubyDefines.TypeDeclBody).l) { case constructor :: Nil =>
+          inside(constructor.astChildren.isBlock.l) { case methodBlock :: Nil =>
+            inside(methodBlock.astChildren.isCall.l) {
+              case beforeActionCall :: skipBeforeActionCall :: layoutCall :: Nil =>
+                inside(beforeActionCall.argument.l) { case identArg :: adminArg :: ifArg :: exceptArg :: Nil =>
+                  adminArg.code shouldBe ":administrative"
+                  ifArg.code shouldBe ":admin_param"
+                  exceptArg.code shouldBe "[:get_user]"
+                }
+            }
           }
+        }
 
-        case _ => fail("Expected one typeDecl for AdminController")
       }
     }
   }
@@ -579,56 +549,43 @@ class ClassTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "create respective member nodes" in {
-      inside(cpg.typeDecl.name("Foo").l) {
-        case fooType :: Nil =>
-          inside(fooType.member.name("@.*").l) {
-            case aMember :: bMember :: cMember :: dMember :: oMember :: Nil =>
-              // Test that all members in class are present
-              aMember.code shouldBe "@a"
-              bMember.code shouldBe "@b"
-              cMember.code shouldBe "@c"
-              dMember.code shouldBe "@d"
-              oMember.code shouldBe "@o"
-            case _ => fail("Expected 5 members")
-          }
-        case xs => fail(s"Expected TypeDecl for Foo, instead got ${xs.name.mkString(", ")}")
+      inside(cpg.typeDecl.name("Foo").l) { case fooType :: Nil =>
+        inside(fooType.member.name("@.*").l) { case aMember :: bMember :: cMember :: dMember :: oMember :: Nil =>
+          // Test that all members in class are present
+          aMember.code shouldBe "@a"
+          bMember.code shouldBe "@b"
+          cMember.code shouldBe "@c"
+          dMember.code shouldBe "@d"
+          oMember.code shouldBe "@o"
+        }
       }
     }
 
     "create nil assignments under the class initializer" in {
-      inside(cpg.typeDecl.name("Foo").l) {
-        case fooType :: Nil =>
-          inside(fooType.method.name(RubyDefines.TypeDeclBody).l) {
-            case initMethod :: Nil =>
-              inside(initMethod.block.astChildren.isCall.name(Operators.assignment).l) {
-                case aAssignment :: bAssignment :: cAssignment :: dAssignment :: oAssignment :: Nil =>
-                  aAssignment.code shouldBe "@a = nil"
+      inside(cpg.typeDecl.name("Foo").l) { case fooType :: Nil =>
+        inside(fooType.method.name(RubyDefines.TypeDeclBody).l) { case initMethod :: Nil =>
+          inside(initMethod.block.astChildren.isCall.name(Operators.assignment).l) {
+            case aAssignment :: bAssignment :: cAssignment :: dAssignment :: oAssignment :: Nil =>
+              aAssignment.code shouldBe "@a = nil"
 
-                  bAssignment.code shouldBe "@b = nil"
-                  cAssignment.code shouldBe "@c = nil"
-                  dAssignment.code shouldBe "@d = nil"
-                  oAssignment.code shouldBe "@o = nil"
+              bAssignment.code shouldBe "@b = nil"
+              cAssignment.code shouldBe "@c = nil"
+              dAssignment.code shouldBe "@d = nil"
+              oAssignment.code shouldBe "@o = nil"
 
-                  inside(aAssignment.argument.l) {
-                    case (lhs: Call) :: (rhs: Literal) :: Nil =>
-                      lhs.code shouldBe s"${RubyDefines.Self}.@a"
-                      lhs.methodFullName shouldBe Operators.fieldAccess
+              inside(aAssignment.argument.l) { case (lhs: Call) :: (rhs: Literal) :: Nil =>
+                lhs.code shouldBe s"${RubyDefines.Self}.@a"
+                lhs.methodFullName shouldBe Operators.fieldAccess
 
-                      inside(lhs.argument.l) {
-                        case (identifier: Identifier) :: (fieldIdentifier: FieldIdentifier) :: Nil =>
-                          identifier.code shouldBe RubyDefines.Self
-                          fieldIdentifier.code shouldBe "@a"
-                        case _ => fail("Expected identifier and fieldIdentifier for fieldAccess")
-                      }
+                inside(lhs.argument.l) { case (identifier: Identifier) :: (fieldIdentifier: FieldIdentifier) :: Nil =>
+                  identifier.code shouldBe RubyDefines.Self
+                  fieldIdentifier.code shouldBe "@a"
+                }
 
-                      rhs.code shouldBe "nil"
-                    case _ => fail("Expected only LHS and RHS for assignment call")
-                  }
-                case xs => fail(s"Expected assignments, got [${xs.code.mkString}]")
+                rhs.code shouldBe "nil"
               }
-            case xs => fail(s"Expected one method for init, instead got ${xs.name.mkString(", ")}")
           }
-        case xs => fail(s"Expected TypeDecl for Foo, instead got ${xs.name.mkString(", ")}")
+        }
       }
     }
 
@@ -668,56 +625,44 @@ class ClassTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "create respective member nodes" in {
-      inside(cpg.typeDecl.nameExact("Foo<class>").l) {
-        case fooType :: Nil =>
-          inside(fooType.member.name("@.*").l) {
-            case aMember :: bMember :: cMember :: dMember :: oMember :: Nil =>
-              // Test that all members in class are present
-              aMember.code shouldBe "@@a"
-              bMember.code shouldBe "@@b"
-              cMember.code shouldBe "@@c"
-              dMember.code shouldBe "@@d"
-              oMember.code shouldBe "@@o"
-            case xs => fail(s"Expected 5 members, instead got ${xs.size}: [${xs.code.mkString(",")}]")
-          }
-        case xs => fail(s"Expected TypeDecl for Foo, instead got ${xs.name.mkString(", ")}")
+      inside(cpg.typeDecl.nameExact("Foo<class>").l) { case fooType :: Nil =>
+        inside(fooType.member.name("@.*").l) { case aMember :: bMember :: cMember :: dMember :: oMember :: Nil =>
+          // Test that all members in class are present
+          aMember.code shouldBe "@@a"
+          bMember.code shouldBe "@@b"
+          cMember.code shouldBe "@@c"
+          dMember.code shouldBe "@@d"
+          oMember.code shouldBe "@@o"
+        }
       }
     }
 
     "create nil assignments under the class initializer" in {
-      inside(cpg.typeDecl.name("Foo").l) {
-        case fooType :: Nil =>
-          inside(fooType.method.name(RubyDefines.TypeDeclBody).l) {
-            case clinitMethod :: Nil =>
-              inside(clinitMethod.block.astChildren.isCall.name(Operators.assignment).l) {
-                case aAssignment :: bAssignment :: cAssignment :: dAssignment :: oAssignment :: Nil =>
-                  aAssignment.code shouldBe "@@a = nil"
-                  bAssignment.code shouldBe "@@b = nil"
-                  cAssignment.code shouldBe "@@c = nil"
-                  dAssignment.code shouldBe "@@d = nil"
-                  oAssignment.code shouldBe "@@o = nil"
+      inside(cpg.typeDecl.name("Foo").l) { case fooType :: Nil =>
+        inside(fooType.method.name(RubyDefines.TypeDeclBody).l) { case clinitMethod :: Nil =>
+          inside(clinitMethod.block.astChildren.isCall.name(Operators.assignment).l) {
+            case aAssignment :: bAssignment :: cAssignment :: dAssignment :: oAssignment :: Nil =>
+              aAssignment.code shouldBe "@@a = nil"
+              bAssignment.code shouldBe "@@b = nil"
+              cAssignment.code shouldBe "@@c = nil"
+              dAssignment.code shouldBe "@@d = nil"
+              oAssignment.code shouldBe "@@o = nil"
 
-                  inside(aAssignment.argument.l) {
-                    case (lhs: Call) :: (rhs: Literal) :: Nil =>
-                      lhs.code shouldBe s"${RubyDefines.Self}.@@a"
-                      lhs.methodFullName shouldBe Operators.fieldAccess
+              inside(aAssignment.argument.l) { case (lhs: Call) :: (rhs: Literal) :: Nil =>
+                lhs.code shouldBe s"${RubyDefines.Self}.@@a"
+                lhs.methodFullName shouldBe Operators.fieldAccess
 
-                      inside(lhs.argument.l) {
-                        case (identifier: Identifier) :: (fieldIdentifier: FieldIdentifier) :: Nil =>
-                          identifier.code shouldBe RubyDefines.Self
-                          fieldIdentifier.code shouldBe "@@a"
-                        case _ => fail("Expected identifier and fieldIdentifier for fieldAccess")
-                      }
+                inside(lhs.argument.l) { case (identifier: Identifier) :: (fieldIdentifier: FieldIdentifier) :: Nil =>
+                  identifier.code shouldBe RubyDefines.Self
+                  fieldIdentifier.code shouldBe "@@a"
+                }
 
-                      rhs.code shouldBe "nil"
-                    case _ => fail("Expected only LHS and RHS for assignment call")
-                  }
-                case xs =>
-                  fail(s"Expected 5 fields initializers, got ${xs.size} instead ${xs.code.mkString(", ")}")
+                rhs.code shouldBe "nil"
               }
-            case xs => fail(s"Expected one method for <body>, instead got ${xs.name.mkString(", ")}")
+            case xs =>
+              fail(s"Expected 5 fields initializers, got ${xs.size} instead ${xs.code.mkString(", ")}")
           }
-        case xs => fail(s"Expected TypeDecl for Foo, instead got ${xs.name.mkString(", ")}")
+        }
       }
     }
   }
@@ -767,25 +712,17 @@ class ClassTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "be moved to <init> constructor method" in {
-      inside(cpg.typeDecl.name("Foo").l) {
-        case fooClass :: Nil =>
-          inside(fooClass.method.name(RubyDefines.TypeDeclBody).l) {
-            case initMethod :: Nil =>
-              inside(initMethod.astChildren.isBlock.astChildren.isCall.l) {
-                case scopeCall :: Nil =>
-                  scopeCall.code shouldBe "scope :published, -> { where(status: \"Published\") }"
+      inside(cpg.typeDecl.name("Foo").l) { case fooClass :: Nil =>
+        inside(fooClass.method.name(RubyDefines.TypeDeclBody).l) { case initMethod :: Nil =>
+          inside(initMethod.astChildren.isBlock.astChildren.isCall.l) { case scopeCall :: Nil =>
+            scopeCall.code shouldBe "scope :published, -> { where(status: \"Published\") }"
 
-                  inside(scopeCall.argument.l) {
-                    case (self: Identifier) :: (literalArg: Literal) :: unknownArg :: Nil =>
-                      self.code shouldBe "self"
-                      literalArg.code shouldBe ":published"
-                    case xs => fail(s"Expected three arguments, got ${xs.code.mkString(", ")} instead")
-                  }
-                case xs => fail(s"Expected one call under constructor, got ${xs.code.mkString(", ")} instead")
-              }
-            case xs => fail(s"Expected one init method, got ${xs.code.mkString(", ")} instead")
+            inside(scopeCall.argument.l) { case (self: Identifier) :: (literalArg: Literal) :: unknownArg :: Nil =>
+              self.code shouldBe "self"
+              literalArg.code shouldBe ":published"
+            }
           }
-        case xs => fail(s"Expected one class, got ${xs.code.mkString(", ")} instead")
+        }
       }
     }
   }
@@ -801,38 +738,27 @@ class ClassTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "correct method full name for method ref under call" in {
-      inside(cpg.typeDecl.name("Foo").l) {
-        case fooClass :: Nil =>
-          inside(fooClass.method.name(RubyDefines.TypeDeclBody).l) {
-            case initMethod :: Nil =>
-              initMethod.code shouldBe "def <body>; (...); end"
-              inside(initMethod.astChildren.isBlock.l) {
-                case methodBlock :: Nil =>
-                  inside(methodBlock.astChildren.l) {
-                    case methodCall :: Nil =>
-                      inside(methodCall.astChildren.l) {
-                        case (base: Call) :: (self: Identifier) :: (literal: Literal) :: (typeRef: TypeRef) :: Nil =>
-                          base.code shouldBe "self.scope"
-                          self.name shouldBe "self"
-                          literal.code shouldBe ":hits_by_ip"
-                          typeRef.typeFullName shouldBe s"Test0.rb:$Main.Foo.${RubyDefines.TypeDeclBody}.<lambda>0&Proc"
-                          cpg.method
-                            .fullNameExact(
-                              typeRef.typ.referencedTypeDecl.member.name("call").dynamicTypeHintFullName.toSeq*
-                            )
-                            .parameter
-                            .indexGt(0)
-                            .name
-                            .l shouldBe List("ip", "col")
-                        case xs => fail(s"Expected three children, got ${xs.code.mkString(", ")} instead")
-                      }
-                    case xs => fail(s"Expected one call, got ${xs.code.mkString(", ")} instead")
-                  }
-                case xs => fail(s"Expected one block under method, got ${xs.code.mkString(", ")} instead")
+      inside(cpg.typeDecl.name("Foo").l) { case fooClass :: Nil =>
+        inside(fooClass.method.name(RubyDefines.TypeDeclBody).l) { case initMethod :: Nil =>
+          initMethod.code shouldBe "def <body>; (...); end"
+          inside(initMethod.astChildren.isBlock.l) { case methodBlock :: Nil =>
+            inside(methodBlock.astChildren.l) { case methodCall :: Nil =>
+              inside(methodCall.astChildren.l) {
+                case (base: Call) :: (self: Identifier) :: (literal: Literal) :: (typeRef: TypeRef) :: Nil =>
+                  base.code shouldBe "self.scope"
+                  self.name shouldBe "self"
+                  literal.code shouldBe ":hits_by_ip"
+                  typeRef.typeFullName shouldBe s"Test0.rb:$Main.Foo.${RubyDefines.TypeDeclBody}.<lambda>0&Proc"
+                  cpg.method
+                    .fullNameExact(typeRef.typ.referencedTypeDecl.member.name("call").dynamicTypeHintFullName.toSeq*)
+                    .parameter
+                    .indexGt(0)
+                    .name
+                    .l shouldBe List("ip", "col")
               }
-            case xs => fail(s"Expected one init method, got ${xs.code.mkString(", ")} instead")
+            }
           }
-        case xs => fail(s"Expected one class, got ${xs.code.mkString(", ")} instead")
+        }
       }
     }
   }
@@ -846,14 +772,10 @@ class ClassTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "resolve call type" in {
-      inside(cpg.call.nameExact(Operators.assignment).l) {
-        case assignCall :: Nil =>
-          inside(assignCall.argument.l) {
-            case lhs :: (rhs: Call) :: Nil =>
-              rhs.typeFullName shouldBe "__builtin.Encoding.Converter.asciicompat_encoding"
-            case xs => fail(s"Expected lhs and rhs for assignment call, got [${xs.code.mkString(",")}]")
-          }
-        case xs => fail(s"Expected one call for assignment, got [${xs.code.mkString(",")}]")
+      inside(cpg.call.nameExact(Operators.assignment).l) { case assignCall :: Nil =>
+        inside(assignCall.argument.l) { case lhs :: (rhs: Call) :: Nil =>
+          rhs.typeFullName shouldBe "__builtin.Encoding.Converter.asciicompat_encoding"
+        }
       }
     }
   }
@@ -864,18 +786,12 @@ class ClassTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "create TYPE_DECL" in {
-      inside(cpg.typeDecl.name("X").l) {
-        case xClass :: Nil =>
-          inside(xClass.astChildren.isMethod.l) {
-            case bodyMethod :: initMethod :: Nil =>
-              inside(bodyMethod.block.astChildren.l) {
-                case (literal: Literal) :: Nil =>
-                  literal.code shouldBe "1"
-                case xs => fail(s"Expected literal for body method, got [${xs.code.mkString(",")}]")
-              }
-            case xs => fail(s"Expected body and init method, got [${xs.code.mkString(",")}]")
+      inside(cpg.typeDecl.name("X").l) { case xClass :: Nil =>
+        inside(xClass.astChildren.isMethod.l) { case bodyMethod :: initMethod :: Nil =>
+          inside(bodyMethod.block.astChildren.l) { case (literal: Literal) :: Nil =>
+            literal.code shouldBe "1"
           }
-        case xs => fail(s"Expected one class, got [${xs.code.mkString(",")}]")
+        }
       }
     }
   }
@@ -941,32 +857,24 @@ class ClassTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "have an explicit init method" in {
-      inside(cpg.typeDecl.nameExact("Foo").method.l) {
-        case bodyMethod :: initMethod :: Nil =>
-          bodyMethod.name shouldBe TypeDeclBody
+      inside(cpg.typeDecl.nameExact("Foo").method.l) { case bodyMethod :: initMethod :: Nil =>
+        bodyMethod.name shouldBe TypeDeclBody
 
-          initMethod.name shouldBe Initialize
-          inside(initMethod.parameter.l) {
-            case selfParam :: barParam :: Nil =>
-              selfParam.name shouldBe "self"
-              barParam.name shouldBe "bar"
-            case xs => fail(s"Expected two params, got [${xs.code.mkString(",")}]")
-          }
+        initMethod.name shouldBe Initialize
+        inside(initMethod.parameter.l) { case selfParam :: barParam :: Nil =>
+          selfParam.name shouldBe "self"
+          barParam.name shouldBe "bar"
+        }
 
-          inside(initMethod.block.astChildren.l) {
-            case (putsCall: Call) :: Nil =>
-              putsCall.name shouldBe "puts"
-            case xs => fail(s"Expected one call, got [${xs.code.mkString(",")}]")
-          }
+        inside(initMethod.block.astChildren.l) { case (putsCall: Call) :: Nil =>
+          putsCall.name shouldBe "puts"
+        }
 
-          inside(bodyMethod.block.astChildren.l) {
-            case (one: Literal) :: Nil =>
-              one.code shouldBe "1"
-              one.typeFullName shouldBe RubyDefines.prefixAsCoreType("Integer")
-            case xs => fail(s"Expected one literal, got [${xs.code.mkString(",")}]")
-          }
+        inside(bodyMethod.block.astChildren.l) { case (one: Literal) :: Nil =>
+          one.code shouldBe "1"
+          one.typeFullName shouldBe RubyDefines.prefixAsCoreType("Integer")
+        }
 
-        case xs => fail(s"Expected body method and init method, got [${xs.code.mkString(",")}]")
       }
     }
   }
@@ -984,27 +892,24 @@ class ClassTests extends RubyCode2CpgFixture {
 
         mobileClassNamespace.name shouldBe "MobileController<class>"
         mobileClassNamespace.fullName shouldBe s"Test0.rb:$Main.Api.V1.MobileController<class>"
-      case xs => fail(s"Expected two namespace blocks, got ${xs.code.mkString(",")}")
     }
 
-    inside(cpg.typeDecl.name("MobileController").l) {
-      case mobileTypeDecl :: Nil =>
-        mobileTypeDecl.name shouldBe "MobileController"
-        mobileTypeDecl.fullName shouldBe s"Test0.rb:$Main.Api.V1.MobileController"
-        mobileTypeDecl.astParentFullName shouldBe "Test0.rb:<main>.Api.V1"
-        mobileTypeDecl.astParentType shouldBe NodeTypes.NAMESPACE_BLOCK
+    inside(cpg.typeDecl.name("MobileController").l) { case mobileTypeDecl :: Nil =>
+      mobileTypeDecl.name shouldBe "MobileController"
+      mobileTypeDecl.fullName shouldBe s"Test0.rb:$Main.Api.V1.MobileController"
+      mobileTypeDecl.astParentFullName shouldBe "Test0.rb:<main>.Api.V1"
+      mobileTypeDecl.astParentType shouldBe NodeTypes.NAMESPACE_BLOCK
 
-        mobileTypeDecl.astParent.isNamespaceBlock shouldBe true
+      mobileTypeDecl.astParent.isNamespaceBlock shouldBe true
 
-        val namespaceDecl = mobileTypeDecl.astParent.asInstanceOf[NamespaceBlock]
-        namespaceDecl.name shouldBe "Api.V1"
-        namespaceDecl.filename shouldBe "Test0.rb"
+      val namespaceDecl = mobileTypeDecl.astParent.asInstanceOf[NamespaceBlock]
+      namespaceDecl.name shouldBe "Api.V1"
+      namespaceDecl.filename shouldBe "Test0.rb"
 
-        namespaceDecl.astParent.isFile shouldBe true
-        val parentFileDecl = namespaceDecl.astParent.asInstanceOf[File]
-        parentFileDecl.name shouldBe "Test0.rb"
+      namespaceDecl.astParent.isFile shouldBe true
+      val parentFileDecl = namespaceDecl.astParent.asInstanceOf[File]
+      parentFileDecl.name shouldBe "Test0.rb"
 
-      case xs => fail(s"Expected one class decl, got [${xs.code.mkString(",")}]")
     }
   }
 
@@ -1017,10 +922,8 @@ class ClassTests extends RubyCode2CpgFixture {
         |end
         |""".stripMargin)
 
-    inside(cpg.typeDecl.name("Baz").l) {
-      case bazTypeDecl :: Nil =>
-        bazTypeDecl.fullName shouldBe s"Test0.rb:$Main.Baz"
-      case xs => fail(s"Expected one type decl, got [${xs.code.mkString(",")}]")
+    inside(cpg.typeDecl.name("Baz").l) { case bazTypeDecl :: Nil =>
+      bazTypeDecl.fullName shouldBe s"Test0.rb:$Main.Baz"
     }
   }
 
@@ -1053,27 +956,19 @@ class ClassTests extends RubyCode2CpgFixture {
     val List(itunesMethod) = cpg.method.name("itunes_subtitle").l
     val List(bodyMethod)   = cpg.method.name("<body>").l
 
-    inside(titleMethod.methodReturn.toReturn.l) {
-      case methodReturn :: Nil =>
-        methodReturn.code shouldBe "@title"
-      case xs => fail(s"Expected one return, got [${xs.code.mkString(",")}]")
+    inside(titleMethod.methodReturn.toReturn.l) { case methodReturn :: Nil =>
+      methodReturn.code shouldBe "@title"
     }
 
-    inside(itunesMethod.methodReturn.toReturn.l) {
-      case methodReturn :: Nil =>
-        methodReturn.code shouldBe "@itunes_subtitle"
-      case xs => fail(s"Expected one return, got [${xs.code.mkString(",")}]")
+    inside(itunesMethod.methodReturn.toReturn.l) { case methodReturn :: Nil =>
+      methodReturn.code shouldBe "@itunes_subtitle"
     }
 
-    inside(bodyMethod.call.name("attr_reader").l) {
-      case notFoundCall :: Nil =>
-        notFoundCall.code shouldBe "attr_reader(*NOT_FOUND)"
-        inside(notFoundCall.argument.l) {
-          case _ :: splatArg :: Nil =>
-            splatArg.code shouldBe "*NOT_FOUND"
-          case xs => fail(s"Expected two args, got ${xs.size}: [${xs.code.mkString(",")}]")
-        }
-      case xs => fail(s"Expected one call, got [${xs.code.mkString(",")}]")
+    inside(bodyMethod.call.name("attr_reader").l) { case notFoundCall :: Nil =>
+      notFoundCall.code shouldBe "attr_reader(*NOT_FOUND)"
+      inside(notFoundCall.argument.l) { case _ :: splatArg :: Nil =>
+        splatArg.code shouldBe "*NOT_FOUND"
+      }
     }
   }
 
@@ -1086,15 +981,11 @@ class ClassTests extends RubyCode2CpgFixture {
 
     val List(bodyMethod) = cpg.method.name("<body>").l
 
-    inside(bodyMethod.call.name("attr_reader").l) {
-      case notFoundCall :: Nil =>
-        notFoundCall.code shouldBe "attr_reader(*NOT_FOUND)"
-        inside(notFoundCall.argument.l) {
-          case _ :: splatArg :: Nil =>
-            splatArg.code shouldBe "*NOT_FOUND"
-          case xs => fail(s"Expected two args, got ${xs.size}: [${xs.code.mkString(",")}]")
-        }
-      case xs => fail(s"Expected one call, got [${xs.code.mkString(",")}]")
+    inside(bodyMethod.call.name("attr_reader").l) { case notFoundCall :: Nil =>
+      notFoundCall.code shouldBe "attr_reader(*NOT_FOUND)"
+      inside(notFoundCall.argument.l) { case _ :: splatArg :: Nil =>
+        splatArg.code shouldBe "*NOT_FOUND"
+      }
     }
   }
 
@@ -1109,32 +1000,26 @@ class ClassTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "Create required getters and setters directly under TYPE_DECL" in {
-      inside(cpg.typeDecl.name("Foo").astChildren.isMethod.name("bar=?").l) {
-        case barGetter :: barSetter :: Nil =>
-          barGetter.name shouldBe "bar"
-          barGetter.fullName shouldBe s"Test0.rb:$Main.Foo.bar"
+      inside(cpg.typeDecl.name("Foo").astChildren.isMethod.name("bar=?").l) { case barGetter :: barSetter :: Nil =>
+        barGetter.name shouldBe "bar"
+        barGetter.fullName shouldBe s"Test0.rb:$Main.Foo.bar"
 
-          barSetter.name shouldBe "bar="
-          barSetter.fullName shouldBe s"Test0.rb:$Main.Foo.bar="
-        case xs => fail(s"Expected two method calls for getter and setter, got [${xs.code.mkString(",")}]")
+        barSetter.name shouldBe "bar="
+        barSetter.fullName shouldBe s"Test0.rb:$Main.Foo.bar="
       }
     }
 
     "Create required TYPE_DECL nodes directly under class TYPE_DECL" in {
-      inside(cpg.typeDecl.name("Foo").astChildren.isTypeDecl.name("bar=?").l) {
-        case barGetter :: barSetter :: Nil =>
-          barGetter.name shouldBe "bar"
-          barSetter.name shouldBe "bar="
-        case xs => fail(s"Expected two type decls, got [${xs.code.mkString(",")}]")
+      inside(cpg.typeDecl.name("Foo").astChildren.isTypeDecl.name("bar=?").l) { case barGetter :: barSetter :: Nil =>
+        barGetter.name shouldBe "bar"
+        barSetter.name shouldBe "bar="
       }
     }
 
     "Create required MEMBER nodes directly under class TYPE_DECL" in {
-      inside(cpg.typeDecl.name("Foo").astChildren.isMember.name("bar=?").l) {
-        case barGetter :: barSetter :: Nil =>
-          barGetter.name shouldBe "bar"
-          barSetter.name shouldBe "bar="
-        case xs => fail(s"Expected two member nodes, got [${xs.code.mkString(",")}]")
+      inside(cpg.typeDecl.name("Foo").astChildren.isMember.name("bar=?").l) { case barGetter :: barSetter :: Nil =>
+        barGetter.name shouldBe "bar"
+        barSetter.name shouldBe "bar="
       }
     }
   }
@@ -1160,7 +1045,6 @@ class ClassTests extends RubyCode2CpgFixture {
 
           bazGetter.name shouldBe "baz"
           bazGetter.fullName shouldBe s"Test0.rb:$Main.Foo.baz"
-        case xs => fail(s"Expected three method defs for getter and setter, got [${xs.code.mkString(",")}]")
       }
     }
 
@@ -1170,7 +1054,6 @@ class ClassTests extends RubyCode2CpgFixture {
           barGetter.name shouldBe "bar"
           barSetter.name shouldBe "bar="
           bazGetter.name shouldBe "baz"
-        case xs => fail(s"Expected two type decls, got [${xs.code.mkString(",")}]")
       }
     }
 
@@ -1180,7 +1063,6 @@ class ClassTests extends RubyCode2CpgFixture {
           barGetter.name shouldBe "bar"
           barSetter.name shouldBe "bar="
           bazGetter.name shouldBe "baz"
-        case xs => fail(s"Expected two member nodes, got [${xs.code.mkString(",")}]")
       }
     }
   }
@@ -1209,32 +1091,25 @@ class ClassTests extends RubyCode2CpgFixture {
           args.code shouldBe "*args"
           blockArg.code shouldBe "&block"
 
-          inside(lockAliasMethodDef.body.astChildren.isReturn.astChildren.isCall.l) {
-            case origLockCall :: Nil =>
-              origLockCall.name shouldBe "orig_lock!"
-              origLockCall.code shouldBe "orig_lock!(*args, &block)"
-            case xs => fail(s"Expected one call, got ${xs.size}: [${xs.code.mkString(",")}]")
+          inside(lockAliasMethodDef.body.astChildren.isReturn.astChildren.isCall.l) { case origLockCall :: Nil =>
+            origLockCall.name shouldBe "orig_lock!"
+            origLockCall.code shouldBe "orig_lock!(*args, &block)"
           }
 
-        case xs => fail(s"Expected two method defs, got ${xs.size}: [${xs.code.mkString(",")}]")
       }
     }
 
     "Lower method def to directly under TYPE_DECL" in {
-      inside(cpg.typeDecl.name("Pessimistic").astChildren.isMethod.name("lock!").l) {
-        case _ :: lockMethodDef :: Nil =>
-          lockMethodDef.name shouldBe "lock!"
+      inside(cpg.typeDecl.name("Pessimistic").astChildren.isMethod.name("lock!").l) { case _ :: lockMethodDef :: Nil =>
+        lockMethodDef.name shouldBe "lock!"
 
-          val List(_, lockArg) = lockMethodDef.parameter.l
-          lockArg.code shouldBe "lock = true"
+        val List(_, lockArg) = lockMethodDef.parameter.l
+        lockArg.code shouldBe "lock = true"
 
-          inside(lockMethodDef.body.astChildren.isReturn.astChildren.isCall.l) {
-            case origLockCall :: Nil =>
-              origLockCall.name shouldBe "orig_lock!"
-              origLockCall.code shouldBe "orig_lock!(lock)"
-            case xs => fail(s"Expected one call, got ${xs.size}: [${xs.code.mkString(",")}]")
-          }
-        case xs => fail(s"Expected two method defs, got ${xs.size}: [${xs.code.mkString(",")}]")
+        inside(lockMethodDef.body.astChildren.isReturn.astChildren.isCall.l) { case origLockCall :: Nil =>
+          origLockCall.name shouldBe "orig_lock!"
+          origLockCall.code shouldBe "orig_lock!(lock)"
+        }
       }
     }
   }
@@ -1251,19 +1126,17 @@ class ClassTests extends RubyCode2CpgFixture {
         |end
         |""".stripMargin)
 
-    inside(cpg.typeDecl.name("Foo").astChildren.isMethod.l) {
-      case lambdaMethod :: _ :: _ :: _ :: Nil =>
-        val List(lambdaReturn) = lambdaMethod.body.astChildren.isReturn.l
+    inside(cpg.typeDecl.name("Foo").astChildren.isMethod.l) { case lambdaMethod :: _ :: _ :: _ :: Nil =>
+      val List(lambdaReturn) = lambdaMethod.body.astChildren.isReturn.l
 
-        lambdaReturn.code shouldBe "private_class_method :case_sensitive_find_by"
+      lambdaReturn.code shouldBe "private_class_method :case_sensitive_find_by"
 
-        val List(returnCall) = lambdaReturn.astChildren.isCall.l
-        returnCall.code shouldBe "private_class_method :case_sensitive_find_by"
+      val List(returnCall) = lambdaReturn.astChildren.isCall.l
+      returnCall.code shouldBe "private_class_method :case_sensitive_find_by"
 
-        val List(_, methodNameArg) = returnCall.argument.l
-        methodNameArg.code shouldBe "self.:case_sensitive_find_by"
+      val List(_, methodNameArg) = returnCall.argument.l
+      methodNameArg.code shouldBe "self.:case_sensitive_find_by"
 
-      case xs => fail(s"Expected 5 methods, got [${xs.code.mkString(",")}]")
     }
   }
 
@@ -1279,18 +1152,16 @@ class ClassTests extends RubyCode2CpgFixture {
         |  end
         |end
         |""".stripMargin)
-    inside(cpg.typeDecl.name("List").l) {
-      case listTypeDecl :: Nil =>
-        val List(lambdaMethod) = listTypeDecl.astChildren.isMethod.isLambda.l
+    inside(cpg.typeDecl.name("List").l) { case listTypeDecl :: Nil =>
+      val List(lambdaMethod) = listTypeDecl.astChildren.isMethod.isLambda.l
 
-        val List(lambdaReturn) = lambdaMethod.astChildren.isBlock.astChildren.isReturn.l
-        lambdaReturn.code shouldBe "return nil"
+      val List(lambdaReturn) = lambdaMethod.astChildren.isBlock.astChildren.isReturn.l
+      lambdaReturn.code shouldBe "return nil"
 
-        val List(lambdaTypeDecl, lambdaTypeDeclClass) = lambdaMethod.astChildren.isTypeDecl.l
-        lambdaTypeDecl.name shouldBe s"Test0.rb:$Main.Taskbar.List.<body>.<lambda>0.<anon-class-0>"
-        lambdaTypeDeclClass.name shouldBe s"Test0.rb:$Main.Taskbar.List.<body>.<lambda>0.<anon-class-0><class>"
+      val List(lambdaTypeDecl, lambdaTypeDeclClass) = lambdaMethod.astChildren.isTypeDecl.l
+      lambdaTypeDecl.name shouldBe s"Test0.rb:$Main.Taskbar.List.<body>.<lambda>0.<anon-class-0>"
+      lambdaTypeDeclClass.name shouldBe s"Test0.rb:$Main.Taskbar.List.<body>.<lambda>0.<anon-class-0><class>"
 
-      case xs => fail(s"expected 1 type, got ${xs.size}: [${xs.code.mkString(", ")}]")
     }
   }
 
@@ -1325,11 +1196,9 @@ class ClassTests extends RubyCode2CpgFixture {
 
     inside(cpg.method.name("as_batches").l) {
       case batchesMethod :: Nil =>
-        inside(batchesMethod.parameter.l) {
-          case _ :: _ :: procParam :: Nil =>
-            procParam.code shouldBe "&"
-            procParam.name shouldBe "<proc-param-0>"
-          case xs => fail(s"Expected three parameters, got (${xs.size}) [${xs.code.mkString(",")}]")
+        inside(batchesMethod.parameter.l) { case _ :: _ :: procParam :: Nil =>
+          procParam.code shouldBe "&"
+          procParam.name shouldBe "<proc-param-0>"
         }
       case xs =>
     }
@@ -1352,34 +1221,28 @@ class ClassTests extends RubyCode2CpgFixture {
                      |""".stripMargin)
 
     "generate a type decl that does not clash" in {
-      inside(cpg.typeDecl.name(".*<anon-class-0>").l) {
-        case outerAnonClass :: nestedAnonClass :: Nil =>
-          outerAnonClass.name shouldBe s"Test0.rb:$Main.<anon-class-0>"
-          outerAnonClass.fullName shouldBe s"Test0.rb:$Main.<anon-class-0>"
-          inside(outerAnonClass.method.l) {
-            case hello :: defaultConstructor :: Nil =>
-              defaultConstructor.name shouldBe RubyDefines.Initialize
-              defaultConstructor.fullName shouldBe s"Test0.rb:$Main.<anon-class-0>.${RubyDefines.Initialize}"
+      inside(cpg.typeDecl.name(".*<anon-class-0>").l) { case outerAnonClass :: nestedAnonClass :: Nil =>
+        outerAnonClass.name shouldBe s"Test0.rb:$Main.<anon-class-0>"
+        outerAnonClass.fullName shouldBe s"Test0.rb:$Main.<anon-class-0>"
+        inside(outerAnonClass.method.l) { case hello :: defaultConstructor :: Nil =>
+          defaultConstructor.name shouldBe RubyDefines.Initialize
+          defaultConstructor.fullName shouldBe s"Test0.rb:$Main.<anon-class-0>.${RubyDefines.Initialize}"
 
-              hello.name shouldBe "hello"
-              hello.fullName shouldBe s"Test0.rb:$Main.<anon-class-0>.hello"
-            case xs => fail(s"Expected a single method, but got [${xs.map(x => x.label -> x.code).mkString(",")}]")
-          }
+          hello.name shouldBe "hello"
+          hello.fullName shouldBe s"Test0.rb:$Main.<anon-class-0>.hello"
+        }
 
-          nestedAnonClass.name shouldBe s"Test0.rb:$Main.Foo.<body>.<anon-class-0>"
-          nestedAnonClass.fullName shouldBe s"Test0.rb:$Main.Foo.<body>.<anon-class-0>"
+        nestedAnonClass.name shouldBe s"Test0.rb:$Main.Foo.<body>.<anon-class-0>"
+        nestedAnonClass.fullName shouldBe s"Test0.rb:$Main.Foo.<body>.<anon-class-0>"
 
-          inside(nestedAnonClass.method.l) {
-            case hello :: defaultConstructor :: Nil =>
-              defaultConstructor.name shouldBe RubyDefines.Initialize
-              defaultConstructor.fullName shouldBe s"Test0.rb:$Main.Foo.<body>.<anon-class-0>.${RubyDefines.Initialize}"
+        inside(nestedAnonClass.method.l) { case hello :: defaultConstructor :: Nil =>
+          defaultConstructor.name shouldBe RubyDefines.Initialize
+          defaultConstructor.fullName shouldBe s"Test0.rb:$Main.Foo.<body>.<anon-class-0>.${RubyDefines.Initialize}"
 
-              hello.name shouldBe "hello"
-              hello.fullName shouldBe s"Test0.rb:$Main.Foo.<body>.<anon-class-0>.hello"
-            case xs => fail(s"Expected a single method, but got [${xs.map(x => x.label -> x.code).mkString(",")}]")
-          }
+          hello.name shouldBe "hello"
+          hello.fullName shouldBe s"Test0.rb:$Main.Foo.<body>.<anon-class-0>.hello"
+        }
 
-        case xs => fail(s"Expected a single anonymous class, but got [${xs.map(x => x.label -> x.code).mkString(",")}]")
       }
     }
   }
@@ -1409,17 +1272,15 @@ class ClassTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "generate type decls with independent incrementors" in {
-      inside(cpg.typeDecl.name(".*<anon-class-\\d>").l) {
-        case a :: b :: c :: d :: e :: f :: Nil =>
-          a.fullName shouldBe s"Test0.rb:$Main.<anon-class-0>"
-          b.fullName shouldBe s"Test0.rb:$Main.<anon-class-1>"
-          c.fullName shouldBe s"Test0.rb:$Main.<anon-class-2>"
+      inside(cpg.typeDecl.name(".*<anon-class-\\d>").l) { case a :: b :: c :: d :: e :: f :: Nil =>
+        a.fullName shouldBe s"Test0.rb:$Main.<anon-class-0>"
+        b.fullName shouldBe s"Test0.rb:$Main.<anon-class-1>"
+        c.fullName shouldBe s"Test0.rb:$Main.<anon-class-2>"
 
-          d.fullName shouldBe s"Test0.rb:$Main.Foo.<body>.<anon-class-0>"
-          e.fullName shouldBe s"Test0.rb:$Main.Foo.<body>.<anon-class-1>"
+        d.fullName shouldBe s"Test0.rb:$Main.Foo.<body>.<anon-class-0>"
+        e.fullName shouldBe s"Test0.rb:$Main.Foo.<body>.<anon-class-1>"
 
-          f.fullName shouldBe s"Test0.rb:$Main.Foo.hello.<anon-class-0>"
-        case xs => fail(s"Expected 5 anonymous class decls, got ${xs.name.mkString("[", ",", "]")}")
+        f.fullName shouldBe s"Test0.rb:$Main.Foo.hello.<anon-class-0>"
       }
     }
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
@@ -510,18 +510,14 @@ class ClassTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "handle a qualified base type from an external type correctly" in {
-      inside(cpg.typeDecl("Application").headOption) {
-        case Some(app) =>
-          app.inheritsFromTypeFullName.head shouldBe "Rails.Application"
-        case None => fail("Expected a type decl for 'Application', instead got nothing")
+      inside(cpg.typeDecl("Application").headOption) { case Some(app) =>
+        app.inheritsFromTypeFullName.head shouldBe "Rails.Application"
       }
     }
 
     "handle a deeply qualified internal base type correctly" in {
-      inside(cpg.typeDecl("Foo").headOption) {
-        case Some(app) =>
-          app.inheritsFromTypeFullName.head shouldBe "Bar.Baz.Boz"
-        case None => fail("Expected a type decl for 'Foo', instead got nothing")
+      inside(cpg.typeDecl("Foo").headOption) { case Some(app) =>
+        app.inheritsFromTypeFullName.head shouldBe "Bar.Baz.Boz"
       }
     }
   }
@@ -590,14 +586,12 @@ class ClassTests extends RubyCode2CpgFixture {
     }
 
     "call the body method" in {
-      inside(cpg.call.nameExact(RubyDefines.TypeDeclBody).headOption) {
-        case Some(bodyCall) =>
-          bodyCall.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-          bodyCall.methodFullName shouldBe s"Test0.rb:$Main.Foo.${RubyDefines.TypeDeclBody}"
-          bodyCall.code shouldBe "(<tmp-0> = self::Foo)::<body>()"
-          bodyCall.receiver.isEmpty shouldBe true
-          bodyCall.argument(0).code shouldBe "<tmp-0>"
-        case None => fail("Expected <body> call")
+      inside(cpg.call.nameExact(RubyDefines.TypeDeclBody).headOption) { case Some(bodyCall) =>
+        bodyCall.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+        bodyCall.methodFullName shouldBe s"Test0.rb:$Main.Foo.${RubyDefines.TypeDeclBody}"
+        bodyCall.code shouldBe "(<tmp-0> = self::Foo)::<body>()"
+        bodyCall.receiver.isEmpty shouldBe true
+        bodyCall.argument(0).code shouldBe "<tmp-0>"
       }
     }
   }
@@ -659,8 +653,6 @@ class ClassTests extends RubyCode2CpgFixture {
 
                 rhs.code shouldBe "nil"
               }
-            case xs =>
-              fail(s"Expected 5 fields initializers, got ${xs.size} instead ${xs.code.mkString(", ")}")
           }
         }
       }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ConditionalTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ConditionalTests.scala
@@ -12,30 +12,24 @@ class ConditionalTests extends RubyCode2CpgFixture {
                      |x ? y : z
                      |""".stripMargin)
 
-    inside(cpg.controlStructure.l) {
-      case ifStmt :: Nil =>
-        ifStmt.code shouldBe "x ? y : z"
-        ifStmt.lineNumber shouldBe Some(2)
+    inside(cpg.controlStructure.l) { case ifStmt :: Nil =>
+      ifStmt.code shouldBe "x ? y : z"
+      ifStmt.lineNumber shouldBe Some(2)
 
-        inside(ifStmt.condition.l) {
-          case (x: Identifier) :: Nil =>
-            x.name shouldBe "x"
-            x.lineNumber shouldBe Some(2)
-          case xs => fail(s"Expected exactly one identifier conditional, got [${xs.code.mkString(",")}]")
-        }
+      inside(ifStmt.condition.l) { case (x: Identifier) :: Nil =>
+        x.name shouldBe "x"
+        x.lineNumber shouldBe Some(2)
+      }
 
-        inside(ifStmt.astChildren.isBlock.l) {
-          case ifBlock :: elseBlock :: Nil =>
-            val (y: Identifier) :: Nil = ifBlock.astChildren.l: @unchecked
-            y.name shouldBe "y"
-            y.lineNumber shouldBe Some(2)
+      inside(ifStmt.astChildren.isBlock.l) { case ifBlock :: elseBlock :: Nil =>
+        val (y: Identifier) :: Nil = ifBlock.astChildren.l: @unchecked
+        y.name shouldBe "y"
+        y.lineNumber shouldBe Some(2)
 
-            val (z: Identifier) :: Nil = elseBlock.astChildren.l: @unchecked
-            z.name shouldBe "z"
-            z.lineNumber shouldBe Some(2)
-          case xs => fail(s"Expected exactly two blocks under the if-structure, got [${xs.code.mkString(",")}]")
-        }
-      case xs => fail(s"Expected exactly one control structure, got [${xs.code.mkString(",")}]")
+        val (z: Identifier) :: Nil = elseBlock.astChildren.l: @unchecked
+        z.name shouldBe "z"
+        z.lineNumber shouldBe Some(2)
+      }
     }
   }
 
@@ -43,15 +37,11 @@ class ConditionalTests extends RubyCode2CpgFixture {
     val cpg = code("""x, y, z = false, true, false
                      |f(x ? y : z)
                      |""".stripMargin)
-    inside(cpg.call(Operators.conditional).l) {
-      case cond :: Nil =>
-        inside(cond.argument.l) {
-          case x :: y :: z :: Nil =>
-            x.code shouldBe "x"
-            List(y, z).isBlock.astChildren.isIdentifier.code.l shouldBe List("y", "z")
-          case xs => fail(s"Expected exactly three arguments to conditional, got [${xs.code.mkString(",")}]")
-        }
-      case xs => fail(s"Expected exactly one conditional, got [${xs.code.mkString(",")}]")
+    inside(cpg.call(Operators.conditional).l) { case cond :: Nil =>
+      inside(cond.argument.l) { case x :: y :: z :: Nil =>
+        x.code shouldBe "x"
+        List(y, z).isBlock.astChildren.isIdentifier.code.l shouldBe List("y", "z")
+      }
     }
   }
 
@@ -59,22 +49,18 @@ class ConditionalTests extends RubyCode2CpgFixture {
     val cpg = code("""x, y, z = false, true, false
                      |f(unless x then y else z end)
                      |""".stripMargin)
-    inside(cpg.call.nameExact(Operators.conditional).l) {
-      case conditionalCall :: Nil =>
-        conditionalCall.code shouldBe "unless x then y else z end"
-        inside(conditionalCall.argument.l) {
-          case condition :: (trueBranch: Block) :: (falseBranch: Block) :: Nil =>
-            condition.code shouldBe "x"
+    inside(cpg.call.nameExact(Operators.conditional).l) { case conditionalCall :: Nil =>
+      conditionalCall.code shouldBe "unless x then y else z end"
+      inside(conditionalCall.argument.l) { case condition :: (trueBranch: Block) :: (falseBranch: Block) :: Nil =>
+        condition.code shouldBe "x"
 
-            val List(trueBranchIdent) = trueBranch.astChildren.isIdentifier.l
-            trueBranchIdent.code shouldBe "z"
+        val List(trueBranchIdent) = trueBranch.astChildren.isIdentifier.l
+        trueBranchIdent.code shouldBe "z"
 
-            val List(falseBranchIdent) = falseBranch.astChildren.isIdentifier.l
-            falseBranchIdent.code shouldBe "y"
+        val List(falseBranchIdent) = falseBranch.astChildren.isIdentifier.l
+        falseBranchIdent.code shouldBe "y"
 
-          case xs => fail(s"Expected three arguments for conditional call, got [${xs.code.mkString(",")}]")
-        }
-      case xs => fail(s"Expected one call to conditional, got [${xs.code.mkString(",")}]")
+      }
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
@@ -399,7 +399,6 @@ class ControlStructureTests extends RubyCode2CpgFixture {
 
         ensureStruct.controlStructureType shouldBe ControlStructureTypes.FINALLY
         ensureStruct.ast.isLiteral.code.l shouldBe List("6")
-      case xs => fail(s"Expected 6 structures, got ${xs.code.mkString(",")}")
     }
   }
 
@@ -414,19 +413,17 @@ class ControlStructureTests extends RubyCode2CpgFixture {
                      |end
                      |""".stripMargin)
 
-    inside(cpg.method("test2").controlStructure.l) {
-      case tryStruct :: defaultElseStruct :: ensureStruct :: Nil =>
-        tryStruct.controlStructureType shouldBe ControlStructureTypes.TRY
-        val body = tryStruct.astChildren.head
-        body.ast.isLiteral.code.l shouldBe List("1")
+    inside(cpg.method("test2").controlStructure.l) { case tryStruct :: defaultElseStruct :: ensureStruct :: Nil =>
+      tryStruct.controlStructureType shouldBe ControlStructureTypes.TRY
+      val body = tryStruct.astChildren.head
+      body.ast.isLiteral.code.l shouldBe List("1")
 
-        defaultElseStruct.controlStructureType shouldBe ControlStructureTypes.ELSE
-        defaultElseStruct.ast.isLiteral.code.l shouldBe List("nil")
+      defaultElseStruct.controlStructureType shouldBe ControlStructureTypes.ELSE
+      defaultElseStruct.ast.isLiteral.code.l shouldBe List("nil")
 
-        ensureStruct.controlStructureType shouldBe ControlStructureTypes.FINALLY
-        ensureStruct.ast.isLiteral.code.l shouldBe List("2")
+      ensureStruct.controlStructureType shouldBe ControlStructureTypes.FINALLY
+      ensureStruct.ast.isLiteral.code.l shouldBe List("2")
 
-      case xs => fail(s"Expected two structures, got ${xs.code.mkString(",")}")
     }
   }
 
@@ -479,71 +476,63 @@ class ControlStructureTests extends RubyCode2CpgFixture {
                      |""".stripMargin)
 
     "create a FOR control structure node with body with an array iterable" in {
-      inside(cpg.method("foo1").controlStructure.l) {
-        case forEachNode :: Nil =>
-          forEachNode.controlStructureType shouldBe ControlStructureTypes.FOR
+      inside(cpg.method("foo1").controlStructure.l) { case forEachNode :: Nil =>
+        forEachNode.controlStructureType shouldBe ControlStructureTypes.FOR
 
-          inside(forEachNode.astChildren.l) {
-            case (idxLocal: Local) :: (iVarLocal: Local) :: (initAssign: Call) :: (cond: Call) :: (update: Call) :: (forBlock: Block) :: Nil =>
-              idxLocal.name shouldBe "_idx_"
-              idxLocal.typeFullName shouldBe Defines.prefixAsCoreType(Defines.Integer)
+        inside(forEachNode.astChildren.l) {
+          case (idxLocal: Local) :: (iVarLocal: Local) :: (initAssign: Call) :: (cond: Call) :: (update: Call) :: (forBlock: Block) :: Nil =>
+            idxLocal.name shouldBe "_idx_"
+            idxLocal.typeFullName shouldBe Defines.prefixAsCoreType(Defines.Integer)
 
-              iVarLocal.name shouldBe "i"
+            iVarLocal.name shouldBe "i"
 
-              initAssign.code shouldBe "_idx_ = 0"
-              initAssign.name shouldBe Operators.assignment
-              initAssign.methodFullName shouldBe Operators.assignment
+            initAssign.code shouldBe "_idx_ = 0"
+            initAssign.name shouldBe Operators.assignment
+            initAssign.methodFullName shouldBe Operators.assignment
 
-              cond.code shouldBe "_idx_ < x.length"
-              cond.name shouldBe Operators.lessThan
-              cond.methodFullName shouldBe Operators.lessThan
+            cond.code shouldBe "_idx_ < x.length"
+            cond.name shouldBe Operators.lessThan
+            cond.methodFullName shouldBe Operators.lessThan
 
-              update.code shouldBe "i = x[_idx_++]"
-              update.name shouldBe Operators.assignment
-              update.methodFullName shouldBe Operators.assignment
+            update.code shouldBe "i = x[_idx_++]"
+            update.name shouldBe Operators.assignment
+            update.methodFullName shouldBe Operators.assignment
 
-            case xs => fail(s"Expected 6 children for `forEachNode`, got [${xs.code.mkString(",")}]")
-          }
+        }
 
-          inside(forEachNode.astChildren.isBlock.l) {
-            case blockNode :: Nil =>
-              val List(puts) = blockNode.ast.isCall.nameExact("puts").l
-              puts.parentBlock.head shouldBe blockNode
-            case _ => fail("Correct blockNode as child not found for `for-in` statement")
-          }
+        inside(forEachNode.astChildren.isBlock.l) { case blockNode :: Nil =>
+          val List(puts) = blockNode.ast.isCall.nameExact("puts").l
+          puts.parentBlock.head shouldBe blockNode
+        }
 
-        case _ => fail("No control structure node found for `for-in`.")
       }
     }
 
     "create a FOR control structure node with body with a 'range' iterable" in {
-      inside(cpg.method("foo2").controlStructure.l) {
-        case forEachNode :: Nil =>
-          forEachNode.controlStructureType shouldBe ControlStructureTypes.FOR
+      inside(cpg.method("foo2").controlStructure.l) { case forEachNode :: Nil =>
+        forEachNode.controlStructureType shouldBe ControlStructureTypes.FOR
 
-          inside(forEachNode.astChildren.l) {
-            case (idxLocal: Local) :: (iVarLocal: Local) :: (initAssign: Call) :: (cond: Call) :: (update: Call) :: (forBlock: Block) :: Nil =>
-              idxLocal.name shouldBe "_idx_"
-              idxLocal.typeFullName shouldBe Defines.prefixAsCoreType(Defines.Integer)
+        inside(forEachNode.astChildren.l) {
+          case (idxLocal: Local) :: (iVarLocal: Local) :: (initAssign: Call) :: (cond: Call) :: (update: Call) :: (forBlock: Block) :: Nil =>
+            idxLocal.name shouldBe "_idx_"
+            idxLocal.typeFullName shouldBe Defines.prefixAsCoreType(Defines.Integer)
 
-              iVarLocal.name shouldBe "i"
+            iVarLocal.name shouldBe "i"
 
-              initAssign.code shouldBe "_idx_ = 0"
-              initAssign.name shouldBe Operators.assignment
-              initAssign.methodFullName shouldBe Operators.assignment
+            initAssign.code shouldBe "_idx_ = 0"
+            initAssign.name shouldBe Operators.assignment
+            initAssign.methodFullName shouldBe Operators.assignment
 
-              cond.code shouldBe "_idx_ < 1..x.length"
-              cond.name shouldBe Operators.lessThan
-              cond.methodFullName shouldBe Operators.lessThan
+            cond.code shouldBe "_idx_ < 1..x.length"
+            cond.name shouldBe Operators.lessThan
+            cond.methodFullName shouldBe Operators.lessThan
 
-              update.code shouldBe "i = 1..x[_idx_++]"
-              update.name shouldBe Operators.assignment
-              update.methodFullName shouldBe Operators.assignment
+            update.code shouldBe "i = 1..x[_idx_++]"
+            update.name shouldBe Operators.assignment
+            update.methodFullName shouldBe Operators.assignment
 
-            case xs => fail(s"Expected 6 children for `forEachNode`, got [${xs.code.mkString(",")}]")
-          }
+        }
 
-        case _ => fail("No control structure node found for `for-in`.")
       }
     }
 
@@ -570,7 +559,6 @@ class ControlStructureTests extends RubyCode2CpgFixture {
           elsifOneAssignment.code shouldBe "a = 2003"
           elsifTwoAssignment.code shouldBe "a = 982"
           elseAssignment.code shouldBe "a = 456"
-        case xs => fail(s"Expected four assignments, instead found ${xs.code.mkString(", ")}")
       }
     }
   }
@@ -608,11 +596,9 @@ class ControlStructureTests extends RubyCode2CpgFixture {
                      |""".stripMargin)
 
     "create assignment operators for if and default else branch" in {
-      inside(cpg.call.name(Operators.assignment).l) {
-        case ifAssignment :: defaultElseAssignment :: Nil =>
-          ifAssignment.code shouldBe "a = 123"
-          defaultElseAssignment.code shouldBe "a = nil"
-        case xs => fail(s"Expected two assignments, instead found ${xs.code.mkString(", ")}")
+      inside(cpg.call.name(Operators.assignment).l) { case ifAssignment :: defaultElseAssignment :: Nil =>
+        ifAssignment.code shouldBe "a = 123"
+        defaultElseAssignment.code shouldBe "a = nil"
       }
     }
 
@@ -632,31 +618,23 @@ class ControlStructureTests extends RubyCode2CpgFixture {
                      |""".stripMargin)
 
     "Generate return nodes without unknown nodes" in {
-      inside(cpg.method.name("foo").methodReturn.toReturn.l) {
-        case returnZero :: returnX :: returnY :: Nil =>
-          returnZero.code shouldBe "return 0"
-          // Confirms that returnZero child is `Literal` and not `UNKNOWN`
-          inside(returnZero.astChildren.l) {
-            case (zeroLiteral: Literal) :: Nil =>
-              zeroLiteral.code shouldBe "0"
-            case _ => fail("Expected literal for return astChild")
-          }
+      inside(cpg.method.name("foo").methodReturn.toReturn.l) { case returnZero :: returnX :: returnY :: Nil =>
+        returnZero.code shouldBe "return 0"
+        // Confirms that returnZero child is `Literal` and not `UNKNOWN`
+        inside(returnZero.astChildren.l) { case (zeroLiteral: Literal) :: Nil =>
+          zeroLiteral.code shouldBe "0"
+        }
 
-          returnX.code shouldBe "return x"
-          inside(returnX.astChildren.l) {
-            case (x: Identifier) :: Nil =>
-              x.code shouldBe "x"
-            case _ => fail("Expected Identifier for return child")
-          }
+        returnX.code shouldBe "return x"
+        inside(returnX.astChildren.l) { case (x: Identifier) :: Nil =>
+          x.code shouldBe "x"
+        }
 
-          returnY.code shouldBe "return y"
-          inside(returnY.astChildren.l) {
-            case (y: Identifier) :: Nil =>
-              y.code shouldBe "y"
-            case _ => fail("Expected identifier for return child")
-          }
+        returnY.code shouldBe "return y"
+        inside(returnY.astChildren.l) { case (y: Identifier) :: Nil =>
+          y.code shouldBe "y"
+        }
 
-        case xs => fail(s"Expected three return expressions, instead found ${xs.code.mkString(", ")}")
       }
     }
   }
@@ -668,46 +646,40 @@ class ControlStructureTests extends RubyCode2CpgFixture {
                      |end
                      |""".stripMargin)
 
-    inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.CONTINUE).l) {
-      case nextControl :: Nil =>
-        nextControl.code shouldBe "next"
-      case xs => fail(s"Expected next to be continue, got [${xs.code.mkString(",")}]")
+    inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.CONTINUE).l) { case nextControl :: Nil =>
+      nextControl.code shouldBe "next"
     }
   }
 
   "A `raise` call with a string argument should generate a `throw` control structure with explicit `StandardError.new` call" in {
     val cpg = code("raise 'Hello, world!'")
-    inside(cpg.controlStructure.l) {
-      case (ctrlStruct: ControlStructure) :: Nil =>
-        ctrlStruct.code shouldBe "raise 'Hello, world!'"
-        ctrlStruct.controlStructureType shouldBe ControlStructureTypes.THROW
+    inside(cpg.controlStructure.l) { case (ctrlStruct: ControlStructure) :: Nil =>
+      ctrlStruct.code shouldBe "raise 'Hello, world!'"
+      ctrlStruct.controlStructureType shouldBe ControlStructureTypes.THROW
 
-        val constructorBlock = ctrlStruct.astChildren.head.asInstanceOf[Block]
-        constructorBlock.ast.isCall.where(_.name(Operators.alloc)).nonEmpty shouldBe true
+      val constructorBlock = ctrlStruct.astChildren.head.asInstanceOf[Block]
+      constructorBlock.ast.isCall.where(_.name(Operators.alloc)).nonEmpty shouldBe true
 
-        val initialize = constructorBlock.ast.isCall.name(Defines.Initialize).head
-        initialize.code shouldBe "StandardError.new('Hello, world!')"
-        val helloWorld = initialize.argument(1).asInstanceOf[Literal]
-        helloWorld.code shouldBe "'Hello, world!'"
-      case xs => fail(s"Expected single `throw` call, got [${xs.code.mkString(",")}]")
+      val initialize = constructorBlock.ast.isCall.name(Defines.Initialize).head
+      initialize.code shouldBe "StandardError.new('Hello, world!')"
+      val helloWorld = initialize.argument(1).asInstanceOf[Literal]
+      helloWorld.code shouldBe "'Hello, world!'"
     }
   }
 
   "A `raise` call with an explicit error argument should generate a `throw` control structure" in {
     val cpg = code("raise ZeroDivisionError.new 'b should not be 0'")
-    inside(cpg.controlStructure.l) {
-      case (ctrlStruct: ControlStructure) :: Nil =>
-        ctrlStruct.code shouldBe "raise ZeroDivisionError.new 'b should not be 0'"
-        ctrlStruct.controlStructureType shouldBe ControlStructureTypes.THROW
+    inside(cpg.controlStructure.l) { case (ctrlStruct: ControlStructure) :: Nil =>
+      ctrlStruct.code shouldBe "raise ZeroDivisionError.new 'b should not be 0'"
+      ctrlStruct.controlStructureType shouldBe ControlStructureTypes.THROW
 
-        val constructorBlock = ctrlStruct.astChildren.head.asInstanceOf[Block]
-        constructorBlock.ast.isCall.where(_.name(Operators.alloc)).nonEmpty shouldBe true
+      val constructorBlock = ctrlStruct.astChildren.head.asInstanceOf[Block]
+      constructorBlock.ast.isCall.where(_.name(Operators.alloc)).nonEmpty shouldBe true
 
-        val initialize = constructorBlock.ast.isCall.name(Defines.Initialize).head
-        initialize.code shouldBe "ZeroDivisionError.new 'b should not be 0'"
-        val errMsg = initialize.argument(1).asInstanceOf[Literal]
-        errMsg.code shouldBe "'b should not be 0'"
-      case xs => fail(s"Expected single `throw` call, got [${xs.code.mkString(",")}]")
+      val initialize = constructorBlock.ast.isCall.name(Defines.Initialize).head
+      initialize.code shouldBe "ZeroDivisionError.new 'b should not be 0'"
+      val errMsg = initialize.argument(1).asInstanceOf[Literal]
+      errMsg.code shouldBe "'b should not be 0'"
     }
   }
 
@@ -720,28 +692,22 @@ class ControlStructureTests extends RubyCode2CpgFixture {
                      |end
                      |""".stripMargin)
 
-    inside(cpg.method.name("index").l) {
-      case indexMethod :: Nil =>
-        inside(indexMethod.call.name(Operators.conditional).l) {
-          case ternary :: Nil =>
-            ternary.code shouldBe "@user.admin ? User.all : @user"
+    inside(cpg.method.name("index").l) { case indexMethod :: Nil =>
+      inside(indexMethod.call.name(Operators.conditional).l) { case ternary :: Nil =>
+        ternary.code shouldBe "@user.admin ? User.all : @user"
 
-            inside(ternary.argument.l) {
-              case condition :: (leftOpt: Block) :: (rightOpt: Block) :: Nil =>
-                condition.code shouldBe "(<tmp-0> = @user).admin"
-                condition.ast.isFieldIdentifier.code.l shouldBe List("@user", "admin")
+        inside(ternary.argument.l) { case condition :: (leftOpt: Block) :: (rightOpt: Block) :: Nil =>
+          condition.code shouldBe "(<tmp-0> = @user).admin"
+          condition.ast.isFieldIdentifier.code.l shouldBe List("@user", "admin")
 
-                leftOpt.ast.fieldAccess.code.head shouldBe "User.all"
-                leftOpt.ast.isFieldIdentifier.code.l shouldBe List("User", "all")
+          leftOpt.ast.fieldAccess.code.head shouldBe "User.all"
+          leftOpt.ast.isFieldIdentifier.code.l shouldBe List("User", "all")
 
-                rightOpt.ast.fieldAccess.code.head shouldBe "self.@user"
-                rightOpt.ast.isFieldIdentifier.code.head shouldBe "@user"
+          rightOpt.ast.fieldAccess.code.head shouldBe "self.@user"
+          rightOpt.ast.isFieldIdentifier.code.head shouldBe "@user"
 
-              case xs => fail(s"Expected two arguments, got ${xs.code.mkString(",")}")
-            }
-          case xs => fail(s"Expected one call for ternary, got ${xs.code.mkString(",")}")
         }
-      case xs => fail(s"Expected one method, got ${xs.name.mkString(",")}")
+      }
     }
   }
 
@@ -754,14 +720,12 @@ class ControlStructureTests extends RubyCode2CpgFixture {
                      |end
                      |""".stripMargin)
 
-    inside(cpg.method.name("foo").controlStructure.l) {
-      case ifStruct :: Nil =>
-        ifStruct.controlStructureType shouldBe ControlStructureTypes.IF
+    inside(cpg.method.name("foo").controlStructure.l) { case ifStruct :: Nil =>
+      ifStruct.controlStructureType shouldBe ControlStructureTypes.IF
 
-        val List(_: Call, returnCall: Return) = ifStruct.condition.isBlock.astChildren.isCall.argument.l: @unchecked
-        returnCall.code shouldBe "return"
+      val List(_: Call, returnCall: Return) = ifStruct.condition.isBlock.astChildren.isCall.argument.l: @unchecked
+      returnCall.code shouldBe "return"
 
-      case xs => fail(s"Expected one control strucuture, got [${xs.code.mkString(",")}]")
     }
   }
 
@@ -774,13 +738,11 @@ class ControlStructureTests extends RubyCode2CpgFixture {
                      |end
                      |""".stripMargin)
 
-    inside(cpg.method.name("foo").controlStructure.l) {
-      case orIfStruct :: Nil =>
-        orIfStruct.controlStructureType shouldBe ControlStructureTypes.IF
+    inside(cpg.method.name("foo").controlStructure.l) { case orIfStruct :: Nil =>
+      orIfStruct.controlStructureType shouldBe ControlStructureTypes.IF
 
-        val List(_: Call, returnCall: Return) = orIfStruct.condition.isBlock.astChildren.isCall.argument.l: @unchecked
-        returnCall.code shouldBe "return"
-      case xs => fail(s"Expected one IF structure, got [${xs.code.mkString(",")}]")
+      val List(_: Call, returnCall: Return) = orIfStruct.condition.isBlock.astChildren.isCall.argument.l: @unchecked
+      returnCall.code shouldBe "return"
     }
   }
 
@@ -792,35 +754,32 @@ class ControlStructureTests extends RubyCode2CpgFixture {
                      |end
                      |""".stripMargin)
 
-    inside(cpg.method.isModule.controlStructure.l) {
-      case forEachNode :: Nil =>
-        forEachNode.controlStructureType shouldBe ControlStructureTypes.FOR
+    inside(cpg.method.isModule.controlStructure.l) { case forEachNode :: Nil =>
+      forEachNode.controlStructureType shouldBe ControlStructureTypes.FOR
 
-        inside(forEachNode.astChildren.l) {
-          case (idxLocal: Local) :: (numLocal: Local) :: (initAssign: Call) :: (cond: Call) :: (update: Call) :: (forBlock: Block) :: Nil =>
-            idxLocal.name shouldBe "_idx_"
-            idxLocal.typeFullName shouldBe Defines.prefixAsCoreType(Defines.Integer)
+      inside(forEachNode.astChildren.l) {
+        case (idxLocal: Local) :: (numLocal: Local) :: (initAssign: Call) :: (cond: Call) :: (update: Call) :: (forBlock: Block) :: Nil =>
+          idxLocal.name shouldBe "_idx_"
+          idxLocal.typeFullName shouldBe Defines.prefixAsCoreType(Defines.Integer)
 
-            numLocal.name shouldBe "num"
+          numLocal.name shouldBe "num"
 
-            initAssign.code shouldBe "_idx_ = 0"
-            initAssign.name shouldBe Operators.assignment
-            initAssign.methodFullName shouldBe Operators.assignment
+          initAssign.code shouldBe "_idx_ = 0"
+          initAssign.name shouldBe Operators.assignment
+          initAssign.methodFullName shouldBe Operators.assignment
 
-            cond.code shouldBe "_idx_ < fibNumbers.length"
-            cond.name shouldBe Operators.lessThan
-            cond.methodFullName shouldBe Operators.lessThan
+          cond.code shouldBe "_idx_ < fibNumbers.length"
+          cond.name shouldBe Operators.lessThan
+          cond.methodFullName shouldBe Operators.lessThan
 
-            update.code shouldBe "num = fibNumbers[_idx_++]"
-            update.name shouldBe Operators.assignment
-            update.methodFullName shouldBe Operators.assignment
+          update.code shouldBe "num = fibNumbers[_idx_++]"
+          update.name shouldBe Operators.assignment
+          update.methodFullName shouldBe Operators.assignment
 
-            val List(putsCall) = cpg.call.nameExact("puts").l
-            putsCall.astParent shouldBe forBlock
+          val List(putsCall) = cpg.call.nameExact("puts").l
+          putsCall.astParent shouldBe forBlock
 
-          case xs => fail(s"Expected 6 children for `forEachNode`, got [${xs.code.mkString(",")}]")
-        }
-      case xs => fail(s"Expected one node for `forEach` loop, got [${xs.code.mkString(",")}]")
+      }
     }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DependencyTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DependencyTests.scala
@@ -25,7 +25,6 @@ class DependencyTests extends RubyCode2CpgFixture {
           betterErrors.name shouldBe "better_errors"
           betterErrors.version shouldBe "2.5.1"
 
-        case xs => fail(s"Expected exactly three dependencies, instead got [${xs.name.mkString(",")}]")
       }
     }
 
@@ -47,7 +46,6 @@ class DependencyTests extends RubyCode2CpgFixture {
           coffeeRails.name shouldBe "coffee-rails"
           coffeeRails.version shouldBe ""
 
-        case xs => fail(s"Expected exactly three dependencies, instead got [${xs.name.mkString(",")}]")
       }
     }
 
@@ -103,7 +101,6 @@ class DownloadDependencyTest extends RubyCode2CpgFixture(downloadDependencies = 
               constructorCall.methodFullName shouldBe Defines.DynamicCallUnknownFullName
             case None => fail(s"Expected constructor call, did not find one")
           }
-        case xs => fail(s"Expected two arguments under the constructor assignment, got [${xs.code.mkString(", ")}]")
       }
     }
 
@@ -117,7 +114,6 @@ class DownloadDependencyTest extends RubyCode2CpgFixture(downloadDependencies = 
               constructorCall.methodFullName shouldBe Defines.DynamicCallUnknownFullName
             case None => fail(s"Expected constructor call, did not find one")
           }
-        case xs => fail(s"Expected two arguments under the constructor assignment, got [${xs.code.mkString(", ")}]")
       }
     }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DependencyTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DependencyTests.scala
@@ -96,10 +96,8 @@ class DownloadDependencyTest extends RubyCode2CpgFixture(downloadDependencies = 
         case (v: Identifier) :: (block: Block) :: Nil =>
           v.dynamicTypeHintFullName should contain("dummy_logger.Main_module.Main_outer_class")
 
-          inside(block.astChildren.isCall.nameExact(RubyDefines.Initialize).headOption) {
-            case Some(constructorCall) =>
-              constructorCall.methodFullName shouldBe Defines.DynamicCallUnknownFullName
-            case None => fail(s"Expected constructor call, did not find one")
+          inside(block.astChildren.isCall.nameExact(RubyDefines.Initialize).headOption) { case Some(constructorCall) =>
+            constructorCall.methodFullName shouldBe Defines.DynamicCallUnknownFullName
           }
       }
     }
@@ -109,10 +107,8 @@ class DownloadDependencyTest extends RubyCode2CpgFixture(downloadDependencies = 
         case (g: Identifier) :: (block: Block) :: Nil =>
           g.dynamicTypeHintFullName should contain("dummy_logger.Help")
 
-          inside(block.astChildren.isCall.name(RubyDefines.Initialize).headOption) {
-            case Some(constructorCall) =>
-              constructorCall.methodFullName shouldBe Defines.DynamicCallUnknownFullName
-            case None => fail(s"Expected constructor call, did not find one")
+          inside(block.astChildren.isCall.name(RubyDefines.Initialize).headOption) { case Some(constructorCall) =>
+            constructorCall.methodFullName shouldBe Defines.DynamicCallUnknownFullName
           }
       }
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DestructuredAssignmentsTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DestructuredAssignmentsTests.scala
@@ -15,24 +15,22 @@ class DestructuredAssignmentsTests extends RubyCode2CpgFixture {
                     |""".stripMargin)
 
     "separate the assignments into three separate assignment nodes" in {
-      inside(cpg.assignment.l) {
-        case aAssignment :: bAssignment :: cAssignment :: Nil =>
-          aAssignment.code shouldBe "a, b, c = 1, 2, 3"
-          bAssignment.code shouldBe "a, b, c = 1, 2, 3"
-          cAssignment.code shouldBe "a, b, c = 1, 2, 3"
+      inside(cpg.assignment.l) { case aAssignment :: bAssignment :: cAssignment :: Nil =>
+        aAssignment.code shouldBe "a, b, c = 1, 2, 3"
+        bAssignment.code shouldBe "a, b, c = 1, 2, 3"
+        cAssignment.code shouldBe "a, b, c = 1, 2, 3"
 
-          val List(a: Identifier, one: Literal) = aAssignment.argumentOut.toList: @unchecked
-          a.name shouldBe "a"
-          one.code shouldBe "1"
+        val List(a: Identifier, one: Literal) = aAssignment.argumentOut.toList: @unchecked
+        a.name shouldBe "a"
+        one.code shouldBe "1"
 
-          val List(b: Identifier, two: Literal) = bAssignment.argumentOut.toList: @unchecked
-          b.name shouldBe "b"
-          two.code shouldBe "2"
+        val List(b: Identifier, two: Literal) = bAssignment.argumentOut.toList: @unchecked
+        b.name shouldBe "b"
+        two.code shouldBe "2"
 
-          val List(c: Identifier, three: Literal) = cAssignment.argumentOut.toList: @unchecked
-          c.name shouldBe "c"
-          three.code shouldBe "3"
-        case _ => fail("Unexpected number of assignments found")
+        val List(c: Identifier, three: Literal) = cAssignment.argumentOut.toList: @unchecked
+        c.name shouldBe "c"
+        three.code shouldBe "3"
       }
 
     }
@@ -46,24 +44,22 @@ class DestructuredAssignmentsTests extends RubyCode2CpgFixture {
                     |""".stripMargin)
 
     "separate the assignments into 3 and leave `d` undefined" in {
-      inside(cpg.assignment.l) {
-        case aAssignment :: bAssignment :: cAssignment :: Nil =>
-          aAssignment.code shouldBe "a, b, c, d = 1, 2, 3"
-          bAssignment.code shouldBe "a, b, c, d = 1, 2, 3"
-          cAssignment.code shouldBe "a, b, c, d = 1, 2, 3"
+      inside(cpg.assignment.l) { case aAssignment :: bAssignment :: cAssignment :: Nil =>
+        aAssignment.code shouldBe "a, b, c, d = 1, 2, 3"
+        bAssignment.code shouldBe "a, b, c, d = 1, 2, 3"
+        cAssignment.code shouldBe "a, b, c, d = 1, 2, 3"
 
-          val List(a: Identifier, one: Literal) = aAssignment.argumentOut.toList: @unchecked
-          a.name shouldBe "a"
-          one.code shouldBe "1"
+        val List(a: Identifier, one: Literal) = aAssignment.argumentOut.toList: @unchecked
+        a.name shouldBe "a"
+        one.code shouldBe "1"
 
-          val List(b: Identifier, two: Literal) = bAssignment.argumentOut.toList: @unchecked
-          b.name shouldBe "b"
-          two.code shouldBe "2"
+        val List(b: Identifier, two: Literal) = bAssignment.argumentOut.toList: @unchecked
+        b.name shouldBe "b"
+        two.code shouldBe "2"
 
-          val List(c: Identifier, three: Literal) = cAssignment.argumentOut.toList: @unchecked
-          c.name shouldBe "c"
-          three.code shouldBe "3"
-        case _ => fail("Unexpected number of assignments found")
+        val List(c: Identifier, three: Literal) = cAssignment.argumentOut.toList: @unchecked
+        c.name shouldBe "c"
+        three.code shouldBe "3"
       }
 
     }
@@ -96,14 +92,11 @@ class DestructuredAssignmentsTests extends RubyCode2CpgFixture {
           arr.code shouldBe "a, b, *c = 1, 2, 3, 4"
 
           val asgns = arr.astChildren.assignment.where(_.target.isCall.nameExact(Operators.indexAccess)).l
-          inside(asgns.map(_.source)) {
-            case (three: Literal) :: (four: Literal) :: Nil =>
-              three.code shouldBe "3"
-              four.code shouldBe "4"
-            case _ => fail("Unexpected number of array elements in `c`'s assignment")
+          inside(asgns.map(_.source)) { case (three: Literal) :: (four: Literal) :: Nil =>
+            three.code shouldBe "3"
+            four.code shouldBe "4"
           }
 
-        case _ => fail("Unexpected number of assignments found")
       }
 
     }
@@ -128,18 +121,15 @@ class DestructuredAssignmentsTests extends RubyCode2CpgFixture {
           arr.code shouldBe "a, *b, c = 1, 2, 3, 4"
 
           val asgns = arr.astChildren.assignment.where(_.target.isCall.nameExact(Operators.indexAccess)).l
-          inside(asgns.map(_.source)) {
-            case (two: Literal) :: (three: Literal) :: Nil =>
-              two.code shouldBe "2"
-              three.code shouldBe "3"
-            case _ => fail("Unexpected number of array elements in `c`'s assignment")
+          inside(asgns.map(_.source)) { case (two: Literal) :: (three: Literal) :: Nil =>
+            two.code shouldBe "2"
+            three.code shouldBe "3"
           }
 
           val List(c: Identifier, four: Literal) = cAssignment.argumentOut.toList: @unchecked
           c.name shouldBe "c"
           four.code shouldBe "4"
 
-        case _ => fail("Unexpected number of assignments found")
       }
 
     }
@@ -160,11 +150,9 @@ class DestructuredAssignmentsTests extends RubyCode2CpgFixture {
           arr.code shouldBe "*a, b, c = 1, 2, 3, 4"
 
           val asgns = arr.astChildren.assignment.where(_.target.isCall.nameExact(Operators.indexAccess)).l
-          inside(asgns.map(_.source)) {
-            case (one: Literal) :: (two: Literal) :: Nil =>
-              one.code shouldBe "1"
-              two.code shouldBe "2"
-            case _ => fail("Unexpected number of array elements in `c`'s assignment")
+          inside(asgns.map(_.source)) { case (one: Literal) :: (two: Literal) :: Nil =>
+            one.code shouldBe "1"
+            two.code shouldBe "2"
           }
 
           val List(b: Identifier, three: Literal) = bAssignment.argumentOut.toList: @unchecked
@@ -175,7 +163,6 @@ class DestructuredAssignmentsTests extends RubyCode2CpgFixture {
           c.name shouldBe "c"
           four.code shouldBe "4"
 
-        case _ => fail("Unexpected number of assignments found")
       }
 
     }
@@ -185,24 +172,21 @@ class DestructuredAssignmentsTests extends RubyCode2CpgFixture {
                 |a = 1, 2, 3, 4
                 |""".stripMargin)
 
-      inside(cpg.assignment.codeExact("a = 1, 2, 3, 4").l) {
-        case aAssignment :: Nil =>
-          aAssignment.code shouldBe "a = 1, 2, 3, 4"
+      inside(cpg.assignment.codeExact("a = 1, 2, 3, 4").l) { case aAssignment :: Nil =>
+        aAssignment.code shouldBe "a = 1, 2, 3, 4"
 
-          val List(a: Identifier, arr: Block) = aAssignment.argumentOut.toList: @unchecked
-          a.name shouldBe "a"
-          arr.code shouldBe "1, 2, 3, 4"
-          val asgns = arr.astChildren.assignment.where(_.target.isCall.nameExact(Operators.indexAccess)).l
-          inside(asgns.map(_.source)) {
-            case (one: Literal) :: (two: Literal) :: (three: Literal) :: (four: Literal) :: Nil =>
-              one.code shouldBe "1"
-              two.code shouldBe "2"
-              three.code shouldBe "3"
-              four.code shouldBe "4"
-            case _ => fail("Unexpected number of array elements in `a`'s assignment")
-          }
+        val List(a: Identifier, arr: Block) = aAssignment.argumentOut.toList: @unchecked
+        a.name shouldBe "a"
+        arr.code shouldBe "1, 2, 3, 4"
+        val asgns = arr.astChildren.assignment.where(_.target.isCall.nameExact(Operators.indexAccess)).l
+        inside(asgns.map(_.source)) {
+          case (one: Literal) :: (two: Literal) :: (three: Literal) :: (four: Literal) :: Nil =>
+            one.code shouldBe "1"
+            two.code shouldBe "2"
+            three.code shouldBe "3"
+            four.code shouldBe "4"
+        }
 
-        case _ => fail("Unexpected number of assignments found")
       }
 
     }
@@ -235,13 +219,10 @@ class DestructuredAssignmentsTests extends RubyCode2CpgFixture {
           val List(c: Identifier, splat: Call) = cAssignment.argumentOut.toList: @unchecked
           c.name shouldBe "c"
           splat.name shouldBe RubyOperators.splat
-          inside(splat.argumentOut.l) {
-            case (list: Identifier) :: Nil =>
-              list.name shouldBe "list"
-            case _ => fail("Unexpected number of array elements in `c`'s assignment")
+          inside(splat.argumentOut.l) { case (list: Identifier) :: Nil =>
+            list.name shouldBe "list"
           }
 
-        case _ => fail("Unexpected number of assignments found")
       }
 
     }
@@ -266,22 +247,17 @@ class DestructuredAssignmentsTests extends RubyCode2CpgFixture {
           val List(b: Identifier, splatB: Call) = bAssignment.argumentOut.toList: @unchecked
           b.name shouldBe "b"
           splatB.name shouldBe RubyOperators.splat
-          inside(splatB.argumentOut.l) {
-            case (list: Identifier) :: Nil =>
-              list.name shouldBe "list"
-            case _ => fail("Unexpected number of array elements in `b`'s assignment")
+          inside(splatB.argumentOut.l) { case (list: Identifier) :: Nil =>
+            list.name shouldBe "list"
           }
 
           val List(c: Identifier, splatC: Call) = cAssignment.argumentOut.toList: @unchecked
           c.name shouldBe "c"
           splatC.name shouldBe RubyOperators.splat
-          inside(splatC.argumentOut.l) {
-            case (list: Identifier) :: Nil =>
-              list.name shouldBe "list"
-            case _ => fail("Unexpected number of array elements in `c`'s assignment")
+          inside(splatC.argumentOut.l) { case (list: Identifier) :: Nil =>
+            list.name shouldBe "list"
           }
 
-        case _ => fail("Unexpected number of assignments found")
       }
 
     }
@@ -313,13 +289,11 @@ class DestructuredAssignmentsTests extends RubyCode2CpgFixture {
             three.code shouldBe "3"
             four.code shouldBe "4"
             five.code shouldBe "5"
-          case _ => fail("Unexpected number of array elements in `*`'s assignment")
         }
 
         val List(c: Identifier, cLiteral: Literal) = cAssignment.argumentOut.toList: @unchecked
         c.name shouldBe "c"
         cLiteral.code shouldBe "6"
-      case xs => fail(s"Expected three assignments, got ${xs.code.mkString(",")}")
     }
   }
 
@@ -328,26 +302,22 @@ class DestructuredAssignmentsTests extends RubyCode2CpgFixture {
         |*, a = 1, 2, 3
         |""".stripMargin)
 
-    inside(cpg.assignment.codeExact("*, a = 1, 2, 3").l) {
-      case splatAssignment :: _ :: aAssignment :: Nil =>
-        aAssignment.code shouldBe "*, a = 1, 2, 3"
-        splatAssignment.code shouldBe "*, a = 1, 2, 3"
+    inside(cpg.assignment.codeExact("*, a = 1, 2, 3").l) { case splatAssignment :: _ :: aAssignment :: Nil =>
+      aAssignment.code shouldBe "*, a = 1, 2, 3"
+      splatAssignment.code shouldBe "*, a = 1, 2, 3"
 
-        val List(a: Identifier, lit: Literal) = aAssignment.argumentOut.toList: @unchecked
-        a.name shouldBe "a"
-        lit.code shouldBe "3"
+      val List(a: Identifier, lit: Literal) = aAssignment.argumentOut.toList: @unchecked
+      a.name shouldBe "a"
+      lit.code shouldBe "3"
 
-        val List(splat: Identifier, arr: Block) = splatAssignment.argumentOut.toList: @unchecked
-        splat.name shouldBe "_"
-        arr.code shouldBe "*, a = 1, 2, 3"
-        val asgns = arr.astChildren.assignment.where(_.target.isCall.nameExact(Operators.indexAccess)).l
-        inside(asgns.map(_.source)) {
-          case (one: Literal) :: (two: Literal) :: Nil =>
-            one.code shouldBe "1"
-            two.code shouldBe "2"
-          case _ => fail("Unexpected number of array elements in `*`'s assignment")
-        }
-      case _ => fail("Unexpected number of assignments found")
+      val List(splat: Identifier, arr: Block) = splatAssignment.argumentOut.toList: @unchecked
+      splat.name shouldBe "_"
+      arr.code shouldBe "*, a = 1, 2, 3"
+      val asgns = arr.astChildren.assignment.where(_.target.isCall.nameExact(Operators.indexAccess)).l
+      inside(asgns.map(_.source)) { case (one: Literal) :: (two: Literal) :: Nil =>
+        one.code shouldBe "1"
+        two.code shouldBe "2"
+      }
     }
   }
 
@@ -371,24 +341,21 @@ class DestructuredAssignmentsTests extends RubyCode2CpgFixture {
         arr.code shouldBe "a, *b, c = 1, 2, *d, *f, 4"
 
         val asgns = arr.astChildren.assignment.where(_.target.isCall.nameExact(Operators.indexAccess)).l
-        inside(asgns.map(_.source)) {
-          case (two: Literal) :: (d: Call) :: (f: Call) :: Nil =>
-            two.code shouldBe "2"
+        inside(asgns.map(_.source)) { case (two: Literal) :: (d: Call) :: (f: Call) :: Nil =>
+          two.code shouldBe "2"
 
-            d.code shouldBe "*d"
-            d.methodFullName shouldBe RubyOperators.splat
+          d.code shouldBe "*d"
+          d.methodFullName shouldBe RubyOperators.splat
 
-            f.code shouldBe "*f"
-            f.methodFullName shouldBe RubyOperators.splat
+          f.code shouldBe "*f"
+          f.methodFullName shouldBe RubyOperators.splat
 
-          case xs => fail(s"Unexpected number of array elements in `*`'s assignment, got ${xs.code.mkString(",")}")
         }
 
         val List(c: Identifier, cLiteral: Literal) = cAssignment.argumentOut.toList: @unchecked
         c.name shouldBe "c"
         cLiteral.code shouldBe "4"
 
-      case xs => fail(s"Expected 3 assignments, got ${xs.code.mkString(",")}")
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
@@ -52,10 +52,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
     }
 
     "have no parameters in the closure declaration" in {
-      inside(cpg.method("<lambda>0").parameter.indexGt(0).l) {
-        case Nil => // pass
-        case xs  => fail(s"Expected the closure to have no parameters, instead got [${xs.code.mkString(", ")}]")
-      }
+      cpg.method("<lambda>0").parameter.indexGt(0).l shouldBe empty
     }
 
     "have the return node under the closure (returning the literal)" in {
@@ -95,16 +92,13 @@ class DoBlockTests extends RubyCode2CpgFixture {
     }
 
     "specify the closure reference as an argument to the member call with block" in {
-      inside(cpg.call("each").argument.l) {
-        case (myArray: Identifier) :: (lambdaRef: TypeRef) :: Nil =>
-          myArray.argumentIndex shouldBe 0
-          myArray.name shouldBe "my_array"
-          myArray.code shouldBe "my_array"
+      inside(cpg.call("each").argument.l) { case (myArray: Identifier) :: (lambdaRef: TypeRef) :: Nil =>
+        myArray.argumentIndex shouldBe 0
+        myArray.name shouldBe "my_array"
+        myArray.code shouldBe "my_array"
 
-          lambdaRef.argumentIndex shouldBe 1
-          lambdaRef.typeFullName shouldBe s"Test0.rb:$Main.<lambda>0&Proc"
-        case xs =>
-          fail(s"Expected `each` call to have call and method ref arguments, instead got [${xs.code.mkString(", ")}]")
+        lambdaRef.argumentIndex shouldBe 1
+        lambdaRef.typeFullName shouldBe s"Test0.rb:$Main.<lambda>0&Proc"
       }
     }
 
@@ -150,16 +144,13 @@ class DoBlockTests extends RubyCode2CpgFixture {
     }
 
     "specify the closure reference as an argument to the member call with block" in {
-      inside(cpg.call("each").argument.l) {
-        case (hash: Identifier) :: (lambdaRef: TypeRef) :: Nil =>
-          hash.argumentIndex shouldBe 0
-          hash.name shouldBe "hash"
-          hash.code shouldBe "hash"
+      inside(cpg.call("each").argument.l) { case (hash: Identifier) :: (lambdaRef: TypeRef) :: Nil =>
+        hash.argumentIndex shouldBe 0
+        hash.name shouldBe "hash"
+        hash.code shouldBe "hash"
 
-          lambdaRef.argumentIndex shouldBe 1
-          lambdaRef.typeFullName shouldBe s"Test0.rb:$Main.<lambda>0&Proc"
-        case xs =>
-          fail(s"Expected `each` call to have call and method ref arguments, instead got [${xs.code.mkString(", ")}]")
+        lambdaRef.argumentIndex shouldBe 1
+        lambdaRef.typeFullName shouldBe s"Test0.rb:$Main.<lambda>0&Proc"
       }
     }
 
@@ -196,20 +187,14 @@ class DoBlockTests extends RubyCode2CpgFixture {
     }
 
     "nnotate the nodes via CAPTURE bindings" in {
-      cpg.closureBinding.l match {
-        case myValue :: _ :: Nil =>
-          inside(myValue._localViaRefOut) {
-            case Some(local) =>
-              local.name shouldBe "myValue"
-              local.method.fullName.headOption shouldBe Option(s"Test0.rb:$Main")
-            case None => fail("Expected closure binding refer to the captured local")
-          }
-          inside(myValue._captureIn.l) {
-            case (x: TypeRef) :: Nil => x.typeFullName shouldBe s"Test0.rb:$Main.<lambda>0&Proc"
-            case xs                  => fail(s"Expected single method ref binding but got [${xs.mkString(",")}]")
-          }
-        case xs =>
-          fail(s"Expected single closure binding but got [${xs.closureBindingId.mkString(",")}]")
+      inside(cpg.closureBinding.l) { case myValue :: _ :: Nil =>
+        inside(myValue._localViaRefOut) { case Some(local) =>
+          local.name shouldBe "myValue"
+          local.method.fullName.headOption shouldBe Option(s"Test0.rb:$Main")
+        }
+        inside(myValue._captureIn.l) { case (x: TypeRef) :: Nil =>
+          x.typeFullName shouldBe s"Test0.rb:$Main.<lambda>0&Proc"
+        }
       }
     }
 
@@ -241,13 +226,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
                 x.name shouldBe "x"
                 closure.typeFullName should endWith("<lambda>0&Proc")
               }
-            case xs =>
-              fail(
-                s"Expected four nodes under the lowering block of a constructor, instead got [${xs.code.mkString(",")}]"
-              )
           }
-        case xs =>
-          fail(s"Unexpected `foo` assignment children [${xs.code.mkString(",")}]")
       }
     }
   }
@@ -442,24 +421,18 @@ class DoBlockTests extends RubyCode2CpgFixture {
       case _ :: groupedParam :: countAssignment :: Nil =>
         inside(groupedParam.argument.l) {
           case (labelIdAssign: Call) :: (dateAssign: Call) :: (tmp0Splat: Call) :: Nil =>
-            inside(labelIdAssign.argument.l) {
-              case (lhs: Identifier) :: (rhs: Call) :: Nil =>
-                lhs.code shouldBe "label_id"
+            inside(labelIdAssign.argument.l) { case (lhs: Identifier) :: (rhs: Call) :: Nil =>
+              lhs.code shouldBe "label_id"
 
-                rhs.code shouldBe "*<tmp-1>"
-                rhs.methodFullName shouldBe RubyOperators.splat
-              case xs =>
-                fail(s"Expected lhs and rhs for assignment, got ${xs.code.mkString(",")}")
+              rhs.code shouldBe "*<tmp-1>"
+              rhs.methodFullName shouldBe RubyOperators.splat
             }
 
-            inside(dateAssign.argument.l) {
-              case (lhs: Identifier) :: (rhs: Call) :: Nil =>
-                lhs.code shouldBe "date"
+            inside(dateAssign.argument.l) { case (lhs: Identifier) :: (rhs: Call) :: Nil =>
+              lhs.code shouldBe "date"
 
-                rhs.code shouldBe "*<tmp-1>"
-                rhs.methodFullName shouldBe RubyOperators.splat
-              case xs =>
-                fail(s"Expected lhs and rhs for assignment, got ${xs.code.mkString(",")}")
+              rhs.code shouldBe "*<tmp-1>"
+              rhs.methodFullName shouldBe RubyOperators.splat
             }
         }
 
@@ -494,15 +467,10 @@ class DoBlockTests extends RubyCode2CpgFixture {
     "not result in `self` identifiers with multiple refOut edges" in {
       inside(cpg.method.isLambda.ast.fieldAccess.argument.isIdentifier.distinct.nameExact(RubyDefines.Self).l) {
         case (identifier: Identifier) :: Nil =>
-          inside(identifier.refOut.l) {
-            case (local: Local) :: Nil =>
-              local.name shouldBe "self"
-              local.closureBindingId shouldBe Some("Test0.rb:<main>.<lambda>0.self")
-            case xs =>
-              fail(s"Expected a single local, got [${xs.code.mkString(",")}]")
+          inside(identifier.refOut.l) { case (local: Local) :: Nil =>
+            local.name shouldBe "self"
+            local.closureBindingId shouldBe Some("Test0.rb:<main>.<lambda>0.self")
           }
-        case Nil =>
-          fail(s"Expected `self` identifiers, got none")
       }
     }
   }
@@ -525,28 +493,20 @@ class DoBlockTests extends RubyCode2CpgFixture {
           .local
           .nameExact(RubyDefines.Self)
           .l
-      ) {
-        case (local: Local) :: Nil =>
-          local.closureBindingId shouldBe Some("Test0.rb:<main>.UsersController.show.<lambda>0.<lambda>0.self")
+      ) { case (local: Local) :: Nil =>
+        local.closureBindingId shouldBe Some("Test0.rb:<main>.UsersController.show.<lambda>0.<lambda>0.self")
 
-          inside(cpg.closureBinding.closureBindingIdExact(local.closureBindingId.get).l) {
-            case (closureBinding: ClosureBinding) :: Nil =>
-              closureBinding.closureBindingId shouldBe Some(
-                "Test0.rb:<main>.UsersController.show.<lambda>0.<lambda>0.self"
-              )
+        inside(cpg.closureBinding.closureBindingIdExact(local.closureBindingId.get).l) {
+          case (closureBinding: ClosureBinding) :: Nil =>
+            closureBinding.closureBindingId shouldBe Some(
+              "Test0.rb:<main>.UsersController.show.<lambda>0.<lambda>0.self"
+            )
 
-              inside(closureBinding.refOut.isLocal.l) {
-                case (outerLocal: Local) :: Nil =>
-                  outerLocal.name shouldBe RubyDefines.Self
-                  outerLocal.closureBindingId shouldBe Some("Test0.rb:<main>.UsersController.show.<lambda>0.self")
-                case xs =>
-                  fail(s"Expected a single local referenced by the closure binding, got [${xs.code.mkString(",")}]")
-              }
-            case xs =>
-              fail(s"Expected a single closureBinding, got ${xs.size}")
-          }
-        case xs =>
-          fail(s"Expected a single local, got [${xs.code.mkString(",")}]")
+            inside(closureBinding.refOut.isLocal.l) { case (outerLocal: Local) :: Nil =>
+              outerLocal.name shouldBe RubyDefines.Self
+              outerLocal.closureBindingId shouldBe Some("Test0.rb:<main>.UsersController.show.<lambda>0.self")
+            }
+        }
       }
     }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
@@ -24,32 +24,24 @@ class DoBlockTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "create an anonymous method with associated type declaration and wrapper type" in {
-      inside(cpg.method.isModule.l) {
-        case program :: Nil =>
-          inside(program.astChildren.collectAll[Method].l) {
-            case foo :: closureMethod :: Nil =>
-              foo.name shouldBe "foo"
+      inside(cpg.method.isModule.l) { case program :: Nil =>
+        inside(program.astChildren.collectAll[Method].l) { case foo :: closureMethod :: Nil =>
+          foo.name shouldBe "foo"
 
-              closureMethod.name shouldBe s"<lambda>0"
-              closureMethod.fullName shouldBe s"Test0.rb:$Main.<lambda>0"
-            case xs => fail(s"Expected a two method nodes, instead got [${xs.code.mkString(", ")}]")
-          }
+          closureMethod.name shouldBe s"<lambda>0"
+          closureMethod.fullName shouldBe s"Test0.rb:$Main.<lambda>0"
+        }
 
-          inside(program.astChildren.collectAll[TypeDecl].isLambda.l) {
-            case closureType :: Nil =>
-              closureType.name shouldBe "<lambda>0"
-              closureType.fullName shouldBe s"Test0.rb:$Main.<lambda>0"
-            case xs => fail(s"Expected a one closure type node, instead got [${xs.code.mkString(", ")}]")
-          }
+        inside(program.astChildren.collectAll[TypeDecl].isLambda.l) { case closureType :: Nil =>
+          closureType.name shouldBe "<lambda>0"
+          closureType.fullName shouldBe s"Test0.rb:$Main.<lambda>0"
+        }
 
-          inside(program.astChildren.collectAll[TypeDecl].name(".*Proc").l) {
-            case closureType :: Nil =>
-              val callMember = closureType.member.nameExact("call").head
-              callMember.typeFullName shouldBe Defines.Any
-              callMember.dynamicTypeHintFullName shouldBe Seq(s"Test0.rb:$Main.<lambda>0")
-            case xs => fail(s"Expected a one closure type node, instead got [${xs.code.mkString(", ")}]")
-          }
-        case xs => fail(s"Expected a single program module, instead got [${xs.code.mkString(", ")}]")
+        inside(program.astChildren.collectAll[TypeDecl].name(".*Proc").l) { case closureType :: Nil =>
+          val callMember = closureType.member.nameExact("call").head
+          callMember.typeFullName shouldBe Defines.Any
+          callMember.dynamicTypeHintFullName shouldBe Seq(s"Test0.rb:$Main.<lambda>0")
+        }
       }
     }
 
@@ -67,10 +59,8 @@ class DoBlockTests extends RubyCode2CpgFixture {
     }
 
     "have the return node under the closure (returning the literal)" in {
-      inside(cpg.method("<lambda>0").block.astChildren.l) {
-        case ret :: _ :: Nil =>
-          ret.code shouldBe "\"world!\""
-        case xs => fail(s"Expected the closure to have a single call, instead got [${xs.code.mkString(", ")}]")
+      inside(cpg.method("<lambda>0").block.astChildren.l) { case ret :: _ :: Nil =>
+        ret.code shouldBe "\"world!\""
       }
     }
 
@@ -85,30 +75,22 @@ class DoBlockTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "create an anonymous method with associated type declaration" in {
-      inside(cpg.method.isModule.l) {
-        case program :: Nil =>
-          inside(program.astChildren.collectAll[Method].l) {
-            case closureMethod :: Nil =>
-              closureMethod.name shouldBe "<lambda>0"
-              closureMethod.fullName shouldBe s"Test0.rb:$Main.<lambda>0"
-            case xs => fail(s"Expected a one method nodes, instead got [${xs.code.mkString(", ")}]")
-          }
+      inside(cpg.method.isModule.l) { case program :: Nil =>
+        inside(program.astChildren.collectAll[Method].l) { case closureMethod :: Nil =>
+          closureMethod.name shouldBe "<lambda>0"
+          closureMethod.fullName shouldBe s"Test0.rb:$Main.<lambda>0"
+        }
 
-          inside(program.astChildren.collectAll[TypeDecl].isLambda.l) {
-            case closureType :: Nil =>
-              closureType.name shouldBe "<lambda>0"
-              closureType.fullName shouldBe s"Test0.rb:$Main.<lambda>0"
-            case xs => fail(s"Expected a one closure type node, instead got [${xs.code.mkString(", ")}]")
-          }
-        case xs => fail(s"Expected a single program module, instead got [${xs.code.mkString(", ")}]")
+        inside(program.astChildren.collectAll[TypeDecl].isLambda.l) { case closureType :: Nil =>
+          closureType.name shouldBe "<lambda>0"
+          closureType.fullName shouldBe s"Test0.rb:$Main.<lambda>0"
+        }
       }
     }
 
     "have the `item` parameter in the closure declaration" in {
-      inside(cpg.method("<lambda>0").parameter.indexGt(0).l) {
-        case itemParam :: Nil =>
-          itemParam.name shouldBe "item"
-        case xs => fail(s"Expected the closure to have a single parameter, instead got [${xs.code.mkString(", ")}]")
+      inside(cpg.method("<lambda>0").parameter.indexGt(0).l) { case itemParam :: Nil =>
+        itemParam.name shouldBe "item"
       }
     }
 
@@ -127,11 +109,9 @@ class DoBlockTests extends RubyCode2CpgFixture {
     }
 
     "have the call under the closure" in {
-      inside(cpg.method("<lambda>0").call.nameExact("puts").l) {
-        case puts :: Nil =>
-          puts.name shouldBe "puts"
-          puts.code shouldBe "puts item"
-        case xs => fail(s"Expected the closure to have a single call, instead got [${xs.code.mkString(", ")}]")
+      inside(cpg.method("<lambda>0").call.nameExact("puts").l) { case puts :: Nil =>
+        puts.name shouldBe "puts"
+        puts.code shouldBe "puts item"
       }
     }
   }
@@ -147,33 +127,25 @@ class DoBlockTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "create an anonymous method with associated type declaration" in {
-      inside(cpg.method.isModule.l) {
-        case program :: Nil =>
-          inside(program.astChildren.collectAll[Method].l) {
-            case closureMethod :: Nil =>
-              closureMethod.name shouldBe "<lambda>0"
-              closureMethod.fullName shouldBe s"Test0.rb:$Main.<lambda>0"
-              closureMethod.isLambda.nonEmpty shouldBe true
-            case xs => fail(s"Expected a one method nodes, instead got [${xs.code.mkString(", ")}]")
-          }
+      inside(cpg.method.isModule.l) { case program :: Nil =>
+        inside(program.astChildren.collectAll[Method].l) { case closureMethod :: Nil =>
+          closureMethod.name shouldBe "<lambda>0"
+          closureMethod.fullName shouldBe s"Test0.rb:$Main.<lambda>0"
+          closureMethod.isLambda.nonEmpty shouldBe true
+        }
 
-          inside(program.astChildren.collectAll[TypeDecl].isLambda.l) {
-            case closureType :: Nil =>
-              closureType.name shouldBe "<lambda>0"
-              closureType.fullName shouldBe s"Test0.rb:$Main.<lambda>0"
-              closureType.isLambda.nonEmpty shouldBe true
-            case xs => fail(s"Expected a one closure type node, instead got [${xs.code.mkString(", ")}]")
-          }
-        case xs => fail(s"Expected a single program module, instead got [${xs.code.mkString(", ")}]")
+        inside(program.astChildren.collectAll[TypeDecl].isLambda.l) { case closureType :: Nil =>
+          closureType.name shouldBe "<lambda>0"
+          closureType.fullName shouldBe s"Test0.rb:$Main.<lambda>0"
+          closureType.isLambda.nonEmpty shouldBe true
+        }
       }
     }
 
     "have the `key` and `value` parameter in the closure declaration" in {
-      inside(cpg.method("<lambda>0").parameter.indexGt(0).l) {
-        case keyParam :: valParam :: Nil =>
-          keyParam.name shouldBe "key"
-          valParam.name shouldBe "value"
-        case xs => fail(s"Expected the closure to have two calls, instead got [${xs.code.mkString(", ")}]")
+      inside(cpg.method("<lambda>0").parameter.indexGt(0).l) { case keyParam :: valParam :: Nil =>
+        keyParam.name shouldBe "key"
+        valParam.name shouldBe "value"
       }
     }
 
@@ -192,14 +164,12 @@ class DoBlockTests extends RubyCode2CpgFixture {
     }
 
     "have the calls under the closure" in {
-      inside(cpg.method("<lambda>0").call.nameExact("puts").l) {
-        case puts1 :: puts2 :: Nil =>
-          puts1.name shouldBe "puts"
-          puts1.code shouldBe "puts key"
+      inside(cpg.method("<lambda>0").call.nameExact("puts").l) { case puts1 :: puts2 :: Nil =>
+        puts1.name shouldBe "puts"
+        puts1.code shouldBe "puts key"
 
-          puts2.name shouldBe "puts"
-          puts2.code shouldBe "puts value"
-        case xs => fail(s"Expected the closure to have a single parameter, instead got [${xs.code.mkString(", ")}]")
+        puts2.name shouldBe "puts"
+        puts2.code shouldBe "puts value"
       }
     }
 
@@ -214,18 +184,14 @@ class DoBlockTests extends RubyCode2CpgFixture {
 
     // Basic assertions for expected behaviour
     "create the declarations for the closure with captured local" in {
-      inside(cpg.method.isLambda.l) {
-        case m :: Nil =>
-          m.name should startWith("<lambda>")
-          val myValue = m.local.nameExact("myValue").head
-          myValue.closureBindingId shouldBe Option(s"Test0.rb:$Main.myValue")
-        case xs => fail(s"Expected exactly one closure method decl, instead got [${xs.code.mkString(",")}]")
+      inside(cpg.method.isLambda.l) { case m :: Nil =>
+        m.name should startWith("<lambda>")
+        val myValue = m.local.nameExact("myValue").head
+        myValue.closureBindingId shouldBe Option(s"Test0.rb:$Main.myValue")
       }
 
-      inside(cpg.typeDecl.isLambda.l) {
-        case m :: Nil =>
-          m.name should startWith("<lambda>")
-        case xs => fail(s"Expected exactly one closure type decl, instead got [${xs.code.mkString(",")}]")
+      inside(cpg.typeDecl.isLambda.l) { case m :: Nil =>
+        m.name should startWith("<lambda>")
       }
     }
 
@@ -271,11 +237,9 @@ class DoBlockTests extends RubyCode2CpgFixture {
               newCall.methodFullName shouldBe Defines.DynamicCallUnknownFullName
               newCall.dynamicTypeHintFullName should contain(s"${RubyDefines.prefixAsCoreType(s"Array")}.$Initialize")
 
-              inside(newCall.argument.l) {
-                case (_: Identifier) :: (x: Identifier) :: (closure: TypeRef) :: Nil =>
-                  x.name shouldBe "x"
-                  closure.typeFullName should endWith("<lambda>0&Proc")
-                case xs => fail(s"Expected a base, `x`, and closure ref, instead got [${xs.code.mkString(",")}]")
+              inside(newCall.argument.l) { case (_: Identifier) :: (x: Identifier) :: (closure: TypeRef) :: Nil =>
+                x.name shouldBe "x"
+                closure.typeFullName should endWith("<lambda>0&Proc")
               }
             case xs =>
               fail(
@@ -296,11 +260,9 @@ class DoBlockTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "Create correct parameter for args" in {
-      inside(cpg.parameter.name("args").l) {
-        case argParam :: Nil =>
-          argParam.name shouldBe "args"
-          argParam.code shouldBe "**args"
-        case _ => fail("Expected parameter `**args` to exist")
+      inside(cpg.parameter.name("args").l) { case argParam :: Nil =>
+        argParam.name shouldBe "args"
+        argParam.code shouldBe "**args"
       }
     }
   }
@@ -322,7 +284,6 @@ class DoBlockTests extends RubyCode2CpgFixture {
             .call
             .nameExact("puts")
             .nonEmpty shouldBe true
-        case xs => fail(s"Expected a literal and method ref argument, instead got $xs")
       }
     }
 
@@ -335,20 +296,16 @@ class DoBlockTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "create a lambda method with a `y` parameter" in {
-      inside(cpg.method.isLambda.headOption) {
-        case Some(lambda) =>
-          lambda.code shouldBe "->(y) { y }"
-          lambda.parameter.name.l shouldBe List("y")
-        case xs => fail(s"Expected a lambda method")
+      inside(cpg.method.isLambda.headOption) { case Some(lambda) =>
+        lambda.code shouldBe "->(y) { y }"
+        lambda.parameter.name.l shouldBe List("y")
       }
     }
 
     "create a method ref assigned to `arrow_lambda`" in {
-      inside(cpg.method.isModule.assignment.code("arrow_lambda.*").headOption) {
-        case Some(lambdaAssign) =>
-          lambdaAssign.target.asInstanceOf[Identifier].name shouldBe "arrow_lambda"
-          lambdaAssign.source.asInstanceOf[TypeRef].typeFullName shouldBe s"Test0.rb:$Main.<lambda>0&Proc"
-        case xs => fail(s"Expected an assignment to a lambda")
+      inside(cpg.method.isModule.assignment.code("arrow_lambda.*").headOption) { case Some(lambdaAssign) =>
+        lambdaAssign.target.asInstanceOf[Identifier].name shouldBe "arrow_lambda"
+        lambdaAssign.source.asInstanceOf[TypeRef].typeFullName shouldBe s"Test0.rb:$Main.<lambda>0&Proc"
       }
     }
 
@@ -361,20 +318,16 @@ class DoBlockTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "create a lambda method with a `y` parameter" in {
-      inside(cpg.method.isLambda.headOption) {
-        case Some(lambda) =>
-          lambda.code shouldBe "lambda { |y| y }"
-          lambda.parameter.name.l shouldBe List("y")
-        case xs => fail(s"Expected a lambda method")
+      inside(cpg.method.isLambda.headOption) { case Some(lambda) =>
+        lambda.code shouldBe "lambda { |y| y }"
+        lambda.parameter.name.l shouldBe List("y")
       }
     }
 
     "create a method ref assigned to `arrow_lambda`" in {
-      inside(cpg.method.isModule.assignment.code("a_lambda.*").headOption) {
-        case Some(lambdaAssign) =>
-          lambdaAssign.target.asInstanceOf[Identifier].name shouldBe "a_lambda"
-          lambdaAssign.source.asInstanceOf[TypeRef].typeFullName shouldBe s"Test0.rb:$Main.<lambda>0&Proc"
-        case xs => fail(s"Expected an assignment to a lambda")
+      inside(cpg.method.isModule.assignment.code("a_lambda.*").headOption) { case Some(lambdaAssign) =>
+        lambdaAssign.target.asInstanceOf[Identifier].name shouldBe "a_lambda"
+        lambdaAssign.source.asInstanceOf[TypeRef].typeFullName shouldBe s"Test0.rb:$Main.<lambda>0&Proc"
       }
     }
 
@@ -405,15 +358,12 @@ class DoBlockTests extends RubyCode2CpgFixture {
         hashInsideLocal.closureBindingId shouldBe None
         jfsCapturedLocal.closureBindingId shouldBe Some("Test0.rb:<main>.get_pto_schedule.jfs")
         selfCapturedLocal.closureBindingId shouldBe Some("Test0.rb:<main>.get_pto_schedule.<lambda>0.self")
-      case xs => fail(s"Expected 6 locals, got ${xs.code.mkString(",")}")
     }
 
-    inside(cpg.method.isLambda.local.l) {
-      case hashLocal :: _ :: jfsLocal :: selfLocal :: Nil =>
-        hashLocal.closureBindingId shouldBe None
-        jfsLocal.closureBindingId shouldBe Some("Test0.rb:<main>.get_pto_schedule.jfs")
-        selfLocal.closureBindingId shouldBe Some("Test0.rb:<main>.get_pto_schedule.<lambda>0.self")
-      case xs => fail(s"Expected 3 locals in lambda, got ${xs.code.mkString(",")}")
+    inside(cpg.method.isLambda.local.l) { case hashLocal :: _ :: jfsLocal :: selfLocal :: Nil =>
+      hashLocal.closureBindingId shouldBe None
+      jfsLocal.closureBindingId shouldBe Some("Test0.rb:<main>.get_pto_schedule.jfs")
+      selfLocal.closureBindingId shouldBe Some("Test0.rb:<main>.get_pto_schedule.<lambda>0.self")
     }
   }
 
@@ -447,34 +397,29 @@ class DoBlockTests extends RubyCode2CpgFixture {
 
           iParam.name shouldBe "i"
           iParam.code shouldBe "&i"
-        case xs => fail(s"Expected 8 parameters, got [${xs.name.mkString(", ")}]")
       }
     }
 
     "Generate required locals" in {
-      inside(cpg.method.isLambda.body.local.l) {
-        case bLocal :: cLocal :: fLocal :: gSplatLocal :: selfLocal :: Nil =>
-          bLocal.code shouldBe "b"
-          cLocal.code shouldBe "c"
+      inside(cpg.method.isLambda.body.local.l) { case bLocal :: cLocal :: fLocal :: gSplatLocal :: selfLocal :: Nil =>
+        bLocal.code shouldBe "b"
+        cLocal.code shouldBe "c"
 
-          fLocal.code shouldBe "f"
-          gSplatLocal.code shouldBe "g"
+        fLocal.code shouldBe "f"
+        gSplatLocal.code shouldBe "g"
 
-          selfLocal.code shouldBe "self"
-          selfLocal.closureBindingId shouldBe Some("Test0.rb:<main>.<lambda>0.self")
-        case xs => fail(s"Expected 4 locals, got [${xs.name.mkString(", ")}]")
+        selfLocal.code shouldBe "self"
+        selfLocal.closureBindingId shouldBe Some("Test0.rb:<main>.<lambda>0.self")
       }
     }
 
     "Generate required `assignment` calls" in {
-      inside(cpg.method.isLambda.call(Operators.assignment).l) {
-        case bAssign :: cAssign :: fAssign :: gAssign :: Nil =>
-          bAssign.code shouldBe "b = *<tmp-0>"
-          cAssign.code shouldBe "c = *<tmp-0>"
+      inside(cpg.method.isLambda.call(Operators.assignment).l) { case bAssign :: cAssign :: fAssign :: gAssign :: Nil =>
+        bAssign.code shouldBe "b = *<tmp-0>"
+        cAssign.code shouldBe "c = *<tmp-0>"
 
-          fAssign.code shouldBe "f = *<tmp-1>"
-          gAssign.code shouldBe "*g = *<tmp-1>"
-        case xs => fail(s"Expected 4 assignments, got [${xs.code.mkString(", ")}]")
+        fAssign.code shouldBe "f = *<tmp-1>"
+        gAssign.code shouldBe "*g = *<tmp-1>"
       }
     }
 
@@ -516,17 +461,13 @@ class DoBlockTests extends RubyCode2CpgFixture {
               case xs =>
                 fail(s"Expected lhs and rhs for assignment, got ${xs.code.mkString(",")}")
             }
-          case xs => fail(s"Expected four arguments for call, got [${xs.code.mkString(",")}]")
         }
 
-        inside(countAssignment.argument.l) {
-          case (lhs: Identifier) :: (rhs: Call) :: Nil =>
-            lhs.code shouldBe "count"
-            rhs.code shouldBe "*<tmp-0>"
-            rhs.methodFullName shouldBe RubyOperators.splat
-          case xs => fail(s"Expected LHS and RHS for assignment, got ${xs.code.mkString(",")}")
+        inside(countAssignment.argument.l) { case (lhs: Identifier) :: (rhs: Call) :: Nil =>
+          lhs.code shouldBe "count"
+          rhs.code shouldBe "*<tmp-0>"
+          rhs.methodFullName shouldBe RubyOperators.splat
         }
-      case xs => fail(s"Expected three assignment calls, got [${xs.code.mkString(",")}]")
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ErbTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ErbTests.scala
@@ -223,12 +223,9 @@ class ErbTests extends RubyCode2CpgFixture {
         formCall.lineNumber shouldBe None
         formCall.code shouldBe "form_with(url: some_url)"
 
-        inside(formCall.receiver.l) {
-          case (formCallReceiver: Call) :: Nil =>
-            formCallReceiver.code shouldBe "self.form_with"
-            formCallReceiver.methodFullName shouldBe "<operator>.fieldAccess"
-          case xs =>
-            fail(s"Expected one receiver call to `self.form_with`, got ${xs.code.mkString("[", ",", "]")}")
+        inside(formCall.receiver.l) { case (formCallReceiver: Call) :: Nil =>
+          formCallReceiver.code shouldBe "self.form_with"
+          formCallReceiver.methodFullName shouldBe "<operator>.fieldAccess"
         }
       }
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ErbTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ErbTests.scala
@@ -32,41 +32,35 @@ class ErbTests extends RubyCode2CpgFixture {
     )
 
     "Condition for IF should be `equals`" in {
-      inside(cpg.controlStructure.isIf.condition.l) {
-        case (condition: Call) :: Nil =>
-          condition.lineNumber shouldBe None
-          condition.columnNumber shouldBe None
-          condition.methodFullName shouldBe Operators.equals
-        case xs => fail(s"Expected one condition for if, got ${xs.code.mkString("[", ",", "]")}")
+      inside(cpg.controlStructure.isIf.condition.l) { case (condition: Call) :: Nil =>
+        condition.lineNumber shouldBe None
+        condition.columnNumber shouldBe None
+        condition.methodFullName shouldBe Operators.equals
       }
     }
 
     "True branch contains appends" in {
-      inside(cpg.controlStructure.isIf.whenTrue.astChildren.isCall.l) {
-        case appendCallOne :: appendCallTwo :: Nil =>
-          appendCallOne.lineNumber shouldBe None
-          appendCallTwo.lineNumber shouldBe None
+      inside(cpg.controlStructure.isIf.whenTrue.astChildren.isCall.l) { case appendCallOne :: appendCallTwo :: Nil =>
+        appendCallOne.lineNumber shouldBe None
+        appendCallTwo.lineNumber shouldBe None
 
-          appendCallOne.code shouldBe
-            """self.joernBufferAppend(self.joernBuffer, "redis:\nhost:")""".stripMargin
-          appendCallOne.typeFullName shouldBe Constants.stringPrefix
+        appendCallOne.code shouldBe
+          """self.joernBufferAppend(self.joernBuffer, "redis:\nhost:")""".stripMargin
+        appendCallOne.typeFullName shouldBe Constants.stringPrefix
 
-          appendCallTwo.code shouldBe "self.joernBufferAppend(self.joernBuffer, <%= ENV['REDIS_HOST'] %>)"
-          appendCallTwo.typeFullName shouldBe Constants.stringPrefix
+        appendCallTwo.code shouldBe "self.joernBufferAppend(self.joernBuffer, <%= ENV['REDIS_HOST'] %>)"
+        appendCallTwo.typeFullName shouldBe Constants.stringPrefix
 
-          inside(appendCallTwo.argument.l) {
-            case (argOne: Call) :: (argTwo: Call) :: Nil =>
-              argOne.code shouldBe "self.joernBuffer"
-              argOne.methodFullName shouldBe "<operator>.fieldAccess"
-              argOne.typeFullName shouldBe Constants.stringPrefix
+        inside(appendCallTwo.argument.l) { case (argOne: Call) :: (argTwo: Call) :: Nil =>
+          argOne.code shouldBe "self.joernBuffer"
+          argOne.methodFullName shouldBe "<operator>.fieldAccess"
+          argOne.typeFullName shouldBe Constants.stringPrefix
 
-              argTwo.code shouldBe "<%= ENV['REDIS_HOST'] %>"
-              argTwo.methodFullName shouldBe RubyOperators.templateOutEscape
-            case xs => fail(s"Expected two arguments for append call, got ${xs.code.mkString("[", ",", "]")}")
-          }
+          argTwo.code shouldBe "<%= ENV['REDIS_HOST'] %>"
+          argTwo.methodFullName shouldBe RubyOperators.templateOutEscape
+        }
 
-          appendCallTwo.receiver shouldBe empty
-        case xs => fail(s"Expected one true branch, got ${xs.code.mkString("[", ",", "]")}")
+        appendCallTwo.receiver shouldBe empty
       }
     }
 
@@ -97,41 +91,35 @@ class ErbTests extends RubyCode2CpgFixture {
     )
 
     "Contain IF ControlStruct" in {
-      inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).l) {
-        case ifStruct :: _ :: Nil =>
-          inside(ifStruct.condition.l) {
-            case (cond: Call) :: Nil =>
-              cond.methodFullName shouldBe Operators.equals
-              val List(lhs: Call, rhs: Literal) = cond.argument.l: @unchecked
-              lhs.methodFullName shouldBe Operators.indexAccess
-              rhs.code shouldBe "'true'"
-            case xs => fail(s"Expected one condition, got [${xs.code.mkString(",")}]")
-          }
+      inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).l) { case ifStruct :: _ :: Nil =>
+        inside(ifStruct.condition.l) { case (cond: Call) :: Nil =>
+          cond.methodFullName shouldBe Operators.equals
+          val List(lhs: Call, rhs: Literal) = cond.argument.l: @unchecked
+          lhs.methodFullName shouldBe Operators.indexAccess
+          rhs.code shouldBe "'true'"
+        }
 
-          inside(ifStruct.whenTrue.isBlock.astChildren.isCall.l) {
-            case appendCallStatic :: appendCallTemplate :: Nil =>
-              appendCallStatic.receiver shouldBe empty
-              appendCallStatic.typeFullName shouldBe Constants.stringPrefix
+        inside(ifStruct.whenTrue.isBlock.astChildren.isCall.l) { case appendCallStatic :: appendCallTemplate :: Nil =>
+          appendCallStatic.receiver shouldBe empty
+          appendCallStatic.typeFullName shouldBe Constants.stringPrefix
 
-              val List(callArgStaticOne: Call, callArgStaticTwo) = appendCallStatic.argument.l: @unchecked
-              callArgStaticOne.code shouldBe "self.joernBuffer"
-              callArgStaticOne.typeFullName shouldBe Constants.stringPrefix
-              callArgStaticTwo.code shouldBe
-                """redis:
+          val List(callArgStaticOne: Call, callArgStaticTwo) = appendCallStatic.argument.l: @unchecked
+          callArgStaticOne.code shouldBe "self.joernBuffer"
+          callArgStaticOne.typeFullName shouldBe Constants.stringPrefix
+          callArgStaticTwo.code shouldBe
+            """redis:
                   |host:""".stripMargin
 
-              appendCallTemplate.receiver shouldBe empty
+          appendCallTemplate.receiver shouldBe empty
 
-              val List(callArgOne: Call, callArgTwo: Call) = appendCallTemplate.argument.l: @unchecked
-              callArgOne.code shouldBe "self.joernBuffer"
-              callArgOne.typeFullName shouldBe Constants.stringPrefix
+          val List(callArgOne: Call, callArgTwo: Call) = appendCallTemplate.argument.l: @unchecked
+          callArgOne.code shouldBe "self.joernBuffer"
+          callArgOne.typeFullName shouldBe Constants.stringPrefix
 
-              callArgTwo.methodFullName shouldBe RubyOperators.templateOutEscape
-              callArgTwo.code shouldBe "<%= ENV['REDIS_HOST'] %>"
+          callArgTwo.methodFullName shouldBe RubyOperators.templateOutEscape
+          callArgTwo.code shouldBe "<%= ENV['REDIS_HOST'] %>"
 
-            case xs => fail(s"Expected two appends for true branch, got [${xs.code.mkString(",")}]")
-          }
-        case xs => fail(s"Expected one IF Structure, got [${xs.code.mkString(",")}]")
+        }
       }
     }
 
@@ -144,36 +132,31 @@ class ErbTests extends RubyCode2CpgFixture {
           .astChildren
           .isControlStructure
           .l
-      ) {
-        case elsifStruct :: Nil =>
-          inside(elsifStruct.condition.l) {
-            case (cond: Call) :: Nil =>
-              cond.methodFullName shouldBe Operators.equals
-              val List(lhs: Call, rhs: Literal) = cond.argument.l: @unchecked
-              lhs.methodFullName shouldBe Operators.indexAccess
-              rhs.code shouldBe "'true'"
-            case xs => fail(s"Expected one condition, got [${xs.code.mkString(",")}]")
-          }
+      ) { case elsifStruct :: Nil =>
+        inside(elsifStruct.condition.l) { case (cond: Call) :: Nil =>
+          cond.methodFullName shouldBe Operators.equals
+          val List(lhs: Call, rhs: Literal) = cond.argument.l: @unchecked
+          lhs.methodFullName shouldBe Operators.indexAccess
+          rhs.code shouldBe "'true'"
+        }
 
-          inside(elsifStruct.whenTrue.isBlock.astChildren.isCall.l) {
-            case appendCallStatic :: appendCallTemplate :: Nil =>
-              appendCallStatic.argument.l.size shouldBe 2
-              val List(callArgStaticOne, callArgStaticTwo) = appendCallStatic.argument.l: @unchecked
-              callArgStaticOne.code shouldBe "self.joernBuffer"
-              callArgStaticTwo.code shouldBe
-                """rabbitmq:
+        inside(elsifStruct.whenTrue.isBlock.astChildren.isCall.l) {
+          case appendCallStatic :: appendCallTemplate :: Nil =>
+            appendCallStatic.argument.l.size shouldBe 2
+            val List(callArgStaticOne, callArgStaticTwo) = appendCallStatic.argument.l: @unchecked
+            callArgStaticOne.code shouldBe "self.joernBuffer"
+            callArgStaticTwo.code shouldBe
+              """rabbitmq:
                   |port:""".stripMargin
 
-              appendCallTemplate.argument.l.size shouldBe 2
-              val List(callArgOne: Call, callArgTwo: Call) =
-                appendCallTemplate.argument.l: @unchecked
-              callArgOne.code shouldBe "self.joernBuffer"
-              callArgTwo.methodFullName shouldBe RubyOperators.templateOutRaw
-              callArgTwo.code shouldBe "<%== ENV['RABBITMQ_PORT'] %>"
+            appendCallTemplate.argument.l.size shouldBe 2
+            val List(callArgOne: Call, callArgTwo: Call) =
+              appendCallTemplate.argument.l: @unchecked
+            callArgOne.code shouldBe "self.joernBuffer"
+            callArgTwo.methodFullName shouldBe RubyOperators.templateOutRaw
+            callArgTwo.code shouldBe "<%== ENV['RABBITMQ_PORT'] %>"
 
-            case xs => fail(s"Expected two appends for true branch, got [${xs.code.mkString(",")}]")
-          }
-        case xs => fail(s"Expected one ELSE-IF block, got ${xs.code.mkString("[", ",", "]")}")
+        }
       }
     }
 
@@ -197,10 +180,8 @@ class ErbTests extends RubyCode2CpgFixture {
       "test.erb"
     )
 
-    inside(cpg.method.name(Constants.Main).body.astChildren.isCall.l) {
-      case fmtString :: Nil =>
-        fmtString.methodFullName shouldBe Operators.formatString
-      case xs => fail(s"Expected one call to fmtString, got [${xs.code.mkString(",")}]")
+    inside(cpg.method.name(Constants.Main).body.astChildren.isCall.l) { case fmtString :: Nil =>
+      fmtString.methodFullName shouldBe Operators.formatString
     }
   }
 
@@ -238,73 +219,59 @@ class ErbTests extends RubyCode2CpgFixture {
     )
 
     "Contains call to main function" in {
-      inside(cpg.call.name("form_with").l) {
-        case formCall :: Nil =>
-          formCall.lineNumber shouldBe None
-          formCall.code shouldBe "form_with(url: some_url)"
+      inside(cpg.call.name("form_with").l) { case formCall :: Nil =>
+        formCall.lineNumber shouldBe None
+        formCall.code shouldBe "form_with(url: some_url)"
 
-          inside(formCall.receiver.l) {
-            case (formCallReceiver: Call) :: Nil =>
-              formCallReceiver.code shouldBe "self.form_with"
-              formCallReceiver.methodFullName shouldBe "<operator>.fieldAccess"
-            case xs =>
-              fail(s"Expected one receiver call to `self.form_with`, got ${xs.code.mkString("[", ",", "]")}")
-          }
-        case xs => fail(s"Expected one call to `form_with`, got ${xs.code.mkString("[", ",", "]")}")
+        inside(formCall.receiver.l) {
+          case (formCallReceiver: Call) :: Nil =>
+            formCallReceiver.code shouldBe "self.form_with"
+            formCallReceiver.methodFullName shouldBe "<operator>.fieldAccess"
+          case xs =>
+            fail(s"Expected one receiver call to `self.form_with`, got ${xs.code.mkString("[", ",", "]")}")
+        }
       }
     }
 
     "Lower to a lambda" in {
-      inside(cpg.typeDecl.isLambda.l) {
-        case lambda :: Nil =>
-          lambda.fullName shouldBe "index.html.erb:<main>.<lambda>0"
-        case xs => fail(s"Expected one lambda, got ${xs.code.mkString("[", ",", "]")}")
+      inside(cpg.typeDecl.isLambda.l) { case lambda :: Nil =>
+        lambda.fullName shouldBe "index.html.erb:<main>.<lambda>0"
       }
 
-      inside(cpg.method.isLambda.l) {
-        case lambdaMethod :: Nil =>
-          val List(lambdaParamForm) = lambdaMethod.parameter.l
-          lambdaParamForm.code shouldBe "form"
+      inside(cpg.method.isLambda.l) { case lambdaMethod :: Nil =>
+        val List(lambdaParamForm) = lambdaMethod.parameter.l
+        lambdaParamForm.code shouldBe "form"
 
-          inside(lambdaMethod.body.astChildren.l) {
-            case _ :: _ :: (appendCallTemplate: Call) :: _ :: _ :: Nil =>
-              appendCallTemplate.code shouldBe "self.joernBufferAppend(joernInnerBuffer, <%= form.text_field :name %>)"
-              appendCallTemplate.methodFullName shouldBe "<operator>.joernBufferAppend"
-              val List(appendCallArgOne, appendCallArgTwo: Call) = appendCallTemplate.argument.l: @unchecked
-              appendCallArgOne.code shouldBe "joernInnerBuffer"
-              appendCallArgTwo.code shouldBe "<%= form.text_field :name %>"
-              appendCallArgTwo.methodFullName shouldBe RubyOperators.templateOutEscape
+        inside(lambdaMethod.body.astChildren.l) { case _ :: _ :: (appendCallTemplate: Call) :: _ :: _ :: Nil =>
+          appendCallTemplate.code shouldBe "self.joernBufferAppend(joernInnerBuffer, <%= form.text_field :name %>)"
+          appendCallTemplate.methodFullName shouldBe "<operator>.joernBufferAppend"
+          val List(appendCallArgOne, appendCallArgTwo: Call) = appendCallTemplate.argument.l: @unchecked
+          appendCallArgOne.code shouldBe "joernInnerBuffer"
+          appendCallArgTwo.code shouldBe "<%= form.text_field :name %>"
+          appendCallArgTwo.methodFullName shouldBe RubyOperators.templateOutEscape
 
-              val List(templateOutEscapeArg) = appendCallArgTwo.argument.l
-              templateOutEscapeArg.code shouldBe "form.text_field :name"
-            case xs => fail(s"Expected 3 children for body, got ${xs.code.mkString("[", ",", "]")}")
-          }
+          val List(templateOutEscapeArg) = appendCallArgTwo.argument.l
+          templateOutEscapeArg.code shouldBe "form.text_field :name"
+        }
 
-          inside(lambdaMethod.methodReturn.toReturn.l) {
-            case lambdaRet :: Nil =>
-              val List(innerBuff) = lambdaRet.astChildren.l
-              innerBuff.code shouldBe "joernInnerBuffer"
-            case xs => fail(s"Expected one RETURN, got ${xs.code.mkString("[", ",", "]")}")
-          }
-        case xs => fail(s"Expected one lambda method, got ${xs.code.mkString("[", ",", "]")}")
+        inside(lambdaMethod.methodReturn.toReturn.l) { case lambdaRet :: Nil =>
+          val List(innerBuff) = lambdaRet.astChildren.l
+          innerBuff.code shouldBe "joernInnerBuffer"
+        }
       }
     }
 
     "Assign the lambda to a variable" in {
-      inside(cpg.call.name(Operators.assignment).l) {
-        case _ :: _ :: lambdaAssign :: Nil =>
-          val List(lhs, rhs: TypeRef) = lambdaAssign.argument.l: @unchecked
-          lhs.code shouldBe "rails_lambda_0"
-          rhs.code shouldBe "<lambda>0&Proc"
-        case xs => fail(s"Expected one assignment, got ${xs.code.mkString("[", ",", "]")}")
+      inside(cpg.call.name(Operators.assignment).l) { case _ :: _ :: lambdaAssign :: Nil =>
+        val List(lhs, rhs: TypeRef) = lambdaAssign.argument.l: @unchecked
+        lhs.code shouldBe "rails_lambda_0"
+        rhs.code shouldBe "<lambda>0&Proc"
       }
     }
 
     "Contains a call to the lowered lambda" in {
-      inside(cpg.call.name("call").l) {
-        case lambdaCall :: Nil =>
-          lambdaCall.code shouldBe "rails_lambda_0.call(form)"
-        case xs => fail(s"Expected one call to `call`, got ${xs.code.mkString("[", ",", "]")}")
+      inside(cpg.call.name("call").l) { case lambdaCall :: Nil =>
+        lambdaCall.code shouldBe "rails_lambda_0.call(form)"
       }
     }
   }
@@ -325,29 +292,23 @@ class ErbTests extends RubyCode2CpgFixture {
       "index.html.erb"
     )
 
-    inside(cpg.controlStructure.isIf.l) {
-      case ifStruct :: Nil =>
-        inside(ifStruct.condition.l) {
-          case (condition: Call) :: Nil =>
-            condition.methodFullName shouldBe Operators.equals
-            condition.code shouldBe "a == \"a\""
-            val List(lhs, rhs) = condition.argument.l
-            lhs.code shouldBe "self.a"
-            rhs.code shouldBe "\"a\""
-          case xs => fail(s"Expected one condition, got ${xs.code.mkString("[", ",", "]")}")
-        }
+    inside(cpg.controlStructure.isIf.l) { case ifStruct :: Nil =>
+      inside(ifStruct.condition.l) { case (condition: Call) :: Nil =>
+        condition.methodFullName shouldBe Operators.equals
+        condition.code shouldBe "a == \"a\""
+        val List(lhs, rhs) = condition.argument.l
+        lhs.code shouldBe "self.a"
+        rhs.code shouldBe "\"a\""
+      }
 
-        inside(ifStruct.whenTrue.l) {
-          case trueBranch :: Nil =>
-            val List(appendCall: Call) = trueBranch.astChildren.isCall.l
-            appendCall.code shouldBe "self.joernBufferAppend(self.joernBuffer, <%= link_to(url: some_url) %>)"
-            val List(appendArgOne, appendArgTwo: Call) = appendCall.argument.l: @unchecked
-            appendArgOne.code shouldBe "self.joernBuffer"
-            appendArgTwo.methodFullName shouldBe RubyOperators.templateOutEscape
-            appendArgTwo.code shouldBe "<%= link_to(url: some_url) %>"
-          case xs => fail(s"Expected one true branch, got ${xs.code.mkString("[", ",", "]")}")
-        }
-      case xs => fail(s"Expected one ifStruct, got ${xs.code.mkString("[", ",", "]")}")
+      inside(ifStruct.whenTrue.l) { case trueBranch :: Nil =>
+        val List(appendCall: Call) = trueBranch.astChildren.isCall.l
+        appendCall.code shouldBe "self.joernBufferAppend(self.joernBuffer, <%= link_to(url: some_url) %>)"
+        val List(appendArgOne, appendArgTwo: Call) = appendCall.argument.l: @unchecked
+        appendArgOne.code shouldBe "self.joernBuffer"
+        appendArgTwo.methodFullName shouldBe RubyOperators.templateOutEscape
+        appendArgTwo.code shouldBe "<%= link_to(url: some_url) %>"
+      }
     }
   }
 
@@ -361,29 +322,23 @@ class ErbTests extends RubyCode2CpgFixture {
       "index.html.erb"
     )
 
-    inside(cpg.method.isLambda.l) {
-      case eachLambda :: Nil =>
-        val List(varParam) = eachLambda.parameter.l
-        varParam.code shouldBe "var"
+    inside(cpg.method.isLambda.l) { case eachLambda :: Nil =>
+      val List(varParam) = eachLambda.parameter.l
+      varParam.code shouldBe "var"
 
-        inside(eachLambda.methodReturn.toReturn.l) {
-          case ret :: Nil =>
-            ret.code shouldBe "self.joernBufferAppend(self.joernBuffer, <%= var.out %>)"
-            inside(ret.astChildren.l) {
-              case (appendCall: Call) :: Nil =>
-                appendCall.receiver shouldBe empty
-                appendCall.typeFullName shouldBe Constants.stringPrefix
+      inside(eachLambda.methodReturn.toReturn.l) { case ret :: Nil =>
+        ret.code shouldBe "self.joernBufferAppend(self.joernBuffer, <%= var.out %>)"
+        inside(ret.astChildren.l) { case (appendCall: Call) :: Nil =>
+          appendCall.receiver shouldBe empty
+          appendCall.typeFullName shouldBe Constants.stringPrefix
 
-                val List(callArgOne: Call, callArgTwo: Call) = appendCall.argument.l: @unchecked
-                callArgOne.code shouldBe "self.joernBuffer"
-                callArgOne.typeFullName shouldBe Constants.stringPrefix
-                callArgTwo.methodFullName shouldBe RubyOperators.templateOutEscape
-                callArgTwo.code shouldBe "<%= var.out %>"
-              case xs => fail(s"Expected one call in the return, got ${xs.code.mkString("[", ",", "]")}")
-            }
-          case xs => fail(s"Expected one return, got ${xs.code.mkString("[", ",", "]")}")
+          val List(callArgOne: Call, callArgTwo: Call) = appendCall.argument.l: @unchecked
+          callArgOne.code shouldBe "self.joernBuffer"
+          callArgOne.typeFullName shouldBe Constants.stringPrefix
+          callArgTwo.methodFullName shouldBe RubyOperators.templateOutEscape
+          callArgTwo.code shouldBe "<%= var.out %>"
         }
-      case xs => fail(s"Expected one lambda, got ${xs.code.mkString("[", ",", "]")}")
+      }
     }
   }
 
@@ -410,19 +365,15 @@ class ErbTests extends RubyCode2CpgFixture {
       "index.html.erb"
     )
 
-    inside(cpg.method.name("<main>").parameter.name("self").l) {
-      case selfMain :: Nil =>
-        selfMain._closureBindingViaRefIn.map(_.closureBindingId).toList shouldBe List(
-          Some("index.html.erb:<main>.<lambda>0.self")
-        )
-        selfMain.closureBindingId shouldBe None
-      case xs => fail(s"Expected one local in global, got ${xs.name.mkString("[", ",", "]")}")
+    inside(cpg.method.name("<main>").parameter.name("self").l) { case selfMain :: Nil =>
+      selfMain._closureBindingViaRefIn.map(_.closureBindingId).toList shouldBe List(
+        Some("index.html.erb:<main>.<lambda>0.self")
+      )
+      selfMain.closureBindingId shouldBe None
     }
 
-    inside(cpg.method.isLambda.local.name("self").l) {
-      case selfLocal :: Nil =>
-        selfLocal.closureBindingId shouldBe Some("index.html.erb:<main>.<lambda>0.self")
-      case xs => fail(s"Expected one self local, got ${xs.name.mkString("[", ",", "]")}")
+    inside(cpg.method.isLambda.local.name("self").l) { case selfLocal :: Nil =>
+      selfLocal.closureBindingId shouldBe Some("index.html.erb:<main>.<lambda>0.self")
     }
   }
 
@@ -473,16 +424,13 @@ class ErbTests extends RubyCode2CpgFixture {
 
     inside(
       cpg.method.fullNameExact("Test0.rb:<main>.Admin.UsersController.show.<lambda>0.<lambda>0").local.name("self").l
-    ) {
-      case selfLocal :: Nil =>
-        selfLocal.closureBindingId shouldBe Some("Test0.rb:<main>.Admin.UsersController.show.<lambda>0.<lambda>0.self")
-      case xs => fail(s"Expected one local for self, got ${xs.name.mkString("[", ",", "]")}")
+    ) { case selfLocal :: Nil =>
+      selfLocal.closureBindingId shouldBe Some("Test0.rb:<main>.Admin.UsersController.show.<lambda>0.<lambda>0.self")
     }
 
     inside(cpg.method.fullNameExact("Test0.rb:<main>.Admin.UsersController.show.<lambda>0").local.name("self").l) {
       case selfLocal :: Nil =>
         selfLocal.closureBindingId shouldBe Some("Test0.rb:<main>.Admin.UsersController.show.<lambda>0.self")
-      case xs => fail(s"Expected one local for self, got ${xs.name.mkString("[", ",", "]")}")
     }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/FieldAccessTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/FieldAccessTests.scala
@@ -47,15 +47,13 @@ class FieldAccessTests extends RubyCode2CpgFixture {
         sickDays.methodFullName shouldBe Operators.fieldAccess
         sickDays.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
 
-        inside(sickDays.argument.l) {
-          case (self: Identifier) :: (sickDaysId: FieldIdentifier) :: Nil =>
-            self.name shouldBe "self"
-            self.code shouldBe "self"
-            self.typeFullName should endWith("PaidTimeOff")
+        inside(sickDays.argument.l) { case (self: Identifier) :: (sickDaysId: FieldIdentifier) :: Nil =>
+          self.name shouldBe "self"
+          self.code shouldBe "self"
+          self.typeFullName should endWith("PaidTimeOff")
 
-            sickDaysId.canonicalName shouldBe "@sick_days_earned"
-            sickDaysId.code shouldBe "sick_days_earned"
-          case xs => fail(s"Expected exactly two field access arguments, instead got [${xs.code.mkString(", ")}]")
+          sickDaysId.canonicalName shouldBe "@sick_days_earned"
+          sickDaysId.code shouldBe "sick_days_earned"
         }
       case Nil => fail("Expected at least one call with `self` base, but got none.")
     }
@@ -86,24 +84,22 @@ class FieldAccessTests extends RubyCode2CpgFixture {
         |f.func()           # self.f.func
         |""".stripMargin)
     "assign an alias for type declarations to the singleton" in {
-      inside(cpg.method.isModule.assignment.where(_.source.isTypeRef).l) {
-        case baz :: foo :: Nil =>
-          val bazAssign = baz.argument(1).asInstanceOf[Call]
-          bazAssign.name shouldBe Operators.fieldAccess
-          bazAssign.code shouldBe "self.Baz"
+      inside(cpg.method.isModule.assignment.where(_.source.isTypeRef).l) { case baz :: foo :: Nil =>
+        val bazAssign = baz.argument(1).asInstanceOf[Call]
+        bazAssign.name shouldBe Operators.fieldAccess
+        bazAssign.code shouldBe "self.Baz"
 
-          val bazTypeRef = baz.argument(2).asInstanceOf[TypeRef]
-          bazTypeRef.typeFullName shouldBe s"Test0.rb:$Main.Baz<class>"
-          bazTypeRef.code shouldBe "module Baz (...)"
+        val bazTypeRef = baz.argument(2).asInstanceOf[TypeRef]
+        bazTypeRef.typeFullName shouldBe s"Test0.rb:$Main.Baz<class>"
+        bazTypeRef.code shouldBe "module Baz (...)"
 
-          val fooAssign = foo.argument(1).asInstanceOf[Call]
-          fooAssign.name shouldBe Operators.fieldAccess
-          fooAssign.code shouldBe "self.Foo"
+        val fooAssign = foo.argument(1).asInstanceOf[Call]
+        fooAssign.name shouldBe Operators.fieldAccess
+        fooAssign.code shouldBe "self.Foo"
 
-          val fooTypeRef = foo.argument(2).asInstanceOf[TypeRef]
-          fooTypeRef.typeFullName shouldBe s"Test0.rb:$Main.Foo<class>"
-          fooTypeRef.code shouldBe "class Foo (...)"
-        case _ => fail(s"Expected two type ref assignments on the module level")
+        val fooTypeRef = foo.argument(2).asInstanceOf[TypeRef]
+        fooTypeRef.typeFullName shouldBe s"Test0.rb:$Main.Foo<class>"
+        fooTypeRef.code shouldBe "class Foo (...)"
       }
     }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/FieldAccessTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/FieldAccessTests.scala
@@ -15,14 +15,12 @@ class FieldAccessTests extends RubyCode2CpgFixture {
         |x.y
         |""".stripMargin)
 
-    inside(cpg.fieldAccess.code("x.y").headOption) {
-      case Some(xyCall) =>
-        xyCall.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-        xyCall.name shouldBe Operators.fieldAccess
-        xyCall.methodFullName shouldBe Operators.fieldAccess
-        xyCall.lineNumber shouldBe Some(3)
-        xyCall.code shouldBe "x.y"
-      case None => fail("Expected a field access with the code `x.y`")
+    inside(cpg.fieldAccess.code("x.y").headOption) { case Some(xyCall) =>
+      xyCall.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+      xyCall.name shouldBe Operators.fieldAccess
+      xyCall.methodFullName shouldBe Operators.fieldAccess
+      xyCall.lineNumber shouldBe Some(3)
+      xyCall.code shouldBe "x.y"
     }
   }
 
@@ -40,22 +38,20 @@ class FieldAccessTests extends RubyCode2CpgFixture {
         |end
         |""".stripMargin)
 
-    inside(cpg.fieldAccess.code("self.sick_days_earned").l) {
-      case sickDays :: _ =>
-        sickDays.code shouldBe "self.sick_days_earned"
-        sickDays.name shouldBe Operators.fieldAccess
-        sickDays.methodFullName shouldBe Operators.fieldAccess
-        sickDays.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+    inside(cpg.fieldAccess.code("self.sick_days_earned").l) { case sickDays :: _ =>
+      sickDays.code shouldBe "self.sick_days_earned"
+      sickDays.name shouldBe Operators.fieldAccess
+      sickDays.methodFullName shouldBe Operators.fieldAccess
+      sickDays.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
 
-        inside(sickDays.argument.l) { case (self: Identifier) :: (sickDaysId: FieldIdentifier) :: Nil =>
-          self.name shouldBe "self"
-          self.code shouldBe "self"
-          self.typeFullName should endWith("PaidTimeOff")
+      inside(sickDays.argument.l) { case (self: Identifier) :: (sickDaysId: FieldIdentifier) :: Nil =>
+        self.name shouldBe "self"
+        self.code shouldBe "self"
+        self.typeFullName should endWith("PaidTimeOff")
 
-          sickDaysId.canonicalName shouldBe "@sick_days_earned"
-          sickDaysId.code shouldBe "sick_days_earned"
-        }
-      case Nil => fail("Expected at least one call with `self` base, but got none.")
+        sickDaysId.canonicalName shouldBe "@sick_days_earned"
+        sickDaysId.code shouldBe "sick_days_earned"
+      }
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/HashTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/HashTests.scala
@@ -85,54 +85,46 @@ class HashTests extends RubyCode2CpgFixture {
         |{'a'..'c' => "abc"}
         |""".stripMargin)
 
-    inside(cpg.call.name(RubyOperators.hashInitializer).l) {
-      case hashInitializerInt :: hashInitializerString :: Nil =>
-        inside(hashInitializerInt.inCall.astSiblings.assignment.l) {
-          case firstCall :: secondCall :: thirdCall :: fourthCall :: fifthCall :: Nil =>
-            firstCall.code shouldBe "<tmp-0>[1] = \"abc\""
-            secondCall.code shouldBe "<tmp-0>[2] = \"abc\""
-            thirdCall.code shouldBe "<tmp-0>[3] = \"abc\""
-            fourthCall.code shouldBe "<tmp-0>[4] = \"ade\""
-            fifthCall.code shouldBe "<tmp-0>[5] = \"ade\""
+    inside(cpg.call.name(RubyOperators.hashInitializer).l) { case hashInitializerInt :: hashInitializerString :: Nil =>
+      inside(hashInitializerInt.inCall.astSiblings.assignment.l) {
+        case firstCall :: secondCall :: thirdCall :: fourthCall :: fifthCall :: Nil =>
+          firstCall.code shouldBe "<tmp-0>[1] = \"abc\""
+          secondCall.code shouldBe "<tmp-0>[2] = \"abc\""
+          thirdCall.code shouldBe "<tmp-0>[3] = \"abc\""
+          fourthCall.code shouldBe "<tmp-0>[4] = \"ade\""
+          fifthCall.code shouldBe "<tmp-0>[5] = \"ade\""
 
-            inside(firstCall.argument.l) {
-              case (lhs: Call) :: (rhs: Literal) :: Nil =>
-                lhs.code shouldBe "<tmp-0>[1]"
-                lhs.name shouldBe Operators.indexAccess
+          inside(firstCall.argument.l) { case (lhs: Call) :: (rhs: Literal) :: Nil =>
+            lhs.code shouldBe "<tmp-0>[1]"
+            lhs.name shouldBe Operators.indexAccess
 
-                rhs.code shouldBe "\"abc\""
-                rhs.typeFullName shouldBe Defines.prefixAsCoreType("String")
-              case _ => fail("Expected LHS and RHS after lowering")
-            }
+            rhs.code shouldBe "\"abc\""
+            rhs.typeFullName shouldBe Defines.prefixAsCoreType("String")
+          }
 
-            inside(fourthCall.argument.l) { case (lhs: Call) :: (rhs: Literal) :: Nil =>
-              lhs.code shouldBe "<tmp-0>[4]"
-              lhs.name shouldBe Operators.indexAccess
+          inside(fourthCall.argument.l) { case (lhs: Call) :: (rhs: Literal) :: Nil =>
+            lhs.code shouldBe "<tmp-0>[4]"
+            lhs.name shouldBe Operators.indexAccess
 
-              rhs.code shouldBe "\"ade\""
-              rhs.typeFullName shouldBe Defines.prefixAsCoreType("String")
-            }
-          case _ => fail("Expected 5 calls (one per item in range)")
-        }
+            rhs.code shouldBe "\"ade\""
+            rhs.typeFullName shouldBe Defines.prefixAsCoreType("String")
+          }
+      }
 
-        inside(hashInitializerString.inCall.astSiblings.assignment.l) {
-          case firstCall :: secondCall :: thirdCall :: Nil =>
-            firstCall.code shouldBe "<tmp-1>['a'] = \"abc\""
-            secondCall.code shouldBe "<tmp-1>['b'] = \"abc\""
-            thirdCall.code shouldBe "<tmp-1>['c'] = \"abc\""
+      inside(hashInitializerString.inCall.astSiblings.assignment.l) {
+        case firstCall :: secondCall :: thirdCall :: Nil =>
+          firstCall.code shouldBe "<tmp-1>['a'] = \"abc\""
+          secondCall.code shouldBe "<tmp-1>['b'] = \"abc\""
+          thirdCall.code shouldBe "<tmp-1>['c'] = \"abc\""
 
-            inside(firstCall.argument.l) {
-              case (lhs: Call) :: (rhs: Literal) :: Nil =>
-                lhs.code shouldBe "<tmp-1>['a']"
-                lhs.name shouldBe Operators.indexAccess
+          inside(firstCall.argument.l) { case (lhs: Call) :: (rhs: Literal) :: Nil =>
+            lhs.code shouldBe "<tmp-1>['a']"
+            lhs.name shouldBe Operators.indexAccess
 
-                rhs.code shouldBe "\"abc\""
-                rhs.typeFullName shouldBe Defines.prefixAsCoreType("String")
-              case _ => fail("Expected LHS and RHS after lowering")
-            }
-          case _ => fail("Expected 3 calls (one per item in range)")
-        }
-      case _ => fail("Expected two hash initializer functions")
+            rhs.code shouldBe "\"abc\""
+            rhs.typeFullName shouldBe Defines.prefixAsCoreType("String")
+          }
+      }
     }
 
   }
@@ -142,16 +134,13 @@ class HashTests extends RubyCode2CpgFixture {
                      |{1...3 => "abc"}
                      |""".stripMargin)
 
-    inside(cpg.call.name(RubyOperators.hashInitializer).l) {
-      case hashInitializer :: Nil =>
-        inside(hashInitializer.inCall.astSiblings.l) {
-          case (firstCall: Call) :: (secondCall: Call) :: (tmp: Identifier) :: Nil =>
-            firstCall.code shouldBe "<tmp-0>[1] = \"abc\""
-            secondCall.code shouldBe "<tmp-0>[2] = \"abc\""
-            tmp.name shouldBe "<tmp-0>"
-          case _ => fail("Expected 2 calls (one per item in range)")
-        }
-      case _ => fail("Expected one hash initializer function")
+    inside(cpg.call.name(RubyOperators.hashInitializer).l) { case hashInitializer :: Nil =>
+      inside(hashInitializer.inCall.astSiblings.l) {
+        case (firstCall: Call) :: (secondCall: Call) :: (tmp: Identifier) :: Nil =>
+          firstCall.code shouldBe "<tmp-0>[1] = \"abc\""
+          secondCall.code shouldBe "<tmp-0>[2] = \"abc\""
+          tmp.name shouldBe "<tmp-0>"
+      }
     }
   }
 
@@ -160,29 +149,21 @@ class HashTests extends RubyCode2CpgFixture {
         |{:a...:b => "a"}
         |""".stripMargin)
 
-    inside(cpg.call.name(RubyOperators.hashInitializer).l) {
-      case hashInitializer :: Nil =>
-        inside(hashInitializer.inCall.astSiblings.assignment.l) {
-          case rangeExprArg :: Nil =>
-            inside(rangeExprArg.argument.l) {
-              case (lhs: Call) :: (rhs: Literal) :: Nil =>
-                lhs.name shouldBe Operators.indexAccess
-                lhs.code shouldBe "<tmp-0>[:a...:b]"
+    inside(cpg.call.name(RubyOperators.hashInitializer).l) { case hashInitializer :: Nil =>
+      inside(hashInitializer.inCall.astSiblings.assignment.l) { case rangeExprArg :: Nil =>
+        inside(rangeExprArg.argument.l) { case (lhs: Call) :: (rhs: Literal) :: Nil =>
+          lhs.name shouldBe Operators.indexAccess
+          lhs.code shouldBe "<tmp-0>[:a...:b]"
 
-                inside(lhs.argument.isCall.l) {
-                  case rangeExp :: Nil =>
-                    rangeExp.name shouldBe Operators.range
-                  case _ => fail("Expected range operator for non-primitive range key")
-                }
+          inside(lhs.argument.isCall.l) { case rangeExp :: Nil =>
+            rangeExp.name shouldBe Operators.range
+          }
 
-                rhs.typeFullName shouldBe Defines.prefixAsCoreType("String")
-                rhs.code shouldBe "\"a\""
-              case _ => fail("Expected LHS and RHS for association")
-            }
-
-          case _ => fail("Expected one argument for range expression")
+          rhs.typeFullName shouldBe Defines.prefixAsCoreType("String")
+          rhs.code shouldBe "\"a\""
         }
-      case _ => fail("Expected one hash initializer function")
+
+      }
     }
   }
 
@@ -191,21 +172,18 @@ class HashTests extends RubyCode2CpgFixture {
         |x = Hash [1 => "a", 2 => "b", 3 => "c"]
         |""".stripMargin)
 
-    inside(cpg.call.nameExact("[]").l) {
-      case hashCall :: Nil =>
-        hashCall.code shouldBe "Hash [1 => \"a\", 2 => \"b\", 3 => \"c\"]"
-        hashCall.lineNumber shouldBe Some(2)
-        hashCall.methodFullName shouldBe s"${Defines.prefixAsCoreType("Hash")}.[]"
-        hashCall.typeFullName shouldBe Defines.prefixAsCoreType("Hash")
+    inside(cpg.call.nameExact("[]").l) { case hashCall :: Nil =>
+      hashCall.code shouldBe "Hash [1 => \"a\", 2 => \"b\", 3 => \"c\"]"
+      hashCall.lineNumber shouldBe Some(2)
+      hashCall.methodFullName shouldBe s"${Defines.prefixAsCoreType("Hash")}.[]"
+      hashCall.typeFullName shouldBe Defines.prefixAsCoreType("Hash")
 
-        inside(hashCall.astChildren.l) {
-          case (_: Call) :: (_: TypeRef) :: (one: Call) :: (two: Call) :: (three: Call) :: Nil =>
-            one.code shouldBe "1 => \"a\""
-            two.code shouldBe "2 => \"b\""
-            three.code shouldBe "3 => \"c\""
-          case xs => fail(s"Expected 3 literals under the hash initializer, instead got [${xs.code.mkString(", ")}]")
-        }
-      case xs => fail(s"Expected a single array initializer call, instead got [${xs.code.mkString(", ")}]")
+      inside(hashCall.astChildren.l) {
+        case (_: Call) :: (_: TypeRef) :: (one: Call) :: (two: Call) :: (three: Call) :: Nil =>
+          one.code shouldBe "1 => \"a\""
+          two.code shouldBe "2 => \"b\""
+          three.code shouldBe "3 => \"c\""
+      }
     }
   }
 
@@ -214,15 +192,13 @@ class HashTests extends RubyCode2CpgFixture {
         |a = {**x, **y}
         |""".stripMargin)
 
-    inside(cpg.call.name(RubyOperators.hashInitializer).l) {
-      case hashCall :: Nil =>
-        val List(xSplatCall, ySplatCall) = hashCall.inCall.astSiblings.isCall.l
-        xSplatCall.code shouldBe "**x"
-        xSplatCall.methodFullName shouldBe RubyOperators.splat
+    inside(cpg.call.name(RubyOperators.hashInitializer).l) { case hashCall :: Nil =>
+      val List(xSplatCall, ySplatCall) = hashCall.inCall.astSiblings.isCall.l
+      xSplatCall.code shouldBe "**x"
+      xSplatCall.methodFullName shouldBe RubyOperators.splat
 
-        ySplatCall.code shouldBe "**y"
-        ySplatCall.methodFullName shouldBe RubyOperators.splat
-      case xs => fail(s"Expected call to hashInitializer, [${xs.code.mkString(",")}]")
+      ySplatCall.code shouldBe "**y"
+      ySplatCall.methodFullName shouldBe RubyOperators.splat
     }
   }
 
@@ -232,19 +208,17 @@ class HashTests extends RubyCode2CpgFixture {
         |a = {**foo(bar)}
         |""".stripMargin)
 
-    inside(cpg.call.name(RubyOperators.hashInitializer).l) {
-      case hashInitializer :: Nil =>
-        val List(splatCall) = hashInitializer.inCall.astSiblings.isCall.l
-        splatCall.code shouldBe "**foo(bar)"
-        splatCall.name shouldBe RubyOperators.splat
+    inside(cpg.call.name(RubyOperators.hashInitializer).l) { case hashInitializer :: Nil =>
+      val List(splatCall) = hashInitializer.inCall.astSiblings.isCall.l
+      splatCall.code shouldBe "**foo(bar)"
+      splatCall.name shouldBe RubyOperators.splat
 
-        val List(splatCallArg: Call) = splatCall.argument.l: @unchecked
+      val List(splatCallArg: Call) = splatCall.argument.l: @unchecked
 
-        splatCallArg.code shouldBe "foo(bar)"
+      splatCallArg.code shouldBe "foo(bar)"
 
-        val List(_, barCallArg) = splatCallArg.argument.l
-        barCallArg.code shouldBe "bar"
-      case xs => fail(s"Expected one call for init, got [${xs.code.mkString(",")}]")
+      val List(_, barCallArg) = splatCallArg.argument.l
+      barCallArg.code shouldBe "bar"
     }
   }
 
@@ -253,19 +227,17 @@ class HashTests extends RubyCode2CpgFixture {
         |a = {**(foo 13)}
         |""".stripMargin)
 
-    inside(cpg.call.name(RubyOperators.hashInitializer).l) {
-      case hashInitializer :: Nil =>
-        val List(splatCall) = hashInitializer.inCall.astSiblings.isCall.l
-        splatCall.code shouldBe "**(foo 13)"
-        splatCall.name shouldBe RubyOperators.splat
+    inside(cpg.call.name(RubyOperators.hashInitializer).l) { case hashInitializer :: Nil =>
+      val List(splatCall) = hashInitializer.inCall.astSiblings.isCall.l
+      splatCall.code shouldBe "**(foo 13)"
+      splatCall.name shouldBe RubyOperators.splat
 
-        val List(splatCallArg: Call) = splatCall.argument.l: @unchecked
+      val List(splatCallArg: Call) = splatCall.argument.l: @unchecked
 
-        splatCallArg.code shouldBe "foo 13"
+      splatCallArg.code shouldBe "foo 13"
 
-        val List(selfCallArg, literalCallArg) = splatCallArg.argument.l
-        literalCallArg.code shouldBe "13"
-      case xs => fail(s"Expected one call for init, got [${xs.code.mkString(",")}]")
+      val List(selfCallArg, literalCallArg) = splatCallArg.argument.l
+      literalCallArg.code shouldBe "13"
     }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/HereDocTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/HereDocTests.scala
@@ -19,19 +19,17 @@ class HereDocTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "have a LITERAL node" in {
-      inside(cpg.method.name("f").l) {
-        case func :: Nil =>
-          inside(func.block.astChildren.l) {
-            case (localAst: Local) :: (callAst: Call) :: (literalAst: Literal) :: (returnAst: Return) :: Nil =>
-              localAst.code shouldBe "a"
-              callAst.code shouldBe "a = 10"
+      inside(cpg.method.name("f").l) { case func :: Nil =>
+        inside(func.block.astChildren.l) {
+          case (localAst: Local) :: (callAst: Call) :: (literalAst: Literal) :: (returnAst: Return) :: Nil =>
+            localAst.code shouldBe "a"
+            callAst.code shouldBe "a = 10"
 
-              literalAst.typeFullName shouldBe Defines.prefixAsCoreType("String")
+            literalAst.typeFullName shouldBe Defines.prefixAsCoreType("String")
 
-              returnAst.code shouldBe "a"
-            case _ =>
-          }
-        case _ => fail("Expected one method for f")
+            returnAst.code shouldBe "a"
+          case _ =>
+        }
       }
     }
   }
@@ -48,19 +46,13 @@ class HereDocTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "parse Heredocs" in {
-      inside(cpg.method.name("foo").l) {
-        case fooFunc :: Nil =>
-          inside(fooFunc.block.astChildren.isCall.l) {
-            case assignmentCall :: Nil =>
-              inside(assignmentCall.argument.l) {
-                case lhsArg :: (rhsArg: Literal) :: Nil =>
-                  lhsArg.code shouldBe "a"
-                  rhsArg.typeFullName shouldBe Defines.prefixAsCoreType("String")
-                case _ => fail("Expected LHS and RHS for assignment")
-              }
-            case _ => fail("Expected call for assignment")
+      inside(cpg.method.name("foo").l) { case fooFunc :: Nil =>
+        inside(fooFunc.block.astChildren.isCall.l) { case assignmentCall :: Nil =>
+          inside(assignmentCall.argument.l) { case lhsArg :: (rhsArg: Literal) :: Nil =>
+            lhsArg.code shouldBe "a"
+            rhsArg.typeFullName shouldBe Defines.prefixAsCoreType("String")
           }
-        case _ => fail("Expected one method for foo")
+        }
       }
     }
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
@@ -353,22 +353,16 @@ class ImportTests extends RubyCode2CpgFixture(withPostProcessing = true) with In
       )
 
     "be explicitly detected and imported for a constructor type" in {
-      inside(cpg.imports.where(_.call.file.name(".*Foo.*")).headOption) {
-        case Some(i) =>
-          i.importedAs shouldBe Some("A")
-          i.importedEntity shouldBe Some("A")
-        case None =>
-          fail("Expected `A` to be explicitly imported into `Foo.rb`")
+      inside(cpg.imports.where(_.call.file.name(".*Foo.*")).headOption) { case Some(i) =>
+        i.importedAs shouldBe Some("A")
+        i.importedEntity shouldBe Some("A")
       }
     }
 
     "be explicitly detected and imported for a call invocation" in {
-      inside(cpg.imports.where(_.call.file.name(".*Bar.*")).headOption) {
-        case Some(i) =>
-          i.importedAs shouldBe Some("bar/B")
-          i.importedEntity shouldBe Some("bar/B")
-        case None =>
-          fail("Expected `B` to be explicitly imported into `Foo.rb`")
+      inside(cpg.imports.where(_.call.file.name(".*Bar.*")).headOption) { case Some(i) =>
+        i.importedAs shouldBe Some("bar/B")
+        i.importedEntity shouldBe Some("bar/B")
       }
     }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ImportTests.scala
@@ -397,12 +397,10 @@ class ImportTests extends RubyCode2CpgFixture(withPostProcessing = true) with In
         |""".stripMargin)
 
     "resolve calls to builtin functions" in {
-      inside(cpg.call.methodFullName("(pp|csv).*").l) {
-        case csvParseCall :: csvTableCall :: ppCall :: Nil =>
-          csvParseCall.methodFullName shouldBe "csv.CSV.parse"
-          csvTableCall.methodFullName shouldBe "csv.CSV.Table.initialize"
-          ppCall.methodFullName shouldBe "pp.PP.pp"
-        case xs => fail(s"Expected calls, got [${xs.code.mkString(",")}] instead")
+      inside(cpg.call.methodFullName("(pp|csv).*").l) { case csvParseCall :: csvTableCall :: ppCall :: Nil =>
+        csvParseCall.methodFullName shouldBe "csv.CSV.parse"
+        csvTableCall.methodFullName shouldBe "csv.CSV.Table.initialize"
+        ppCall.methodFullName shouldBe "pp.PP.pp"
       }
 
       // TODO: fixme - set is empty
@@ -457,7 +455,6 @@ class ImportTests extends RubyCode2CpgFixture(withPostProcessing = true) with In
           requireAll.isWildcard shouldBe Option(true)
           requireRelative.importedAs shouldBe Option("../foo")
           load.importedAs shouldBe Option("pp")
-        case xs => fail(s"Expected two imports, got [${xs.code.mkString(",")}] instead")
       }
     }
   }
@@ -508,12 +505,10 @@ class ImportTests extends RubyCode2CpgFixture(withPostProcessing = true) with In
     )
 
     "resolve the calls directly" in {
-      inside(cpg.call.name("foo.*").l) {
-        case foo1 :: foo2 :: foo3 :: Nil =>
-          foo1.methodFullName shouldBe s"lib/file1.rb:$Main.File1.foo"
-          foo2.methodFullName shouldBe s"lib/file2.rb:$Main.File2.foo"
-          foo3.methodFullName shouldBe s"src/file3.rb:$Main.File3.foo"
-        case xs => fail(s"Expected 3 calls, got [${xs.code.mkString(",")}] instead")
+      inside(cpg.call.name("foo.*").l) { case foo1 :: foo2 :: foo3 :: Nil =>
+        foo1.methodFullName shouldBe s"lib/file1.rb:$Main.File1.foo"
+        foo2.methodFullName shouldBe s"lib/file2.rb:$Main.File2.foo"
+        foo3.methodFullName shouldBe s"src/file3.rb:$Main.File3.foo"
       }
     }
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/IndexAccessTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/IndexAccessTests.scala
@@ -56,18 +56,14 @@ class IndexAccessTests extends RubyCode2CpgFixture {
         |end
         |""".stripMargin)
 
-    inside(cpg.call.name(Operators.indexAccess).l) {
-      case indexCall :: Nil =>
-        indexCall.code shouldBe "@params.dig(:event, :links)&.first&.[](:url)"
+    inside(cpg.call.name(Operators.indexAccess).l) { case indexCall :: Nil =>
+      indexCall.code shouldBe "@params.dig(:event, :links)&.first&.[](:url)"
 
-        inside(indexCall.argument.l) {
-          case target :: index :: Nil =>
-            target.code shouldBe "(<tmp-1> = @params.dig(:event, :links))&.first"
-            index.code shouldBe ":url"
-          case xs => fail(s"Expected target and index, got [${xs.code.mkString(",")}]")
-        }
+      inside(indexCall.argument.l) { case target :: index :: Nil =>
+        target.code shouldBe "(<tmp-1> = @params.dig(:event, :links))&.first"
+        index.code shouldBe ":url"
+      }
 
-      case xs => fail(s"Expected one index access, got [${xs.code.mkString(",")}]")
     }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/LiteralTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/LiteralTests.scala
@@ -261,16 +261,12 @@ class LiteralTests extends RubyCode2CpgFixture {
         |-> (a, *b, &c) {}
         |""".stripMargin)
 
-    inside(cpg.method.isLambda.l) {
-      case lambdaLiteral :: Nil =>
-        inside(lambdaLiteral.parameter.l) {
-          case aParam :: bParam :: cParam :: Nil =>
-            aParam.code shouldBe "a"
-            bParam.code shouldBe "*b"
-            cParam.code shouldBe "&c"
-          case xs => fail(s"Expected four parameters, got [${xs.code.mkString(",")}]")
-        }
-      case xs => fail(s"Expected one lambda, got [${xs.name.mkString(",")}]")
+    inside(cpg.method.isLambda.l) { case lambdaLiteral :: Nil =>
+      inside(lambdaLiteral.parameter.l) { case aParam :: bParam :: cParam :: Nil =>
+        aParam.code shouldBe "a"
+        bParam.code shouldBe "*b"
+        cParam.code shouldBe "&c"
+      }
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
@@ -182,27 +182,23 @@ class MethodReturnTests extends RubyCode2CpgFixture {
 
     // Lowered as `def f; if true then return 20 else return nil end`
 
-    inside(cpg.method.name("f").l) {
-      case f :: Nil =>
-        // Check the two return statements
-        inside(f.methodReturn.toReturn.l) {
-          case return20 :: returnNil :: Nil =>
-            return20.code shouldBe "20"
-            return20.lineNumber shouldBe Some(4)
-            val List(twenty: Literal) = return20.astChildren.l: @unchecked
-            twenty.code shouldBe "20"
-            twenty.lineNumber shouldBe Some(4)
-            twenty.typeFullName shouldBe RubyDefines.prefixAsCoreType("Integer")
+    inside(cpg.method.name("f").l) { case f :: Nil =>
+      // Check the two return statements
+      inside(f.methodReturn.toReturn.l) { case return20 :: returnNil :: Nil =>
+        return20.code shouldBe "20"
+        return20.lineNumber shouldBe Some(4)
+        val List(twenty: Literal) = return20.astChildren.l: @unchecked
+        twenty.code shouldBe "20"
+        twenty.lineNumber shouldBe Some(4)
+        twenty.typeFullName shouldBe RubyDefines.prefixAsCoreType("Integer")
 
-            returnNil.code shouldBe "return nil"
-            returnNil.lineNumber shouldBe Some(3)
-            val List(nil: Literal) = returnNil.astChildren.l: @unchecked
-            nil.code shouldBe "nil"
-            nil.lineNumber shouldBe Some(3)
-            nil.typeFullName shouldBe RubyDefines.prefixAsCoreType("NilClass")
-          case xs => fail(s"Expected exactly two return nodes, instead got [${xs.code.mkString(",")}]")
-        }
-      case xs => fail(s"Expected exactly one method with the name `f`, instead got [${xs.code.mkString(",")}]")
+        returnNil.code shouldBe "return nil"
+        returnNil.lineNumber shouldBe Some(3)
+        val List(nil: Literal) = returnNil.astChildren.l: @unchecked
+        nil.code shouldBe "nil"
+        nil.lineNumber shouldBe Some(3)
+        nil.typeFullName shouldBe RubyDefines.prefixAsCoreType("NilClass")
+      }
     }
   }
 
@@ -217,27 +213,23 @@ class MethodReturnTests extends RubyCode2CpgFixture {
         |end
         |""".stripMargin)
 
-    inside(cpg.method.name("f").l) {
-      case f :: Nil =>
-        // Check the two return statements
-        inside(f.methodReturn.toReturn.l) {
-          case return20 :: return40 :: Nil =>
-            return20.code shouldBe "20"
-            return20.lineNumber shouldBe Some(4)
-            val List(twenty: Literal) = return20.astChildren.l: @unchecked
-            twenty.code shouldBe "20"
-            twenty.lineNumber shouldBe Some(4)
-            twenty.typeFullName shouldBe RubyDefines.prefixAsCoreType("Integer")
+    inside(cpg.method.name("f").l) { case f :: Nil =>
+      // Check the two return statements
+      inside(f.methodReturn.toReturn.l) { case return20 :: return40 :: Nil =>
+        return20.code shouldBe "20"
+        return20.lineNumber shouldBe Some(4)
+        val List(twenty: Literal) = return20.astChildren.l: @unchecked
+        twenty.code shouldBe "20"
+        twenty.lineNumber shouldBe Some(4)
+        twenty.typeFullName shouldBe RubyDefines.prefixAsCoreType("Integer")
 
-            return40.code shouldBe "40"
-            return40.lineNumber shouldBe Some(6)
-            val List(forty: Literal) = return40.astChildren.l: @unchecked
-            forty.code shouldBe "40"
-            forty.lineNumber shouldBe Some(6)
-            forty.typeFullName shouldBe RubyDefines.prefixAsCoreType("Integer")
-          case xs => fail(s"Expected exactly two return nodes, instead got [${xs.code.mkString(",")}]")
-        }
-      case xs => fail(s"Expected exactly one method with the name `f`, instead got [${xs.code.mkString(",")}]")
+        return40.code shouldBe "40"
+        return40.lineNumber shouldBe Some(6)
+        val List(forty: Literal) = return40.astChildren.l: @unchecked
+        forty.code shouldBe "40"
+        forty.lineNumber shouldBe Some(6)
+        forty.typeFullName shouldBe RubyDefines.prefixAsCoreType("Integer")
+      }
     }
   }
 
@@ -260,25 +252,21 @@ class MethodReturnTests extends RubyCode2CpgFixture {
       | end
       |""".stripMargin)
 
-    inside(cpg.method.name("f").l) {
-      case f :: Nil =>
-        inside(cpg.methodReturn.toReturn.l) {
-          case return1 :: return2 :: return3 :: return4 :: Nil =>
-            return1.code shouldBe "1"
-            return1.lineNumber shouldBe Some(5)
+    inside(cpg.method.name("f").l) { case f :: Nil =>
+      inside(cpg.methodReturn.toReturn.l) { case return1 :: return2 :: return3 :: return4 :: Nil =>
+        return1.code shouldBe "1"
+        return1.lineNumber shouldBe Some(5)
 
-            return2.code shouldBe "2"
-            return2.lineNumber shouldBe Some(7)
+        return2.code shouldBe "2"
+        return2.lineNumber shouldBe Some(7)
 
-            return3.code shouldBe "3"
-            return3.lineNumber shouldBe Some(11)
+        return3.code shouldBe "3"
+        return3.lineNumber shouldBe Some(11)
 
-            return4.code shouldBe "4"
-            return4.lineNumber shouldBe Some(13)
+        return4.code shouldBe "4"
+        return4.lineNumber shouldBe Some(13)
 
-          case xs => fail(s"Expected 4 returns, instead got [${xs.code.mkString(",")}]")
-        }
-      case xs => fail(s"Expected exactly one method with the name `f`, instead got [${xs.code.mkString(",")}]")
+      }
     }
   }
 
@@ -287,27 +275,23 @@ class MethodReturnTests extends RubyCode2CpgFixture {
         |def f(x) = x ? 20 : 40
         |""".stripMargin)
 
-    inside(cpg.method.name("f").l) {
-      case f :: Nil =>
-        // Check the two return statements
-        inside(f.methodReturn.toReturn.l) {
-          case return20 :: return40 :: Nil =>
-            return20.code shouldBe "20"
-            return20.lineNumber shouldBe Some(2)
-            val List(twenty: Literal) = return20.astChildren.l: @unchecked
-            twenty.code shouldBe "20"
-            twenty.lineNumber shouldBe Some(2)
-            twenty.typeFullName shouldBe RubyDefines.prefixAsCoreType("Integer")
+    inside(cpg.method.name("f").l) { case f :: Nil =>
+      // Check the two return statements
+      inside(f.methodReturn.toReturn.l) { case return20 :: return40 :: Nil =>
+        return20.code shouldBe "20"
+        return20.lineNumber shouldBe Some(2)
+        val List(twenty: Literal) = return20.astChildren.l: @unchecked
+        twenty.code shouldBe "20"
+        twenty.lineNumber shouldBe Some(2)
+        twenty.typeFullName shouldBe RubyDefines.prefixAsCoreType("Integer")
 
-            return40.code shouldBe "40"
-            return40.lineNumber shouldBe Some(2)
-            val List(forty: Literal) = return40.astChildren.l: @unchecked
-            forty.code shouldBe "40"
-            forty.lineNumber shouldBe Some(2)
-            forty.typeFullName shouldBe RubyDefines.prefixAsCoreType("Integer")
-          case xs => fail(s"Expected exactly two return nodes, instead got [${xs.code.mkString(",")}]")
-        }
-      case xs => fail(s"Expected exactly one method with the name `f`, instead got [${xs.code.mkString(",")}]")
+        return40.code shouldBe "40"
+        return40.lineNumber shouldBe Some(2)
+        val List(forty: Literal) = return40.astChildren.l: @unchecked
+        forty.code shouldBe "40"
+        forty.lineNumber shouldBe Some(2)
+        forty.typeFullName shouldBe RubyDefines.prefixAsCoreType("Integer")
+      }
     }
   }
 
@@ -325,17 +309,13 @@ class MethodReturnTests extends RubyCode2CpgFixture {
                      |end
                      |""".stripMargin)
 
-    inside(cpg.method.name("j").l) {
-      case jMethod :: Nil =>
-        inside(jMethod.methodReturn.toReturn.l) {
-          case retMemAccess :: Nil =>
-            retMemAccess.code shouldBe "f.x(1)"
+    inside(cpg.method.name("j").l) { case jMethod :: Nil =>
+      inside(jMethod.methodReturn.toReturn.l) { case retMemAccess :: Nil =>
+        retMemAccess.code shouldBe "f.x(1)"
 
-            val List(call: Call) = retMemAccess.astChildren.l: @unchecked
-            call.name shouldBe "x"
-          case xs => fail(s"Expected exactly one return nodes, instead got [${xs.code.mkString(",")}]")
-        }
-      case _ => fail("Only one method expected")
+        val List(call: Call) = retMemAccess.astChildren.l: @unchecked
+        call.name shouldBe "x"
+      }
     }
   }
 
@@ -346,18 +326,14 @@ class MethodReturnTests extends RubyCode2CpgFixture {
                      |end
                      |""".stripMargin)
 
-    inside(cpg.method.name("j").l) {
-      case jMethod :: Nil =>
-        inside(jMethod.methodReturn.toReturn.l) {
-          case retAssoc :: Nil =>
-            retAssoc.code shouldBe "super(only: [\"a\"])"
+    inside(cpg.method.name("j").l) { case jMethod :: Nil =>
+      inside(jMethod.methodReturn.toReturn.l) { case retAssoc :: Nil =>
+        retAssoc.code shouldBe "super(only: [\"a\"])"
 
-            val List(call: Call) = retAssoc.astChildren.l: @unchecked
-            call.name shouldBe "super"
-            call.code shouldBe "super(only: [\"a\"])"
-          case xs => fail(s"Expected exactly one return nodes, instead got [${xs.code.mkString(",")}]")
-        }
-      case _ => fail("Only one method expected")
+        val List(call: Call) = retAssoc.astChildren.l: @unchecked
+        call.name shouldBe "super"
+        call.code shouldBe "super(only: [\"a\"])"
+      }
     }
   }
 
@@ -375,31 +351,23 @@ class MethodReturnTests extends RubyCode2CpgFixture {
                      |""".stripMargin)
 
     "Create closureMethod and return structures" in {
-      inside(cpg.method.name("bar").l) {
-        case bar :: Nil =>
-          inside(bar.astChildren.collectAll[Method].l) {
-            case closureMethod :: Nil =>
-              closureMethod.name shouldBe "<lambda>0"
-              closureMethod.fullName shouldBe s"Test0.rb:$Main.bar.<lambda>0"
-            case xs => fail(s"Expected closure method, but found ${xs.code.mkString(", ")} instead")
+      inside(cpg.method.name("bar").l) { case bar :: Nil =>
+        inside(bar.astChildren.collectAll[Method].l) { case closureMethod :: Nil =>
+          closureMethod.name shouldBe "<lambda>0"
+          closureMethod.fullName shouldBe s"Test0.rb:$Main.bar.<lambda>0"
+        }
+
+        inside(bar.methodReturn.toReturn.l) { case barReturn :: Nil =>
+          inside(barReturn.astChildren.l) { case (returnCall: Call) :: Nil =>
+            returnCall.code should startWith("foo")
+
+            returnCall.name shouldBe "foo"
+
+            val List(_, arg: TypeRef) = returnCall.argument.l: @unchecked
+            arg.typeFullName shouldBe s"Test0.rb:$Main.bar.<lambda>0&Proc"
           }
 
-          inside(bar.methodReturn.toReturn.l) {
-            case barReturn :: Nil =>
-              inside(barReturn.astChildren.l) {
-                case (returnCall: Call) :: Nil =>
-                  returnCall.code should startWith("foo")
-
-                  returnCall.name shouldBe "foo"
-
-                  val List(_, arg: TypeRef) = returnCall.argument.l: @unchecked
-                  arg.typeFullName shouldBe s"Test0.rb:$Main.bar.<lambda>0&Proc"
-                case xs => fail(s"Expected one call for return, but found ${xs.code.mkString(", ")} instead")
-              }
-
-            case xs => fail(s"Expected one return, but found ${xs.code.mkString(", ")} instead")
-          }
-        case xs => fail(s"Expected one method, but found ${xs.code.mkString(", ")} instead")
+        }
       }
     }
 
@@ -411,10 +379,8 @@ class MethodReturnTests extends RubyCode2CpgFixture {
     }
 
     "have the return node under the closure (returning the literal)" in {
-      inside(cpg.method("<lambda>0").block.astChildren.l) {
-        case ret :: _ :: Nil =>
-          ret.code shouldBe "\"hello\""
-        case xs => fail(s"Expected the closure to have a single call, instead got [${xs.code.mkString(", ")}]")
+      inside(cpg.method("<lambda>0").block.astChildren.l) { case ret :: _ :: Nil =>
+        ret.code shouldBe "\"hello\""
       }
     }
   }
@@ -428,11 +394,9 @@ class MethodReturnTests extends RubyCode2CpgFixture {
           |end
           |""".stripMargin)
 
-    inside(cpg.method.nameExact("foo").methodReturn.toReturn.astChildren.l) {
-      case (heredoc: Literal) :: Nil =>
-        heredoc.typeFullName shouldBe RubyDefines.prefixAsCoreType("String")
-        heredoc.code should startWith("   puts \"hello\"")
-      case xs => fail(s"Expected a single literal node, instead got [${xs.code.mkString(", ")}]")
+    inside(cpg.method.nameExact("foo").methodReturn.toReturn.astChildren.l) { case (heredoc: Literal) :: Nil =>
+      heredoc.typeFullName shouldBe RubyDefines.prefixAsCoreType("String")
+      heredoc.code should startWith("   puts \"hello\"")
     }
   }
 
@@ -444,18 +408,16 @@ class MethodReturnTests extends RubyCode2CpgFixture {
         |end
         |""".stripMargin)
 
-    inside(cpg.method.nameExact("foo").ast.isReturn.l) {
-      case ret1 :: ret2 :: ret3 :: Nil =>
-        ret1.code shouldBe "return nil"
-        ret1.astChildren.size shouldBe 1
-        ret1.astParent.astParent.code shouldBe "return unless baz()"
+    inside(cpg.method.nameExact("foo").ast.isReturn.l) { case ret1 :: ret2 :: ret3 :: Nil =>
+      ret1.code shouldBe "return nil"
+      ret1.astChildren.size shouldBe 1
+      ret1.astParent.astParent.code shouldBe "return unless baz()"
 
-        ret2.code shouldBe "return"
-        ret2.astChildren.size shouldBe 0
-        ret2.astParent.astParent.code shouldBe "return unless baz()"
+      ret2.code shouldBe "return"
+      ret2.astChildren.size shouldBe 0
+      ret2.astParent.astParent.code shouldBe "return unless baz()"
 
-        ret3.code shouldBe "bar()"
-      case xs => fail(s"Expected 3 return nodes, got ${xs.size}")
+      ret3.code shouldBe "bar()"
     }
   }
 
@@ -473,11 +435,9 @@ class MethodReturnTests extends RubyCode2CpgFixture {
         zAssoc.code shouldBe ":z => 1"
         zAssoc.methodFullName shouldBe RubyOperators.association
 
-        inside(zAssoc.argument.l) {
-          case (key: Literal) :: (value: Literal) :: Nil =>
-            key.code shouldBe ":z"
-            value.code shouldBe "1"
-          case xs => fail(s"Expected two args, got ${xs.code.mkString(",")}")
+        inside(zAssoc.argument.l) { case (key: Literal) :: (value: Literal) :: Nil =>
+          key.code shouldBe ":z"
+          value.code shouldBe "1"
         }
       case None => fail(s"Expected at least one return node")
     }
@@ -490,30 +450,28 @@ class MethodReturnTests extends RubyCode2CpgFixture {
         |end
         |""".stripMargin)
 
-    inside(cpg.method.name("foo").body.astChildren.isControlStructure.l) {
-      case ifNode :: Nil =>
-        ifNode.controlStructureType shouldBe ControlStructureTypes.IF
+    inside(cpg.method.name("foo").body.astChildren.isControlStructure.l) { case ifNode :: Nil =>
+      ifNode.controlStructureType shouldBe ControlStructureTypes.IF
 
-        val List(successCall: Call) = ifNode.condition.l: @unchecked
-        successCall.code shouldBe "self.success"
+      val List(successCall: Call) = ifNode.condition.l: @unchecked
+      successCall.code shouldBe "self.success"
 
-        val List(ifReturnFalse: Return) = ifNode.whenFalse.isBlock.astChildren.isReturn.l
-        ifReturnFalse.code shouldBe "return render json: {}, status: :internal_server_error"
+      val List(ifReturnFalse: Return) = ifNode.whenFalse.isBlock.astChildren.isReturn.l
+      ifReturnFalse.code shouldBe "return render json: {}, status: :internal_server_error"
 
-        val List(_, jsonArg: Block, statusArg: Literal) = ifReturnFalse.astChildren.isCall.argument.l: @unchecked
-        jsonArg.argumentName shouldBe Some("json")
-        jsonArg.code shouldBe "<empty>"
+      val List(_, jsonArg: Block, statusArg: Literal) = ifReturnFalse.astChildren.isCall.argument.l: @unchecked
+      jsonArg.argumentName shouldBe Some("json")
+      jsonArg.code shouldBe "<empty>"
 
-        val List(_: Identifier, hashInitCall: Call) = jsonArg.astChildren.isCall.argument.l: @unchecked
-        hashInitCall.methodFullName shouldBe RubyOperators.hashInitializer
+      val List(_: Identifier, hashInitCall: Call) = jsonArg.astChildren.isCall.argument.l: @unchecked
+      hashInitCall.methodFullName shouldBe RubyOperators.hashInitializer
 
-        statusArg.argumentName shouldBe Some("status")
-        statusArg.code shouldBe ":internal_server_error"
+      statusArg.argumentName shouldBe Some("status")
+      statusArg.code shouldBe ":internal_server_error"
 
-        val List(ifReturnTrue: Return) = ifNode.whenTrue.isBlock.astChildren.isReturn.l
-        ifReturnTrue.code shouldBe "return nil"
+      val List(ifReturnTrue: Return) = ifNode.whenTrue.isBlock.astChildren.isReturn.l
+      ifReturnTrue.code shouldBe "return nil"
 
-      case xs => fail(s"Expected two method returns, got [${xs.code.mkString(",")}]")
     }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodReturnTests.scala
@@ -372,10 +372,7 @@ class MethodReturnTests extends RubyCode2CpgFixture {
     }
 
     "have no parameters in the closure declaration" in {
-      inside(cpg.method("<lambda>0").parameter.indexGt(0).l) {
-        case Nil => // pass
-        case xs  => fail(s"Expected the closure to have no parameters, instead got [${xs.code.mkString(", ")}]")
-      }
+      cpg.method("<lambda>0").parameter.indexGt(0).l shouldBe empty
     }
 
     "have the return node under the closure (returning the literal)" in {
@@ -428,18 +425,16 @@ class MethodReturnTests extends RubyCode2CpgFixture {
         |end
         |""".stripMargin)
 
-    inside(cpg.method.nameExact("foo").ast.isReturn.headOption) {
-      case Some(ret) =>
-        val List(oneLiteral: Literal, zAssoc: Call) = ret.astChildren.l: @unchecked
-        oneLiteral.code shouldBe "1"
-        zAssoc.code shouldBe ":z => 1"
-        zAssoc.methodFullName shouldBe RubyOperators.association
+    inside(cpg.method.nameExact("foo").ast.isReturn.headOption) { case Some(ret) =>
+      val List(oneLiteral: Literal, zAssoc: Call) = ret.astChildren.l: @unchecked
+      oneLiteral.code shouldBe "1"
+      zAssoc.code shouldBe ":z => 1"
+      zAssoc.methodFullName shouldBe RubyOperators.association
 
-        inside(zAssoc.argument.l) { case (key: Literal) :: (value: Literal) :: Nil =>
-          key.code shouldBe ":z"
-          value.code shouldBe "1"
-        }
-      case None => fail(s"Expected at least one return node")
+      inside(zAssoc.argument.l) { case (key: Literal) :: (value: Literal) :: Nil =>
+        key.code shouldBe ":z"
+        value.code shouldBe "1"
+      }
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -119,27 +119,19 @@ class MethodTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "generated IF control structure for only the default value" in {
-      inside(cpg.method.name("foo").l) {
-        case fooFunc :: Nil =>
-          inside(fooFunc.controlStructure.isIf.l) {
-            case defaultIf :: Nil =>
-              inside(defaultIf.condition.isCall.l) {
-                case defaultIfCond :: Nil =>
-                  defaultIfCond.code shouldBe "!defined?(x)"
-                  defaultIfCond.methodFullName shouldBe Operators.logicalNot
-                case _ => fail("Only expected on call for condition")
-              }
-
-              inside(defaultIf.whenTrue.isBlock.astChildren.isCall.l) {
-                case thenCall :: Nil =>
-                  thenCall.code shouldBe "x=\"default\""
-                  thenCall.methodFullName shouldBe Operators.assignment
-                case _ => fail("Only one call expected in true block for default parameter")
-              }
-
-            case _ => fail("Expected single if statement for default parameter")
+      inside(cpg.method.name("foo").l) { case fooFunc :: Nil =>
+        inside(fooFunc.controlStructure.isIf.l) { case defaultIf :: Nil =>
+          inside(defaultIf.condition.isCall.l) { case defaultIfCond :: Nil =>
+            defaultIfCond.code shouldBe "!defined?(x)"
+            defaultIfCond.methodFullName shouldBe Operators.logicalNot
           }
-        case _ => fail("Expected one method")
+
+          inside(defaultIf.whenTrue.isBlock.astChildren.isCall.l) { case thenCall :: Nil =>
+            thenCall.code shouldBe "x=\"default\""
+            thenCall.methodFullName shouldBe Operators.assignment
+          }
+
+        }
       }
     }
   }
@@ -152,41 +144,29 @@ class MethodTests extends RubyCode2CpgFixture {
                      |""".stripMargin)
 
     "generated IF control structure for only the default value" in {
-      inside(cpg.method.name("foo").l) {
-        case fooFunc :: Nil =>
-          inside(fooFunc.controlStructure.isIf.l) {
-            case defaultIfForX :: defaultIfForY :: Nil =>
-              inside(defaultIfForX.condition.isCall.l) {
-                case defaultIfCond :: Nil =>
-                  defaultIfCond.code shouldBe "!defined?(x)"
-                  defaultIfCond.methodFullName shouldBe Operators.logicalNot
-                case _ => fail("Only expected one call for condition")
-              }
-
-              inside(defaultIfForX.whenTrue.isBlock.astChildren.isCall.l) {
-                case thenCall :: Nil =>
-                  thenCall.code shouldBe "x=\"default\""
-                  thenCall.methodFullName shouldBe Operators.assignment
-                case _ => fail("Only one call expected in true block for default parameter")
-              }
-
-              inside(defaultIfForY.condition.isCall.l) {
-                case defaultIfCond :: Nil =>
-                  defaultIfCond.code shouldBe "!defined?(y)"
-                  defaultIfCond.methodFullName shouldBe Operators.logicalNot
-                case _ => fail("Only expected one call for condition")
-              }
-
-              inside(defaultIfForY.whenTrue.isBlock.astChildren.isCall.l) {
-                case thenCall :: Nil =>
-                  thenCall.code shouldBe "y=123"
-                  thenCall.methodFullName shouldBe Operators.assignment
-                case _ => fail("Only one call expected in true block for default parameter")
-              }
-
-            case _ => fail("Expected two if statements for two default parameters")
+      inside(cpg.method.name("foo").l) { case fooFunc :: Nil =>
+        inside(fooFunc.controlStructure.isIf.l) { case defaultIfForX :: defaultIfForY :: Nil =>
+          inside(defaultIfForX.condition.isCall.l) { case defaultIfCond :: Nil =>
+            defaultIfCond.code shouldBe "!defined?(x)"
+            defaultIfCond.methodFullName shouldBe Operators.logicalNot
           }
-        case _ => fail("Expected one method")
+
+          inside(defaultIfForX.whenTrue.isBlock.astChildren.isCall.l) { case thenCall :: Nil =>
+            thenCall.code shouldBe "x=\"default\""
+            thenCall.methodFullName shouldBe Operators.assignment
+          }
+
+          inside(defaultIfForY.condition.isCall.l) { case defaultIfCond :: Nil =>
+            defaultIfCond.code shouldBe "!defined?(y)"
+            defaultIfCond.methodFullName shouldBe Operators.logicalNot
+          }
+
+          inside(defaultIfForY.whenTrue.isBlock.astChildren.isCall.l) { case thenCall :: Nil =>
+            thenCall.code shouldBe "y=123"
+            thenCall.methodFullName shouldBe Operators.assignment
+          }
+
+        }
       }
     }
   }
@@ -200,26 +180,20 @@ class MethodTests extends RubyCode2CpgFixture {
                      |end
                      |""".stripMargin)
 
-    inside(cpg.typeDecl.name("C").l) {
-      case classC :: Nil =>
-        inside(classC.method.name("f").l) {
-          case funcF :: Nil =>
-            inside(funcF.parameter.l) {
-              case thisParam :: xParam :: Nil =>
-                thisParam.code shouldBe RDefines.Self
-                thisParam.typeFullName shouldBe s"Test0.rb:$Main.C<class>"
-                thisParam.index shouldBe 0
-                thisParam.isVariadic shouldBe false
+    inside(cpg.typeDecl.name("C").l) { case classC :: Nil =>
+      inside(classC.method.name("f").l) { case funcF :: Nil =>
+        inside(funcF.parameter.l) { case thisParam :: xParam :: Nil =>
+          thisParam.code shouldBe RDefines.Self
+          thisParam.typeFullName shouldBe s"Test0.rb:$Main.C<class>"
+          thisParam.index shouldBe 0
+          thisParam.isVariadic shouldBe false
 
-                xParam.code shouldBe "x"
-                xParam.index shouldBe 1
-                xParam.isVariadic shouldBe false
+          xParam.code shouldBe "x"
+          xParam.index shouldBe 1
+          xParam.isVariadic shouldBe false
 
-              case _ => fail("Expected two parameters")
-            }
-          case _ => fail("Expected one method")
         }
-      case _ => fail("Expected one class definition")
+      }
     }
   }
 
@@ -234,25 +208,19 @@ class MethodTests extends RubyCode2CpgFixture {
                      |end
                      |""".stripMargin)
 
-    inside(cpg.typeDecl.name("C").l) {
-      case classC :: Nil =>
-        inside(classC.method.name("f").l) {
-          case funcF :: Nil =>
-            inside(funcF.parameter.l) {
-              case thisParam :: xParam :: Nil =>
-                thisParam.code shouldBe RDefines.Self
-                thisParam.typeFullName shouldBe s"Test0.rb:$Main.C<class>"
-                thisParam.index shouldBe 0
-                thisParam.isVariadic shouldBe false
+    inside(cpg.typeDecl.name("C").l) { case classC :: Nil =>
+      inside(classC.method.name("f").l) { case funcF :: Nil =>
+        inside(funcF.parameter.l) { case thisParam :: xParam :: Nil =>
+          thisParam.code shouldBe RDefines.Self
+          thisParam.typeFullName shouldBe s"Test0.rb:$Main.C<class>"
+          thisParam.index shouldBe 0
+          thisParam.isVariadic shouldBe false
 
-                xParam.code shouldBe "x"
-                xParam.index shouldBe 1
-                xParam.isVariadic shouldBe false
-              case _ => fail("Expected two parameters")
-            }
-          case _ => fail("Expected one method")
+          xParam.code shouldBe "x"
+          xParam.index shouldBe 1
+          xParam.isVariadic shouldBe false
         }
-      case _ => fail("Expected one class definition")
+      }
     }
   }
 
@@ -267,24 +235,20 @@ class MethodTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "be interpreted as an array type parameter if a single star given" in {
-      inside(cpg.method("foo").parameter.indexGt(0).l) {
-        case xs :: Nil =>
-          xs.name shouldBe "xs"
-          xs.code shouldBe "*xs"
-          xs.isVariadic shouldBe true
-          xs.typeFullName shouldBe RDefines.prefixAsCoreType("Array")
-        case xs => fail(s"Expected `foo` to have one parameter, got [${xs.code.mkString(", ")}]")
+      inside(cpg.method("foo").parameter.indexGt(0).l) { case xs :: Nil =>
+        xs.name shouldBe "xs"
+        xs.code shouldBe "*xs"
+        xs.isVariadic shouldBe true
+        xs.typeFullName shouldBe RDefines.prefixAsCoreType("Array")
       }
     }
 
     "be interpreted as a hash type parameter if two stars given" in {
-      inside(cpg.method("bar").parameter.indexGt(0).l) {
-        case ys :: Nil =>
-          ys.name shouldBe "ys"
-          ys.code shouldBe "**ys"
-          ys.isVariadic shouldBe true
-          ys.typeFullName shouldBe RDefines.prefixAsCoreType("Hash")
-        case xs => fail(s"Expected `foo` to have one parameter, got [${xs.code.mkString(", ")}]")
+      inside(cpg.method("bar").parameter.indexGt(0).l) { case ys :: Nil =>
+        ys.name shouldBe "ys"
+        ys.code shouldBe "**ys"
+        ys.isVariadic shouldBe true
+        ys.typeFullName shouldBe RDefines.prefixAsCoreType("Hash")
       }
     }
 
@@ -314,36 +278,30 @@ class MethodTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "create a method under `Foo` for both `x=`, `x`, and `bar=`, where `bar=` forwards parameters to a call to `x=`" in {
-      inside(cpg.typeDecl("Foo").l) {
-        case foo :: Nil =>
-          inside(foo.method.nameNot(RDefines.Initialize, RDefines.TypeDeclBody).l) {
-            case xeq :: x :: bar :: Nil =>
-              xeq.name shouldBe "x="
-              x.name shouldBe "x"
-              bar.name shouldBe "bar="
+      inside(cpg.typeDecl("Foo").l) { case foo :: Nil =>
+        inside(foo.method.nameNot(RDefines.Initialize, RDefines.TypeDeclBody).l) { case xeq :: x :: bar :: Nil =>
+          xeq.name shouldBe "x="
+          x.name shouldBe "x"
+          bar.name shouldBe "bar="
 
-              bar.parameter.name.l shouldBe List("self", "args", "&block")
-              // bar forwards parameters to a call to the aliased method
-              inside(bar.call.name("x=").l) {
-                case barCall :: Nil =>
-                  inside(barCall.argument.l) {
-                    case _ :: (args: Call) :: (blockId: Identifier) :: Nil =>
-                      args.name shouldBe RubyOperators.splat
-                      args.code shouldBe "*args"
-                      args.argumentIndex shouldBe 1
+          bar.parameter.name.l shouldBe List("self", "args", "&block")
+          // bar forwards parameters to a call to the aliased method
+          inside(bar.call.name("x=").l) { case barCall :: Nil =>
+            inside(barCall.argument.l) {
+              case _ :: (args: Call) :: (blockId: Identifier) :: Nil =>
+                args.name shouldBe RubyOperators.splat
+                args.code shouldBe "*args"
+                args.argumentIndex shouldBe 1
 
-                      blockId.name shouldBe "&block"
-                      blockId.code shouldBe "&block"
-                      blockId.argumentIndex shouldBe 2
-                    case xs =>
-                      fail(s"Expected a two arguments for the call `x=`,  instead got [${xs.code.mkString(",")}]")
-                  }
-                  barCall.code shouldBe "x=(*args, &block)"
-                case xs => fail(s"Expected a single call to `bar=`,  instead got [${xs.code.mkString(",")}]")
-              }
-            case xs => fail(s"Expected a three virtual methods under `Foo`, instead got [${xs.code.mkString(",")}]")
+                blockId.name shouldBe "&block"
+                blockId.code shouldBe "&block"
+                blockId.argumentIndex shouldBe 2
+              case xs =>
+                fail(s"Expected a two arguments for the call `x=`,  instead got [${xs.code.mkString(",")}]")
+            }
+            barCall.code shouldBe "x=(*args, &block)"
           }
-        case xs => fail(s"Expected a single type decl for `Foo`, instead got [${xs.code.mkString(",")}]")
+        }
       }
     }
   }
@@ -365,38 +323,30 @@ class MethodTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "similarly alias the method as if it were calling `alias`" in {
-      inside(cpg.typeDecl("Foo").l) {
-        case foo :: Nil =>
-          inside(foo.method.nameNot(RDefines.Initialize, RDefines.TypeDeclBody).l) {
-            case a :: p :: s :: Nil =>
-              a.name shouldBe "aliasable"
-              p.name shouldBe "print_something"
-              s.name shouldBe "someMethod"
+      inside(cpg.typeDecl("Foo").l) { case foo :: Nil =>
+        inside(foo.method.nameNot(RDefines.Initialize, RDefines.TypeDeclBody).l) { case a :: p :: s :: Nil =>
+          a.name shouldBe "aliasable"
+          p.name shouldBe "print_something"
+          s.name shouldBe "someMethod"
 
-              p.parameter.name.l shouldBe List("self", "args", "&block")
-              // bar forwards parameters to a call to the aliased method
-              inside(p.call.name("aliasable").l) {
-                case aliasableCall :: Nil =>
-                  inside(aliasableCall.argument.l) {
-                    case _ :: (args: Call) :: (blockId: Identifier) :: Nil =>
-                      args.name shouldBe RubyOperators.splat
-                      args.code shouldBe "*args"
-                      args.argumentIndex shouldBe 1
+          p.parameter.name.l shouldBe List("self", "args", "&block")
+          // bar forwards parameters to a call to the aliased method
+          inside(p.call.name("aliasable").l) { case aliasableCall :: Nil =>
+            inside(aliasableCall.argument.l) {
+              case _ :: (args: Call) :: (blockId: Identifier) :: Nil =>
+                args.name shouldBe RubyOperators.splat
+                args.code shouldBe "*args"
+                args.argumentIndex shouldBe 1
 
-                      blockId.name shouldBe "&block"
-                      blockId.code shouldBe "&block"
-                      blockId.argumentIndex shouldBe 2
-                    case xs =>
-                      fail(
-                        s"Expected a two arguments for the call `aliasable`,  instead got [${xs.code.mkString(",")}]"
-                      )
-                  }
-                  aliasableCall.code shouldBe "aliasable(*args, &block)"
-                case xs => fail(s"Expected a single call to `aliasable`,  instead got [${xs.code.mkString(",")}]")
-              }
-            case xs => fail(s"Expected a three virtual methods under `Foo`, instead got [${xs.code.mkString(",")}]")
+                blockId.name shouldBe "&block"
+                blockId.code shouldBe "&block"
+                blockId.argumentIndex shouldBe 2
+              case xs =>
+                fail(s"Expected a two arguments for the call `aliasable`,  instead got [${xs.code.mkString(",")}]")
+            }
+            aliasableCall.code shouldBe "aliasable(*args, &block)"
           }
-        case xs => fail(s"Expected a single type decl for `Foo`, instead got [${xs.code.mkString(",")}]")
+        }
       }
     }
 
@@ -418,29 +368,23 @@ class MethodTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "exist under the module TYPE_DECL" in {
-      inside(cpg.typeDecl.name("F").method.nameExact("bar", "baz").l) {
-        case bar :: baz :: Nil =>
-          inside(bar.parameter.l) {
-            case thisParam :: xParam :: Nil =>
-              thisParam.name shouldBe RDefines.Self
-              thisParam.code shouldBe "F"
-              thisParam.typeFullName shouldBe s"Test0.rb:$Main.F<class>"
+      inside(cpg.typeDecl.name("F").method.nameExact("bar", "baz").l) { case bar :: baz :: Nil =>
+        inside(bar.parameter.l) { case thisParam :: xParam :: Nil =>
+          thisParam.name shouldBe RDefines.Self
+          thisParam.code shouldBe "F"
+          thisParam.typeFullName shouldBe s"Test0.rb:$Main.F<class>"
 
-              xParam.name shouldBe "x"
-            case xs => fail(s"Expected two parameters, got ${xs.name.mkString(", ")}")
-          }
+          xParam.name shouldBe "x"
+        }
 
-          inside(baz.parameter.l) {
-            case thisParam :: xParam :: Nil =>
-              thisParam.name shouldBe RDefines.Self
-              thisParam.code shouldBe "F"
-              thisParam.typeFullName shouldBe s"Test0.rb:$Main.F<class>"
+        inside(baz.parameter.l) { case thisParam :: xParam :: Nil =>
+          thisParam.name shouldBe RDefines.Self
+          thisParam.code shouldBe "F"
+          thisParam.typeFullName shouldBe s"Test0.rb:$Main.F<class>"
 
-              xParam.name shouldBe "x"
-              xParam.code shouldBe "x"
-            case xs => fail(s"Expected two parameters, got ${xs.name.mkString(", ")}")
-          }
-        case xs => fail(s"Expected bar and baz to exist under F, instead got ${xs.code.mkString(", ")}")
+          xParam.name shouldBe "x"
+          xParam.code shouldBe "x"
+        }
       }
     }
 
@@ -451,13 +395,11 @@ class MethodTests extends RubyCode2CpgFixture {
     }
 
     "baz should not exist in the <main> block" in {
-      inside(cpg.method.isModule.l) {
-        case prog :: Nil =>
-          inside(prog.block.astChildren.isMethod.name("baz").l) {
-            case Nil => // passing case
-            case _   => fail("Baz should not exist under program method block")
-          }
-        case _ => fail("Expected one Method for <block>")
+      inside(cpg.method.isModule.l) { case prog :: Nil =>
+        inside(prog.block.astChildren.isMethod.name("baz").l) {
+          case Nil => // passing case
+          case _   => fail("Baz should not exist under program method block")
+        }
       }
     }
   }
@@ -484,18 +426,14 @@ class MethodTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "be represented by a METHOD node" in {
-      inside(cpg.method.name("exists\\?").l) {
-        case existsMethod :: Nil =>
-          existsMethod.fullName shouldBe s"Test0.rb:$Main.exists?"
-          existsMethod.isExternal shouldBe false
+      inside(cpg.method.name("exists\\?").l) { case existsMethod :: Nil =>
+        existsMethod.fullName shouldBe s"Test0.rb:$Main.exists?"
+        existsMethod.isExternal shouldBe false
 
-          inside(existsMethod.methodReturn.cfgIn.l) {
-            case existsMethodReturn :: Nil =>
-              existsMethodReturn.code shouldBe "true"
-            case _ => fail("Expected return for method")
-          }
+        inside(existsMethod.methodReturn.cfgIn.l) { case existsMethodReturn :: Nil =>
+          existsMethodReturn.code shouldBe "true"
+        }
 
-        case xs => fail(s"Expected one method, found ${xs.name.mkString(", ")}")
       }
     }
   }
@@ -508,22 +446,18 @@ class MethodTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "Represented by Return Node" in {
-      inside(cpg.method.name("foo").l) {
-        case fooMethod :: Nil =>
-          inside(fooMethod.methodReturn.toReturn.l) {
-            case returnTrue :: returnNil :: Nil =>
-              returnTrue.code shouldBe "return true"
+      inside(cpg.method.name("foo").l) { case fooMethod :: Nil =>
+        inside(fooMethod.methodReturn.toReturn.l) { case returnTrue :: returnNil :: Nil =>
+          returnTrue.code shouldBe "return true"
 
-              val List(trueVal: Literal) = returnTrue.astChildren.isLiteral.l: @unchecked
-              trueVal.code shouldBe "true"
+          val List(trueVal: Literal) = returnTrue.astChildren.isLiteral.l: @unchecked
+          trueVal.code shouldBe "true"
 
-              returnNil.code shouldBe "return nil"
+          returnNil.code shouldBe "return nil"
 
-              val List(nilVal: Literal) = returnNil.astChildren.isLiteral.l: @unchecked
-              nilVal.code shouldBe "nil"
-            case xs => fail(s"Expected two returns, got ${xs.code.mkString(", ")} instead")
-          }
-        case xs => fail(s"Expected one method for foo, got ${xs.name.mkString(", ")} instead")
+          val List(nilVal: Literal) = returnNil.astChildren.isLiteral.l: @unchecked
+          nilVal.code shouldBe "nil"
+        }
       }
     }
   }
@@ -538,49 +472,33 @@ class MethodTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "generate control structure for break" in {
-      inside(cpg.method.name("foo").l) {
-        case fooMethod :: Nil =>
-          inside(fooMethod.astChildren.isMethod.name("<lambda>0").l) {
-            case loopMethod :: Nil =>
-              inside(loopMethod.block.astChildren.isControlStructure.l) {
-                case ifStruct :: Nil =>
-                  inside(ifStruct.astChildren.isBlock.l) {
-                    case nilBlock :: breakBlock :: Nil =>
-                      inside(breakBlock.astChildren.isControlStructure.l) {
-                        case breakStruct :: Nil =>
-                          breakStruct.code shouldBe "break"
-                        case xs =>
-                          fail(s"Expected on control structure for break, got ${xs.code.mkString(", ")} instead")
-                      }
-                    case xs => fail(s"Expected block for break and nil, got ${xs.code.mkString(", ")} instead")
-                  }
-                case xs => fail(s"Expected one control structure for if, got ${xs.code.mkString(", ")} instead")
+      inside(cpg.method.name("foo").l) { case fooMethod :: Nil =>
+        inside(fooMethod.astChildren.isMethod.name("<lambda>0").l) { case loopMethod :: Nil =>
+          inside(loopMethod.block.astChildren.isControlStructure.l) { case ifStruct :: Nil =>
+            inside(ifStruct.astChildren.isBlock.l) { case nilBlock :: breakBlock :: Nil =>
+              inside(breakBlock.astChildren.isControlStructure.l) {
+                case breakStruct :: Nil =>
+                  breakStruct.code shouldBe "break"
+                case xs =>
+                  fail(s"Expected on control structure for break, got ${xs.code.mkString(", ")} instead")
               }
-
-              inside(loopMethod.methodReturn.toReturn.l) {
-                case lambdaRet :: Nil =>
-                  lambdaRet.code shouldBe "return nil" // break statements cannot be returned, so only false branch should be present which returns nil for UnlessExpression
-                case xs => fail(s"Expected one return for lambda function, got ${xs.code.mkString(", ")} instead")
-              }
-            case xs => fail(s"Expected one lambda method, got ${xs.name.mkString(", ")} instead")
+            }
           }
-        case xs => fail(s"Expected one method for foo, got ${xs.name.mkString(", ")} instead")
+
+          inside(loopMethod.methodReturn.toReturn.l) { case lambdaRet :: Nil =>
+            lambdaRet.code shouldBe "return nil" // break statements cannot be returned, so only false branch should be present which returns nil for UnlessExpression
+          }
+        }
       }
     }
 
     "generate one return for lambda loop do block" in {
-      inside(cpg.method.name("foo").l) {
-        case fooMethod :: Nil =>
-          inside(fooMethod.astChildren.isMethod.name("<lambda>0").l) {
-            case loopMethod :: Nil =>
-              inside(loopMethod.methodReturn.toReturn.l) {
-                case lambdaRet :: Nil =>
-                  lambdaRet.code shouldBe "return nil" // break statements cannot be returned, so only false branch should be present which returns nil for UnlessExpression
-                case xs => fail(s"Expected one return for lambda function, got ${xs.code.mkString(", ")} instead")
-              }
-            case xs => fail(s"Expected one lambda method, got ${xs.name.mkString(", ")} instead")
+      inside(cpg.method.name("foo").l) { case fooMethod :: Nil =>
+        inside(fooMethod.astChildren.isMethod.name("<lambda>0").l) { case loopMethod :: Nil =>
+          inside(loopMethod.methodReturn.toReturn.l) { case lambdaRet :: Nil =>
+            lambdaRet.code shouldBe "return nil" // break statements cannot be returned, so only false branch should be present which returns nil for UnlessExpression
           }
-        case xs => fail(s"Expected one method for foo, got ${xs.name.mkString(", ")} instead")
+        }
       }
     }
   }
@@ -596,19 +514,17 @@ class MethodTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "Should be represented as a TRY structure" in {
-      inside(cpg.method.name("foo").controlStructure.l) {
-        case tryStruct :: emptyElseStruct :: ensureStruct :: Nil =>
-          tryStruct.controlStructureType shouldBe ControlStructureTypes.TRY
-          val body = tryStruct.astChildren.head
-          body.ast.isLiteral.code.l shouldBe List("1")
+      inside(cpg.method.name("foo").controlStructure.l) { case tryStruct :: emptyElseStruct :: ensureStruct :: Nil =>
+        tryStruct.controlStructureType shouldBe ControlStructureTypes.TRY
+        val body = tryStruct.astChildren.head
+        body.ast.isLiteral.code.l shouldBe List("1")
 
-          emptyElseStruct.controlStructureType shouldBe ControlStructureTypes.ELSE
-          emptyElseStruct.ast.isLiteral.code.l shouldBe List("nil")
+        emptyElseStruct.controlStructureType shouldBe ControlStructureTypes.ELSE
+        emptyElseStruct.ast.isLiteral.code.l shouldBe List("nil")
 
-          ensureStruct.controlStructureType shouldBe ControlStructureTypes.FINALLY
-          ensureStruct.ast.isLiteral.code.l shouldBe List("2")
+        ensureStruct.controlStructureType shouldBe ControlStructureTypes.FINALLY
+        ensureStruct.ast.isLiteral.code.l shouldBe List("2")
 
-        case xs => fail(s"Expected three structures, got ${xs.code.mkString(",")}")
       }
     }
   }
@@ -629,29 +545,27 @@ class MethodTests extends RubyCode2CpgFixture {
     "have chained calls" in {
       inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).condition.headOption) {
         case Some(ifCond: Call) =>
-          inside(ifCond.argument.l) {
-            case (leftArg: Identifier) :: (rightArg: Call) :: Nil =>
-              leftArg.name shouldBe "a"
+          inside(ifCond.argument.l) { case (leftArg: Identifier) :: (rightArg: Call) :: Nil =>
+            leftArg.name shouldBe "a"
 
-              rightArg.name shouldBe "hexdigest"
-              rightArg.code shouldBe "(<tmp-1> = Digest::MD5).hexdigest(password)"
+            rightArg.name shouldBe "hexdigest"
+            rightArg.code shouldBe "(<tmp-1> = Digest::MD5).hexdigest(password)"
 
-              val hexDigestFa = rightArg.receiver.head.asInstanceOf[FieldAccess]
-              hexDigestFa.code shouldBe "(<tmp-1> = Digest::MD5).hexdigest"
+            val hexDigestFa = rightArg.receiver.head.asInstanceOf[FieldAccess]
+            hexDigestFa.code shouldBe "(<tmp-1> = Digest::MD5).hexdigest"
 
-              val tmp1Assign = hexDigestFa.argument(1).asInstanceOf[Assignment]
-              tmp1Assign.code shouldBe "<tmp-1> = Digest::MD5"
+            val tmp1Assign = hexDigestFa.argument(1).asInstanceOf[Assignment]
+            tmp1Assign.code shouldBe "<tmp-1> = Digest::MD5"
 
-              val md5Fa = tmp1Assign.source.asInstanceOf[FieldAccess]
-              md5Fa.code shouldBe "(<tmp-0> = Digest)::MD5"
+            val md5Fa = tmp1Assign.source.asInstanceOf[FieldAccess]
+            md5Fa.code shouldBe "(<tmp-0> = Digest)::MD5"
 
-              val tmp0Assign = md5Fa.argument(1).asInstanceOf[Assignment]
-              tmp0Assign.code shouldBe "<tmp-0> = Digest"
+            val tmp0Assign = md5Fa.argument(1).asInstanceOf[Assignment]
+            tmp0Assign.code shouldBe "<tmp-0> = Digest"
 
-              val digestFa = tmp0Assign.source.asInstanceOf[FieldAccess]
-              digestFa.argument(1).asInstanceOf[Identifier].name shouldBe RDefines.Self
-              digestFa.argument(2).asInstanceOf[FieldIdentifier].canonicalName shouldBe "Digest"
-            case xs => fail(s"Expected 2 arguments, got ${xs.code.mkString(", ")} instead")
+            val digestFa = tmp0Assign.source.asInstanceOf[FieldAccess]
+            digestFa.argument(1).asInstanceOf[Identifier].name shouldBe RDefines.Self
+            digestFa.argument(2).asInstanceOf[FieldIdentifier].canonicalName shouldBe "Digest"
           }
         case None => fail("Expected if-condition")
       }
@@ -693,32 +607,25 @@ class MethodTests extends RubyCode2CpgFixture {
           classAssignment.code shouldBe "self.B = class B (...)"
           methodAssignment.code shouldBe "self.c = def c (...)"
 
-          inside(moduleAssignment.argument.l) {
-            case (lhs: Call) :: (rhs: TypeRef) :: Nil =>
-              lhs.code shouldBe "self.A"
-              lhs.name shouldBe Operators.fieldAccess
-              rhs.typeFullName shouldBe s"t1.rb:$Main.A<class>"
-            case xs => fail(s"Expected lhs and rhs, instead got ${xs.code.mkString(",")}")
+          inside(moduleAssignment.argument.l) { case (lhs: Call) :: (rhs: TypeRef) :: Nil =>
+            lhs.code shouldBe "self.A"
+            lhs.name shouldBe Operators.fieldAccess
+            rhs.typeFullName shouldBe s"t1.rb:$Main.A<class>"
           }
 
-          inside(classAssignment.argument.l) {
-            case (lhs: Call) :: (rhs: TypeRef) :: Nil =>
-              lhs.code shouldBe "self.B"
-              lhs.name shouldBe Operators.fieldAccess
-              rhs.typeFullName shouldBe s"t1.rb:$Main.B<class>"
-            case xs => fail(s"Expected lhs and rhs, instead got ${xs.code.mkString(",")}")
+          inside(classAssignment.argument.l) { case (lhs: Call) :: (rhs: TypeRef) :: Nil =>
+            lhs.code shouldBe "self.B"
+            lhs.name shouldBe Operators.fieldAccess
+            rhs.typeFullName shouldBe s"t1.rb:$Main.B<class>"
           }
 
-          inside(methodAssignment.argument.l) {
-            case (lhs: Call) :: (rhs: MethodRef) :: Nil =>
-              lhs.code shouldBe "self.c"
-              lhs.name shouldBe Operators.fieldAccess
-              rhs.methodFullName shouldBe s"t1.rb:$Main.c"
-              rhs.typeFullName shouldBe s"t1.rb:$Main.c"
-            case xs => fail(s"Expected lhs and rhs, instead got ${xs.code.mkString(",")}")
+          inside(methodAssignment.argument.l) { case (lhs: Call) :: (rhs: MethodRef) :: Nil =>
+            lhs.code shouldBe "self.c"
+            lhs.name shouldBe Operators.fieldAccess
+            rhs.methodFullName shouldBe s"t1.rb:$Main.c"
+            rhs.typeFullName shouldBe s"t1.rb:$Main.c"
           }
 
-        case xs => fail(s"Expected three assignments, got [${xs.code.mkString(",")}]")
       }
     }
 
@@ -728,24 +635,19 @@ class MethodTests extends RubyCode2CpgFixture {
           classAssignment.code shouldBe "self.D = class D (...)"
           methodAssignment.code shouldBe "self.e = def e (...)"
 
-          inside(classAssignment.argument.l) {
-            case (lhs: Call) :: (rhs: TypeRef) :: Nil =>
-              lhs.code shouldBe "self.D"
-              lhs.name shouldBe Operators.fieldAccess
-              rhs.typeFullName shouldBe s"t2.rb:$Main.D<class>"
-            case xs => fail(s"Expected lhs and rhs, instead got ${xs.code.mkString(",")}")
+          inside(classAssignment.argument.l) { case (lhs: Call) :: (rhs: TypeRef) :: Nil =>
+            lhs.code shouldBe "self.D"
+            lhs.name shouldBe Operators.fieldAccess
+            rhs.typeFullName shouldBe s"t2.rb:$Main.D<class>"
           }
 
-          inside(methodAssignment.argument.l) {
-            case (lhs: Call) :: (rhs: MethodRef) :: Nil =>
-              lhs.code shouldBe "self.e"
-              lhs.name shouldBe Operators.fieldAccess
-              rhs.methodFullName shouldBe s"t2.rb:$Main.e"
-              rhs.typeFullName shouldBe s"t2.rb:$Main.e"
-            case xs => fail(s"Expected lhs and rhs, instead got ${xs.code.mkString(",")}")
+          inside(methodAssignment.argument.l) { case (lhs: Call) :: (rhs: MethodRef) :: Nil =>
+            lhs.code shouldBe "self.e"
+            lhs.name shouldBe Operators.fieldAccess
+            rhs.methodFullName shouldBe s"t2.rb:$Main.e"
+            rhs.typeFullName shouldBe s"t2.rb:$Main.e"
           }
 
-        case xs => fail(s"Expected two assignments, got [${xs.code.mkString(",")}]")
       }
     }
 
@@ -757,7 +659,6 @@ class MethodTests extends RubyCode2CpgFixture {
           a3.code shouldBe "self.B = class B (...)"
           a4.code shouldBe "(<tmp-1> = self::B)::<body>()"
           a5.code shouldBe "self.c = def c (...)"
-        case xs => fail(s"Expected assignments to appear before definitions, instead got [${xs.mkString("\n")}]")
       }
     }
   }
@@ -768,18 +669,14 @@ class MethodTests extends RubyCode2CpgFixture {
         |end
         |""".stripMargin)
 
-    inside(cpg.method.name("foo").l) {
-      case fooMethod :: Nil =>
-        inside(fooMethod.method.parameter.l) {
-          case selfArg :: splatArg :: normalArg :: Nil =>
-            splatArg.code shouldBe "*x"
-            splatArg.index shouldBe 1
+    inside(cpg.method.name("foo").l) { case fooMethod :: Nil =>
+      inside(fooMethod.method.parameter.l) { case selfArg :: splatArg :: normalArg :: Nil =>
+        splatArg.code shouldBe "*x"
+        splatArg.index shouldBe 1
 
-            normalArg.code shouldBe "y"
-            normalArg.index shouldBe 2
-          case xs => fail(s"Expected two parameters, got [${xs.code.mkString(",")}]")
-        }
-      case xs => fail(s"Expected one method, got [${xs.code.mkString(",")}]")
+        normalArg.code shouldBe "y"
+        normalArg.index shouldBe 2
+      }
     }
   }
 
@@ -792,15 +689,11 @@ class MethodTests extends RubyCode2CpgFixture {
         |foo(*x, y)
         |""".stripMargin)
 
-    inside(cpg.call.name("foo").l) {
-      case fooCall :: Nil =>
-        inside(fooCall.argument.l) {
-          case selfArg :: xArg :: yArg :: Nil =>
-            xArg.code shouldBe "*x"
-            yArg.code shouldBe "self.y"
-          case xs => fail(s"Expected two args, got [${xs.code.mkString(",")}]")
-        }
-      case xs => fail(s"Expected one call to foo, got [${xs.code.mkString(",")}]")
+    inside(cpg.call.name("foo").l) { case fooCall :: Nil =>
+      inside(fooCall.argument.l) { case selfArg :: xArg :: yArg :: Nil =>
+        xArg.code shouldBe "*x"
+        yArg.code shouldBe "self.y"
+      }
     }
   }
 
@@ -839,26 +732,22 @@ class MethodTests extends RubyCode2CpgFixture {
         |batch.retry!()
         |""".stripMargin)
 
-    inside(cpg.call.name(".*retry!").l) {
-      case batchCall :: Nil =>
-        batchCall.name shouldBe "retry!"
-        batchCall.code shouldBe "(<tmp-0> = batch).retry!()"
+    inside(cpg.call.name(".*retry!").l) { case batchCall :: Nil =>
+      batchCall.name shouldBe "retry!"
+      batchCall.code shouldBe "(<tmp-0> = batch).retry!()"
 
-        inside(batchCall.receiver.l) {
-          case (receiverCall: Call) :: Nil =>
-            receiverCall.name shouldBe Operators.fieldAccess
-            receiverCall.code shouldBe "(<tmp-0> = batch).retry!"
+      inside(batchCall.receiver.l) { case (receiverCall: Call) :: Nil =>
+        receiverCall.name shouldBe Operators.fieldAccess
+        receiverCall.code shouldBe "(<tmp-0> = batch).retry!"
 
-            val selfBatch = receiverCall.argument(1).asInstanceOf[Call]
-            selfBatch.code shouldBe "<tmp-0> = batch"
+        val selfBatch = receiverCall.argument(1).asInstanceOf[Call]
+        selfBatch.code shouldBe "<tmp-0> = batch"
 
-            val retry = receiverCall.argument(2).asInstanceOf[FieldIdentifier]
-            retry.code shouldBe "retry!"
+        val retry = receiverCall.argument(2).asInstanceOf[FieldIdentifier]
+        retry.code shouldBe "retry!"
 
-          case xs => fail(s"Expected one receiver for call, got [${xs.code.mkString(",")}]")
-        }
+      }
 
-      case xs => fail(s"Expected one method for batch.retry, got [${xs.code.mkString(",")}]")
     }
   }
 
@@ -867,26 +756,22 @@ class MethodTests extends RubyCode2CpgFixture {
         |batch::retry!()
         |""".stripMargin)
 
-    inside(cpg.call.name(".*retry!").l) {
-      case batchCall :: Nil =>
-        batchCall.name shouldBe "retry!"
-        batchCall.code shouldBe "(<tmp-0> = batch)::retry!()"
+    inside(cpg.call.name(".*retry!").l) { case batchCall :: Nil =>
+      batchCall.name shouldBe "retry!"
+      batchCall.code shouldBe "(<tmp-0> = batch)::retry!()"
 
-        inside(batchCall.receiver.l) {
-          case (receiverCall: Call) :: Nil =>
-            receiverCall.name shouldBe Operators.fieldAccess
-            receiverCall.code shouldBe "(<tmp-0> = batch).retry!"
+      inside(batchCall.receiver.l) { case (receiverCall: Call) :: Nil =>
+        receiverCall.name shouldBe Operators.fieldAccess
+        receiverCall.code shouldBe "(<tmp-0> = batch).retry!"
 
-            val selfBatch = receiverCall.argument(1).asInstanceOf[Call]
-            selfBatch.code shouldBe "<tmp-0> = batch"
+        val selfBatch = receiverCall.argument(1).asInstanceOf[Call]
+        selfBatch.code shouldBe "<tmp-0> = batch"
 
-            val retry = receiverCall.argument(2).asInstanceOf[FieldIdentifier]
-            retry.code shouldBe "retry!"
+        val retry = receiverCall.argument(2).asInstanceOf[FieldIdentifier]
+        retry.code shouldBe "retry!"
 
-          case xs => fail(s"Expected one receiver for call, got [${xs.code.mkString(",")}]")
-        }
+      }
 
-      case xs => fail(s"Expected one method for batch.retry, got [${xs.code.mkString(",")}]")
     }
   }
 
@@ -895,26 +780,22 @@ class MethodTests extends RubyCode2CpgFixture {
         |retry.retry!()
         |""".stripMargin)
 
-    inside(cpg.call.name(".*retry!").l) {
-      case batchCall :: Nil =>
-        batchCall.name shouldBe "retry!"
-        batchCall.code shouldBe "(<tmp-0> = retry).retry!()"
+    inside(cpg.call.name(".*retry!").l) { case batchCall :: Nil =>
+      batchCall.name shouldBe "retry!"
+      batchCall.code shouldBe "(<tmp-0> = retry).retry!()"
 
-        inside(batchCall.receiver.l) {
-          case (receiverCall: Call) :: Nil =>
-            receiverCall.name shouldBe Operators.fieldAccess
-            receiverCall.code shouldBe "(<tmp-0> = retry).retry!"
+      inside(batchCall.receiver.l) { case (receiverCall: Call) :: Nil =>
+        receiverCall.name shouldBe Operators.fieldAccess
+        receiverCall.code shouldBe "(<tmp-0> = retry).retry!"
 
-            val selfBatch = receiverCall.argument(1).asInstanceOf[Call]
-            selfBatch.code shouldBe "<tmp-0> = retry"
+        val selfBatch = receiverCall.argument(1).asInstanceOf[Call]
+        selfBatch.code shouldBe "<tmp-0> = retry"
 
-            val retry = receiverCall.argument(2).asInstanceOf[FieldIdentifier]
-            retry.code shouldBe "retry!"
+        val retry = receiverCall.argument(2).asInstanceOf[FieldIdentifier]
+        retry.code shouldBe "retry!"
 
-          case xs => fail(s"Expected one receiver for call, got [${xs.code.mkString(",")}]")
-        }
+      }
 
-      case xs => fail(s"Expected one method for batch.retry, got [${xs.code.mkString(",")}]")
     }
   }
 
@@ -923,26 +804,22 @@ class MethodTests extends RubyCode2CpgFixture {
         |retry::retry!()
         |""".stripMargin)
 
-    inside(cpg.call.name(".*retry!").l) {
-      case batchCall :: Nil =>
-        batchCall.name shouldBe "retry!"
-        batchCall.code shouldBe "(<tmp-0> = retry)::retry!()"
+    inside(cpg.call.name(".*retry!").l) { case batchCall :: Nil =>
+      batchCall.name shouldBe "retry!"
+      batchCall.code shouldBe "(<tmp-0> = retry)::retry!()"
 
-        inside(batchCall.receiver.l) {
-          case (receiverCall: Call) :: Nil =>
-            receiverCall.name shouldBe Operators.fieldAccess
-            receiverCall.code shouldBe "(<tmp-0> = retry).retry!"
+      inside(batchCall.receiver.l) { case (receiverCall: Call) :: Nil =>
+        receiverCall.name shouldBe Operators.fieldAccess
+        receiverCall.code shouldBe "(<tmp-0> = retry).retry!"
 
-            val selfBatch = receiverCall.argument(1).asInstanceOf[Call]
-            selfBatch.code shouldBe "<tmp-0> = retry"
+        val selfBatch = receiverCall.argument(1).asInstanceOf[Call]
+        selfBatch.code shouldBe "<tmp-0> = retry"
 
-            val retry = receiverCall.argument(2).asInstanceOf[FieldIdentifier]
-            retry.code shouldBe "retry!"
+        val retry = receiverCall.argument(2).asInstanceOf[FieldIdentifier]
+        retry.code shouldBe "retry!"
 
-          case xs => fail(s"Expected one receiver for call, got [${xs.code.mkString(",")}]")
-        }
+      }
 
-      case xs => fail(s"Expected one method for batch.retry, got [${xs.code.mkString(",")}]")
     }
   }
 
@@ -951,35 +828,27 @@ class MethodTests extends RubyCode2CpgFixture {
         |%x(ls -l)
         |""".stripMargin)
 
-    inside(cpg.call.name(RubyOperators.backticks).l) {
-      case execCall :: Nil =>
-        execCall.name shouldBe RubyOperators.backticks
-        inside(execCall.argument.l) {
-          case selfArg :: lsArg :: Nil =>
-            selfArg.code shouldBe "self"
-            lsArg.code shouldBe "ls -l"
-          case xs => fail(s"expected 2 arguments, got [${xs.code.mkString(",")}]")
-        }
-      case xs => fail(s"Expected one call to exec, got [${xs.code.mkString(",")}]")
+    inside(cpg.call.name(RubyOperators.backticks).l) { case execCall :: Nil =>
+      execCall.name shouldBe RubyOperators.backticks
+      inside(execCall.argument.l) { case selfArg :: lsArg :: Nil =>
+        selfArg.code shouldBe "self"
+        lsArg.code shouldBe "ls -l"
+      }
     }
   }
 
   "MemberAccessCommand with two parameters" in {
     val cpg = code("foo&.bar 1,2")
 
-    inside(cpg.call.name("bar").l) {
-      case barCall :: Nil =>
-        inside(barCall.argument.l) {
-          case _ :: (arg1: Literal) :: (arg2: Literal) :: Nil =>
-            arg1.code shouldBe "1"
-            arg1.typeFullName shouldBe RDefines.prefixAsCoreType(RDefines.Integer)
+    inside(cpg.call.name("bar").l) { case barCall :: Nil =>
+      inside(barCall.argument.l) { case _ :: (arg1: Literal) :: (arg2: Literal) :: Nil =>
+        arg1.code shouldBe "1"
+        arg1.typeFullName shouldBe RDefines.prefixAsCoreType(RDefines.Integer)
 
-            arg2.code shouldBe "2"
-            arg2.typeFullName shouldBe RDefines.prefixAsCoreType(RDefines.Integer)
-          case xs => fail(s"Expected three args, got [${xs.code.mkString(",")}]")
-        }
+        arg2.code shouldBe "2"
+        arg2.typeFullName shouldBe RDefines.prefixAsCoreType(RDefines.Integer)
+      }
 
-      case xs => fail(s"Expected one call, got [${xs.code.mkString(",")}]")
     }
   }
 
@@ -991,11 +860,9 @@ class MethodTests extends RubyCode2CpgFixture {
         |end
         |""".stripMargin)
 
-    inside(cpg.method.name("show").l) {
-      case showMethod :: Nil =>
-        showMethod.astParentFullName shouldBe "Test0.rb:<main>.Api.V1.MobileController"
-        showMethod.astParentType shouldBe NodeTypes.TYPE_DECL
-      case xs => fail(s"Expected one methood, got ${xs.name.mkString(",")}")
+    inside(cpg.method.name("show").l) { case showMethod :: Nil =>
+      showMethod.astParentFullName shouldBe "Test0.rb:<main>.Api.V1.MobileController"
+      showMethod.astParentType shouldBe NodeTypes.TYPE_DECL
     }
   }
 
@@ -1005,12 +872,10 @@ class MethodTests extends RubyCode2CpgFixture {
         |end
         |""".stripMargin)
 
-    inside(cpg.method.name("foo").parameter.l) {
-      case _ :: aParam :: bParam :: cParam :: Nil =>
-        aParam.code shouldBe "a=1"
-        bParam.code shouldBe "*b"
-        cParam.code shouldBe "c"
-      case xs => fail(s"Expected 4 params, got ${xs.code.mkString(",")}")
+    inside(cpg.method.name("foo").parameter.l) { case _ :: aParam :: bParam :: cParam :: Nil =>
+      aParam.code shouldBe "a=1"
+      bParam.code shouldBe "*b"
+      cParam.code shouldBe "c"
     }
   }
 
@@ -1032,30 +897,24 @@ class MethodTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "generate and reference proc param" in {
-      inside(cpg.method.name("outer_method").l) {
-        case outerMethod :: Nil =>
-          val List(_, procParam) = outerMethod.parameter.l
-          procParam.name shouldBe "<proc-param-0>"
+      inside(cpg.method.name("outer_method").l) { case outerMethod :: Nil =>
+        val List(_, procParam) = outerMethod.parameter.l
+        procParam.name shouldBe "<proc-param-0>"
 
-          inside(outerMethod.call.name("inner_method").argument.l) {
-            case _ :: procParamArg :: Nil =>
-              procParamArg.code shouldBe "<proc-param-0>"
-            case xs => fail(s"Expected two arguments, got [${xs.code.mkString(",")}]")
-          }
+        inside(outerMethod.call.name("inner_method").argument.l) { case _ :: procParamArg :: Nil =>
+          procParamArg.code shouldBe "<proc-param-0>"
+        }
 
-        case xs => fail(s"Expected one method def, got [${xs.name.mkString(",")}]")
       }
     }
 
     "call correct proc param in `yield`" in {
-      inside(cpg.method.name("inner_method").l) {
-        case innerMethod :: Nil =>
-          val List(_, procParam) = innerMethod.parameter.l
-          procParam.name shouldBe "<proc-param-1>"
+      inside(cpg.method.name("inner_method").l) { case innerMethod :: Nil =>
+        val List(_, procParam) = innerMethod.parameter.l
+        procParam.name shouldBe "<proc-param-1>"
 
-          innerMethod.call.nameExact("call").argument.isIdentifier.name.l shouldBe List("<proc-param-1>")
+        innerMethod.call.nameExact("call").argument.isIdentifier.name.l shouldBe List("<proc-param-1>")
 
-        case xs => fail(s"Expected one method def, got [${xs.name.mkString(",")}]")
       }
     }
   }
@@ -1117,18 +976,16 @@ class MethodTests extends RubyCode2CpgFixture {
                      |    1..MAX_FILE_SIZE
                      |end""".stripMargin)
 
-    inside(cpg.method.name("size_range").methodReturn.toReturn.l) {
-      case rangeReturn :: Nil =>
-        rangeReturn.code shouldBe "1..MAX_FILE_SIZE"
+    inside(cpg.method.name("size_range").methodReturn.toReturn.l) { case rangeReturn :: Nil =>
+      rangeReturn.code shouldBe "1..MAX_FILE_SIZE"
 
-        val List(rangeOp) = rangeReturn.astChildren.isCall.l
-        rangeOp.methodFullName shouldBe Operators.range
+      val List(rangeOp) = rangeReturn.astChildren.isCall.l
+      rangeOp.methodFullName shouldBe Operators.range
 
-        val List(lhs: Literal, rhs: Call) = rangeOp.argument.l: @unchecked
-        lhs.code shouldBe "1"
+      val List(lhs: Literal, rhs: Call) = rangeOp.argument.l: @unchecked
+      lhs.code shouldBe "1"
 
-        rhs.code shouldBe "self.MAX_FILE_SIZE"
-      case xs => fail(s"Expected one return, got [${xs.code.mkString(",")}]")
+      rhs.code shouldBe "self.MAX_FILE_SIZE"
     }
   }
 
@@ -1154,15 +1011,12 @@ class MethodTests extends RubyCode2CpgFixture {
         publicCall.code shouldBe "public"
 
         val List(selfArg) = publicCall.argument.l
-      case xs => fail(s"Expected one call, got ${xs.code.mkString(",")}")
     }
 
-    inside(cpg.method.name("not_notifiable").body.astChildren.isCall.name("public").l) {
-      case publicCall :: Nil =>
-        publicCall.code shouldBe "public"
+    inside(cpg.method.name("not_notifiable").body.astChildren.isCall.name("public").l) { case publicCall :: Nil =>
+      publicCall.code shouldBe "public"
 
-        val List(selfArg) = publicCall.argument.l
-      case xs => fail(s"Expected one call, got ${xs.code.mkString(",")}")
+      val List(selfArg) = publicCall.argument.l
     }
   }
 
@@ -1202,7 +1056,6 @@ class MethodTests extends RubyCode2CpgFixture {
         aMethod.name shouldBe "a"
         bMethod.name shouldBe "b"
 
-      case xs => fail(s"Expected seven <tmp-#> vars, got ${xs.code.mkString("[", ",", "]")}")
     }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -287,17 +287,14 @@ class MethodTests extends RubyCode2CpgFixture {
           bar.parameter.name.l shouldBe List("self", "args", "&block")
           // bar forwards parameters to a call to the aliased method
           inside(bar.call.name("x=").l) { case barCall :: Nil =>
-            inside(barCall.argument.l) {
-              case _ :: (args: Call) :: (blockId: Identifier) :: Nil =>
-                args.name shouldBe RubyOperators.splat
-                args.code shouldBe "*args"
-                args.argumentIndex shouldBe 1
+            inside(barCall.argument.l) { case _ :: (args: Call) :: (blockId: Identifier) :: Nil =>
+              args.name shouldBe RubyOperators.splat
+              args.code shouldBe "*args"
+              args.argumentIndex shouldBe 1
 
-                blockId.name shouldBe "&block"
-                blockId.code shouldBe "&block"
-                blockId.argumentIndex shouldBe 2
-              case xs =>
-                fail(s"Expected a two arguments for the call `x=`,  instead got [${xs.code.mkString(",")}]")
+              blockId.name shouldBe "&block"
+              blockId.code shouldBe "&block"
+              blockId.argumentIndex shouldBe 2
             }
             barCall.code shouldBe "x=(*args, &block)"
           }
@@ -332,17 +329,14 @@ class MethodTests extends RubyCode2CpgFixture {
           p.parameter.name.l shouldBe List("self", "args", "&block")
           // bar forwards parameters to a call to the aliased method
           inside(p.call.name("aliasable").l) { case aliasableCall :: Nil =>
-            inside(aliasableCall.argument.l) {
-              case _ :: (args: Call) :: (blockId: Identifier) :: Nil =>
-                args.name shouldBe RubyOperators.splat
-                args.code shouldBe "*args"
-                args.argumentIndex shouldBe 1
+            inside(aliasableCall.argument.l) { case _ :: (args: Call) :: (blockId: Identifier) :: Nil =>
+              args.name shouldBe RubyOperators.splat
+              args.code shouldBe "*args"
+              args.argumentIndex shouldBe 1
 
-                blockId.name shouldBe "&block"
-                blockId.code shouldBe "&block"
-                blockId.argumentIndex shouldBe 2
-              case xs =>
-                fail(s"Expected a two arguments for the call `aliasable`,  instead got [${xs.code.mkString(",")}]")
+              blockId.name shouldBe "&block"
+              blockId.code shouldBe "&block"
+              blockId.argumentIndex shouldBe 2
             }
             aliasableCall.code shouldBe "aliasable(*args, &block)"
           }
@@ -396,10 +390,7 @@ class MethodTests extends RubyCode2CpgFixture {
 
     "baz should not exist in the <main> block" in {
       inside(cpg.method.isModule.l) { case prog :: Nil =>
-        inside(prog.block.astChildren.isMethod.name("baz").l) {
-          case Nil => // passing case
-          case _   => fail("Baz should not exist under program method block")
-        }
+        prog.block.astChildren.isMethod.name("baz").l shouldBe empty
       }
     }
   }
@@ -476,11 +467,8 @@ class MethodTests extends RubyCode2CpgFixture {
         inside(fooMethod.astChildren.isMethod.name("<lambda>0").l) { case loopMethod :: Nil =>
           inside(loopMethod.block.astChildren.isControlStructure.l) { case ifStruct :: Nil =>
             inside(ifStruct.astChildren.isBlock.l) { case nilBlock :: breakBlock :: Nil =>
-              inside(breakBlock.astChildren.isControlStructure.l) {
-                case breakStruct :: Nil =>
-                  breakStruct.code shouldBe "break"
-                case xs =>
-                  fail(s"Expected on control structure for break, got ${xs.code.mkString(", ")} instead")
+              inside(breakBlock.astChildren.isControlStructure.l) { case breakStruct :: Nil =>
+                breakStruct.code shouldBe "break"
               }
             }
           }
@@ -567,7 +555,6 @@ class MethodTests extends RubyCode2CpgFixture {
             digestFa.argument(1).asInstanceOf[Identifier].name shouldBe RDefines.Self
             digestFa.argument(2).asInstanceOf[FieldIdentifier].canonicalName shouldBe "Digest"
           }
-        case None => fail("Expected if-condition")
       }
     }
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ModuleTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ModuleTests.scala
@@ -154,10 +154,7 @@ class ModuleTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     inside(cpg.typeDecl.name("ArticlesHelper").method.l) { case bodyMethod :: _ :: _ :: Nil =>
-      inside(bodyMethod.block.astChildren.l) {
-        case Nil => // bodyMethod should be empty
-        case xs  => fail(s"Expected empty body, got [${xs.code.mkString(",")}]")
-      }
+      bodyMethod.block.astChildren.l shouldBe empty
     }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ModuleTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ModuleTests.scala
@@ -54,27 +54,24 @@ class ModuleTests extends RubyCode2CpgFixture {
 
         mobileClassNamespace.name shouldBe "MobileController<class>"
         mobileClassNamespace.fullName shouldBe "Test0.rb:<main>.Api.V1.MobileController<class>"
-      case xs => fail(s"Expected two namespace blocks, got ${xs.code.mkString(",")}")
     }
 
-    inside(cpg.typeDecl.name("MobileController").l) {
-      case mobileTypeDecl :: Nil =>
-        mobileTypeDecl.name shouldBe "MobileController"
-        mobileTypeDecl.fullName shouldBe "Test0.rb:<main>.Api.V1.MobileController"
-        mobileTypeDecl.astParentFullName shouldBe "Test0.rb:<main>.Api.V1"
-        mobileTypeDecl.astParentType shouldBe NodeTypes.NAMESPACE_BLOCK
+    inside(cpg.typeDecl.name("MobileController").l) { case mobileTypeDecl :: Nil =>
+      mobileTypeDecl.name shouldBe "MobileController"
+      mobileTypeDecl.fullName shouldBe "Test0.rb:<main>.Api.V1.MobileController"
+      mobileTypeDecl.astParentFullName shouldBe "Test0.rb:<main>.Api.V1"
+      mobileTypeDecl.astParentType shouldBe NodeTypes.NAMESPACE_BLOCK
 
-        mobileTypeDecl.astParent.isNamespaceBlock shouldBe true
+      mobileTypeDecl.astParent.isNamespaceBlock shouldBe true
 
-        val namespaceDecl = mobileTypeDecl.astParent.asInstanceOf[NamespaceBlock]
-        namespaceDecl.name shouldBe "Api.V1"
-        namespaceDecl.filename shouldBe "Test0.rb"
+      val namespaceDecl = mobileTypeDecl.astParent.asInstanceOf[NamespaceBlock]
+      namespaceDecl.name shouldBe "Api.V1"
+      namespaceDecl.filename shouldBe "Test0.rb"
 
-        namespaceDecl.astParent.isFile shouldBe true
-        val parentFileDecl = namespaceDecl.astParent.asInstanceOf[File]
-        parentFileDecl.name shouldBe "Test0.rb"
+      namespaceDecl.astParent.isFile shouldBe true
+      val parentFileDecl = namespaceDecl.astParent.asInstanceOf[File]
+      parentFileDecl.name shouldBe "Test0.rb"
 
-      case xs => fail(s"Expected one class decl, got [${xs.code.mkString(",")}]")
     }
   }
 
@@ -106,7 +103,6 @@ class ModuleTests extends RubyCode2CpgFixture {
         case virtualModifier :: privateModifier :: Nil =>
           virtualModifier.modifierType shouldBe ModifierTypes.VIRTUAL
           privateModifier.modifierType shouldBe ModifierTypes.PRIVATE
-        case xs => fail(s"Expected two modifiers, got [${xs.modifierType.mkString(",")}]")
       }
     }
 
@@ -115,7 +111,6 @@ class ModuleTests extends RubyCode2CpgFixture {
         case virtualModifier :: publicModifier :: Nil =>
           virtualModifier.modifierType shouldBe ModifierTypes.VIRTUAL
           publicModifier.modifierType shouldBe ModifierTypes.PUBLIC
-        case xs => fail(s"Expected got [${xs.modifierType.mkString(",")}]")
       }
     }
   }
@@ -130,22 +125,18 @@ class ModuleTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "Have the correct proc arg in call" in {
-      inside(cpg.call.name("protected").argument.l) {
-        case _ :: (proc: TypeRef) :: Nil =>
-          proc.typeFullName shouldBe s"Test0.rb:$Main.QA.<body>.<lambda>0.<lambda>0&Proc"
-          proc.code shouldBe "<lambda>0&Proc"
-        case xs => fail(s"Expected one call for protected, got [${xs.code.mkString(",")}]")
+      inside(cpg.call.name("protected").argument.l) { case _ :: (proc: TypeRef) :: Nil =>
+        proc.typeFullName shouldBe s"Test0.rb:$Main.QA.<body>.<lambda>0.<lambda>0&Proc"
+        proc.code shouldBe "<lambda>0&Proc"
       }
     }
 
     "Generate a lambda with true body" in {
-      inside(cpg.method.isLambda.l) {
-        case protectedLambda :: _ :: Nil =>
-          protectedLambda.name shouldBe "<lambda>0"
-          protectedLambda.fullName shouldBe s"Test0.rb:$Main.QA.<body>.<lambda>0.<lambda>0"
-          val List(lambdaReturn) = protectedLambda.body.astChildren.isReturn.l
-          lambdaReturn.code shouldBe "true"
-        case xs => fail(s"Expected two lambdas, got [${xs.code.mkString(",")}]")
+      inside(cpg.method.isLambda.l) { case protectedLambda :: _ :: Nil =>
+        protectedLambda.name shouldBe "<lambda>0"
+        protectedLambda.fullName shouldBe s"Test0.rb:$Main.QA.<body>.<lambda>0.<lambda>0"
+        val List(lambdaReturn) = protectedLambda.body.astChildren.isReturn.l
+        lambdaReturn.code shouldBe "true"
       }
     }
   }
@@ -162,13 +153,11 @@ class ModuleTests extends RubyCode2CpgFixture {
         |
         |""".stripMargin)
 
-    inside(cpg.typeDecl.name("ArticlesHelper").method.l) {
-      case bodyMethod :: _ :: _ :: Nil =>
-        inside(bodyMethod.block.astChildren.l) {
-          case Nil => // bodyMethod should be empty
-          case xs  => fail(s"Expected empty body, got [${xs.code.mkString(",")}]")
-        }
-      case xs => fail(s"Expected three methods got [${xs.name.mkString(",")}]")
+    inside(cpg.typeDecl.name("ArticlesHelper").method.l) { case bodyMethod :: _ :: _ :: Nil =>
+      inside(bodyMethod.block.astChildren.l) {
+        case Nil => // bodyMethod should be empty
+        case xs  => fail(s"Expected empty body, got [${xs.code.mkString(",")}]")
+      }
     }
   }
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ProcParameterAndYieldTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ProcParameterAndYieldTests.scala
@@ -101,20 +101,16 @@ class ProcParameterAndYieldTests extends RubyCode2CpgFixture with Inspectors {
         |end
         |""".stripMargin)
 
-    inside(cpg.method.name("foo").call.nameExact("call").l) {
-      case yieldCall :: Nil =>
-        inside(yieldCall.argument.l) {
-          case (base: Identifier) :: (oneLiteral: Literal) :: (twoLiteral: Literal) :: Nil =>
-            base.name shouldBe "<proc-param-0>"
-            base.code shouldBe "<proc-param-0>"
+    inside(cpg.method.name("foo").call.nameExact("call").l) { case yieldCall :: Nil =>
+      inside(yieldCall.argument.l) { case (base: Identifier) :: (oneLiteral: Literal) :: (twoLiteral: Literal) :: Nil =>
+        base.name shouldBe "<proc-param-0>"
+        base.code shouldBe "<proc-param-0>"
 
-            oneLiteral.code shouldBe "1"
-            oneLiteral.argumentIndex shouldBe 1
-            twoLiteral.code shouldBe "2"
-            twoLiteral.argumentName shouldBe Some("z")
-          case xs => fail(s"Expected two arguments for yieldCall, got ${xs.code.mkString(",")}")
-        }
-      case xs => fail(s"Expected one call for yield, got ${xs.code.mkString(",")}")
+        oneLiteral.code shouldBe "1"
+        oneLiteral.argumentIndex shouldBe 1
+        twoLiteral.code shouldBe "2"
+        twoLiteral.argumentName shouldBe Some("z")
+      }
     }
   }
 
@@ -129,14 +125,12 @@ class ProcParameterAndYieldTests extends RubyCode2CpgFixture with Inspectors {
 
     val initMethod = cpg.method.name("initialize").head
 
-    inside(initMethod.parameter.l) {
-      case _ :: procParam :: Nil =>
-        // This seems a bit strange, but the `<body>` method is being processed first which generates a procParam
-        // for the `MethodScope` which is why the procParam for this ConstructorScope is [1] instead of [0]
-        procParam.name shouldBe "<proc-param-1>"
-        procParam.code shouldBe "&<proc-param-1>"
-        procParam.index shouldBe 1
-      case xs => fail(s"Expected two arguments, got [${xs.code.mkString(",")}]")
+    inside(initMethod.parameter.l) { case _ :: procParam :: Nil =>
+      // This seems a bit strange, but the `<body>` method is being processed first which generates a procParam
+      // for the `MethodScope` which is why the procParam for this ConstructorScope is [1] instead of [0]
+      procParam.name shouldBe "<proc-param-1>"
+      procParam.code shouldBe "&<proc-param-1>"
+      procParam.index shouldBe 1
     }
 
     inside(initMethod.call.nameExact("call").argument.l) { case selfBase :: selfParam :: Nil =>

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/SingleAssignmentTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/SingleAssignmentTests.scala
@@ -50,21 +50,17 @@ class SingleAssignmentTests extends RubyCode2CpgFixture {
         |end
         |""".stripMargin)
 
-    inside(cpg.method.name("foo").controlStructure.l) {
-      case ifStruct :: Nil =>
-        ifStruct.controlStructureType shouldBe ControlStructureTypes.IF
-        ifStruct.condition.code.l shouldBe List("!x")
+    inside(cpg.method.name("foo").controlStructure.l) { case ifStruct :: Nil =>
+      ifStruct.controlStructureType shouldBe ControlStructureTypes.IF
+      ifStruct.condition.code.l shouldBe List("!x")
 
-        inside(ifStruct.whenTrue.ast.isCall.name(Operators.assignment).l) {
-          case assignmentCall :: Nil =>
-            assignmentCall.code shouldBe "x = false"
-            val List(lhs, rhs) = assignmentCall.argument.l
-            lhs.code shouldBe "x"
-            rhs.code shouldBe "false"
-          case xs => fail(s"Expected assignment call in true branch, got ${xs.code.mkString}")
-        }
+      inside(ifStruct.whenTrue.ast.isCall.name(Operators.assignment).l) { case assignmentCall :: Nil =>
+        assignmentCall.code shouldBe "x = false"
+        val List(lhs, rhs) = assignmentCall.argument.l
+        lhs.code shouldBe "x"
+        rhs.code shouldBe "false"
+      }
 
-      case xs => fail(s"Expected one control structure, got ${xs.code.mkString(",")}")
     }
   }
 
@@ -75,21 +71,17 @@ class SingleAssignmentTests extends RubyCode2CpgFixture {
         |end
         |""".stripMargin)
 
-    inside(cpg.method.name("foo").controlStructure.l) {
-      case ifStruct :: Nil =>
-        ifStruct.controlStructureType shouldBe ControlStructureTypes.IF
-        ifStruct.condition.code.l shouldBe List("x")
+    inside(cpg.method.name("foo").controlStructure.l) { case ifStruct :: Nil =>
+      ifStruct.controlStructureType shouldBe ControlStructureTypes.IF
+      ifStruct.condition.code.l shouldBe List("x")
 
-        inside(ifStruct.whenTrue.ast.isCall.name(Operators.assignment).l) {
-          case assignmentCall :: Nil =>
-            assignmentCall.code shouldBe "x = true"
-            val List(lhs, rhs) = assignmentCall.argument.l
-            lhs.code shouldBe "x"
-            rhs.code shouldBe "true"
-          case xs => fail(s"Expected assignment call in true branch, got ${xs.code.mkString}")
-        }
+      inside(ifStruct.whenTrue.ast.isCall.name(Operators.assignment).l) { case assignmentCall :: Nil =>
+        assignmentCall.code shouldBe "x = true"
+        val List(lhs, rhs) = assignmentCall.argument.l
+        lhs.code shouldBe "x"
+        rhs.code shouldBe "true"
+      }
 
-      case xs => fail(s"Expected one control structure, got ${xs.code.mkString(",")}")
     }
   }
 
@@ -181,28 +173,26 @@ class SingleAssignmentTests extends RubyCode2CpgFixture {
       |
       |""".stripMargin)
 
-    inside(cpg.assignment.l) {
-      case assign1 :: assign2 :: assign3 :: assign4 :: Nil =>
-        assign1.lineNumber shouldBe Some(4)
-        assign1.argument(1).code shouldBe "x"
-        assign1.argument(2).code shouldBe "1"
-        assign1.argument(2).lineNumber shouldBe Some(4)
+    inside(cpg.assignment.l) { case assign1 :: assign2 :: assign3 :: assign4 :: Nil =>
+      assign1.lineNumber shouldBe Some(4)
+      assign1.argument(1).code shouldBe "x"
+      assign1.argument(2).code shouldBe "1"
+      assign1.argument(2).lineNumber shouldBe Some(4)
 
-        assign2.lineNumber shouldBe Some(6)
-        assign2.argument(1).code shouldBe "x"
-        assign2.argument(2).code shouldBe "2"
-        assign2.argument(2).lineNumber shouldBe Some(6)
+      assign2.lineNumber shouldBe Some(6)
+      assign2.argument(1).code shouldBe "x"
+      assign2.argument(2).code shouldBe "2"
+      assign2.argument(2).lineNumber shouldBe Some(6)
 
-        assign3.lineNumber shouldBe Some(10)
-        assign3.argument(1).code shouldBe "x"
-        assign3.argument(2).code shouldBe "3"
-        assign3.argument(2).lineNumber shouldBe Some(10)
+      assign3.lineNumber shouldBe Some(10)
+      assign3.argument(1).code shouldBe "x"
+      assign3.argument(2).code shouldBe "3"
+      assign3.argument(2).lineNumber shouldBe Some(10)
 
-        assign4.lineNumber shouldBe Some(12)
-        assign4.argument(1).code shouldBe "x"
-        assign4.argument(2).code shouldBe "4"
-        assign4.argument(2).lineNumber shouldBe Some(12)
-      case xs => fail(s"Expected 4 assignments, instead got [${xs.code.mkString(",")}]")
+      assign4.lineNumber shouldBe Some(12)
+      assign4.argument(1).code shouldBe "x"
+      assign4.argument(2).code shouldBe "4"
+      assign4.argument(2).lineNumber shouldBe Some(12)
     }
 
   }
@@ -217,20 +207,18 @@ class SingleAssignmentTests extends RubyCode2CpgFixture {
       |""".stripMargin)
 
     val assigns = cpg.assignment.l
-    inside(cpg.assignment.l) {
-      case assign1 :: assignNil1 :: assignNil2 :: Nil =>
-        assign1.argument(1).code shouldBe "x"
-        assign1.argument(2).code shouldBe "1"
-        assign1.lineNumber shouldBe Some(4)
+    inside(cpg.assignment.l) { case assign1 :: assignNil1 :: assignNil2 :: Nil =>
+      assign1.argument(1).code shouldBe "x"
+      assign1.argument(2).code shouldBe "1"
+      assign1.lineNumber shouldBe Some(4)
 
-        assignNil1.argument(1).code shouldBe "x"
-        assignNil1.argument(2).code shouldBe "nil"
-        assignNil1.lineNumber shouldBe Some(3)
+      assignNil1.argument(1).code shouldBe "x"
+      assignNil1.argument(2).code shouldBe "nil"
+      assignNil1.lineNumber shouldBe Some(3)
 
-        assignNil2.argument(1).code shouldBe "x"
-        assignNil2.argument(2).code shouldBe "nil"
-        assignNil2.lineNumber shouldBe Some(2)
-      case xs => fail(s"Expected 3 assignments, instead got [${xs.code.mkString(",")}]")
+      assignNil2.argument(1).code shouldBe "x"
+      assignNil2.argument(2).code shouldBe "nil"
+      assignNil2.lineNumber shouldBe Some(2)
     }
   }
 
@@ -242,15 +230,11 @@ class SingleAssignmentTests extends RubyCode2CpgFixture {
         |end
         |""".stripMargin)
 
-    inside(cpg.assignment.code("y = p").l) {
-      case assign :: Nil =>
-        inside(assign.argument.l) {
-          case (y: Identifier) :: (p: Identifier) :: Nil =>
-            y.name shouldBe "y"
-            p.name shouldBe "p"
-          case _ => fail(s"Expected two assigment identifiers arguments")
-        }
-      case _ => fail("Unable to find assignment `y = p`")
+    inside(cpg.assignment.code("y = p").l) { case assign :: Nil =>
+      inside(assign.argument.l) { case (y: Identifier) :: (p: Identifier) :: Nil =>
+        y.name shouldBe "y"
+        p.name shouldBe "p"
+      }
     }
   }
 
@@ -276,37 +260,27 @@ class SingleAssignmentTests extends RubyCode2CpgFixture {
                      |  end
                      |""".stripMargin)
 
-    inside(cpg.method.isLambda.l) {
-      case scheduleLambda :: _ :: _ :: Nil =>
-        inside(scheduleLambda.call.name(Operators.assignment).l) {
-          case _ :: id :: title :: start :: end :: _ :: Nil =>
-            id.code shouldBe "hash[:id] = s[:id]"
+    inside(cpg.method.isLambda.l) { case scheduleLambda :: _ :: _ :: Nil =>
+      inside(scheduleLambda.call.name(Operators.assignment).l) { case _ :: id :: title :: start :: end :: _ :: Nil =>
+        id.code shouldBe "hash[:id] = s[:id]"
 
-            inside(id.argument.l) {
-              case (lhs: Call) :: (rhs: Call) :: Nil =>
-                lhs.methodFullName shouldBe Operators.indexAccess
-                lhs.code shouldBe "hash[:id]"
+        inside(id.argument.l) { case (lhs: Call) :: (rhs: Call) :: Nil =>
+          lhs.methodFullName shouldBe Operators.indexAccess
+          lhs.code shouldBe "hash[:id]"
 
-                rhs.methodFullName shouldBe Operators.indexAccess
-                rhs.code shouldBe "s[:id]"
+          rhs.methodFullName shouldBe Operators.indexAccess
+          rhs.code shouldBe "s[:id]"
 
-                inside(lhs.argument.l) {
-                  case base :: (index: Literal) :: Nil =>
-                    index.typeFullName shouldBe RubyDefines.prefixAsCoreType(RubyDefines.Symbol)
-                  case xs => fail(s"Expected base and index, got [${xs.code.mkString(",")}]")
-                }
+          inside(lhs.argument.l) { case base :: (index: Literal) :: Nil =>
+            index.typeFullName shouldBe RubyDefines.prefixAsCoreType(RubyDefines.Symbol)
+          }
 
-                inside(rhs.argument.l) {
-                  case base :: (index: Literal) :: Nil =>
-                    index.typeFullName shouldBe RubyDefines.prefixAsCoreType(RubyDefines.Symbol)
-                  case xs => fail(s"Expected base and index, got [${xs.code.mkString(",")}]")
-                }
+          inside(rhs.argument.l) { case base :: (index: Literal) :: Nil =>
+            index.typeFullName shouldBe RubyDefines.prefixAsCoreType(RubyDefines.Symbol)
+          }
 
-              case xs => fail(s"Expected lhs and rhs, got ${xs.code.mkString(";")}]")
-            }
-          case xs => fail(s"Expected six assignments, got [${xs.code.mkString(";")}]")
         }
-      case xs => fail(s"Expected three lambdas, got ${xs.size} lambdas instead")
+      }
     }
   }
 
@@ -316,21 +290,17 @@ class SingleAssignmentTests extends RubyCode2CpgFixture {
         |  hash[:id] ||= s[:id]
         |end
         |""".stripMargin)
-    inside(cpg.method.name("foo").controlStructure.l) {
-      case ifStruct :: Nil =>
-        ifStruct.controlStructureType shouldBe ControlStructureTypes.IF
-        ifStruct.condition.code.l shouldBe List("!hash[:id]")
+    inside(cpg.method.name("foo").controlStructure.l) { case ifStruct :: Nil =>
+      ifStruct.controlStructureType shouldBe ControlStructureTypes.IF
+      ifStruct.condition.code.l shouldBe List("!hash[:id]")
 
-        inside(ifStruct.whenTrue.ast.isCall.name(Operators.assignment).l) {
-          case assignmentCall :: Nil =>
-            assignmentCall.code shouldBe "hash[:id] = s[:id]"
-            val List(lhs, rhs) = assignmentCall.argument.l
-            lhs.code shouldBe "hash[:id]"
-            rhs.code shouldBe "s[:id]"
-          case xs => fail(s"Expected assignment call in true branch, got ${xs.code.mkString}")
-        }
+      inside(ifStruct.whenTrue.ast.isCall.name(Operators.assignment).l) { case assignmentCall :: Nil =>
+        assignmentCall.code shouldBe "hash[:id] = s[:id]"
+        val List(lhs, rhs) = assignmentCall.argument.l
+        lhs.code shouldBe "hash[:id]"
+        rhs.code shouldBe "s[:id]"
+      }
 
-      case xs => fail(s"Expected one control structure, got ${xs.code.mkString(",")}")
     }
   }
 
@@ -339,18 +309,14 @@ class SingleAssignmentTests extends RubyCode2CpgFixture {
         |hash[:id] += s[:id]
         |""".stripMargin)
 
-    inside(cpg.call.name(Operators.assignmentPlus).l) {
-      case assignmentCall :: Nil =>
-        assignmentCall.code shouldBe "hash[:id] += s[:id]"
-        assignmentCall.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+    inside(cpg.call.name(Operators.assignmentPlus).l) { case assignmentCall :: Nil =>
+      assignmentCall.code shouldBe "hash[:id] += s[:id]"
+      assignmentCall.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
 
-        inside(assignmentCall.argument.l) {
-          case lhs :: rhs :: Nil =>
-            lhs.code shouldBe "hash[:id]"
-            rhs.code shouldBe "s[:id]"
-          case xs => fail(s"Expected lhs and rhs arguments, got ${xs.code.mkString(",")}")
-        }
-      case xs => fail(s"Expected on assignmentOr call, got ${xs.code.mkString(",")}")
+      inside(assignmentCall.argument.l) { case lhs :: rhs :: Nil =>
+        lhs.code shouldBe "hash[:id]"
+        rhs.code shouldBe "s[:id]"
+      }
     }
   }
 
@@ -360,21 +326,17 @@ class SingleAssignmentTests extends RubyCode2CpgFixture {
                      |  hash[:id] &&= s[:id]
                      |end
                      |""".stripMargin)
-    inside(cpg.method.name("foo").controlStructure.l) {
-      case ifStruct :: Nil =>
-        ifStruct.controlStructureType shouldBe ControlStructureTypes.IF
-        ifStruct.condition.code.l shouldBe List("hash[:id]")
+    inside(cpg.method.name("foo").controlStructure.l) { case ifStruct :: Nil =>
+      ifStruct.controlStructureType shouldBe ControlStructureTypes.IF
+      ifStruct.condition.code.l shouldBe List("hash[:id]")
 
-        inside(ifStruct.whenTrue.ast.isCall.name(Operators.assignment).l) {
-          case assignmentCall :: Nil =>
-            assignmentCall.code shouldBe "hash[:id] = s[:id]"
-            val List(lhs, rhs) = assignmentCall.argument.l
-            lhs.code shouldBe "hash[:id]"
-            rhs.code shouldBe "s[:id]"
-          case xs => fail(s"Expected assignment call in true branch, got ${xs.code.mkString}")
-        }
+      inside(ifStruct.whenTrue.ast.isCall.name(Operators.assignment).l) { case assignmentCall :: Nil =>
+        assignmentCall.code shouldBe "hash[:id] = s[:id]"
+        val List(lhs, rhs) = assignmentCall.argument.l
+        lhs.code shouldBe "hash[:id]"
+        rhs.code shouldBe "s[:id]"
+      }
 
-      case xs => fail(s"Expected one control structure, got ${xs.code.mkString(",")}")
     }
   }
 
@@ -383,18 +345,14 @@ class SingleAssignmentTests extends RubyCode2CpgFixture {
         |hash[:id] /= s[:id]
         |""".stripMargin)
 
-    inside(cpg.call.name(Operators.assignmentDivision).l) {
-      case assignmentCall :: Nil =>
-        assignmentCall.code shouldBe "hash[:id] /= s[:id]"
-        assignmentCall.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+    inside(cpg.call.name(Operators.assignmentDivision).l) { case assignmentCall :: Nil =>
+      assignmentCall.code shouldBe "hash[:id] /= s[:id]"
+      assignmentCall.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
 
-        inside(assignmentCall.argument.l) {
-          case lhs :: rhs :: Nil =>
-            lhs.code shouldBe "hash[:id]"
-            rhs.code shouldBe "s[:id]"
-          case xs => fail(s"Expected lhs and rhs arguments, got ${xs.code.mkString(",")}")
-        }
-      case xs => fail(s"Expected on assignmentOr call, got ${xs.code.mkString(",")}")
+      inside(assignmentCall.argument.l) { case lhs :: rhs :: Nil =>
+        lhs.code shouldBe "hash[:id]"
+        rhs.code shouldBe "s[:id]"
+      }
     }
   }
 
@@ -405,24 +363,20 @@ class SingleAssignmentTests extends RubyCode2CpgFixture {
         |end
         |""".stripMargin)
 
-    inside(cpg.method.name("foo").controlStructure.l) {
-      case ifStruct :: Nil =>
-        ifStruct.controlStructureType shouldBe ControlStructureTypes.IF
-        ifStruct.condition.code.l shouldBe List("!A.B")
+    inside(cpg.method.name("foo").controlStructure.l) { case ifStruct :: Nil =>
+      ifStruct.controlStructureType shouldBe ControlStructureTypes.IF
+      ifStruct.condition.code.l shouldBe List("!A.B")
 
-        inside(ifStruct.whenTrue.ast.isCall.name(Operators.assignment).l) {
-          case assignmentCall :: Nil =>
-            assignmentCall.code shouldBe "A.B = c 1"
-            val List(lhs, rhs: Call) = assignmentCall.argument.l: @unchecked
-            lhs.code shouldBe "A.B"
+      inside(ifStruct.whenTrue.ast.isCall.name(Operators.assignment).l) { case assignmentCall :: Nil =>
+        assignmentCall.code shouldBe "A.B = c 1"
+        val List(lhs, rhs: Call) = assignmentCall.argument.l: @unchecked
+        lhs.code shouldBe "A.B"
 
-            rhs.code shouldBe "c 1"
-            val List(_, litArg) = rhs.argument.l
-            litArg.code shouldBe "1"
-          case xs => fail(s"Expected assignment call in true branch, got ${xs.code.mkString}")
-        }
+        rhs.code shouldBe "c 1"
+        val List(_, litArg) = rhs.argument.l
+        litArg.code shouldBe "1"
+      }
 
-      case xs => fail(s"Expected one if statement, got ${xs.code.mkString(",")}")
     }
   }
 
@@ -433,25 +387,21 @@ class SingleAssignmentTests extends RubyCode2CpgFixture {
                      |end
                      |""".stripMargin)
 
-    inside(cpg.method.name("foo").controlStructure.l) {
-      case ifStruct :: Nil =>
-        ifStruct.controlStructureType shouldBe ControlStructureTypes.IF
-        ifStruct.condition.code.l shouldBe List("A.B")
+    inside(cpg.method.name("foo").controlStructure.l) { case ifStruct :: Nil =>
+      ifStruct.controlStructureType shouldBe ControlStructureTypes.IF
+      ifStruct.condition.code.l shouldBe List("A.B")
 
-        inside(ifStruct.whenTrue.ast.isCall.name(Operators.assignment).l) {
-          case assignmentCall :: Nil =>
-            assignmentCall.code shouldBe "A.B = c 1"
-            val List(lhs: Call, rhs: Call) = assignmentCall.argument.l: @unchecked
-            lhs.code shouldBe "A.B"
-            lhs.methodFullName shouldBe Operators.fieldAccess
+      inside(ifStruct.whenTrue.ast.isCall.name(Operators.assignment).l) { case assignmentCall :: Nil =>
+        assignmentCall.code shouldBe "A.B = c 1"
+        val List(lhs: Call, rhs: Call) = assignmentCall.argument.l: @unchecked
+        lhs.code shouldBe "A.B"
+        lhs.methodFullName shouldBe Operators.fieldAccess
 
-            rhs.code shouldBe "c 1"
-            val List(_, litArg) = rhs.argument.l
-            litArg.code shouldBe "1"
-          case xs => fail(s"Expected assignment call in true branch, got ${xs.code.mkString}")
-        }
+        rhs.code shouldBe "c 1"
+        val List(_, litArg) = rhs.argument.l
+        litArg.code shouldBe "1"
+      }
 
-      case xs => fail(s"Expected one if statement, got ${xs.code.mkString(",")}")
     }
   }
 
@@ -460,15 +410,13 @@ class SingleAssignmentTests extends RubyCode2CpgFixture {
         |A::b += 1
         |""".stripMargin)
 
-    inside(cpg.call.name(Operators.assignmentPlus).l) {
-      case assignmentCall :: Nil =>
-        val List(lhs: Call, rhs) = assignmentCall.argument.l: @unchecked
+    inside(cpg.call.name(Operators.assignmentPlus).l) { case assignmentCall :: Nil =>
+      val List(lhs: Call, rhs) = assignmentCall.argument.l: @unchecked
 
-        lhs.code shouldBe "A::b"
-        lhs.methodFullName shouldBe Operators.fieldAccess
+      lhs.code shouldBe "A::b"
+      lhs.methodFullName shouldBe Operators.fieldAccess
 
-        rhs.code shouldBe "1"
-      case xs => fail(s"Expected one call for assignment, got ${xs.code.mkString(",")}")
+      rhs.code shouldBe "1"
     }
   }
 
@@ -477,16 +425,14 @@ class SingleAssignmentTests extends RubyCode2CpgFixture {
         |A::b *= 1
         |""".stripMargin)
 
-    inside(cpg.call.name(Operators.assignmentMultiplication).l) {
-      case assignmentCall :: Nil =>
-        assignmentCall.code shouldBe "A::b *= 1"
-        val List(lhs: Call, rhs) = assignmentCall.argument.l: @unchecked
+    inside(cpg.call.name(Operators.assignmentMultiplication).l) { case assignmentCall :: Nil =>
+      assignmentCall.code shouldBe "A::b *= 1"
+      val List(lhs: Call, rhs) = assignmentCall.argument.l: @unchecked
 
-        lhs.code shouldBe "A::b"
-        lhs.methodFullName shouldBe Operators.fieldAccess
+      lhs.code shouldBe "A::b"
+      lhs.methodFullName shouldBe Operators.fieldAccess
 
-        rhs.code shouldBe "1"
-      case xs => fail(s"Expected one call for assignment, got ${xs.code.mkString(",")}")
+      rhs.code shouldBe "1"
     }
   }
 
@@ -497,12 +443,10 @@ class SingleAssignmentTests extends RubyCode2CpgFixture {
         |end
         |""".stripMargin)
 
-    inside(cpg.call.name("render").argument.l) {
-      case _ :: (symbolArg: Literal) :: (blockArg: Identifier) :: Nil =>
-        symbolArg.code shouldBe ":some_symbol"
-        blockArg.code shouldBe "block"
+    inside(cpg.call.name("render").argument.l) { case _ :: (symbolArg: Literal) :: (blockArg: Identifier) :: Nil =>
+      symbolArg.code shouldBe ":some_symbol"
+      blockArg.code shouldBe "block"
 
-      case xs => fail(s"Expected two args, found [${xs.code.mkString(",")}]")
     }
   }
 
@@ -543,17 +487,15 @@ class SingleAssignmentTests extends RubyCode2CpgFixture {
         |$alfred = "123"
         |""".stripMargin)
 
-    inside(cpg.call.name(Operators.assignment).l) {
-      case alfredAssign :: Nil =>
-        alfredAssign.code shouldBe "$alfred = \"123\""
+    inside(cpg.call.name(Operators.assignment).l) { case alfredAssign :: Nil =>
+      alfredAssign.code shouldBe "$alfred = \"123\""
 
-        val List(lhs: Call, rhs: Literal) = alfredAssign.argument.l: @unchecked
+      val List(lhs: Call, rhs: Literal) = alfredAssign.argument.l: @unchecked
 
-        lhs.methodFullName shouldBe Operators.fieldAccess
-        lhs.code shouldBe "self.$alfred"
+      lhs.methodFullName shouldBe Operators.fieldAccess
+      lhs.code shouldBe "self.$alfred"
 
-        rhs.code shouldBe "\"123\""
-      case xs => fail(s"Expected one assignment call, got [${xs.code.mkString(",")}]")
+      rhs.code shouldBe "\"123\""
     }
   }
 }


### PR DESCRIPTION
Remove usages of ScalaTest's `fail(...)` method in tests