### PR TITLE
[linting] Added SingleLetterIdentifiers linter

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -59,7 +59,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0 # Fetch full history for diff comparison
+          fetch-depth: 1
+      - name: Fetch base branch with depth 1
+        run: git fetch --depth=1 origin ${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 1
+          fetch-depth: 0 # Fetch full history for diff comparison
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
@@ -67,8 +67,8 @@ jobs:
           java-version: 21
           cache: sbt
       - uses: sbt/setup-sbt@v1
-      - name: Check for usage of restricted imports
-        run: sbt "scalafix RestrictedImports"
+      - name: Run scalafix linting
+        run: sbt "scalafix --diff-base origin/${{ github.event.pull_request.base.ref }} RestrictedImports SingleLetterIdentifiers"
       - run: echo "Previous step failed because certain coding quality expectations were violated. Please check the logs."
         if: ${{ failure() }}
 

--- a/linter-rules/src/main/resources/META-INF/services/scalafix.v1.Rule
+++ b/linter-rules/src/main/resources/META-INF/services/scalafix.v1.Rule
@@ -1,1 +1,2 @@
 fix.RestrictedImports
+fix.SingleLetterIdentifiers

--- a/linter-rules/src/main/scala/fix/SingleLetterIdentifiers.scala
+++ b/linter-rules/src/main/scala/fix/SingleLetterIdentifiers.scala
@@ -1,0 +1,76 @@
+package fix
+
+import scalafix.v1._
+
+import scala.meta._
+
+object SingleLetterIdentifiers {
+
+  /** Allowlist for short names that are acceptable in specific contexts. E.g., a simple counter variable in index-based
+    * loops.
+    */
+  private val allowedIdentifiers: Set[String] = Set("_", "i", "j", "k")
+
+  private def isForbidden(name: String): Boolean =
+    name.length == 1 && !allowedIdentifiers.contains(name)
+
+  private def lint(name: String, pos: Position): Patch = {
+    Patch.lint(
+      Diagnostic(
+        id = "SingleLetterIdentifier",
+        message = s"Avoid single-letter identifier '$name'. Use a more descriptive name.",
+        position = pos
+      )
+    )
+  }
+
+}
+
+class SingleLetterIdentifiers extends SyntacticRule("SingleLetterIdentifiers") {
+
+  override def isLinter = true
+
+  override def fix(implicit doc: SyntacticDocument): Patch = {
+    val patches = doc.tree.collect {
+
+      // method / constructor / lambda params
+      case param: Term.Param if SingleLetterIdentifiers.isForbidden(param.name.value) =>
+        SingleLetterIdentifiers.lint(param.name.value, param.name.pos)
+
+      // val x = ...
+      case v: Defn.Val =>
+        Patch.fromIterable(v.pats.collect {
+          case name: Pat.Var if SingleLetterIdentifiers.isForbidden(name.name.value) =>
+            SingleLetterIdentifiers.lint(name.name.value, name.name.pos)
+        })
+
+      // var x = ...
+      case v: Defn.Var =>
+        Patch.fromIterable(v.pats.collect {
+          case name: Pat.Var if SingleLetterIdentifiers.isForbidden(name.name.value) =>
+            SingleLetterIdentifiers.lint(name.name.value, name.name.pos)
+        })
+
+      // for (x <- xs) yield ...
+      case gen: Enumerator.Generator =>
+        gen.pat match {
+          case name: Pat.Var if SingleLetterIdentifiers.isForbidden(name.name.value) =>
+            SingleLetterIdentifiers.lint(name.name.value, name.name.pos)
+          case _ =>
+            Patch.empty
+        }
+
+      // case x =>
+      case c: Case =>
+        c.pat match {
+          case name: Pat.Var if SingleLetterIdentifiers.isForbidden(name.name.value) =>
+            SingleLetterIdentifiers.lint(name.name.value, name.name.pos)
+          case _ =>
+            Patch.empty
+        }
+    }
+
+    Patch.fromIterable(patches)
+  }
+
+}


### PR DESCRIPTION
Only run linting on actual changes.

With that, we do not have to fix thousands of single letter identifiers sitting in the existing code base right now.