### PR TITLE
[swiftsrc2cpg] Use --version flag for SwiftAstGen binary validation

### DIFF
--- a/joern-cli/frontends/swiftsrc2cpg/README.md
+++ b/joern-cli/frontends/swiftsrc2cpg/README.md
@@ -37,7 +37,7 @@ At runtime swiftsrc2cpg locates the `SwiftAstGen` binary in this order:
 2. A `SwiftAstGen` binary on the system `PATH`.
 3. The bundled binary at `bin/astgen/`, which is downloaded automatically by the build.
 
-Each candidate is probed via `astgen --version` and skipped if it does not pass the version check.
+Each candidate is probed via `SwiftAstGen --version` and skipped if it does not pass the version check.
 
 ## Running
 

--- a/joern-cli/frontends/swiftsrc2cpg/README.md
+++ b/joern-cli/frontends/swiftsrc2cpg/README.md
@@ -37,7 +37,7 @@ At runtime swiftsrc2cpg locates the `SwiftAstGen` binary in this order:
 2. A `SwiftAstGen` binary on the system `PATH`.
 3. The bundled binary at `bin/astgen/`, which is downloaded automatically by the build.
 
-Each candidate is probed via `SwiftAstGen -h`; SwiftAstGen does not expose a comparable version string, so any successful exit is treated as compatible.
+Each candidate is probed via `astgen --version` and skipped if it does not pass the version check.
 
 ## Running
 

--- a/joern-cli/frontends/swiftsrc2cpg/build.sbt
+++ b/joern-cli/frontends/swiftsrc2cpg/build.sbt
@@ -1,5 +1,6 @@
 import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.sbt.packager.Keys.stagingDirectory
+import versionsort.VersionHelper
 
 import scala.sys.process.stringToProcess
 import scala.util.Try
@@ -49,9 +50,10 @@ lazy val astGenDlUrl = settingKey[String]("astgen download url")
 astGenDlUrl := s"https://github.com/joernio/astgen-monorepo/releases/download/swift-astgen/v${astGenVersion.value}/"
 
 def hasCompatibleAstGenVersion(astGenVersion: String): Boolean = {
-  Try("SwiftAstGen -h".!).toOption match {
-    case Some(0) => true
-    case _       => false
+  Try("SwiftAstGen --version".!!).toOption.map(_.strip()) match {
+    case Some(installedVersion) if installedVersion != "unknown" =>
+      VersionHelper.compare(installedVersion, astGenVersion) >= 0
+    case _ => false
   }
 }
 

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 swiftsrc2cpg {
-    astgen_version: "0.4.1"
+    astgen_version: "0.4.2"
 }

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/utils/AstGenRunner.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/utils/AstGenRunner.scala
@@ -21,15 +21,12 @@ object AstGenRunner {
       s"spec${Pattern.quote(java.io.File.separator)}.*".r
     )
 
-  // SwiftAstGen does not expose a comparable version string; `-h` is used purely as a
-  // "is this a working binary?" probe, and any successful exit is treated as compatible.
   private object astGenMetaData
       extends AstGenProgramMetaData(
         name = "SwiftAstGen",
         configPrefix = "swiftsrc2cpg",
         binEnvVar = Some("SWIFTASTGEN_BIN"),
-        versionFlag = "-h",
-        skipVersionComparison = true,
+        versionFlag = "--version",
         versionConfigKey = Some("swiftsrc2cpg.astgen_version")
       )
 }


### PR DESCRIPTION
Updates version check by using `SwiftAstGen --version` with semantic version comparison.