### PR TITLE
[rust2cpg] rust_ast_gen-based methodFullNames

### DIFF
--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/AstCreator.scala
@@ -6,9 +6,8 @@ import io.joern.rust2cpg.parser.RustJsonParser.ParseResult
 import io.joern.rust2cpg.parser.RustNodeSyntax
 import io.joern.rust2cpg.parser.RustNodeSyntax.RustNode
 import io.joern.x2cpg.datastructures.Stack.*
-import io.joern.x2cpg.passes.frontend.MetaDataPass
 import io.joern.x2cpg.{Ast, AstCreatorBase, Defines, ValidationMode}
-import io.shiftleft.codepropertygraph.generated.nodes.{NewCall, NewMethod, NewNode}
+import io.shiftleft.codepropertygraph.generated.nodes.{NewCall, NewMethod, NewNamespaceBlock, NewNode}
 import io.shiftleft.codepropertygraph.generated.{NodeTypes, Operators, PropertyDefaults, PropertyNames}
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 import org.slf4j.LoggerFactory
@@ -17,7 +16,8 @@ import java.nio.charset.StandardCharsets
 
 class AstCreator(val config: Config, val parseResult: ParseResult)(implicit withSchemaValidation: ValidationMode)
     extends AstCreatorBase[RustNode, AstCreator](parseResult.filename)
-    with RustVisitor {
+    with RustVisitor
+    with RustFullNames {
 
   private val logger = LoggerFactory.getLogger(getClass)
 
@@ -42,18 +42,6 @@ class AstCreator(val config: Config, val parseResult: ParseResult)(implicit with
     case _                        => None
   }
 
-  protected def globalMethodNode(): NewMethod = {
-    val name     = NamespaceTraversal.globalNamespaceName
-    val fullName = MetaDataPass.getGlobalNamespaceBlockFullName(Some(parseResult.filename))
-    NewMethod()
-      .name(name)
-      .code(name)
-      .fullName(fullName)
-      .filename(parseResult.filename)
-      .astParentType(NodeTypes.NAMESPACE_BLOCK)
-      .astParentFullName(fullName)
-  }
-
   protected def notHandledYet(node: RustNode): Ast = {
     val text =
       s"""Node type '${node.getClass.getSimpleName}' not handled yet!
@@ -70,27 +58,45 @@ class AstCreator(val config: Config, val parseResult: ParseResult)(implicit with
     operatorCallNode(node = node, name = Operators.assignment, code = code, typeFullName = None)
   }
 
-  private def composeMethodFullName(name: String): String = {
-    // TODO
-    val astParentFullName = methodAstParentStack.head.properties(PropertyNames.FullName).toString
-    formatMethodFullName(Seq(astParentFullName, name))
-  }
-
-  private def formatMethodFullName(names: Seq[String]): String = {
-    // TODO
-    names.mkString(".")
-  }
-
-  protected def methodNode(node: RustNodeSyntax.RustNode, name: String): NewMethod = {
-    // TODO
-    val methodFullName  = composeMethodFullName(name)
-    val methodSignature = ""
+  protected def methodNode(node: RustNode, name: String): NewMethod = {
     methodNode(
       node = node,
       name = name,
-      fullName = methodFullName,
-      signature = methodSignature,
-      fileName = parseResult.filename
+      code = code(node),
+      fullName = composeRustFullName(name),
+      signature = Some(""),
+      fileName = parseResult.filename,
+      astParentType = Some(methodAstParentStack.head.label),
+      astParentFullName = Some(methodAstParentStack.head.properties(PropertyNames.FullName).toString)
+    )
+  }
+
+  protected def globalNamespaceBlockNode(): NewNamespaceBlock = {
+    NewNamespaceBlock()
+      .name(rustNamespaceFullName)
+      .fullName(globalNamespaceFullName)
+      .filename(parseResult.filename)
+      .order(1)
+  }
+
+  private def globalNamespaceFullName: String = {
+    s"${parseResult.filename}:$rustNamespaceFullName"
+  }
+
+  protected def globalFakeMethodNode(
+    sourceFile: RustNodeSyntax.SourceFile,
+    namespaceBlock: NewNamespaceBlock
+  ): NewMethod = {
+    val name = NamespaceTraversal.globalNamespaceName
+    methodNode(
+      node = sourceFile,
+      name = name,
+      code = name,
+      fullName = combineRustFullName(namespaceBlock.fullName, name),
+      signature = Some(""),
+      fileName = parseResult.filename,
+      astParentType = Some(NodeTypes.NAMESPACE_BLOCK),
+      astParentFullName = Some(namespaceBlock.fullName)
     )
   }
 
@@ -164,19 +170,6 @@ class AstCreator(val config: Config, val parseResult: ParseResult)(implicit with
     case Some(_: RustNodeSyntax.BangToken)  => Some(Operators.logicalNot)
     case Some(_: RustNodeSyntax.StarToken)  => Some(Operators.indirection)
     case _                                  => None
-  }
-
-  protected def methodFullNameForCallExpr(nameRefs: Seq[RustNodeSyntax.NameRef]): String = {
-    // TODO
-    nameRefs.map(code) match {
-      case Nil   => Defines.Unknown
-      case names => formatMethodFullName(names)
-    }
-  }
-
-  protected def methodFullNameForMethodCallExpr(methodCallExpr: RustNodeSyntax.MethodCallExpr): String = {
-    // TODO
-    Defines.DynamicCallUnknownFullName
   }
 
   protected def typeFullNameForMethodCallExpr(methodCallExpr: RustNodeSyntax.MethodCallExpr): String = {

--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustFullNames.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustFullNames.scala
@@ -1,0 +1,70 @@
+package io.joern.rust2cpg.astcreation
+
+import io.joern.rust2cpg.parser.RustNodeSyntax
+import io.joern.rust2cpg.parser.RustNodeSyntax.RustNode
+import io.joern.x2cpg.Defines
+import io.shiftleft.codepropertygraph.generated.PropertyNames
+import io.shiftleft.codepropertygraph.generated.nodes.{NewMethod, NewNamespaceBlock}
+import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
+
+// Computes rust-style full names, e.g. `crate::module::item`.
+// rust_ast_gen-provided methodFullName/typeFullName are always preferred.
+// The fallback is to rely on the current enclosing scope.
+trait RustFullNames { this: AstCreator =>
+
+  private val PathSep = "::"
+
+  protected def combineRustFullName(parent: String, child: String): String = {
+    s"$parent$PathSep$child"
+  }
+
+  private def crateName: String = {
+    parseResult.crateName.getOrElse(Defines.UnresolvedNamespace)
+  }
+
+  protected def rustNamespaceFullName: String = parseResult.modulePath match {
+    case Some(path) => combineRustFullName(crateName, path)
+    case None       => crateName
+  }
+
+  protected def composeRustFullName(name: String): String = {
+    combineRustFullName(rustParentFullName, name)
+  }
+
+  private def rustParentFullName: String = {
+    // We don't want to have the "global method"'s fullname propagated since that
+    // would not match rust_ast_gen's full names.
+    val parent = methodAstParentStack.find {
+      case method: NewMethod if method.name == NamespaceTraversal.globalNamespaceName => false
+      case _                                                                          => true
+    }.get
+    // When the parent is a namespace_block, we don't want its fullName since it's
+    // file-prefix in order to be unique, but rather its name. For other nodes,
+    // we do want the fullName.
+    parent match {
+      case ns: NewNamespaceBlock => ns.name
+      case other                 => other.properties(PropertyNames.FullName).toString
+    }
+  }
+
+  private def rustAstGenMethodFullName(node: RustNode): Option[String] =
+    node.json.obj.get("methodFullName").flatMap(_.strOpt)
+
+  protected def methodFullNameForCallExpr(
+    callExpr: RustNodeSyntax.CallExpr,
+    nameRefs: Seq[RustNodeSyntax.NameRef]
+  ): String = {
+    rustAstGenMethodFullName(callExpr).getOrElse {
+      // TODO: take into account `use` (imports). We are incorrectly assuming here that an
+      //  unresolved call e.g. `a::b::c()` has fullName `a::b::c`.
+      nameRefs match {
+        case name :: Nil => combineRustFullName(Defines.UnresolvedNamespace, code(name))
+        case names       => names.map(code).mkString(PathSep)
+      }
+    }
+  }
+
+  protected def methodFullNameForMethodCallExpr(methodCallExpr: RustNodeSyntax.MethodCallExpr): String =
+    rustAstGenMethodFullName(methodCallExpr).getOrElse(Defines.DynamicCallUnknownFullName)
+
+}

--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
@@ -10,7 +10,7 @@ import io.shiftleft.codepropertygraph.generated.{
   ModifierTypes,
   Operators
 }
-import io.shiftleft.codepropertygraph.generated.nodes.{NewFile, NewModifier}
+import io.shiftleft.codepropertygraph.generated.nodes.{NewFile, NewModifier, NewNamespaceBlock}
 
 import scala.annotation.tailrec
 
@@ -25,30 +25,25 @@ trait RustVisitor(implicit withValidationMode: ValidationMode) { this: AstCreato
     val fileNode = NewFile().name(parseResult.filename).order(0)
     Option.unless(config.disableFileContent)(parseResult.fileContent).foreach(fileNode.content(_))
 
-    val namespaceBlockNode = globalNamespaceBlock()
-    methodAstParentStack.push(namespaceBlockNode)
-
-    val methodNode = globalMethodNode()
-    methodAstParentStack.push(methodNode)
-
-    val itemAsts = sourceFile.item.flatMap(visitItem)
-
-    methodAstParentStack.pop()
-    methodAstParentStack.pop()
-
-    val globalMethodAst =
-      methodAst(
-        method = methodNode,
-        parameters = Nil,
-        body = Ast(blockNode(sourceFile)).withChildren(itemAsts),
-        methodReturn = methodReturnNode(sourceFile, Defines.Any),
-        modifiers = Seq(
-          modifierNode(sourceFile, ModifierTypes.VIRTUAL).order(0),
-          modifierNode(sourceFile, ModifierTypes.MODULE).order(1)
-        )
-      )
+    val namespaceBlockNode = globalNamespaceBlockNode()
+    val globalMethodAst    = astInFakeMethod(sourceFile, namespaceBlockNode)
 
     Ast(fileNode).withChild(Ast(namespaceBlockNode).withChild(globalMethodAst))
+  }
+
+  private def astInFakeMethod(sourceFile: SourceFile, namespaceBlockNode: NewNamespaceBlock): Ast = {
+    val method = globalFakeMethodNode(sourceFile, namespaceBlockNode)
+
+    methodAstParentStack.push(namespaceBlockNode)
+    methodAstParentStack.push(method)
+    val itemAsts = sourceFile.item.flatMap(visitItem)
+    methodAstParentStack.pop()
+    methodAstParentStack.pop()
+
+    val block        = blockNode(sourceFile)
+    val methodReturn = methodReturnNode(sourceFile, "()")
+    val modifiers    = Seq(ModifierTypes.VIRTUAL, ModifierTypes.MODULE).map(modifierNode(sourceFile, _))
+    methodAst(method, parameters = Nil, body = Ast(block).withChildren(itemAsts), methodReturn, modifiers)
   }
 
   private def visitItem(item: Item): Seq[Ast] = item match {
@@ -277,7 +272,7 @@ trait RustVisitor(implicit withValidationMode: ValidationMode) { this: AstCreato
     viewExprAsPathExpr(callExpr.expr) match {
       case Some(nameRefs) =>
         val name           = code(nameRefs.last)
-        val methodFullName = methodFullNameForCallExpr(nameRefs)
+        val methodFullName = methodFullNameForCallExpr(callExpr, nameRefs)
         val dispatch       = DispatchTypes.STATIC_DISPATCH
         val call           = callNode(callExpr, code(callExpr), name, methodFullName, dispatch)
         val args           = callExpr.argList.expr.map(visitExpr)

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/CallTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/CallTests.scala
@@ -1,0 +1,82 @@
+package io.joern.rust2cpg.passes.ast
+
+import io.joern.rust2cpg.testfixtures.Rust2CpgSuite
+import io.joern.x2cpg.Defines
+import io.shiftleft.codepropertygraph.generated.DispatchTypes
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.*
+
+class CallTests extends Rust2CpgSuite(noSysRoot = true) {
+
+  "`let x = foo()`" should {
+    val cpg = code("""
+        |fn main() {
+        | let x = foo();
+        |}
+        |""".stripMargin)
+
+    "create a local for the binding" in {
+      inside(cpg.method.name("main").block.local.name("x").l) { case local :: Nil =>
+        local.typeFullName shouldBe Defines.Any
+        local.code shouldBe "x"
+      }
+    }
+
+    "have the call as the assignment's second argument" in {
+      inside(cpg.assignment.argument(2).l) { case (rhs: Call) :: Nil =>
+        rhs.name shouldBe "foo"
+        rhs.code shouldBe "foo()"
+        rhs.methodFullName shouldBe s"${Defines.UnresolvedNamespace}::foo"
+        rhs.typeFullName shouldBe Defines.Any
+      }
+    }
+  }
+
+  "an unresolved fully-qualified call" should {
+    val cpg = code("""
+        |fn main() {
+        | a::b::c();
+        |}
+        |""".stripMargin)
+
+    "preserve the full path in methodFullName" in {
+      inside(cpg.call.name("c").l) { case cCall :: Nil =>
+        cCall.code shouldBe "a::b::c()"
+        cCall.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+        cCall.argument shouldBe empty
+        cCall.methodFullName shouldBe "a::b::c"
+      }
+    }
+  }
+
+  "an unresolved chained method call" should {
+    val cpg = code("""
+        |fn main() {
+        | external().chain().tail();
+        |}
+        |""".stripMargin)
+
+    "have DynamicCallUnknownFullName for the inner method call" in {
+      cpg.call.nameExact("chain").methodFullName.l shouldBe List(Defines.DynamicCallUnknownFullName)
+    }
+
+    "have DynamicCallUnknownFullName for the outer method call" in {
+      cpg.call.nameExact("tail").methodFullName.l shouldBe List(Defines.DynamicCallUnknownFullName)
+    }
+
+    "have an unresolved-namespace methodFullName for the function call" in {
+      cpg.call.nameExact("external").methodFullName.l shouldBe List(s"${Defines.UnresolvedNamespace}::external")
+    }
+  }
+
+  "a call to a function defined in the same file" should {
+    val cpg = code("""
+        |fn callee() {}
+        |fn main() { callee(); }
+        |""".stripMargin)
+
+    "have a crate-prefixed methodFullName" in {
+      cpg.call.name("callee").methodFullName.l shouldBe List("rust2cpgtest::callee")
+    }
+  }
+}

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/MethodTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/MethodTests.scala
@@ -1,0 +1,97 @@
+package io.joern.rust2cpg.passes.ast
+
+import io.joern.rust2cpg.testfixtures.Rust2CpgSuite
+import io.shiftleft.codepropertygraph.generated.NodeTypes
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal.globalNamespaceName
+import io.shiftleft.semanticcpg.utils.FileUtil.*
+
+import java.nio.file.Paths
+
+class MethodTests extends Rust2CpgSuite(noSysRoot = true) {
+
+  "a top-level fn" should {
+    val libPath = (Paths.get("src") / "lib.rs").toString
+    val cpg     = code("fn main() {}")
+
+    "have a crate-prefixed fullName" in {
+      cpg.method.name("main").fullName.l shouldBe List("rust2cpgtest::main")
+    }
+
+    "be parented by the fake global method" in {
+      inside(cpg.method.name("main").l) { case main :: Nil =>
+        main.astParentType shouldBe NodeTypes.METHOD
+        main.astParentFullName shouldBe s"$libPath:rust2cpgtest::$globalNamespaceName"
+      }
+    }
+  }
+
+  "a fn with a single parameter and a tail expression" should {
+    val cpg = code("""
+        |fn id(x: i32) -> i32 {
+        | x
+        |}
+        |""".stripMargin)
+
+    "have the parameter at index 1 with its declared type" in {
+      inside(cpg.method.name("id").parameter.sortBy(_.order).l) { case (param: MethodParameterIn) :: Nil =>
+        param.name shouldBe "x"
+        param.index shouldBe 1
+        param.typeFullName shouldBe "i32"
+      }
+    }
+
+    "lower the tail expression into a RETURN" in {
+      inside(cpg.method.name("id").block.astChildren.l) { case (ret: Return) :: Nil =>
+        ret.code shouldBe "x"
+
+        inside(ret.astChildren.l) { case (ident: Identifier) :: Nil =>
+          ident.name shouldBe "x"
+          ident.code shouldBe "x"
+        // TODO: update once typeFullNames are recorded.
+        //  ident.typeFullName shouldBe "i32"
+        }
+      }
+    }
+  }
+
+  "a fn with multiple parameters" should {
+    val cpg = code("fn foo(p1: i32, p2: i64, p3: f32) {}")
+
+    "preserve their order and declared types" in {
+      inside(cpg.method.name("foo").parameter.sortBy(_.order).l) { case p1 :: p2 :: p3 :: Nil =>
+        p1.name shouldBe "p1"
+        p1.index shouldBe 1
+        p1.typeFullName shouldBe "i32"
+
+        p2.name shouldBe "p2"
+        p2.index shouldBe 2
+        p2.typeFullName shouldBe "i64"
+
+        p3.name shouldBe "p3"
+        p3.index shouldBe 3
+        p3.typeFullName shouldBe "f32"
+      }
+    }
+  }
+
+  "a nested fn" should {
+    val cpg = code("""
+        |fn outer() {
+        |    fn inner() {}
+        |}
+        |""".stripMargin)
+
+    "have its enclosing method's fullName as prefix" in {
+      cpg.method.name("inner").fullName.l shouldBe List("rust2cpgtest::outer::inner")
+    }
+
+    "be parented by its enclosing method" in {
+      inside(cpg.method.name("inner").l) { case (inner: Method) :: Nil =>
+        inner.astParentType shouldBe NodeTypes.METHOD
+        inner.astParentFullName shouldBe "rust2cpgtest::outer"
+      }
+    }
+  }
+}

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/NamespaceBlockTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/NamespaceBlockTests.scala
@@ -1,0 +1,79 @@
+package io.joern.rust2cpg.passes.ast
+
+import io.joern.rust2cpg.testfixtures.Rust2CpgSuite
+import io.shiftleft.codepropertygraph.generated.{ModifierTypes, NodeTypes}
+import io.shiftleft.codepropertygraph.generated.nodes.Method
+import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal.globalNamespaceName
+import io.shiftleft.semanticcpg.utils.FileUtil.*
+
+import java.nio.file.Paths
+
+class NamespaceBlockTests extends Rust2CpgSuite(noSysRoot = true) {
+
+  "the crate namespace block" should {
+    val mainPath = (Paths.get("src") / "main.rs").toString
+    val cpg      = code("", mainPath)
+
+    "use the crate name as name" in {
+      cpg.namespaceBlock.filenameExact(mainPath).name.l shouldBe List("rust2cpgtest")
+    }
+
+    "have a file-prefixed fullName" in {
+      cpg.namespaceBlock.filenameExact(mainPath).fullName.l shouldBe List(s"$mainPath:rust2cpgtest")
+    }
+  }
+
+  "a submodule's namespace block" should {
+    val libPath = (Paths.get("src") / "lib.rs").toString
+    val fooPath = (Paths.get("src") / "foo.rs").toString
+    val cpg     = code("mod foo;", libPath).moreCode("fn bar() {}", fooPath)
+
+    "prefix name with the crate name" in {
+      cpg.namespaceBlock.filenameExact(fooPath).name.l shouldBe List("rust2cpgtest::foo")
+    }
+
+    "prefix fullName with the file and crate name" in {
+      cpg.namespaceBlock.filenameExact(fooPath).fullName.l shouldBe List(s"$fooPath:rust2cpgtest::foo")
+    }
+  }
+
+  "the fake global method" should {
+    val libPath = (Paths.get("src") / "lib.rs").toString
+    val cpg = code("""
+        |fn one() {}
+        |fn two(x: i32) -> i32 { x }
+        |""".stripMargin)
+
+    "have a file-prefixed fullName" in {
+      cpg.method.nameExact(globalNamespaceName).fullName.l shouldBe
+        List(s"$libPath:rust2cpgtest::$globalNamespaceName")
+    }
+
+    "be parented by the crate namespace block" in {
+      inside(cpg.method.nameExact(globalNamespaceName).l) { case fakeMethod :: Nil =>
+        fakeMethod.astParentType shouldBe NodeTypes.NAMESPACE_BLOCK
+        fakeMethod.astParentFullName shouldBe s"$libPath:rust2cpgtest"
+      }
+    }
+
+    "have a () return type" in {
+      cpg.method.nameExact(globalNamespaceName).methodReturn.typeFullName.l shouldBe List("()")
+    }
+
+    "have VIRTUAL and MODULE modifiers" in {
+      cpg.method.nameExact(globalNamespaceName).modifier.modifierType.toSet shouldBe
+        Set(ModifierTypes.VIRTUAL, ModifierTypes.MODULE)
+    }
+
+    "own top-level fns as AST children" in {
+      inside(cpg.method.nameExact(globalNamespaceName).block.astChildren.sortBy(_.order).l) {
+        case (one: Method) :: (two: Method) :: Nil =>
+          one.name shouldBe "one"
+          one.fullName shouldBe "rust2cpgtest::one"
+          two.name shouldBe "two"
+          two.fullName shouldBe "rust2cpgtest::two"
+      }
+    }
+  }
+}

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -11,36 +11,6 @@ import java.nio.file.Paths
 
 class SimpleAstCreationPassTest extends Rust2CpgSuite {
 
-  "test 03" in {
-    val mainPath = (Paths.get("src") / "main.rs").toString
-    val cpg      = code("", mainPath)
-    inside(cpg.namespaceBlock.filenameExact(mainPath).l) { case namespaceBlock :: Nil =>
-      namespaceBlock.name shouldBe "<global>"
-      namespaceBlock.fullName shouldBe s"$mainPath:<global>"
-    }
-  }
-
-  "test 04" in {
-    val mainPath = (Paths.get("src") / "main.rs").toString
-    val cpg      = code("", mainPath)
-    inside(cpg.namespaceBlock.filenameExact(mainPath).astChildren.l) { case (method: Method) :: Nil =>
-      method.name shouldBe "<global>"
-      method.fullName shouldBe s"$mainPath:<global>"
-      method.code shouldBe "<global>"
-      method.astParentType shouldBe NodeTypes.NAMESPACE_BLOCK
-      method.astParentFullName shouldBe s"$mainPath:<global>"
-
-      inside(method.start.methodReturn.l) { case methodRet :: Nil =>
-        methodRet.typeFullName shouldBe Defines.Any
-      }
-
-      inside(method.start.modifier.sortBy(_.order).l) { case modifier0 :: modifier1 :: Nil =>
-        modifier0.modifierType shouldBe ModifierTypes.VIRTUAL
-        modifier1.modifierType shouldBe ModifierTypes.MODULE
-      }
-    }
-  }
-
   "test 05" in {
     val cpg = code("const MAX_SIZE: usize = 1024;")
     cpg.local.name("MAX_SIZE").typeFullName.l shouldBe List("usize")
@@ -144,26 +114,6 @@ class SimpleAstCreationPassTest extends Rust2CpgSuite {
     inside(cpg.assignment.argument(2).l) { case (rhs: Literal) :: Nil =>
       rhs.code shouldBe "1"
       rhs.typeFullName shouldBe "i32"
-    }
-  }
-
-  "test 09" in {
-    val cpg = code("""
-        |fn main() {
-        | let x = foo();
-        |}
-        |""".stripMargin)
-
-    inside(cpg.method.name("main").block.local.name("x").l) { case local :: Nil =>
-      local.typeFullName shouldBe Defines.Any
-      local.code shouldBe "x"
-    }
-
-    inside(cpg.assignment.argument(2).l) { case (rhs: Call) :: Nil =>
-      rhs.name shouldBe "foo"
-      rhs.code shouldBe "foo()"
-      rhs.methodFullName shouldBe "foo"
-      rhs.typeFullName shouldBe Defines.Any
     }
   }
 
@@ -345,35 +295,6 @@ class SimpleAstCreationPassTest extends Rust2CpgSuite {
     }
   }
 
-  "test 17" in {
-    val cpg = code("""
-        |fn main() {
-        | env_logger::init();
-        |}
-        |""".stripMargin)
-    inside(cpg.call.name("init").l) { case init :: Nil =>
-      init.argument shouldBe empty
-      init.code shouldBe "env_logger::init()"
-      init.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-      init.methodFullName shouldBe "env_logger.init"
-    }
-  }
-
-  "test 18" in {
-    val cpg = code("""
-        |fn main() {
-        | a::b::c();
-        |}
-        |""".stripMargin)
-
-    inside(cpg.call.name("c").l) { case c :: Nil =>
-      c.code shouldBe "a::b::c()"
-      c.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-      c.argument shouldBe empty
-      c.methodFullName shouldBe "a.b.c"
-    }
-  }
-
   "test 19" in {
     val cpg = code("""
         |fn gtz(x: i32) -> bool {
@@ -405,8 +326,7 @@ class SimpleAstCreationPassTest extends Rust2CpgSuite {
 
     inside(cpg.call.name("foo").l) { case foo :: Nil =>
       foo.code shouldBe "foo::<u32>()"
-      // TODO
-      foo.methodFullName shouldBe "foo"
+      foo.methodFullName shouldBe s"${Defines.UnresolvedNamespace}::foo"
       foo.argument shouldBe empty
     }
   }
@@ -505,22 +425,6 @@ class SimpleAstCreationPassTest extends Rust2CpgSuite {
     }
   }
 
-  "test 25" in {
-    val filePath = (Paths.get("src") / "lib.rs").toString
-    val cpg = code("""
-        |fn main() {}
-        |""".stripMargin)
-
-    inside(cpg.method.name("main").l) { case main :: Nil =>
-      main.fullName shouldBe s"$filePath:<global>.main"
-      // TODO: main.astParentFullName shouldBe s"$filePath:<global>"
-      main.parameter shouldBe empty
-      main.methodReturn.typeFullName shouldBe "()"
-      main.block.typeFullName shouldBe Defines.Any
-      main.block.astChildren shouldBe empty
-    }
-  }
-
   "test 26" in {
     val cpg = code("""
         |fn main() -> i32 { 1 }
@@ -558,65 +462,6 @@ class SimpleAstCreationPassTest extends Rust2CpgSuite {
         lit.typeFullName shouldBe "char"
       }
     }
-  }
-
-  "test 28" in {
-    val filePath = (Paths.get("src") / "lib.rs").toString
-    val cpg = code("""
-        |fn id(x: i32) -> i32 {
-        | x
-        |}
-        |""".stripMargin)
-
-    inside(cpg.method.name("id").l) { case (method: Method) :: Nil =>
-      method.fullName shouldBe s"$filePath:<global>.id"
-    }
-
-    inside(cpg.method.name("id").parameter.sortBy(_.order).l) { case (param: MethodParameterIn) :: Nil =>
-      param.name shouldBe "x"
-      param.index shouldBe 1
-      param.typeFullName shouldBe "i32"
-    }
-
-    inside(cpg.method.name("id").block.astChildren.l) { case (ret: Return) :: Nil =>
-      ret.code shouldBe "x"
-
-      inside(ret.astChildren.l) { case (ident: Identifier) :: Nil =>
-        ident.name shouldBe "x"
-        ident.code shouldBe "x"
-      // TODO: ident.typeFullName shouldBe "i32"
-      }
-    }
-  }
-
-  "test 29" in {
-    val filePath = (Paths.get("src") / "lib.rs").toString
-    val cpg = code(
-      """
-        |fn foo(p1: i32, p2: i64, p3: f32) {}
-        |""".stripMargin,
-      filePath
-    )
-
-    inside(cpg.method.name("foo").l) { case (method: Method) :: Nil =>
-      method.fullName shouldBe s"$filePath:<global>.foo"
-    }
-
-    inside(cpg.method.name("foo").parameter.sortBy(_.order).l) { case p1 :: p2 :: p3 :: Nil =>
-      p1.name shouldBe "p1"
-      p1.index shouldBe 1
-      p1.typeFullName shouldBe "i32"
-
-      p2.name shouldBe "p2"
-      p2.index shouldBe 2
-      p2.typeFullName shouldBe "i64"
-
-      p3.name shouldBe "p3"
-      p3.index shouldBe 3
-      p3.typeFullName shouldBe "f32"
-    }
-
-    cpg.method.name("foo").block.astChildren shouldBe empty
   }
 
   "test 30" in {


### PR DESCRIPTION
Split of #5971 containing just the support for method fullNames + few fixes/cleanups. A follow up PR will do the same for typeFullNames.

- Each Rust file has a "global" namespace block: `name` is rust-derived (e.g. `my_crate::sub_module`), but `fullName` is unique by prefixing the (relative) file name, e.g. `src/lib.rs:my_crate::sub_module`. There's no "global" type decl.
- Each Rust file has a "global" fake method enclosing the actual AST to allow top-level constant declarations to be lowered as locals. (Tests for consts in the follow-up.) This fake method's fullName does not contribute to the names of its child AST nodes.
- Unresolved `foo()` calls have methodFullName `<unresolvedNamespace>::foo`.