### PR TITLE
[x2cpg] Unify jssrc2cpg and swiftsrc2cpg on the shared AstGenRunner

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/README.md
+++ b/joern-cli/frontends/jssrc2cpg/README.md
@@ -31,6 +31,16 @@ yarn install
 
 Copy the resulting `astgen-linux`, `astgen-macos`, `astgen-macos-arm`, and `astgen-win.exe` to `joern/joern-cli/frontends/jssrc2cpg/bin/astgen`.
 
+### Binary Resolution Order
+
+At runtime jssrc2cpg locates the `astgen` binary in this order:
+
+1. The `ASTGEN_BIN` environment variable, if set. May point at the binary itself or at a directory containing it.
+2. An `astgen` binary on the system `PATH`.
+3. The bundled binary at `bin/astgen/`, which is downloaded automatically by the build.
+
+Each candidate is probed via `astgen --version` and skipped if it does not pass the version check.
+
 ## Running
 
 To produce a code property graph  issue the command:

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/JsSrc2Cpg.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/JsSrc2Cpg.scala
@@ -25,7 +25,7 @@ class JsSrc2Cpg extends X2CpgFrontend {
       FileUtil.usingTemporaryDirectory("jssrc2cpgOut") { tmpDir =>
         val report       = new Report()
         val astGenResult = new AstGenRunner(config).execute(tmpDir)
-        val hash         = HashUtil.sha256(astGenResult.parsedFiles.map { case (_, file) => Paths.get(file) })
+        val hash         = HashUtil.sha256(astGenResult.parsedFiles.map(Paths.get(_)))
 
         val astCreationPass = new AstCreationPass(cpg, astGenResult, config, report)(config.schemaValidation)
         astCreationPass.createAndApply()

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/AstCreationPass.scala
@@ -3,8 +3,8 @@ package io.joern.jssrc2cpg.passes
 import io.joern.jssrc2cpg.Config
 import io.joern.jssrc2cpg.astcreation.AstCreator
 import io.joern.jssrc2cpg.parser.BabelJsonParser
-import io.joern.jssrc2cpg.utils.AstGenRunner.AstGenRunnerResult
 import io.joern.x2cpg.ValidationMode
+import io.joern.x2cpg.astgen.AstGenRunner.AstGenRunnerResult
 import io.joern.x2cpg.utils.{Report, TimeUtils}
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.passes.ForkJoinParallelCpgPassWithAccumulator
@@ -17,7 +17,7 @@ import scala.util.{Failure, Success, Try}
 
 class AstCreationPass(cpg: Cpg, astGenRunnerResult: AstGenRunnerResult, config: Config, report: Report = new Report())(
   implicit withSchemaValidation: ValidationMode
-) extends ForkJoinParallelCpgPassWithAccumulator[(String, String), mutable.HashSet[String]](cpg) {
+) extends ForkJoinParallelCpgPassWithAccumulator[String, mutable.HashSet[String]](cpg) {
 
   private val logger: Logger = LoggerFactory.getLogger(classOf[AstCreationPass])
 
@@ -33,12 +33,11 @@ class AstCreationPass(cpg: Cpg, astGenRunnerResult: AstGenRunnerResult, config: 
     collectedTypes = accumulator.toSet
   }
 
-  override def generateParts(): Array[(String, String)] = astGenRunnerResult.parsedFiles.toArray
+  override def generateParts(): Array[String] = astGenRunnerResult.parsedFiles.toArray
 
   override def finish(): Unit = {
-    astGenRunnerResult.skippedFiles.foreach { skippedFile =>
-      val (rootPath, fileName) = skippedFile
-      val filePath             = Paths.get(rootPath, fileName)
+    astGenRunnerResult.skippedFiles.foreach { fileName =>
+      val filePath = Paths.get(config.inputPath, fileName)
       val fileLOC = Try(IOUtils.readLinesInFile(filePath)) match {
         case Success(fileContent) => fileContent.size
         case Failure(exception) =>
@@ -51,11 +50,10 @@ class AstCreationPass(cpg: Cpg, astGenRunnerResult: AstGenRunnerResult, config: 
 
   override def runOnPart(
     diffGraph: DiffGraphBuilder,
-    input: (String, String),
+    jsonFilename: String,
     usedTypes: mutable.HashSet[String]
   ): Unit = {
-    val (rootPath, jsonFilename) = input
-    val parseResultMaybe         = BabelJsonParser.readFile(Paths.get(rootPath), Paths.get(jsonFilename))
+    val parseResultMaybe = BabelJsonParser.readFile(Paths.get(config.inputPath), Paths.get(jsonFilename))
     val ((gotCpg, filename), duration) = TimeUtils.time {
       parseResultMaybe match {
         case Success(parseResult) =>

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/utils/AstGenRunner.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/utils/AstGenRunner.scala
@@ -1,26 +1,20 @@
 package io.joern.jssrc2cpg.utils
 
-import com.typesafe.config.ConfigFactory
 import io.joern.jssrc2cpg.Config
 import io.joern.jssrc2cpg.preprocessing.EjsPreprocessor
 import io.joern.x2cpg.SourceFiles
-import io.joern.x2cpg.utils.Environment
+import io.joern.x2cpg.astgen.AstGenRunner.{AstGenProgramMetaData, DefaultAstGenRunnerResult}
 import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.semanticcpg.utils.{ExternalCommand, FileUtil}
 import io.shiftleft.utils.IOUtils
 import org.slf4j.LoggerFactory
-import versionsort.VersionHelper
 
 import java.nio.file.{Files, Path, Paths}
 import java.util.regex.Pattern
-import scala.util.Failure
-import scala.util.Success
+import scala.util.{Failure, Success, Try}
 import scala.util.matching.Regex
-import scala.util.Try
 
 object AstGenRunner {
-
-  private val logger = LoggerFactory.getLogger(getClass)
 
   private val LineLengthThreshold: Int = 10000
 
@@ -31,7 +25,7 @@ object AstGenRunner {
   private val SourceFileExtensions =
     Set(".js", ".jsx", ".cjs", ".mjs", ".xsjs", ".xsjslib", ".ts", ".tsx", ".vue", ".ejs")
 
-  private val AstGenDefaultIgnoreRegex: Seq[Regex] =
+  val AstGenDefaultIgnoreRegex: Seq[Regex] =
     List(
       "(conf|test|spec|[.-]min|\\.d)\\.(js|jsx|cjs|mjs|xsjs|xsjslib|ts|tsx)$".r,
       s"node_modules${Pattern.quote(java.io.File.separator)}.*".r,
@@ -85,101 +79,20 @@ object AstGenRunner {
     ".*i18n.*\\.json".r
   )
 
-  case class AstGenRunnerResult(
-    parsedFiles: List[(String, String)] = List.empty,
-    skippedFiles: List[(String, String)] = List.empty
-  )
-
-  // full path to the astgen binary from the env var ASTGEN_BIN
-  private val AstGenBin: Option[String] = scala.util.Properties.envOrNone("ASTGEN_BIN").flatMap {
-    case path if Files.isDirectory(Paths.get(path)) => Some((Paths.get(path) / "astgen").toString)
-    case path if Files.exists(Paths.get(path))      => Some(Paths.get(path).toString)
-    case _                                          => None
-  }
-
-  lazy private val executableName = (Environment.operatingSystem, Environment.architecture) match {
-    case (Environment.OperatingSystemType.Windows, _)                                => "astgen-win.exe"
-    case (Environment.OperatingSystemType.Linux, Environment.ArchitectureType.X86)   => "astgen-linux"
-    case (Environment.OperatingSystemType.Linux, Environment.ArchitectureType.ARMv8) => "astgen-linux-arm"
-    case (Environment.OperatingSystemType.Mac, Environment.ArchitectureType.X86)     => "astgen-macos"
-    case (Environment.OperatingSystemType.Mac, Environment.ArchitectureType.ARMv8)   => "astgen-macos-arm"
-    case _ =>
-      logger.warn("Could not detect OS version! Defaulting to Linux/x86_64.")
-      "astgen-linux"
-  }
-
-  lazy private val executableDir: String = {
-    val packagePath = Paths.get(getClass.getProtectionDomain.getCodeSource.getLocation.toURI)
-    io.shiftleft.semanticcpg.utils.ExternalCommand
-      .executableDir(packagePath)
-      .resolve("astgen")
-      .toString
-  }
-
-  private def hasCompatibleAstGenVersionAtPath(astGenVersion: String, path: Option[String]): Boolean = {
-    val astGenCommand = path.getOrElse("astgen")
-    val localPath     = path.flatMap(Paths.get(_).parentOption)
-    val debugMsgPath  = path.getOrElse("PATH")
-    ExternalCommand
-      .run(Seq(astGenCommand, "--version"), localPath)
-      .successOption
-      .map(_.mkString.strip()) match {
-      case Some(installedVersion)
-          if installedVersion != "unknown" &&
-            Try(VersionHelper.compare(installedVersion, astGenVersion)).toOption.getOrElse(-1) >= 0 =>
-        logger.debug(s"Found astgen v$installedVersion in '$debugMsgPath'")
-        true
-      case Some(installedVersion) =>
-        logger.debug(
-          s"Found astgen v$installedVersion in '$debugMsgPath' but jssrc2cpg requires at least v$astGenVersion"
-        )
-        false
-      case _ =>
-        false
-    }
-  }
-
-  /** @return
-    *   the full path to the astgen binary found on the system
-    */
-  private def compatibleAstGenPath(astGenVersion: String): String = {
-    AstGenBin match {
-      // 1. case: we try it at env var ASTGEN_BIN
-      case Some(path) if hasCompatibleAstGenVersionAtPath(astGenVersion, Some(path)) =>
-        path
-      // 2. case: we try it with the systems PATH
-      case _ if hasCompatibleAstGenVersionAtPath(astGenVersion, None) =>
-        "astgen"
-      // otherwise: we use the default local astgen executable path
-      case _ =>
-        logger.debug(
-          s"Did not find any astgen binary on this system (environment variable ASTGEN_BIN not set and no entry in the systems PATH)"
-        )
-        val localPath = s"$executableDir/$executableName"
-        if (io.joern.x2cpg.astgen.AstGenRunner.isExecutableFile(localPath)) {
-          localPath
-        } else {
-          logger.error(s"""Local astgen binary not found at '$localPath' or is not executable!
-               |Please make sure to have a compatible astgen version installed and available
-               |on this system or set the environment variable ASTGEN_BIN to the full path of an executable astgen binary.
-               |""".stripMargin)
-          scala.sys.exit(1)
-        }
-    }
-  }
-
-  private lazy val astGenCommand = {
-    val conf          = ConfigFactory.load
-    val astGenVersion = conf.getString("jssrc2cpg.astgen_version")
-    val astGenPath    = compatibleAstGenPath(astGenVersion)
-    logger.info(s"Using astgen from '$astGenPath'")
-    astGenPath
-  }
+  private object astGenMetaData
+      extends AstGenProgramMetaData(
+        name = "astgen",
+        configPrefix = "jssrc2cpg",
+        binEnvVar = Some("ASTGEN_BIN"),
+        versionFlag = "--version"
+      )
 }
 
-class AstGenRunner(config: Config) {
+class AstGenRunner(config: Config) extends io.joern.x2cpg.astgen.AstGenRunner(AstGenRunner.astGenMetaData, config) {
 
   import io.joern.jssrc2cpg.utils.AstGenRunner.*
+
+  private val logger = LoggerFactory.getLogger(getClass)
 
   private val executableArgs = {
     val tsArgs = if (!config.tsTypes) Seq("--no-tsTypes") else Seq.empty
@@ -193,7 +106,7 @@ class AstGenRunner(config: Config) {
     tsArgs ++ ignoredFilesRegex ++ ignoreFileArgs
   }
 
-  private def skippedFiles(astGenOut: List[String]): List[String] = {
+  override protected def skippedFiles(in: Path, astGenOut: List[String]): List[String] = {
     val skipped = astGenOut.collect {
       case out if out.startsWith("Parsing") =>
         val filename = out.substring(out.indexOf(" ") + 1, out.indexOf(":") - 1)
@@ -212,17 +125,23 @@ class AstGenRunner(config: Config) {
     skipped.flatten
   }
 
-  private def isIgnoredByUserConfig(filePath: String): Boolean = {
-    lazy val isInIgnoredFiles = config.ignoredFiles.exists {
-      case ignorePath if Files.isDirectory(Paths.get(ignorePath)) => filePath.startsWith(ignorePath)
-      case ignorePath                                             => filePath == ignorePath
-    }
-    lazy val isInIgnoredFileRegex = config.ignoredFilesRegex.matches(filePath)
-    if (isInIgnoredFiles || isInIgnoredFileRegex) {
-      logger.debug(s"'$filePath' ignored by user configuration")
-      true
-    } else {
-      false
+  override protected def fileFilter(file: String, out: Path): Boolean = {
+    Try {
+      file.stripSuffix(".json").replace(out.toString, config.inputPath) match {
+        // We are not interested in JS / TS type definition files at this stage.
+        // TODO: maybe we can enable that later on and use the type definitions there
+        //  for enhancing the CPG with additional type information for functions
+        case filePath if TypeDefinitionFileExtensions.exists(filePath.endsWith)    => false
+        case filePath if isIgnoredByUserConfig(filePath)                           => false
+        case filePath if isIgnoredByDefault(filePath)                              => false
+        case filePath if isTranspiledFile(filePath) && !hasEjsSourceFile(filePath) => false
+        case _                                                                     => true
+      }
+    } match {
+      case Success(result) => result
+      case Failure(exception) =>
+        logger.warn(s"An error occurred while processing file path $file during filtering stage : ", exception)
+        false
     }
   }
 
@@ -272,7 +191,6 @@ class AstGenRunner(config: Config) {
     } else {
       false
     }
-
   }
 
   private def hasEjsSourceFile(filePath: String): Boolean = {
@@ -290,29 +208,6 @@ class AstGenRunner(config: Config) {
     }
   }
 
-  private def filterFiles(files: List[String], out: Path): List[String] = {
-    files.filter { file =>
-      Try {
-        file.stripSuffix(".json").replace(out.toString, config.inputPath) match {
-          // We are not interested in JS / TS type definition files at this stage.
-          // TODO: maybe we can enable that later on and use the type definitions there
-          //  for enhancing the CPG with additional type information for functions
-          case filePath if TypeDefinitionFileExtensions.exists(filePath.endsWith)    => false
-          case filePath if isIgnoredByUserConfig(filePath)                           => false
-          case filePath if isIgnoredByDefault(filePath)                              => false
-          case filePath if isTranspiledFile(filePath) && !hasEjsSourceFile(filePath) => false
-          case _                                                                     => true
-        }
-      } match {
-        case Success(result)    => result
-        case Failure(exception) =>
-          // Log the exception for debugging purposes
-          logger.warn(s"An error occurred while processing file path $file during filtering stage : ", exception)
-          false
-      }
-    }
-  }
-
   /** Changes the file-extension by renaming this file; if file does not have an extension, it adds the extension. If
     * file does not exist (or is a directory) no change is done and the current file is returned.
     */
@@ -321,7 +216,6 @@ class AstGenRunner(config: Config) {
     if (Files.isRegularFile(file)) Files.move(file, file.resolveSibling(newName))
     else if (Files.notExists(file)) Paths.get(newName)
     else file
-
   }
 
   private def processEjsFiles(in: Path, out: Path, ejsFiles: List[String]): Try[Seq[String]] = {
@@ -403,11 +297,14 @@ class AstGenRunner(config: Config) {
       .toTry
   }
 
-  private def runAstGenNative(in: Path, out: Path): Try[Seq[String]] = for {
-    ejsResult <- ejsFiles(in, out)
-    vueResult <- vueFiles(in, out)
-    jsResult  <- jsFiles(in, out)
-  } yield jsResult ++ vueResult ++ ejsResult
+  override protected def runAstGenNative(in: String, out: Path, exclude: String, include: String): Try[Seq[String]] = {
+    val inPath = Paths.get(in)
+    for {
+      ejsResult <- ejsFiles(inPath, out)
+      vueResult <- vueFiles(inPath, out)
+      jsResult  <- jsFiles(inPath, out)
+    } yield jsResult ++ vueResult ++ ejsResult
+  }
 
   private def checkParsedFiles(files: List[String], in: Path): List[String] = {
     val numOfParsedFiles = files.size
@@ -419,18 +316,17 @@ class AstGenRunner(config: Config) {
     files
   }
 
-  def execute(out: Path): AstGenRunnerResult = {
+  override def execute(out: Path): DefaultAstGenRunnerResult = {
     val in = Paths.get(config.inputPath)
-    runAstGenNative(in, out) match {
+    runAstGenNative(config.inputPath, out, config.ignoredFilesRegex.toString(), "") match {
       case Success(result) =>
         val parsed  = checkParsedFiles(filterFiles(SourceFiles.determine(out.toString, Set(".json")), out), in)
-        val skipped = skippedFiles(result.toList)
-        AstGenRunnerResult(parsed.map((in.toString, _)), skipped.map((in.toString, _)))
+        val skipped = skippedFiles(in, result.toList)
+        DefaultAstGenRunnerResult(parsed, skipped)
       case Failure(f) =>
         logger.error("\t- running astgen failed!", f)
-        val parsed  = checkParsedFiles(filterFiles(SourceFiles.determine(out.toString, Set(".json")), out), in)
-        val skipped = List.empty
-        AstGenRunnerResult(parsed.map((in.toString, _)), skipped.map((in.toString, _)))
+        val parsed = checkParsedFiles(filterFiles(SourceFiles.determine(out.toString, Set(".json")), out), in)
+        DefaultAstGenRunnerResult(parsed, List.empty)
     }
   }
 

--- a/joern-cli/frontends/swiftsrc2cpg/README.md
+++ b/joern-cli/frontends/swiftsrc2cpg/README.md
@@ -29,6 +29,16 @@ swift build
 ```
 (requires `swift`).
 
+### Binary Resolution Order
+
+At runtime swiftsrc2cpg locates the `SwiftAstGen` binary in this order:
+
+1. The `SWIFTASTGEN_BIN` environment variable, if set. May point at the binary itself or at a directory containing it.
+2. A `SwiftAstGen` binary on the system `PATH`.
+3. The bundled binary at `bin/astgen/`, which is downloaded automatically by the build.
+
+Each candidate is probed via `SwiftAstGen -h`; SwiftAstGen does not expose a comparable version string, so any successful exit is treated as compatible.
+
 ## Running
 
 ### Required Runtime Dependencies:

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/passes/AstCreationPass.scala
@@ -4,7 +4,7 @@ import io.joern.swiftsrc2cpg.Config
 import io.joern.swiftsrc2cpg.astcreation.AstCreator
 import io.joern.swiftsrc2cpg.parser.SwiftJsonParser
 import io.joern.swiftsrc2cpg.passes.AstCreationPass.FileAndTypesMap
-import io.joern.swiftsrc2cpg.utils.AstGenRunner.AstGenRunnerResult
+import io.joern.x2cpg.astgen.AstGenRunner.AstGenRunnerResult
 import io.joern.swiftsrc2cpg.utils.SwiftTypesProvider
 import io.joern.swiftsrc2cpg.utils.SwiftTypesProvider.{MutableSwiftTypeMapping, SwiftFileLocalTypeMapping}
 import io.joern.x2cpg.ValidationMode

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/utils/AstGenRunner.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/utils/AstGenRunner.scala
@@ -1,22 +1,15 @@
 package io.joern.swiftsrc2cpg.utils
 
 import io.joern.swiftsrc2cpg.Config
-import io.joern.x2cpg.SourceFiles
-import io.joern.x2cpg.utils.Environment
-import io.shiftleft.semanticcpg.utils.FileUtil
-import io.shiftleft.semanticcpg.utils.FileUtil.*
+import io.joern.x2cpg.astgen.AstGenRunner.AstGenProgramMetaData
 import org.slf4j.LoggerFactory
 
-import java.nio.file.{Files, Path, Paths}
+import java.nio.file.Path
 import java.util.regex.Pattern
-import scala.util.Failure
-import scala.util.Success
 import scala.util.Try
 import scala.util.matching.Regex
 
 object AstGenRunner {
-
-  private val logger = LoggerFactory.getLogger(getClass)
 
   val AstGenDefaultIgnoreRegex: Seq[Regex] =
     List(
@@ -28,87 +21,29 @@ object AstGenRunner {
       s"spec${Pattern.quote(java.io.File.separator)}.*".r
     )
 
-  case class AstGenRunnerResult(parsedFiles: List[String] = List.empty, skippedFiles: List[String] = List.empty)
-
-  // full path to the SwiftAstGen binary from the env var SWIFTASTGEN_BIN
-  private val AstGenBin: Option[String] = scala.util.Properties.envOrNone("SWIFTASTGEN_BIN").flatMap {
-    case path if Files.isDirectory(Paths.get(path)) => Option((Paths.get(path) / "SwiftAstGen").toString)
-    case path if Files.exists(Paths.get(path))      => Option(Paths.get(path).toString)
-    case _                                          => None
-  }
-
-  lazy private val executableName = Environment.operatingSystem match {
-    case Environment.OperatingSystemType.Windows => "SwiftAstGen-win.exe"
-    case Environment.OperatingSystemType.Linux =>
-      Environment.architecture match {
-        case Environment.ArchitectureType.X86   => "SwiftAstGen-linux"
-        case Environment.ArchitectureType.ARMv8 => "SwiftAstGen-linux-arm64"
-      }
-    case Environment.OperatingSystemType.Mac => "SwiftAstGen-mac"
-    case Environment.OperatingSystemType.Unknown =>
-      logger.warn("Could not detect OS version! Defaulting to 'Linux'.")
-      "SwiftAstGen-linux"
-  }
-
-  lazy private val executableDir: String = {
-    val packagePath = Paths.get(getClass.getProtectionDomain.getCodeSource.getLocation.toURI)
-    io.shiftleft.semanticcpg.utils.ExternalCommand
-      .executableDir(packagePath)
-      .resolve("astgen")
-      .toString
-  }
-
-  private def hasCompatibleAstGenVersionAtPath(path: Option[String]): Boolean = {
-    val astGenCommand = path.getOrElse("SwiftAstGen")
-    val localPath     = path.flatMap(Paths.get(_).parentOption.map(_.toString)).getOrElse(".")
-    val debugMsgPath  = path.getOrElse("PATH")
-    ExternalCommand.run(Seq(astGenCommand, "-h"), localPath).toOption match {
-      case Some(_) =>
-        logger.debug(s"Using SwiftAstGen from $debugMsgPath")
-        true
-      case _ =>
-        false
-    }
-  }
-
-  /** @return
-    *   the full path to the astgen binary found on the system
-    */
-  private def compatibleAstGenPath(): String = {
-    AstGenBin match {
-      // 1. case: we try it at env var SWIFTASTGEN_BIN
-      case Some(path) if hasCompatibleAstGenVersionAtPath(Option(path)) =>
-        path
-      // 2. case: we try it with the systems PATH
-      case _ if hasCompatibleAstGenVersionAtPath(None) =>
-        "SwiftAstGen"
-      // otherwise: we use the default local SwiftAstGen executable path
-      case _ =>
-        logger.debug(
-          s"Did not find any SwiftAstGen binary on this system (environment variable SWIFTASTGEN_BIN not set and no entry in the systems PATH)"
-        )
-        val localPath = s"$executableDir/$executableName"
-        if (io.joern.x2cpg.astgen.AstGenRunner.isExecutableFile(localPath)) {
-          logger.debug(s"Using SwiftAstGen from '$localPath'")
-          localPath
-        } else {
-          logger.error(s"""Local SwiftAstGen binary not found at '$localPath' or is not executable!
-               |Please make sure to have a compatible astgen version installed and available
-               |on this system or set the environment variable SWIFTASTGEN_BIN to the full path of an executable astgen binary.
-               |""".stripMargin)
-          scala.sys.exit(1)
-        }
-    }
-  }
-
-  private lazy val astGenCommand = compatibleAstGenPath()
+  // SwiftAstGen does not expose a comparable version string; `-h` is used purely as a
+  // "is this a working binary?" probe, and any successful exit is treated as compatible.
+  private object astGenMetaData
+      extends AstGenProgramMetaData(
+        name = "SwiftAstGen",
+        configPrefix = "swiftsrc2cpg",
+        binEnvVar = Some("SWIFTASTGEN_BIN"),
+        versionFlag = "-h",
+        skipVersionComparison = true,
+        versionConfigKey = Some("swiftsrc2cpg.astgen_version")
+      )
 }
 
-class AstGenRunner(config: Config) {
+class AstGenRunner(config: Config) extends io.joern.x2cpg.astgen.AstGenRunner(AstGenRunner.astGenMetaData, config) {
 
-  import io.joern.swiftsrc2cpg.utils.AstGenRunner._
+  private val logger = LoggerFactory.getLogger(getClass)
 
-  private def skippedFiles(astGenOut: List[String]): List[String] = {
+  // SwiftAstGen ships a single universal macOS binary, so x86 and ARM map to the same suffix.
+  override val MacX86: String   = "mac"
+  override val MacArm: String   = "mac"
+  override val LinuxArm: String = "linux-arm64"
+
+  override protected def skippedFiles(in: Path, astGenOut: List[String]): List[String] = {
     val skipped = astGenOut.collect {
       case out if !out.startsWith("Generated") =>
         val filename = out.substring(out.indexOf(": `") + 3, out.indexOf("swift`") + 5)
@@ -122,54 +57,7 @@ class AstGenRunner(config: Config) {
     skipped.flatten
   }
 
-  private def isIgnoredByUserConfig(filePath: String): Boolean = {
-    lazy val isInIgnoredFiles = config.ignoredFiles.exists {
-      case ignorePath if Files.isDirectory(Paths.get(ignorePath)) => filePath.startsWith(ignorePath)
-      case ignorePath                                             => filePath == ignorePath
-    }
-    lazy val isInIgnoredFileRegex = config.ignoredFilesRegex.matches(filePath)
-    if (isInIgnoredFiles || isInIgnoredFileRegex) {
-      logger.debug(s"'$filePath' ignored by user configuration")
-      true
-    } else {
-      false
-    }
-  }
-
-  private def filterFiles(files: List[String], out: Path): List[String] = {
-    files.filter { file =>
-      file.stripSuffix(".json").replace(out.toString, config.inputPath) match {
-        case filePath if isIgnoredByUserConfig(filePath) => false
-        case _                                           => true
-      }
-    }
-  }
-
-  private def runAstGenNative(in: Path, out: Path): Try[Seq[String]] =
-    ExternalCommand.run(Seq(astGenCommand, "-o", out.toString), in.toString)
-
-  private def checkParsedFiles(files: List[String], in: Path): List[String] = {
-    val numOfParsedFiles = files.size
-    logger.info(s"Parsed $numOfParsedFiles files.")
-    if (numOfParsedFiles == 0) {
-      logger.warn("You may want to check the DEBUG logs for a list of files that are ignored by default.")
-      SourceFiles.determine(in.toString, Set(".swift"), ignoredDefaultRegex = Option(AstGenDefaultIgnoreRegex))
-    }
-    files
-  }
-
-  def execute(out: Path): AstGenRunnerResult = {
-    val in = Paths.get(config.inputPath)
-    logger.info(s"Running SwiftAstGen in '$in' ...")
-    runAstGenNative(in, out) match {
-      case Success(result) =>
-        val parsed  = checkParsedFiles(filterFiles(SourceFiles.determine(out.toString, Set(".json")), out), in)
-        val skipped = skippedFiles(result.toList)
-        AstGenRunnerResult(parsed, skipped)
-      case Failure(f) =>
-        logger.error("\t- running SwiftAstGen failed!", f)
-        AstGenRunnerResult()
-    }
-  }
+  override protected def runAstGenNative(in: String, out: Path, exclude: String, include: String): Try[Seq[String]] =
+    ExternalCommand.run(Seq(astGenCommand, "-o", out.toString), in)
 
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/astgen/AstGenRunner.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/astgen/AstGenRunner.scala
@@ -36,6 +36,16 @@ object AstGenRunner {
     *   the prefix of the executable's respective configuration path.
     * @param multiArchitectureBuilds
     *   whether there is a binary for specific architectures or not.
+    * @param binEnvVar
+    *   optional environment variable that may point to a user-provided binary location, e.g. `ASTGEN_BIN`.
+    * @param versionFlag
+    *   the CLI flag used to query the binary's version (or any flag whose successful exit indicates a working binary).
+    * @param skipVersionComparison
+    *   if true, only the successful exit of the version probe is required - the output is not compared against the
+    *   configured version. Useful for binaries that do not expose a comparable version string.
+    * @param versionConfigKey
+    *   optional override for the `application.conf` key holding the required binary version. Defaults to
+    *   `${configPrefix}.${name}_version` when not provided.
     *
     * This class must be abstract, because it determines the path of the ast gen binary from the class path location of
     * its derived class.
@@ -43,9 +53,14 @@ object AstGenRunner {
   abstract class AstGenProgramMetaData(
     val name: String,
     val configPrefix: String,
-    val multiArchitectureBuilds: Boolean = false
+    val multiArchitectureBuilds: Boolean = false,
+    val binEnvVar: Option[String] = None,
+    val versionFlag: String = "-version",
+    val skipVersionComparison: Boolean = false,
+    versionConfigKey: Option[String] = None
   ) {
-    val packagePath: URL = getClass.getProtectionDomain.getCodeSource.getLocation
+    val packagePath: URL                 = getClass.getProtectionDomain.getCodeSource.getLocation
+    val resolvedVersionConfigKey: String = versionConfigKey.getOrElse(s"$configPrefix.${name}_version")
   }
 
   def isExecutableFile(filePath: String): Boolean = {
@@ -145,22 +160,46 @@ abstract class AstGenRunner(metaData: AstGenProgramMetaData, config: X2CpgConfig
 
   protected def runAstGenNative(in: String, out: Path, exclude: String, include: String): Try[Seq[String]]
 
-  protected def astGenCommand: String = {
+  // Lazy so path resolution and the version probe run at most once per runner instance.
+  protected lazy val astGenCommand: String = {
     val conf          = ConfigFactory.load
-    val astGenVersion = conf.getString(s"${metaData.configPrefix}.${metaData.name}_version")
-    if (hasCompatibleAstGenVersion(astGenVersion)) {
-      metaData.name
-    } else {
-      val localPath = s"$executableDir/$executableName"
-      if (AstGenRunner.isExecutableFile(localPath)) {
-        localPath
-      } else {
-        logger.error(s"""Local ${metaData.name} binary not found at '$localPath' or is not executable!
-             |Please make sure to have a compatible astgen version installed and available on this system.
-             |""".stripMargin)
-        scala.sys.exit(1)
+    val astGenVersion = conf.getString(metaData.resolvedVersionConfigKey)
+    val resolvedPath  = resolveAstGenPath(astGenVersion)
+    logger.info(s"Using ${metaData.name} from '$resolvedPath'")
+    resolvedPath
+  }
+
+  /** Resolution order:
+    *
+    *   - user-provided path via `metaData.binEnvVar` (if set and binary passes the version probe)
+    *   - binary on the system `PATH` named `metaData.name` (if it passes the version probe)
+    *   - bundled binary at `$executableDir/$executableName`
+    */
+  private def resolveAstGenPath(astGenVersion: String): String = {
+    binFromEnvVar
+      .filter(path => hasCompatibleAstGenVersion(astGenVersion, Option(path)))
+      .orElse(Option.when(hasCompatibleAstGenVersion(astGenVersion, None))(metaData.name))
+      .getOrElse {
+        val localPath = s"$executableDir/$executableName"
+        if (AstGenRunner.isExecutableFile(localPath)) {
+          localPath
+        } else {
+          val envHint =
+            metaData.binEnvVar
+              .map(envVar => s" or set the environment variable $envVar to a working binary")
+              .getOrElse("")
+          logger.error(s"""Local ${metaData.name} binary not found at '$localPath' or is not executable!
+               |Please make sure to have a compatible ${metaData.name} version installed and available on this system$envHint.
+               |""".stripMargin)
+          scala.sys.exit(1)
+        }
       }
-    }
+  }
+
+  private def binFromEnvVar: Option[String] = metaData.binEnvVar.flatMap(scala.util.Properties.envOrNone).flatMap {
+    case path if Files.isDirectory(Paths.get(path)) => Some(Paths.get(path).resolve(metaData.name).toString)
+    case path if Files.exists(Paths.get(path))      => Some(Paths.get(path).toString)
+    case _                                          => None
   }
 
   def execute(out: Path): AstGenRunnerResult = {
@@ -189,18 +228,31 @@ abstract class AstGenRunner(metaData: AstGenProgramMetaData, config: X2CpgConfig
       .resolve("astgen")
       .toString
 
-  def hasCompatibleAstGenVersion(compatibleVersion: String): Boolean = {
-    ExternalCommand.run(Seq(metaData.name, "-version")).successOption.map(_.mkString.strip()) match {
-      case Some(installedVersion)
-          if installedVersion != "unknown" &&
-            Try(VersionHelper.compare(installedVersion, compatibleVersion)).toOption.getOrElse(-1) >= 0 =>
-        logger.debug(s"Using local ${metaData.name} v$installedVersion from systems PATH")
+  def hasCompatibleAstGenVersion(compatibleVersion: String): Boolean =
+    hasCompatibleAstGenVersion(compatibleVersion, None)
+
+  def hasCompatibleAstGenVersion(compatibleVersion: String, path: Option[String]): Boolean = {
+    val command      = path.getOrElse(metaData.name)
+    val workingDir   = path.flatMap(binPath => Option(Paths.get(binPath).getParent))
+    val debugMsgPath = path.getOrElse("PATH")
+    ExternalCommand.run(Seq(command, metaData.versionFlag), workingDir).successOption match {
+      case Some(_) if metaData.skipVersionComparison =>
+        logger.debug(s"Using ${metaData.name} from '$debugMsgPath'")
         true
-      case Some(installedVersion) =>
-        logger.debug(
-          s"Found local ${metaData.name} v$installedVersion in systems PATH but ${metaData.name} requires at least v$compatibleVersion"
-        )
-        false
+      case Some(out) =>
+        val installedVersion = out.mkString.strip()
+        if (
+          installedVersion != "unknown" &&
+          Try(VersionHelper.compare(installedVersion, compatibleVersion)).toOption.getOrElse(-1) >= 0
+        ) {
+          logger.debug(s"Using ${metaData.name} v$installedVersion from '$debugMsgPath'")
+          true
+        } else {
+          logger.debug(
+            s"Found ${metaData.name} v$installedVersion in '$debugMsgPath' but ${metaData.name} requires at least v$compatibleVersion"
+          )
+          false
+        }
       case _ =>
         false
     }


### PR DESCRIPTION
Make jssrc2cpg and swiftsrc2cpg extend `io.joern.x2cpg.astgen.AstGenRunner` instead of carrying their own path resolution/filtering and version checks. Path lookup and the version testing now run at most once per runner instance via a lazy val on the base.

buildbot is happy.

This also revealed that swift-astgen still misses support for regex-based filtering.
I fixed that with: https://github.com/joernio/astgen-monorepo/pull/34
Will do a follow-up PR do bring this into joern.