### PR TITLE
[pysrc2cpg] Fix parser bug.

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/pythonGrammar.jj
+++ b/joern-cli/frontends/pysrc2cpg/pythonGrammar.jj
@@ -1305,7 +1305,6 @@ ArrayList<istmt> simpleStatement(): {
   } catch (ParseException exception) {
     Token lastCorrectToken = token;
     try {
-      token = reparseStartToken;
       setCurrentToken(reparseStartToken);
       Name name = name();
 
@@ -2622,22 +2621,7 @@ istmt withStatement(boolean isAsync, Token asyncToken): {
   ArrayList<istmt> blockStmts;
 } {
   <WITH> { if (!isAsync) {startToken = token;} }
-  // The following choice starts with an ambiguity because the first Withitem could
-  // be a parenthesized expression. Without LOOKAHEAD(2) JavaCC thus complains as
-  // expected. With LOOKAHEAD(2) there is still an ambiguity but JavaCC for whatever
-  // reason stops complaining an opportunistically takes the first choice if possible
-  // which is what we want here, although i dont fully understand it.
-  (LOOKAHEAD(2)
-    (
-      <PAREN_OPEN>
-      items = withItems()
-      <PAREN_CLOSE>
-    )
-  | (
-      items = withItems()
-    )
-  )
-  <COLON>
+  items = withItemsAndColon()
   blockStmts = block()
   {
     if (isAsync) {
@@ -2646,6 +2630,52 @@ istmt withStatement(boolean isAsync, Token asyncToken): {
       return new With(items, blockStmts, null, attributes(startToken, token));
     }
   }
+}
+
+ArrayList<Withitem> withItemsAndColon(): {
+  ArrayList<Withitem> items;
+  Token reparseStartToken = null;
+} {
+  try {
+    // The following choice starts with an ambiguity because the first Withitem could
+    // be a parenthesized expression. Without LOOKAHEAD(2) JavaCC thus complains as
+    // expected. With LOOKAHEAD(2) there is still an ambiguity but JavaCC for whatever
+    // reason stops complaining an opportunistically takes the first choice if possible
+    // which is what we want here.
+    // In case the opportunistic first choice fails we end up in the catch block and
+    // try the alternative. The performance impact of this is negligible because the
+    // reparsed code is usually very small.
+    (LOOKAHEAD(2)
+      (
+        { reparseStartToken = token; }
+        <PAREN_OPEN>
+        items = withItems()
+        <PAREN_CLOSE>
+      )
+    |
+     (
+        items = withItems()
+      )
+    )
+    <COLON>
+    { return items; }
+  } catch (ParseException exception) {
+    if (reparseStartToken != null) {
+      setCurrentToken(reparseStartToken);
+
+      items = withItems();
+      consumeColon();
+      return items;
+    } else {
+      throw exception;
+    }
+  }
+}
+
+void consumeColon(): {
+
+} {
+  <COLON>
 }
 
 ArrayList<Withitem> withItems(): {

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pythonparser/ParserTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pythonparser/ParserTests.scala
@@ -243,6 +243,7 @@ class ParserTests extends AnyFreeSpec with Matchers {
       testT("with x as y, z:\n\tpass")
       testT("with x as y, z as a:\n\tpass")
       testT("with x as y, z as a,:\n\tpass", s"with x as y, z as a:\n\tpass")
+      testT("with (x).y:\n\tpass", "with x.y:\n\tpass")
     }
 
     "for statement tests" in {


### PR DESCRIPTION
Parser was unable to parse constructs like `with (x).y:`
where there is a open bracket after `with` which is not closed right
before the colon. Only constructs like `with (x):` and `with (x,):`
were handled which cannot run via the usual expression parsing rules
because the brackets in the later two examples are just ignored by
Python and do not constitute a tuple (the later case).
This is one of the cases where we run into problems with our LL(k)
parser which cannot decide on a branch with constant look ahead.
We solve this the usual way by just trying to parse the second
option once the first failed.
