### PR TITLE
[pysrc2cpg] Add OFFSET/OFFSET_END to further nodes.

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/NodeBuilder.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/NodeBuilder.scala
@@ -25,6 +25,8 @@ class NodeBuilder(diffGraph: DiffGraphBuilder) {
       .typeFullName(Constants.ANY)
       .lineNumber(lineAndColumn.line)
       .columnNumber(lineAndColumn.column)
+      .offset(lineAndColumn.offset)
+      .offsetEnd(lineAndColumn.endOffset)
     addNodeToDiff(callNode)
   }
 
@@ -66,6 +68,8 @@ class NodeBuilder(diffGraph: DiffGraphBuilder) {
       .typeFullName(typeFullName)
       .lineNumber(lineAndColumn.line)
       .columnNumber(lineAndColumn.column)
+      .offset(lineAndColumn.offset)
+      .offsetEnd(lineAndColumn.endOffset)
     addNodeToDiff(typeRefNode)
   }
 
@@ -82,6 +86,8 @@ class NodeBuilder(diffGraph: DiffGraphBuilder) {
     memberNode(name)
       .lineNumber(lineAndColumn.line)
       .columnNumber(lineAndColumn.column)
+      .offset(lineAndColumn.offset)
+      .offsetEnd(lineAndColumn.endOffset)
   }
 
   def memberNode(name: String, dynamicTypeHintFullName: String): nodes.NewMember =
@@ -122,6 +128,8 @@ class NodeBuilder(diffGraph: DiffGraphBuilder) {
       .typeFullName(fullName)
       .lineNumber(lineAndColumn.line)
       .columnNumber(lineAndColumn.column)
+      .offset(lineAndColumn.offset)
+      .offsetEnd(lineAndColumn.endOffset)
     addNodeToDiff(methodRefNode)
   }
 
@@ -149,6 +157,8 @@ class NodeBuilder(diffGraph: DiffGraphBuilder) {
       .isVariadic(isVariadic)
       .lineNumber(lineAndColumn.line)
       .columnNumber(lineAndColumn.column)
+      .offset(lineAndColumn.offset)
+      .offsetEnd(lineAndColumn.endOffset)
     index.foreach(idx => methodParameterNode.index(idx))
     addNodeToDiff(methodParameterNode)
   }
@@ -189,6 +199,8 @@ class NodeBuilder(diffGraph: DiffGraphBuilder) {
       .columnNumber(lineAndColumn.column)
       .code("RET")
       .evaluationStrategy(EvaluationStrategies.BY_SHARING)
+      .offset(lineAndColumn.offset)
+      .offsetEnd(lineAndColumn.endOffset)
 
     addNodeToDiff(methodReturnNode)
   }
@@ -199,6 +211,8 @@ class NodeBuilder(diffGraph: DiffGraphBuilder) {
       .code(code)
       .lineNumber(lineAndColumn.line)
       .columnNumber(lineAndColumn.column)
+      .offset(lineAndColumn.offset)
+      .offsetEnd(lineAndColumn.endOffset)
 
     addNodeToDiff(returnNode)
   }
@@ -211,6 +225,8 @@ class NodeBuilder(diffGraph: DiffGraphBuilder) {
       .typeFullName(Constants.ANY)
       .lineNumber(lineAndColumn.line)
       .columnNumber(lineAndColumn.column)
+      .offset(lineAndColumn.offset)
+      .offsetEnd(lineAndColumn.endOffset)
     addNodeToDiff(identifierNode)
   }
 
@@ -221,6 +237,8 @@ class NodeBuilder(diffGraph: DiffGraphBuilder) {
       .canonicalName(name)
       .lineNumber(lineAndColumn.line)
       .columnNumber(lineAndColumn.column)
+      .offset(lineAndColumn.offset)
+      .offsetEnd(lineAndColumn.endOffset)
     addNodeToDiff(fieldIdentifierNode)
   }
 
@@ -232,6 +250,8 @@ class NodeBuilder(diffGraph: DiffGraphBuilder) {
       .dynamicTypeHintFullName(dynamicTypeHint.toList)
       .lineNumber(lineAndColumn.line)
       .columnNumber(lineAndColumn.column)
+      .offset(lineAndColumn.offset)
+      .offsetEnd(lineAndColumn.endOffset)
     addNodeToDiff(literalNode)
   }
 
@@ -262,6 +282,8 @@ class NodeBuilder(diffGraph: DiffGraphBuilder) {
       .typeFullName(Constants.ANY)
       .lineNumber(lineAndColumn.line)
       .columnNumber(lineAndColumn.column)
+      .offset(lineAndColumn.offset)
+      .offsetEnd(lineAndColumn.endOffset)
     addNodeToDiff(blockNode)
   }
 
@@ -276,6 +298,8 @@ class NodeBuilder(diffGraph: DiffGraphBuilder) {
       .controlStructureType(controlStructureName)
       .lineNumber(lineAndColumn.line)
       .columnNumber(lineAndColumn.column)
+      .offset(lineAndColumn.offset)
+      .offsetEnd(lineAndColumn.endOffset)
     addNodeToDiff(controlStructureNode)
   }
 
@@ -339,6 +363,8 @@ class NodeBuilder(diffGraph: DiffGraphBuilder) {
       .typeFullName(Constants.ANY)
       .lineNumber(lineAndColumn.line)
       .columnNumber(lineAndColumn.column)
+      .offset(lineAndColumn.offset)
+      .offsetEnd(lineAndColumn.endOffset)
     addNodeToDiff(unknownNode)
   }
 }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/CallCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/CallCpgTests.scala
@@ -17,6 +17,8 @@ class CallCpgTests extends PySrc2CpgFixture(withOssDataflow = false) {
       callNode.signature shouldBe ""
       callNode.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
       callNode.lineNumber shouldBe Some(1)
+      callNode.offset shouldBe Some(0)
+      callNode.offsetEnd shouldBe Some(10)
     }
 
     "test call receiver" in {


### PR DESCRIPTION
So far the pysrc2cpg frontend only set OFFSET and OFFSET_END properties
for METHOD and TYPE_DECL nodes. Now it also does so for all other nodes
where offsets can be specified.
