### PR TITLE
[linting] Added SingleLetterIdentifiers linter

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 1
+          fetch-depth: 0
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
@@ -67,8 +67,30 @@ jobs:
           java-version: 21
           cache: sbt
       - uses: sbt/setup-sbt@v1
-      - name: Check for usage of restricted imports
-        run: sbt "scalafix RestrictedImports"
+      - name: Run scalafix linting
+        run: |
+          # Get base branch
+          BASE_BRANCH="${{ github.base_ref }}"
+
+          # Get list of changed Scala files (excluding linter-rules/)
+          CHANGED_FILES=$(git diff --name-only --diff-filter=d origin/$BASE_BRANCH...HEAD | grep '\.scala$' | grep -v '^linter-rules/' || true)
+
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No Scala files changed in this PR, running RestrictedImports on entire codebase"
+            sbt "scalafix RestrictedImports"
+          else
+            echo "Changed Scala files:"
+            echo "$CHANGED_FILES"
+
+            # Build scalafix command with repeated --files and --rules flags (as per scalafix docs)
+            FILES_ARGS=""
+            for file in $CHANGED_FILES; do
+              FILES_ARGS="$FILES_ARGS --files $file"
+            done
+
+            echo "Running linters on changed files..."
+            sbt "scalafix $FILES_ARGS --rules RestrictedImports --rules SingleLetterIdentifiers"
+          fi
       - run: echo "Previous step failed because certain coding quality expectations were violated. Please check the logs."
         if: ${{ failure() }}
 

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/ExtendedCfgNode.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/ExtendedCfgNode.scala
@@ -70,6 +70,7 @@ class ExtendedCfgNode(val traversal: Iterator[CfgNode]) extends AnyVal {
   }
 
   private def removeConsecutiveDuplicates[T](l: Vector[T]): List[T] = {
+    // test comment to trigger linting
     l.headOption.map(x => x :: l.sliding(2).collect { case Seq(a, b) if a != b => b }.toList).getOrElse(List())
   }
 

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/Main.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/Main.scala
@@ -50,7 +50,7 @@ object Frontend {
       opt[String]("define")
         .unbounded()
         .text("define a name")
-        .action((d, c) => c.withDefines(c.defines + d)),
+        .action((d, c) => c.withDefines(c.defines + d)), // test comment to trigger linting
       opt[Unit]("swift-build")
         .text("build the project to retrieve full Swift compiler type information (requires Swift > 6.1)")
         .action((path, c) => c.withSwiftBuild(true)),

--- a/linter-rules/src/main/resources/META-INF/services/scalafix.v1.Rule
+++ b/linter-rules/src/main/resources/META-INF/services/scalafix.v1.Rule
@@ -1,1 +1,2 @@
 fix.RestrictedImports
+fix.SingleLetterIdentifiers

--- a/linter-rules/src/main/scala/fix/SingleLetterIdentifiers.scala
+++ b/linter-rules/src/main/scala/fix/SingleLetterIdentifiers.scala
@@ -1,0 +1,81 @@
+package fix
+
+import scalafix.v1._
+
+import scala.meta._
+
+object SingleLetterIdentifiers {
+
+  /** Allowlist for short names that are acceptable in specific contexts.
+   *  E.g., a simple counter variable in index-based loops.
+    */
+  private val allowedIdentifiers: Set[String] = Set("_", "i", "j", "k")
+
+  private def isForbidden(name: String): Boolean =
+    name.length == 1 && !allowedIdentifiers.contains(name)
+
+  private def lint(name: String, pos: Position): Patch = {
+    Patch.lint(
+      Diagnostic(
+        id = "SingleLetterIdentifier",
+        message = s"Avoid single-letter identifier '$name'. Use a more descriptive name.",
+        position = pos
+      )
+    )
+  }
+
+}
+
+class SingleLetterIdentifiers extends SyntacticRule("SingleLetterIdentifiers") {
+
+  override def isLinter = true
+
+  override def fix(implicit doc: SyntacticDocument): Patch = {
+    val patches = doc.tree.collect {
+
+      // method / constructor / lambda params
+      case param: Term.Param
+          if SingleLetterIdentifiers.isForbidden(param.name.value) =>
+        SingleLetterIdentifiers.lint(param.name.value, param.name.pos)
+
+      // val x = ...
+      case v: Defn.Val =>
+        Patch.fromIterable(
+          v.pats.collect {
+            case name: Pat.Var if SingleLetterIdentifiers.isForbidden(name.name.value) =>
+              SingleLetterIdentifiers.lint(name.name.value, name.name.pos)
+          }
+        )
+
+      // var x = ...
+      case v: Defn.Var =>
+        Patch.fromIterable(
+          v.pats.collect {
+            case name: Pat.Var if SingleLetterIdentifiers.isForbidden(name.name.value) =>
+              SingleLetterIdentifiers.lint(name.name.value, name.name.pos)
+          }
+        )
+
+      // for (x <- xs) yield ...
+      case gen: Enumerator.Generator =>
+        gen.pat match {
+          case name: Pat.Var if SingleLetterIdentifiers.isForbidden(name.name.value) =>
+            SingleLetterIdentifiers.lint(name.name.value, name.name.pos)
+          case _ =>
+            Patch.empty
+        }
+
+      // case x =>
+      case c: Case =>
+        c.pat match {
+          case name: Pat.Var if SingleLetterIdentifiers.isForbidden(name.name.value) =>
+            SingleLetterIdentifiers.lint(name.name.value, name.name.pos)
+          case _ =>
+            Patch.empty
+        }
+    }
+
+    Patch.fromIterable(patches)
+  }
+
+}


### PR DESCRIPTION
Only checks new code from PRs.
This way we do not have to fix the existing thousands of single letter identifiers currently sitting in the code base right now and all in once.