### PR TITLE
[jssrc2cpg] bump astgen version to 3.45.0

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/jssrc2cpg/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 jssrc2cpg {
-    astgen_version: "3.43.0"
+    astgen_version: "3.45.0"
 }


### PR DESCRIPTION
This brings in: https://github.com/joernio/astgen-monorepo/pull/41

With this, `javascript-astgen` parallelizes per-file parsing (babel) via a worker pool and reduces file reads / checks to a minimum for less memory consumption and improved performance on large repos.

https://github.com/microsoft/TypeScript is handled in ~1sec instead of ~5sec on my machine with that (full babel parsing for AST -> JSON pipeline).