### PR TITLE
[kotlin2cpg] Add fallback without dependencies and bump compiler version

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/build.sbt
+++ b/joern-cli/frontends/kotlin2cpg/build.sbt
@@ -1,6 +1,6 @@
 name := "kotlin2cpg"
 
-val kotlinVersion = "2.2.20"
+val kotlinVersion = "2.3.21"
 
 dependsOn(
   Projects.dataflowengineoss  % "test->test",

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Kotlin2Cpg.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Kotlin2Cpg.scala
@@ -34,7 +34,7 @@ import java.util.regex.Pattern
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 import scala.jdk.CollectionConverters.EnumerationHasAsScala
 import scala.jdk.StreamConverters.StreamHasToScala
-import scala.util.{Failure, Try}
+import scala.util.{Failure, Try, Using}
 import scala.util.matching.Regex
 
 object Kotlin2Cpg {
@@ -244,14 +244,17 @@ class Kotlin2Cpg extends X2CpgFrontend with UsesService {
               logger.warn("Kotlin compiler analysis failed with exception", exception)
               logger.warn("Fallback: Reconfiguring kotlin compiler environment without dependencies")
 
-              val fallbackEnvironment = CompilerAPI.makeEnvironment(
-                dirsForSourcesToCompile,
-                filesWithJavaExtension,
-                stdlibJars,
-                new ErrorLoggingMessageCollector
-              )
+              Using.resource(
+                CompilerAPI.makeEnvironment(
+                  dirsForSourcesToCompile,
+                  filesWithJavaExtension,
+                  stdlibJars,
+                  new ErrorLoggingMessageCollector
+                )
+              ) { fallbackEnvironment =>
+                createBindingContext(fallbackEnvironment)
+              }(fallbackEnvironment => Disposer.dispose(fallbackEnvironment.getProjectEnvironment.getParentDisposable))
 
-              createBindingContext(fallbackEnvironment)
             } else {
               Failure(exception)
             }

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Kotlin2Cpg.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Kotlin2Cpg.scala
@@ -34,7 +34,7 @@ import java.util.regex.Pattern
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 import scala.jdk.CollectionConverters.EnumerationHasAsScala
 import scala.jdk.StreamConverters.StreamHasToScala
-import scala.util.Try
+import scala.util.{Failure, Try}
 import scala.util.matching.Regex
 
 object Kotlin2Cpg {
@@ -112,25 +112,6 @@ class Kotlin2Cpg extends X2CpgFrontend with UsesService {
     filesWithJavaExtension
   }
 
-  private def gatherDependenciesPaths(
-    sourceDir: String,
-    config: Config,
-    filesWithJavaExtension: List[String]
-  ): Seq[String] = {
-    val jar4ImportServiceOpt = config.jar4importServiceUrl.flatMap(reachableServiceMaybe)
-    if (jar4ImportServiceOpt.isDefined) {
-      val filesWithKtExtension = gatherFilesWithKtExtension(sourceDir, config)
-      val importNames          = importNamesForFilesAtPaths(filesWithKtExtension ++ filesWithJavaExtension)
-      logger.trace(s"Found imports: `$importNames`")
-      dependenciesFromService(jar4ImportServiceOpt.get, importNames)
-    } else if (config.downloadDependencies) {
-      downloadDependencies(sourceDir, config)
-    } else {
-      logger.info(s"Not downloading any dependencies.")
-      Seq()
-    }
-  }
-
   private def gatherMavenCoordinates(sourceDir: String, config: Config): Seq[String] = {
     if (config.generateNodesForDependencies) {
       logger.info(s"Fetching maven coordinates.")
@@ -138,7 +119,39 @@ class Kotlin2Cpg extends X2CpgFrontend with UsesService {
     } else Seq()
   }
 
-  private def gatherJarsAtConfigClassPath(config: Config): Seq[String] = {
+  private def gatherJarsOfDependencies(
+    sourceDir: String,
+    config: Config,
+    filesWithJavaExtension: List[String]
+  ): Seq[DefaultContentRootJarPath] = {
+    val jar4ImportServiceOpt = config.jar4importServiceUrl.flatMap(reachableServiceMaybe)
+    val dependencies =
+      if (jar4ImportServiceOpt.isDefined) {
+        val filesWithKtExtension = gatherFilesWithKtExtension(sourceDir, config)
+        val importNames          = importNamesForFilesAtPaths(filesWithKtExtension ++ filesWithJavaExtension)
+        logger.trace(s"Found imports: `$importNames`")
+        dependenciesFromService(jar4ImportServiceOpt.get, importNames)
+      } else if (config.downloadDependencies) {
+        downloadDependencies(sourceDir, config)
+      } else {
+        logger.info(s"Not downloading any dependencies.")
+        Seq()
+      }
+
+    dependencies.map { path =>
+      DefaultContentRootJarPath(path, isResource = false)
+    }
+  }
+
+  private def gatherJarsFromStdLib(config: Config): Seq[DefaultContentRootJarPath] = {
+    if (config.withStdlibJarsInClassPath) {
+      defaultKotlinStdlibContentRootJarPaths
+    } else {
+      Seq()
+    }
+  }
+
+  private def gatherJarsFromConfigClassPath(config: Config): Seq[DefaultContentRootJarPath] = {
     val jarsAtConfigClassPath = findJarsIn(config.classpath)
     if (config.classpath.nonEmpty) {
       if (jarsAtConfigClassPath.nonEmpty) {
@@ -147,23 +160,7 @@ class Kotlin2Cpg extends X2CpgFrontend with UsesService {
         logger.warn("No jars found in the specified classpath.")
       }
     }
-    jarsAtConfigClassPath
-  }
-
-  private def gatherDefaultContentRootJars(
-    sourceDir: String,
-    config: Config,
-    filesWithJavaExtension: List[String]
-  ): Seq[DefaultContentRootJarPath] = {
-    val stdlibJars            = if (config.withStdlibJarsInClassPath) defaultKotlinStdlibContentRootJarPaths else Seq()
-    val jarsAtConfigClassPath = gatherJarsAtConfigClassPath(config)
-    val dependenciesPaths     = gatherDependenciesPaths(sourceDir, config, filesWithJavaExtension)
-    val defaultContentRootJars = stdlibJars ++
-      jarsAtConfigClassPath.map { path => DefaultContentRootJarPath(path, isResource = false) } ++
-      dependenciesPaths.map { path =>
-        DefaultContentRootJarPath(path, isResource = false)
-      }
-    defaultContentRootJars
+    jarsAtConfigClassPath.map { path => DefaultContentRootJarPath(path, isResource = false) }
   }
 
   private def gatherDirsForSourcesToCompile(sourceDir: String): Seq[String] = {
@@ -222,12 +219,16 @@ class Kotlin2Cpg extends X2CpgFrontend with UsesService {
 
       val filesWithJavaExtension  = gatherFilesWithJavaExtension(sourceDir, config)
       val mavenCoordinates        = gatherMavenCoordinates(sourceDir, config)
-      val defaultContentRootJars  = gatherDefaultContentRootJars(sourceDir, config, filesWithJavaExtension)
+      val stdlibJars              = gatherJarsFromStdLib(config)
+      val classPathJars           = gatherJarsFromConfigClassPath(config)
+      val dependencyJars          = gatherJarsOfDependencies(sourceDir, config, filesWithJavaExtension)
       val dirsForSourcesToCompile = gatherDirsForSourcesToCompile(sourceDir)
+      val dependencyContentRoots  = stdlibJars ++ classPathJars ++ dependencyJars
+
       val environment = CompilerAPI.makeEnvironment(
         dirsForSourcesToCompile,
         filesWithJavaExtension,
-        defaultContentRootJars,
+        dependencyContentRoots,
         new ErrorLoggingMessageCollector
       )
 
@@ -236,7 +237,31 @@ class Kotlin2Cpg extends X2CpgFrontend with UsesService {
 
       new MetaDataPass(cpg, Languages.KOTLIN, config.inputPath).createAndApply()
 
-      val bindingContext = createBindingContext(environment)
+      val bindingContext =
+        createBindingContext(environment)
+          .recoverWith { exception =>
+            if (dependencyContentRoots != stdlibJars) {
+              logger.warn("Kotlin compiler analysis failed with exception", exception)
+              logger.warn("Fallback: Reconfiguring kotlin compiler environment without dependencies")
+
+              val fallbackEnvironment = CompilerAPI.makeEnvironment(
+                dirsForSourcesToCompile,
+                filesWithJavaExtension,
+                stdlibJars,
+                new ErrorLoggingMessageCollector
+              )
+
+              createBindingContext(fallbackEnvironment)
+            } else {
+              Failure(exception)
+            }
+          }
+          .recover { exception =>
+            logger.error("Kotlin compiler analysis failed with exception", exception)
+            BindingContext.EMPTY
+          }
+          .get
+
       val astCreator =
         new AstCreationPass(sourceFiles, bindingContext, cpg, config.disableFileContent)(config.schemaValidation)
       astCreator.createAndApply()
@@ -335,18 +360,14 @@ class Kotlin2Cpg extends X2CpgFrontend with UsesService {
     } yield FileContentAtPath(fileContents, relPath, fileName)
   }
 
-  private def createBindingContext(environment: KotlinCoreEnvironment): BindingContext = {
-    try {
+  private def createBindingContext(environment: KotlinCoreEnvironment): Try[BindingContext] = {
+    Try {
       logger.info("Running Kotlin compiler analysis...")
       val t0             = System.nanoTime()
       val analysisResult = KotlinToJVMBytecodeCompiler.INSTANCE.analyze(environment)
       val t1             = System.nanoTime()
       logger.info(s"Kotlin compiler analysis finished in `${(t1 - t0) / 1000000}` ms.")
       analysisResult.getBindingContext
-    } catch {
-      case exc: Exception =>
-        logger.error(s"Kotlin compiler analysis failed with exception `${exc.toString}`:`${exc.getMessage}`.", exc)
-        BindingContext.EMPTY
     }
   }
 }

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstCreator.scala
@@ -27,7 +27,6 @@ import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
 import scala.util.Try
 import org.jetbrains.kotlin.types.KotlinType
-import org.jetbrains.kotlin.it.unimi.dsi.fastutil.objects.s
 
 object AstCreator {
   case class AnonymousObjectContext(declaration: KtElement)


### PR DESCRIPTION
Try a second time to create the compiler binding context if the first
attempt fails. The second time we only include the standard library as
dependency.
This is mainly aimed at not failing completely for very very large
project with multiple million lines of code and not enough memory.
