### PR TITLE
repl: allow to pass scalacoptions

### DIFF
--- a/console/src/main/scala/io/joern/console/BridgeBase.scala
+++ b/console/src/main/scala/io/joern/console/BridgeBase.scala
@@ -40,8 +40,15 @@ case class Config(
   maxHeight: Option[Int] = None,
   scanMaxCallDepth: Option[Int] = None,
   scanScriptNames: Array[String] = Array.empty,
-  scanTagNames: Array[String] = Array.empty
+  scanTagNames: Array[String] = Array.empty,
+  scalacOptions: Seq[String] = Config.DefaultScalacOptions
 )
+
+object Config {
+  val DefaultScalacOptions: Seq[String] = Seq(
+    "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s"
+  )
+}
 
 /** Base class for ReplBridge, split by topic into multiple self types.
   */
@@ -198,6 +205,13 @@ trait BridgeBase extends InteractiveShell with ScriptExecution with PluginHandli
         .action((x, c) => c.copy(maxHeight = Some(x)))
         .text("Maximum number lines to print before output gets truncated (default: no limit)")
 
+      opt[String]("scalacOption")
+        .valueName("-Xfatal-warnings")
+        .unbounded()
+        .optional()
+        .action((x, c) => c.copy(scalacOptions = c.scalacOptions :+ x))
+        .text("additional scalac option passed to the underlying compiler - may be passed multiple times")
+
       help("help")
         .text("Print this help text")
     }
@@ -303,7 +317,8 @@ trait InteractiveShell { this: BridgeBase =>
           ),
         greeting = Option(greeting),
         prompt = Option(promptStr),
-        maxHeight = config.maxHeight
+        maxHeight = config.maxHeight,
+        scalacOptions = config.scalacOptions
       )
     )
   }
@@ -327,7 +342,8 @@ trait ScriptExecution { this: BridgeBase =>
           params = config.params,
           verbose = config.verbose,
           classpathConfig = replpp.Config
-            .ForClasspath(inheritClasspath = true, dependencies = config.dependencies, resolvers = config.resolvers)
+            .ForClasspath(inheritClasspath = true, dependencies = config.dependencies, resolvers = config.resolvers),
+          scalacOptions = config.scalacOptions
         )
       )
       if (config.verbose && scriptReturn.isFailure) {
@@ -450,7 +466,8 @@ trait ServerHandling { this: BridgeBase =>
       runAfter = buildRunAfterCode(config),
       verbose = true, // always print what's happening - helps debugging
       classpathConfig = replpp.Config
-        .ForClasspath(inheritClasspath = true, dependencies = config.dependencies, resolvers = config.resolvers)
+        .ForClasspath(inheritClasspath = true, dependencies = config.dependencies, resolvers = config.resolvers),
+      scalacOptions = config.scalacOptions
     )
 
     replpp.server.ReplServer.startHttpServer(

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -31,7 +31,7 @@ object Versions {
   val requests               = "0.8.0"
   val scalaParallel          = "1.0.4"
   val scalaParserCombinators = "2.4.0"
-  val scalaReplPP            = "0.6.2+1-8d9616de"
+  val scalaReplPP            = "0.6.3"
   val scalatest              = "3.2.18"
   val scopt                  = "4.1.0"
   val semverParser           = "0.0.6"

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -31,7 +31,7 @@ object Versions {
   val requests               = "0.8.0"
   val scalaParallel          = "1.0.4"
   val scalaParserCombinators = "2.4.0"
-  val scalaReplPP            = "0.6.2"
+  val scalaReplPP            = "0.6.2+1-8d9616de"
   val scalatest              = "3.2.18"
   val scopt                  = "4.1.0"
   val semverParser           = "0.0.6"


### PR DESCRIPTION
... and preconfigure one that's annoying for us.

depends on https://github.com/mpollmeier/scala-repl-pp/pull/231

removes this warning:
```
joern> Iterator("a").repeat(identity)(_.until(identity))
1 warning found
-- Warning:
--------------------------------------------------------------------
1 |Iterator("a").repeat(identity)(_.until(identity))
  |                               ^^^^^^^^^^^^^^^^^
  |Implicit parameters should be provided with a `using` clause.
  |To disable the warning, please use the following option:
  |  "-Wconf:msg=Implicit parameters should be provided with a `using`
clause:s"
val res0: Iterator[String] = non-empty iterator
```