### PR TITLE
[php2cpg] chore: cleanup unnecessary foreach nodes

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForControlStructuresCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForControlStructuresCreator.scala
@@ -173,10 +173,6 @@ trait AstForControlStructuresCreator(implicit withSchemaValidation: ValidationMo
     val iterIdentifier = getTmpIdentifier(stmt, maybeTypeFullName = None, prefix = "iter_")
     val localN         = handleVariableOccurrence(stmt, iterIdentifier.name)
 
-    stmt.keyVar.collect { case PhpVariable(name: PhpNameExpr, _) =>
-      handleVariableOccurrence(stmt, name.name)
-    }
-
     // keep this just used to construct the `code` field
     val assignItemTargetString = stmt.keyVar match {
       case Some(key) => s"${codeForExpr(key)} => ${codeForExpr(stmt.valueVar)}"

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/ControlStructureTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/ControlStructureTests.scala
@@ -1322,9 +1322,8 @@ class ControlStructureTests extends PhpCode2CpgFixture {
       |""".stripMargin)
 
     val foreachStruct = inside(cpg.method.name("foo").body.astChildren.l) {
-      case List(iterLocal: Local, keyLocal: Local, valLocal: Local, foreachStruct: ControlStructure) =>
+      case List(iterLocal: Local, valLocal: Local, foreachStruct: ControlStructure) =>
         iterLocal.name shouldBe "foo@iter_tmp-0"
-        keyLocal.name shouldBe "key"
         valLocal.name shouldBe "val"
 
         foreachStruct
@@ -1335,6 +1334,17 @@ class ControlStructureTests extends PhpCode2CpgFixture {
     val (initAsts, updateAsts, body) = inside(foreachStruct.astChildren.l) {
       case List(initAsts: Block, _, updateAsts: Block, body: Block) =>
         (initAsts, updateAsts, body)
+    }
+
+    inside(initAsts.astChildren.l) { case List(assign: Call, kvBlock: Block) =>
+      assign.code shouldBe "$foo@iter_tmp-0 = $arr"
+
+      inside(kvBlock.astChildren.l) { case List(value: Local, key: Local, _, _) =>
+        value.code shouldBe "$val"
+        value.name shouldBe "val"
+        key.code shouldBe "$key"
+        key.name shouldBe "key"
+      }
     }
 
     inside(initAsts.assignment.l) { case List(_: Call, keyInit: Call, valInit: Call) =>
@@ -1390,7 +1400,7 @@ class ControlStructureTests extends PhpCode2CpgFixture {
       |""".stripMargin)
 
     val foreachStruct = inside(cpg.method.name("foo").body.astChildren.l) {
-      case List(iterLocal: Local, keyLocal: Local, aLocal: Local, bLocal: Local, foreachStruct: ControlStructure) =>
+      case List(iterLocal: Local, aLocal: Local, bLocal: Local, keyLocal: Local, foreachStruct: ControlStructure) =>
         iterLocal.name shouldBe "foo@iter_tmp-0"
         keyLocal.name shouldBe "key"
         aLocal.name shouldBe "a"


### PR DESCRIPTION
There's no need to call `handleVariableOccurrence` here. It creates unnecessary temp nodes. 
This was added in https://github.com/joernio/joern/pull/5942 to avoid regressions