### PR TITLE
[swiftsrc2cpg] Add --exclude-regex support for swift-astgen v0.4.1

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/io/ExcludeTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/io/ExcludeTests.scala
@@ -149,4 +149,22 @@ class ExcludeTests extends AnyWordSpec with Matchers with TableDrivenPropertyChe
 
   }
 
+  "Forwarding --exclude-regex to astgen" should {
+    "prevent the binary from emitting a JSON for an excluded file" in {
+      // Verifies that the regex actually reaches the binary: post-filtering in
+      // execute() would also drop the file from the CPG, so we inspect the raw
+      // astgen output directory directly.
+      FileUtil.usingTemporaryDirectory("jssrc2cpgTests") { tmpDir =>
+        val config = Config()
+          .withInputPath(projectUnderTest.toString)
+          .withOutputPath(tmpDir.toString)
+          .withIgnoredFilesRegex(".*index\\..*")
+        new AstGenRunner(config).execute(tmpDir)
+        val emittedJsons = tmpDir.listFiles().map(_.getFileName.toString).toSet
+        emittedJsons should not contain "index.js.json"
+        emittedJsons should contain("a.js.json")
+      }
+    }
+  }
+
 }

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 swiftsrc2cpg {
-    astgen_version: "0.4.0"
+    astgen_version: "0.4.1"
 }

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/utils/AstGenRunner.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/utils/AstGenRunner.scala
@@ -57,7 +57,9 @@ class AstGenRunner(config: Config) extends io.joern.x2cpg.astgen.AstGenRunner(As
     skipped.flatten
   }
 
-  override protected def runAstGenNative(in: String, out: Path, exclude: String, include: String): Try[Seq[String]] =
-    ExternalCommand.run(Seq(astGenCommand, "-o", out.toString), in)
+  override protected def runAstGenNative(in: String, out: Path, exclude: String, include: String): Try[Seq[String]] = {
+    val excludeArgs = if (exclude.nonEmpty) Seq("--exclude-regex", exclude) else Seq.empty
+    ExternalCommand.run(Seq(astGenCommand, "-o", out.toString) ++ excludeArgs, in)
+  }
 
 }

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/io/ExcludeTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/io/ExcludeTests.scala
@@ -151,4 +151,22 @@ class ExcludeTests extends AnyWordSpec with Matchers with TableDrivenPropertyChe
 
   }
 
+  "Forwarding --exclude-regex to SwiftAstGen" should {
+    "prevent the binary from emitting a JSON for an excluded file" in {
+      // Verifies that the regex actually reaches the binary: post-filtering in
+      // execute() would also drop the file from the CPG, so we inspect the raw
+      // astgen output directory directly.
+      FileUtil.usingTemporaryDirectory("swiftsrc2cpgTests") { tmpDir =>
+        val config = Config()
+          .withInputPath(projectUnderTest.toString)
+          .withOutputPath(tmpDir.toString)
+          .withIgnoredFilesRegex(".*index\\..*")
+        new AstGenRunner(config).execute(tmpDir)
+        val emittedJsons = tmpDir.listFiles().map(_.getFileName.toString).toSet
+        emittedJsons should not contain "index.swift.json"
+        emittedJsons should contain("a.swift.json")
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
Integrates swift-astgen v0.4.1 (released in joernio/astgen-monorepo#34), which adds `--exclude-regex` for skipping files by absolute path pattern. Same as jssrc2cpg's existing support for javascript-astgen.

Changes:
- Bump swift-astgen version to 0.4.1
- Wire up `--exclude-regex` flag in `AstGenRunner.runAstGenNative`
- Add explicit tests verifying the binary receives the flag (checks raw JSON output, not just post-filtered CPG)