### PR TITLE
[rubysrc2cpg] assignments in block should be first

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyJsonToNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyJsonToNodeCreator.scala
@@ -289,8 +289,8 @@ class RubyJsonToNodeCreator(
     }
 
     val body = obj.visitOption(ParserKeys.Body) match {
-      case Some(stmt: StatementList) => stmt.copy(stmt.statements ++ assignments)(stmt.span)
-      case Some(expr)                => StatementList(expr +: assignments)(expr.span)
+      case Some(stmt: StatementList) => stmt.copy(assignments ++ stmt.statements)(stmt.span)
+      case Some(expr)                => StatementList(assignments :+ expr)(expr.span)
       case None                      => StatementList(Nil)(obj.toTextSpan)
     }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
@@ -402,9 +402,10 @@ class DoBlockTests extends RubyCode2CpgFixture {
       }
     }
 
-    "Return nil and not the desugaring" in {
-      val nilLiteral = cpg.method.isLambda.methodReturn.toReturn.astChildren.isLiteral.head
-      nilLiteral.code shouldBe "return nil"
+    "Return the 'puts' call" in {
+      val returnCall = cpg.method.isLambda.methodReturn.toReturn.astChildren.isCall.head
+      returnCall.code shouldBe "puts a"
+      returnCall.name shouldBe "puts"
     }
   }
 
@@ -418,7 +419,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     inside(cpg.method.isLambda.body.astChildren.isCall.name(Operators.assignment).l) {
-      case _ :: groupedParam :: countAssignment :: Nil =>
+      case groupedParam :: countAssignment :: _ :: Nil =>
         inside(groupedParam.argument.l) {
           case (labelIdAssign: Call) :: (dateAssign: Call) :: (tmp0Splat: Call) :: Nil =>
             inside(labelIdAssign.argument.l) { case (lhs: Identifier) :: (rhs: Call) :: Nil =>


### PR DESCRIPTION
Fix to ensure that lowered assignment in a block come first before block body statements