### PR TITLE
[rust2cpg] rust_ast_gen-based typeFullNames

### DIFF
--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/AstCreator.scala
@@ -6,7 +6,7 @@ import io.joern.rust2cpg.parser.RustJsonParser.ParseResult
 import io.joern.rust2cpg.parser.RustNodeSyntax
 import io.joern.rust2cpg.parser.RustNodeSyntax.RustNode
 import io.joern.x2cpg.datastructures.Stack.*
-import io.joern.x2cpg.{Ast, AstCreatorBase, Defines, ValidationMode}
+import io.joern.x2cpg.{Ast, AstCreatorBase, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.nodes.{NewCall, NewMethod, NewNamespaceBlock, NewNode}
 import io.shiftleft.codepropertygraph.generated.{NodeTypes, Operators, PropertyDefaults, PropertyNames}
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
@@ -100,38 +100,6 @@ class AstCreator(val config: Config, val parseResult: ParseResult)(implicit with
     )
   }
 
-  // TODO
-  protected def typeFullNameForType(typ: RustNodeSyntax.Type): String = {
-    text(typ).getOrElse(Defines.Any)
-  }
-
-  // TODO
-  protected def typeFullNameForNameRef(nameRef: RustNodeSyntax.NameRef): String = {
-    Defines.Any
-  }
-
-  // TODO
-  protected def typeFullNameForPath(path: RustNodeSyntax.Path): String = {
-    Defines.Any
-  }
-
-  protected def typeFullNameForLiteral(lit: RustNodeSyntax.Literal): String = {
-    lit.value.map(typeFullNameForLiteralToken).getOrElse(Defines.Any)
-  }
-
-  protected def typeFullNameForLiteralToken(tok: RustNodeSyntax.RustToken): String = tok match {
-    case _: RustNodeSyntax.IntNumberToken   => "i32"
-    case _: RustNodeSyntax.FloatNumberToken => "f64"
-    case _: RustNodeSyntax.StringToken      => "&str"
-    case _: RustNodeSyntax.ByteStringToken  => "&[u8]"
-    case _: RustNodeSyntax.CStringToken     => "&CStr"
-    case _: RustNodeSyntax.CharToken        => "char"
-    case _: RustNodeSyntax.ByteToken        => "u8"
-    case _: RustNodeSyntax.TrueKwToken      => "bool"
-    case _: RustNodeSyntax.FalseKwToken     => "bool"
-    case _                                  => Defines.Any
-  }
-
   protected def operatorNameFor(binExpr: RustNodeSyntax.BinExpr): Option[String] = binExpr.op match {
     case Some(_: RustNodeSyntax.Pipe2Token)     => Some(Operators.logicalOr)
     case Some(_: RustNodeSyntax.Amp2Token)      => Some(Operators.logicalAnd)
@@ -170,11 +138,6 @@ class AstCreator(val config: Config, val parseResult: ParseResult)(implicit with
     case Some(_: RustNodeSyntax.BangToken)  => Some(Operators.logicalNot)
     case Some(_: RustNodeSyntax.StarToken)  => Some(Operators.indirection)
     case _                                  => None
-  }
-
-  protected def typeFullNameForMethodCallExpr(methodCallExpr: RustNodeSyntax.MethodCallExpr): String = {
-    // TODO
-    Defines.Any
   }
 
 }

--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustFullNames.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustFullNames.scala
@@ -47,8 +47,15 @@ trait RustFullNames { this: AstCreator =>
     }
   }
 
-  private def rustAstGenMethodFullName(node: RustNode): Option[String] =
+  private def rustAstGenMethodFullName(node: RustNode): Option[String] = {
+    // TODO: move this key into a constant in RustNodeSyntax, or provide the accessor there.
     node.json.obj.get("methodFullName").flatMap(_.strOpt)
+  }
+
+  private def rustAstGenTypeFullName(node: RustNode): Option[String] = {
+    // TODO: move this key into a constant in RustNodeSyntax, or provide the accessor there.
+    node.json.obj.get("typeFullName").flatMap(_.strOpt)
+  }
 
   protected def methodFullNameForCallExpr(
     callExpr: RustNodeSyntax.CallExpr,
@@ -64,7 +71,49 @@ trait RustFullNames { this: AstCreator =>
     }
   }
 
-  protected def methodFullNameForMethodCallExpr(methodCallExpr: RustNodeSyntax.MethodCallExpr): String =
+  protected def methodFullNameForMethodCallExpr(methodCallExpr: RustNodeSyntax.MethodCallExpr): String = {
     rustAstGenMethodFullName(methodCallExpr).getOrElse(Defines.DynamicCallUnknownFullName)
+  }
+
+  // TODO
+  protected def typeFullNameForType(typ: RustNodeSyntax.Type): String = {
+    text(typ).getOrElse(Defines.Any)
+  }
+
+  // TODO
+  protected def typeFullNameForNameRef(nameRef: RustNodeSyntax.NameRef): String = {
+    Defines.Any
+  }
+
+  protected def typeFullNameForPath(path: RustNodeSyntax.Path): String = {
+    rustAstGenTypeFullName(path)
+      .orElse(path.pathSegment.nameRef.flatMap(rustAstGenTypeFullName))
+      .getOrElse(Defines.Any)
+  }
+
+  protected def typeFullNameForExpr(expr: RustNodeSyntax.Expr): String = {
+    rustAstGenTypeFullName(expr).getOrElse(Defines.Any)
+  }
+
+  protected def typeFullNameForLiteral(lit: RustNodeSyntax.Literal): String = {
+    rustAstGenTypeFullName(lit).orElse(lit.value.map(typeFullNameForLiteralToken)).getOrElse(Defines.Any)
+  }
+
+  protected def typeFullNameForIdentPat(identPat: RustNodeSyntax.IdentPat): String = {
+    rustAstGenTypeFullName(identPat).getOrElse(Defines.Any)
+  }
+
+  protected def typeFullNameForLiteralToken(tok: RustNodeSyntax.RustToken): String = tok match {
+    case _: RustNodeSyntax.IntNumberToken   => "i32"
+    case _: RustNodeSyntax.FloatNumberToken => "f64"
+    case _: RustNodeSyntax.StringToken      => "&str"
+    case _: RustNodeSyntax.ByteStringToken  => "&[u8]"
+    case _: RustNodeSyntax.CStringToken     => "&CStr"
+    case _: RustNodeSyntax.CharToken        => "char"
+    case _: RustNodeSyntax.ByteToken        => "u8"
+    case _: RustNodeSyntax.TrueKwToken      => "bool"
+    case _: RustNodeSyntax.FalseKwToken     => "bool"
+    case _                                  => Defines.Any
+  }
 
 }

--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
@@ -150,11 +150,15 @@ trait RustVisitor(implicit withValidationMode: ValidationMode) { this: AstCreato
   //  LetElse?
   //  ';'
   private def visitLetStmt(letStmt: LetStmt): Seq[Ast] = {
-    viewPatAsIdentPat(letStmt.pat).flatMap(_.name.identToken) match {
-      case Some(identToken) =>
-        val typeFullName = letStmt.`type`.map(typeFullNameForType).getOrElse(Defines.Any)
-        lowerIdentifierDecl(identToken, letStmt.expr, typeFullName, code(letStmt))
-      case None => notHandledYet(letStmt) :: Nil
+    letStmt.pat match {
+      case identPat: IdentPat =>
+        identPat.name.identToken match {
+          case Some(identToken) =>
+            val typeFullName = letStmt.`type`.map(typeFullNameForType).getOrElse(typeFullNameForIdentPat(identPat))
+            lowerIdentifierDecl(identToken, letStmt.expr, typeFullName, code(letStmt))
+          case None => notHandledYet(letStmt) :: Nil
+        }
+      case _ => notHandledYet(letStmt) :: Nil
     }
   }
 
@@ -178,11 +182,6 @@ trait RustVisitor(implicit withValidationMode: ValidationMode) { this: AstCreato
     val assignmentAst = callAst(assignmentNode(lhsToken, declCode), Seq(lhsAst, rhsAst))
 
     Seq(localAst, assignmentAst)
-  }
-
-  private def viewPatAsIdentPat(pat: Pat): Option[IdentPat] = pat match {
-    case identPat: IdentPat => Some(identPat)
-    case _                  => None
   }
 
   // Name =
@@ -273,9 +272,11 @@ trait RustVisitor(implicit withValidationMode: ValidationMode) { this: AstCreato
       case Some(nameRefs) =>
         val name           = code(nameRefs.last)
         val methodFullName = methodFullNameForCallExpr(callExpr, nameRefs)
+        val typeFullName   = typeFullNameForExpr(callExpr)
         val dispatch       = DispatchTypes.STATIC_DISPATCH
-        val call           = callNode(callExpr, code(callExpr), name, methodFullName, dispatch)
-        val args           = callExpr.argList.expr.map(visitExpr)
+        val call =
+          callNode(callExpr, code(callExpr), name, methodFullName, dispatch, None, Some(typeFullName))
+        val args = callExpr.argList.expr.map(visitExpr)
         callAst(call, args)
       case None => notHandledYet(callExpr)
     }
@@ -419,8 +420,9 @@ trait RustVisitor(implicit withValidationMode: ValidationMode) { this: AstCreato
   private def visitBinExpr(binExpr: BinExpr): Ast = {
     operatorNameFor(binExpr) match {
       case Some(opName) =>
-        val callNode = operatorCallNode(node = binExpr, code = code(binExpr), name = opName, typeFullName = None)
-        val lhsRhs   = binExpr.expr.map(visitExpr)
+        val typeFullName = typeFullNameForExpr(binExpr)
+        val callNode     = operatorCallNode(binExpr, code(binExpr), opName, Some(typeFullName))
+        val lhsRhs       = binExpr.expr.map(visitExpr)
         callAst(callNode, lhsRhs)
       case None => notHandledYet(binExpr)
     }
@@ -464,8 +466,9 @@ trait RustVisitor(implicit withValidationMode: ValidationMode) { this: AstCreato
   private def visitPrefixExpr(prefixExpr: PrefixExpr): Ast = {
     operatorNameFor(prefixExpr) match {
       case Some(opName) =>
-        val callNode = operatorCallNode(node = prefixExpr, code = code(prefixExpr), name = opName, typeFullName = None)
-        val exprAst  = visitExpr(prefixExpr.expr)
+        val typeFullName = typeFullNameForExpr(prefixExpr)
+        val callNode     = operatorCallNode(prefixExpr, code(prefixExpr), opName, Some(typeFullName))
+        val exprAst      = visitExpr(prefixExpr.expr)
         callAst(callNode, Seq(exprAst))
       case None => notHandledYet(prefixExpr)
     }
@@ -570,9 +573,10 @@ trait RustVisitor(implicit withValidationMode: ValidationMode) { this: AstCreato
   // IndexExpr =
   //  Attr* base:Expr '[' index:Expr ']'
   private def visitIndexExpr(indexExpr: IndexExpr): Ast = {
-    val callNode = operatorCallNode(indexExpr, code(indexExpr), Operators.indexAccess, None)
-    val baseAst  = visitExpr(indexExpr.base)
-    val indexAst = visitExpr(indexExpr.index)
+    val typeFullName = typeFullNameForExpr(indexExpr)
+    val callNode     = operatorCallNode(indexExpr, code(indexExpr), Operators.indexAccess, Some(typeFullName))
+    val baseAst      = visitExpr(indexExpr.base)
+    val indexAst     = visitExpr(indexExpr.index)
     callAst(callNode, Seq(baseAst, indexAst))
   }
 
@@ -607,17 +611,13 @@ trait RustVisitor(implicit withValidationMode: ValidationMode) { this: AstCreato
   private def visitMethodCallExpr(methodCallExpr: MethodCallExpr): Ast = {
     val methodName     = code(methodCallExpr.nameRef)
     val methodFullName = methodFullNameForMethodCallExpr(methodCallExpr)
-    val typeFullName   = typeFullNameForMethodCallExpr(methodCallExpr)
-    // TODO dispatch should be STATIC unless the receiver type is `dyn ...`
-    val call = callNode(
-      methodCallExpr,
-      code(methodCallExpr),
-      methodName,
-      methodFullName,
-      DispatchTypes.STATIC_DISPATCH,
-      None,
-      Some(typeFullName)
-    )
+    val typeFullName   = typeFullNameForExpr(methodCallExpr)
+    // TODO: should also be DYNAMIC_DISPATCH when the type is `dyn`.
+    val dispatch =
+      if (methodFullName == Defines.DynamicCallUnknownFullName) DispatchTypes.DYNAMIC_DISPATCH
+      else DispatchTypes.STATIC_DISPATCH
+    val call =
+      callNode(methodCallExpr, code(methodCallExpr), methodName, methodFullName, dispatch, None, Some(typeFullName))
     val receiverAst = visitExpr(methodCallExpr.expr)
     val args        = methodCallExpr.argList.expr.map(visitExpr)
     callAst(call, args, base = Some(receiverAst))

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/CallTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/CallTests.scala
@@ -67,6 +67,18 @@ class CallTests extends Rust2CpgSuite(noSysRoot = true) {
     "have an unresolved-namespace methodFullName for the function call" in {
       cpg.call.nameExact("external").methodFullName.l shouldBe List(s"${Defines.UnresolvedNamespace}::external")
     }
+
+    "have STATIC_DISPATCH for the function call" in {
+      cpg.call.nameExact("external").dispatchType.l shouldBe List(DispatchTypes.STATIC_DISPATCH)
+    }
+
+    "have DYNAMIC_DISPATCH for each method call in the chain" in {
+      cpg.call.nameExact("chain", "tail").dispatchType.toSet shouldBe Set(DispatchTypes.DYNAMIC_DISPATCH)
+    }
+
+    "have Any as typeFullName for each call in the chain" in {
+      cpg.call.nameExact("external", "chain", "tail").typeFullName.toSet shouldBe Set(Defines.Any)
+    }
   }
 
   "a call to a function defined in the same file" should {
@@ -77,6 +89,137 @@ class CallTests extends Rust2CpgSuite(noSysRoot = true) {
 
     "have a crate-prefixed methodFullName" in {
       cpg.call.name("callee").methodFullName.l shouldBe List("rust2cpgtest::callee")
+    }
+  }
+
+  "a `Vec::push` call" should {
+    val cpg = code("""
+        |fn foo(xs: Vec<i32>) {
+        | xs.push(1);
+        |}
+        |""".stripMargin)
+
+    "have DynamicCallUnknownFullName as methodFullName" in {
+      inside(cpg.call.nameExact("push").l) { case push :: Nil =>
+        push.code shouldBe "xs.push(1)"
+        push.methodFullName shouldBe Defines.DynamicCallUnknownFullName
+        push.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
+        push.typeFullName shouldBe Defines.Any
+      }
+    }
+
+    "have the variable as receiver" in {
+      inside(cpg.call.nameExact("push").receiver.l) { case (receiver: Identifier) :: Nil =>
+        receiver.code shouldBe "xs"
+        receiver.argumentIndex shouldBe 0
+        receiver.typeFullName shouldBe Defines.Any
+      }
+    }
+
+    "have the receiver and the literal as arguments" in {
+      inside(cpg.call.nameExact("push").argument.l) { case (receiver: Identifier) :: (lit: Literal) :: Nil =>
+        receiver shouldBe cpg.call.nameExact("push").receiver.head
+
+        lit.code shouldBe "1"
+        lit.argumentIndex shouldBe 1
+        lit.typeFullName shouldBe "i32"
+      }
+    }
+  }
+
+  "a `String` method chain" should {
+    val cpg = code("""
+        |fn foo() {
+        | String::from(" hello ").trim().to_string();
+        |}
+        |""".stripMargin)
+
+    "lower `trim` as a method call on the result of `from`" in {
+      inside(cpg.call.nameExact("trim").l) { case trim :: Nil =>
+        trim.code shouldBe """String::from(" hello ").trim()"""
+        trim.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
+        trim.arguments(1) shouldBe empty
+        trim.methodFullName shouldBe Defines.DynamicCallUnknownFullName
+
+        inside(trim.receiver.l) { case (from: Call) :: Nil =>
+          from.name shouldBe "from"
+          from.code shouldBe """String::from(" hello ")"""
+          from.argumentIndex shouldBe 0
+        }
+      }
+    }
+
+    "lower `to_string` as a method call on the result of `trim`" in {
+      inside(cpg.call.nameExact("to_string").l) { case toString :: Nil =>
+        toString.code shouldBe """String::from(" hello ").trim().to_string()"""
+        toString.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
+        toString.arguments(1) shouldBe empty
+        toString.methodFullName shouldBe Defines.DynamicCallUnknownFullName
+
+        inside(toString.receiver.l) { case (trim: Call) :: Nil =>
+          trim.name shouldBe "trim"
+          trim.code shouldBe """String::from(" hello ").trim()"""
+          trim.argumentIndex shouldBe 0
+        }
+      }
+    }
+  }
+}
+
+class CallTestsWithSysroot extends Rust2CpgSuite(noSysRoot = false) {
+
+  "a `Vec` method call resolved against the sysroot" should {
+    val cpg = code("""
+        |fn foo(xs: Vec<i32>) -> usize {
+        | xs.push(1);
+        | xs.len()
+        |}
+        |""".stripMargin)
+
+    "resolve `push` to alloc::vec::Vec" in {
+      inside(cpg.call.nameExact("push").l) { case push :: Nil =>
+        push.methodFullName shouldBe "alloc::vec::Vec<T, A>::push"
+        push.typeFullName shouldBe "()"
+      }
+    }
+
+    "resolve `len` to alloc::vec::Vec" in {
+      inside(cpg.call.nameExact("len").l) { case len :: Nil =>
+        len.methodFullName shouldBe "alloc::vec::Vec<T, A>::len"
+        len.typeFullName shouldBe "usize"
+      }
+    }
+  }
+
+  "a `String` method chain resolved against the sysroot" should {
+    val cpg = code("""
+        |fn foo() -> String {
+        | String::from(" hello ").trim().to_string()
+        |}
+        |""".stripMargin)
+
+    // TODO: we would expect the typeFullName to be `String`, not `&str`.
+    //  Need to confirm if that's from rust-analyzer or rust_ast_gen.
+    "resolve `from` to core::convert::From" in {
+      inside(cpg.call.nameExact("from").l) { case from :: Nil =>
+        from.methodFullName shouldBe "core::convert::From<T>::from"
+        from.typeFullName shouldBe "&str"
+      }
+    }
+
+    "resolve `trim` to str::trim" in {
+      inside(cpg.call.nameExact("trim").l) { case trim :: Nil =>
+        trim.code shouldBe """String::from(" hello ").trim()"""
+        trim.methodFullName shouldBe "str::trim"
+        trim.typeFullName shouldBe "&str"
+      }
+    }
+
+    "resolve `to_string` to alloc::string::ToString" in {
+      inside(cpg.call.nameExact("to_string").l) { case toString :: Nil =>
+        toString.methodFullName shouldBe "<T as alloc::string::ToString>::to_string"
+        toString.typeFullName shouldBe "alloc::string::String"
+      }
     }
   }
 }

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/DeclarationTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/DeclarationTests.scala
@@ -1,0 +1,184 @@
+package io.joern.rust2cpg.passes.ast
+
+import io.joern.rust2cpg.testfixtures.Rust2CpgSuite
+import io.joern.x2cpg.Defines
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.*
+
+class DeclarationTests extends Rust2CpgSuite(noSysRoot = true) {
+
+  "a top-level const" should {
+    val cpg = code("const MAX_SIZE: usize = 1024;")
+
+    "create a LOCAL with the annotated type" in {
+      cpg.local.name("MAX_SIZE").typeFullName.l shouldBe List("usize")
+    }
+
+    "lower the initializer into an assignment" in {
+      inside(cpg.assignment.l) { case assignment :: Nil =>
+        assignment.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+        assignment.code shouldBe "const MAX_SIZE: usize = 1024;"
+        assignment.typeFullName shouldBe Defines.Any
+        assignment.methodFullName shouldBe Operators.assignment
+      }
+    }
+
+    "have an Identifier as the assignment's first argument" in {
+      inside(cpg.assignment.argument(1).l) { case (lhs: Identifier) :: Nil =>
+        lhs.name shouldBe "MAX_SIZE"
+        lhs.typeFullName shouldBe "usize"
+        lhs.code shouldBe "MAX_SIZE"
+      }
+    }
+
+    "have a Literal as the assignment's second argument" in {
+      inside(cpg.assignment.argument(2).l) { case (rhs: Literal) :: Nil =>
+        rhs.code shouldBe "1024"
+        rhs.typeFullName shouldBe "usize"
+      }
+    }
+  }
+
+  "a const inside a function body" should {
+    val cpg = code("""
+        |fn main() {
+        | const FOO: i32 = 0;
+        |}
+        |""".stripMargin)
+
+    "create a LOCAL with the annotated type" in {
+      inside(cpg.method.name("main").block.local.name("FOO").l) { case local :: Nil =>
+        local.typeFullName shouldBe "i32"
+        local.code shouldBe "FOO"
+      }
+    }
+
+    "lower the initializer into an assignment" in {
+      inside(cpg.method.name("main").block.assignment.l) { case assignment :: Nil =>
+        assignment.code shouldBe "const FOO: i32 = 0;"
+        assignment.lineNumber shouldBe Some(3)
+      }
+    }
+
+    "have an Identifier as the assignment's first argument" in {
+      inside(cpg.assignment.argument(1).l) { case (lhs: Identifier) :: Nil =>
+        lhs.name shouldBe "FOO"
+        lhs.typeFullName shouldBe "i32"
+        lhs.code shouldBe "FOO"
+      }
+    }
+
+    "have a Literal as the assignment's second argument" in {
+      inside(cpg.assignment.argument(2).l) { case (rhs: Literal) :: Nil =>
+        rhs.code shouldBe "0"
+        rhs.typeFullName shouldBe "i32"
+      }
+    }
+  }
+
+  "an untyped let bound to an integer literal" should {
+    val cpg = code("""
+        |fn main() {
+        | let x = 1;
+        |}
+        |""".stripMargin)
+
+    "create an i32 LOCAL" in {
+      inside(cpg.method.name("main").block.local.name("x").l) { case local :: Nil =>
+        local.typeFullName shouldBe "i32"
+        local.code shouldBe "x"
+      }
+    }
+
+    "lower the initializer into an assignment" in {
+      inside(cpg.method.name("main").block.assignment.l) { case assignment :: Nil =>
+        assignment.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+        assignment.code shouldBe "let x = 1;"
+        assignment.typeFullName shouldBe Defines.Any
+        assignment.methodFullName shouldBe Operators.assignment
+        assignment.lineNumber shouldBe Some(3)
+      }
+    }
+
+    "have an Identifier as the assignment's first argument" in {
+      inside(cpg.assignment.argument(1).l) { case (lhs: Identifier) :: Nil =>
+        lhs.name shouldBe "x"
+        lhs.typeFullName shouldBe "i32"
+        lhs.code shouldBe "x"
+      }
+    }
+
+    "have a Literal as the assignment's second argument" in {
+      inside(cpg.assignment.argument(2).l) { case (rhs: Literal) :: Nil =>
+        rhs.code shouldBe "1"
+        rhs.typeFullName shouldBe "i32"
+      }
+    }
+  }
+
+  "a typed let bound to an integer literal" should {
+    val cpg = code("""
+        |fn foo() {
+        | let x: usize = 10;
+        |}
+        |""".stripMargin)
+
+    "create a LOCAL with the annotated type" in {
+      inside(cpg.method.name("foo").block.local.name("x").l) { case local :: Nil =>
+        local.typeFullName shouldBe "usize"
+        local.code shouldBe "x"
+      }
+    }
+
+    "have an Identifier as the assignment's first argument" in {
+      inside(cpg.assignment.argument(1).l) { case (lhs: Identifier) :: Nil =>
+        lhs.name shouldBe "x"
+        lhs.typeFullName shouldBe "usize"
+        lhs.code shouldBe "x"
+      }
+    }
+
+    // rust-analyzer sets the RHS type according to the type annotation provided.
+    // Otherwise, 10 alone would be i32.
+    "have a Literal as the assignment's second argument" in {
+      inside(cpg.assignment.argument(2).l) { case (lit: Literal) :: Nil =>
+        lit.code shouldBe "10"
+        lit.typeFullName shouldBe "usize"
+      }
+    }
+  }
+
+  "boolean literals" should {
+    val cpg = code("const TT: bool = true; const FF: bool = false;")
+
+    "have a bool typeFullName for true" in {
+      cpg.literal.code("true").typeFullName.l shouldBe List("bool")
+    }
+
+    "have a bool typeFullName for false" in {
+      cpg.literal.code("false").typeFullName.l shouldBe List("bool")
+    }
+  }
+
+  "an untyped let bound to a string literal" should {
+    val cpg = code("""
+        |fn main() {
+        | let s = "hello";
+        |}
+        |""".stripMargin)
+
+    "create an &str LOCAL" in {
+      inside(cpg.method.name("main").block.local.name("s").l) { case local :: Nil =>
+        local.typeFullName shouldBe "&str"
+      }
+    }
+
+    "have an Identifier as the assignment's first argument" in {
+      inside(cpg.assignment.argument(1).l) { case (lhs: Identifier) :: Nil =>
+        lhs.name shouldBe "s"
+        lhs.typeFullName shouldBe "&str"
+      }
+    }
+  }
+}

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/OperatorTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/OperatorTests.scala
@@ -1,0 +1,181 @@
+package io.joern.rust2cpg.passes.ast
+
+import io.joern.rust2cpg.testfixtures.Rust2CpgSuite
+import io.joern.x2cpg.Defines
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.*
+
+class OperatorTests extends Rust2CpgSuite(noSysRoot = true) {
+
+  "an `as` expression" should {
+    val cpg = code("""
+        |fn main(x: i32) {
+        | let y = x as i64;
+        |}
+        |""".stripMargin)
+
+    "lower to a cast call with the target type as typeFullName" in {
+      inside(cpg.call.nameExact(Operators.cast).l) { case cast :: Nil =>
+        cast.code shouldBe "x as i64"
+        cast.methodFullName shouldBe Operators.cast
+        cast.typeFullName shouldBe "i64"
+      }
+    }
+
+    "have a TypeRef to the target type as the first argument" in {
+      inside(cpg.call.nameExact(Operators.cast).argument(1).l) { case (typeRef: TypeRef) :: Nil =>
+        typeRef.code shouldBe "i64"
+        typeRef.typeFullName shouldBe "i64"
+      }
+    }
+
+    "have the cast operand as the second argument" in {
+      inside(cpg.call.nameExact(Operators.cast).argument(2).l) { case (x: Identifier) :: Nil =>
+        x.name shouldBe "x"
+        x.typeFullName shouldBe "i32"
+      }
+    }
+  }
+
+  "a single index expression" should {
+    val cpg = code("""
+        |fn foo(xs: Vec<i32>, i: usize) -> i32 {
+        | xs[i]
+        |}
+        |""".stripMargin)
+
+    "lower to an indexAccess call with the element type as typeFullName" in {
+      inside(cpg.call.nameExact(Operators.indexAccess).l) { case indexAccess :: Nil =>
+        indexAccess.code shouldBe "xs[i]"
+        indexAccess.methodFullName shouldBe Operators.indexAccess
+        indexAccess.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+        indexAccess.typeFullName shouldBe "i32"
+      }
+    }
+
+    // TODO (rust_ast_gen): confirm why it doesn't have a type
+    "have the base as the first argument" in {
+      inside(cpg.call.nameExact(Operators.indexAccess).argument(1).l) { case (xs: Identifier) :: Nil =>
+        xs.name shouldBe "xs"
+        xs.typeFullName shouldBe Defines.Any
+      }
+    }
+
+    "have the index as the second argument" in {
+      inside(cpg.call.nameExact(Operators.indexAccess).argument(2).l) { case (i: Identifier) :: Nil =>
+        i.name shouldBe "i"
+        i.typeFullName shouldBe "usize"
+      }
+    }
+  }
+
+  "a nested index expression" should {
+    val cpg = code("""
+        |fn foo(xs: Vec<Vec<i32>>, i: usize, j: usize) -> i32 {
+        | xs[i][j]
+        |}
+        |""".stripMargin)
+
+    "lower to two indexAccess calls" in {
+      cpg.call.nameExact(Operators.indexAccess).code.toSet shouldBe Set("xs[i]", "xs[i][j]")
+    }
+
+    "have an i32 typeFullName for the outer indexAccess" in {
+      cpg.call.nameExact(Operators.indexAccess).codeExact("xs[i][j]").typeFullName.l shouldBe List("i32")
+    }
+
+    // TODO (rust_ast_gen): confirm that no type for the inner is to be expected
+    "have Any as typeFullName for the inner indexAccess" in {
+      cpg.call.nameExact(Operators.indexAccess).codeExact("xs[i]").typeFullName.l shouldBe List(Defines.Any)
+    }
+
+    "have the inner indexAccess as the first argument of the outer indexAccess" in {
+      inside(cpg.call.nameExact(Operators.indexAccess).codeExact("xs[i][j]").argument(1).l) {
+        case (inner: Call) :: Nil =>
+          inner.name shouldBe Operators.indexAccess
+          inner.code shouldBe "xs[i]"
+      }
+    }
+
+    "have the index as the second argument of the outer indexAccess" in {
+      inside(cpg.call.nameExact(Operators.indexAccess).codeExact("xs[i][j]").argument(2).l) {
+        case (j: Identifier) :: Nil =>
+          j.name shouldBe "j"
+          j.typeFullName shouldBe "usize"
+      }
+    }
+  }
+
+  "unary operators" should {
+    val cpg = code("""
+        |fn main(x: i32, b: bool, p: *const i32) {
+        | let a = -x;
+        | let c = !b;
+        | let d = *p;
+        |}
+        |""".stripMargin)
+
+    "lower `-x` to a minus call with i32 typeFullName" in {
+      inside(cpg.call.nameExact(Operators.minus).l) { case minus :: Nil =>
+        minus.code shouldBe "-x"
+        minus.methodFullName shouldBe Operators.minus
+        minus.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+        minus.typeFullName shouldBe "i32"
+      }
+    }
+
+    "have the i32 operand as the argument of `-x`" in {
+      inside(cpg.call.nameExact(Operators.minus).argument.l) { case (x: Identifier) :: Nil =>
+        x.name shouldBe "x"
+        x.typeFullName shouldBe "i32"
+      }
+    }
+
+    "lower `!b` to a logicalNot call with bool typeFullName" in {
+      inside(cpg.call.nameExact(Operators.logicalNot).l) { case logicalNot :: Nil =>
+        logicalNot.code shouldBe "!b"
+        logicalNot.methodFullName shouldBe Operators.logicalNot
+        logicalNot.typeFullName shouldBe "bool"
+      }
+    }
+
+    "have the bool operand as the argument of `!b`" in {
+      inside(cpg.call.nameExact(Operators.logicalNot).argument.l) { case (b: Identifier) :: Nil =>
+        b.name shouldBe "b"
+        b.typeFullName shouldBe "bool"
+      }
+    }
+
+    "lower `*p` to an indirection call with i32 typeFullName" in {
+      inside(cpg.call.nameExact(Operators.indirection).l) { case indirection :: Nil =>
+        indirection.code shouldBe "*p"
+        indirection.methodFullName shouldBe Operators.indirection
+        indirection.typeFullName shouldBe "i32"
+      }
+    }
+
+    "have the pointer operand as the argument of `*p`" in {
+      inside(cpg.call.nameExact(Operators.indirection).argument.l) { case (p: Identifier) :: Nil =>
+        p.name shouldBe "p"
+        p.typeFullName shouldBe "*const i32"
+      }
+    }
+  }
+
+  "nested arithmetic and comparison operators" should {
+    val cpg = code("""
+        |fn main(x: i32, y: i32) -> bool {
+        | (x + y) > 0
+        |}
+        |""".stripMargin)
+
+    "have an i32 typeFullName for the addition" in {
+      cpg.call.nameExact(Operators.addition).typeFullName.l shouldBe List("i32")
+    }
+
+    "have a bool typeFullName for the comparison" in {
+      cpg.call.nameExact(Operators.greaterThan).typeFullName.l shouldBe List("bool")
+    }
+  }
+}

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -1,154 +1,11 @@
 package io.joern.rust2cpg.passes.ast
 
 import io.joern.rust2cpg.testfixtures.Rust2CpgSuite
-import io.joern.x2cpg.Defines
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.*
 import io.shiftleft.semanticcpg.language.*
-import io.shiftleft.semanticcpg.utils.FileUtil.*
-
-import java.nio.file.Paths
 
 class SimpleAstCreationPassTest extends Rust2CpgSuite {
-
-  "test 05" in {
-    val cpg = code("const MAX_SIZE: usize = 1024;")
-    cpg.local.name("MAX_SIZE").typeFullName.l shouldBe List("usize")
-
-    inside(cpg.assignment.l) { case assignment :: Nil =>
-      assignment.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-      assignment.code shouldBe "const MAX_SIZE: usize = 1024;"
-      assignment.typeFullName shouldBe Defines.Any
-      assignment.methodFullName shouldBe Operators.assignment
-    }
-
-    inside(cpg.assignment.argument(1).l) { case (lhs: Identifier) :: Nil =>
-      lhs.name shouldBe "MAX_SIZE"
-      lhs.typeFullName shouldBe "usize"
-      lhs.code shouldBe "MAX_SIZE"
-    }
-
-    inside(cpg.assignment.argument(2).l) { case (rhs: Literal) :: Nil =>
-      rhs.code shouldBe "1024"
-      rhs.typeFullName shouldBe "i32"
-    }
-  }
-
-  "test 06" in {
-    val cpg = code("""
-        |fn main() {
-        | const FOO: i32 = 0;
-        |}
-        |""".stripMargin)
-
-    inside(cpg.method.name("main").block.local.name("FOO").l) { case local :: Nil =>
-      local.typeFullName shouldBe "i32"
-      local.code shouldBe "FOO"
-    }
-
-    inside(cpg.method.name("main").block.assignment.l) { case assignment :: Nil =>
-      assignment.code shouldBe "const FOO: i32 = 0;"
-      assignment.lineNumber shouldBe Some(3)
-    }
-
-    inside(cpg.assignment.argument(1).l) { case (lhs: Identifier) :: Nil =>
-      lhs.name shouldBe "FOO"
-      lhs.typeFullName shouldBe "i32"
-      lhs.code shouldBe "FOO"
-    }
-
-    inside(cpg.assignment.argument(2).l) { case (rhs: Literal) :: Nil =>
-      rhs.code shouldBe "0"
-      rhs.typeFullName shouldBe "i32"
-    }
-  }
-
-  "test 07" in {
-    val cpg = code("""
-        |fn main(x: i32) {
-        | let y = x as i64;
-        |}
-        |""".stripMargin)
-
-    inside(cpg.call.nameExact(Operators.cast).l) { case cast :: Nil =>
-      cast.code shouldBe "x as i64"
-      cast.methodFullName shouldBe Operators.cast
-      cast.typeFullName shouldBe "i64"
-
-      inside(cast.argument.l) { case (typeRef: TypeRef) :: (identifier: Identifier) :: Nil =>
-        typeRef.code shouldBe "i64"
-        typeRef.typeFullName shouldBe "i64"
-        identifier.name shouldBe "x"
-        identifier.code shouldBe "x"
-      }
-    }
-  }
-
-  "test 08" in {
-    val cpg = code("""
-        |fn main() {
-        | let x = 1;
-        |}
-        |""".stripMargin)
-
-    inside(cpg.method.name("main").block.local.name("x").l) { case local :: Nil =>
-      local.typeFullName shouldBe Defines.Any
-      local.code shouldBe "x"
-    }
-
-    inside(cpg.method.name("main").block.assignment.l) { case assignment :: Nil =>
-      assignment.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-      assignment.code shouldBe "let x = 1;"
-      assignment.typeFullName shouldBe Defines.Any
-      assignment.methodFullName shouldBe Operators.assignment
-      assignment.lineNumber shouldBe Some(3)
-    }
-
-    inside(cpg.assignment.argument(1).l) { case (lhs: Identifier) :: Nil =>
-      lhs.name shouldBe "x"
-      // TODO
-      lhs.typeFullName shouldBe Defines.Any
-      lhs.code shouldBe "x"
-    }
-
-    inside(cpg.assignment.argument(2).l) { case (rhs: Literal) :: Nil =>
-      rhs.code shouldBe "1"
-      rhs.typeFullName shouldBe "i32"
-    }
-  }
-
-  "test 10" in {
-    val cpg = code("""
-        |fn foo() {
-        | let x: usize = 10;
-        |}
-        |""".stripMargin)
-
-    inside(cpg.method.name("foo").block.local.name("x").l) { case local :: Nil =>
-      local.typeFullName shouldBe "usize"
-      local.code shouldBe "x"
-    }
-
-    inside(cpg.assignment.argument(1).l) { case (lhs: Identifier) :: Nil =>
-      lhs.name shouldBe "x"
-      lhs.typeFullName shouldBe "usize"
-      lhs.code shouldBe "x"
-    }
-
-    inside(cpg.assignment.argument(2).l) { case (lit: Literal) :: Nil =>
-      lit.code shouldBe "10"
-      lit.typeFullName shouldBe "i32"
-    }
-  }
-
-  "test 11" in {
-    val cpg = code("const TT: bool = true; const FF: bool = false;")
-
-    cpg.literal.code("true").typeFullName.l shouldBe List("bool")
-    cpg.literal.code("false").typeFullName.l shouldBe List("bool")
-  }
-
-  //
 
   "test 12" in {
     val cpg = code("""
@@ -295,86 +152,6 @@ class SimpleAstCreationPassTest extends Rust2CpgSuite {
     }
   }
 
-  "test 19" in {
-    val cpg = code("""
-        |fn gtz(x: i32) -> bool {
-        | x > 0
-        |}
-        |
-        |fn foo() -> bool {
-        | gtz(10)
-        |}
-        |""".stripMargin)
-
-    inside(cpg.call.name("gtz").l) { case gtz :: Nil =>
-      gtz.code shouldBe "gtz(10)"
-      // TODO gtz.methodFullName shouldBe
-      inside(gtz.argument.l) { case (lit: Literal) :: Nil =>
-        lit.code shouldBe "10"
-        lit.argumentIndex shouldBe 1
-        lit.typeFullName shouldBe "i32"
-      }
-    }
-  }
-
-  "test 20" in {
-    val cpg = code("""
-        |fn main() {
-        | foo::<u32>();
-        |}
-        |""".stripMargin)
-
-    inside(cpg.call.name("foo").l) { case foo :: Nil =>
-      foo.code shouldBe "foo::<u32>()"
-      foo.methodFullName shouldBe s"${Defines.UnresolvedNamespace}::foo"
-      foo.argument shouldBe empty
-    }
-  }
-
-  "test 21" in {
-    val cpg = code("""
-        |fn foo(xs: Vec<i32>, i: usize) -> i32 {
-        | xs[i]
-        |}
-        |""".stripMargin)
-
-    inside(cpg.call.nameExact(Operators.indexAccess).l) { case indexAccess :: Nil =>
-      indexAccess.code shouldBe "xs[i]"
-      indexAccess.methodFullName shouldBe Operators.indexAccess
-      indexAccess.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-
-      inside(indexAccess.argument.l) { case base :: index :: Nil =>
-        base.code shouldBe "xs"
-        base.argumentIndex shouldBe 1
-        index.code shouldBe "i"
-        index.argumentIndex shouldBe 2
-      }
-    }
-  }
-
-  "test 22" in {
-    val cpg = code("""
-        |fn foo(xs: Vec<Vec<i32>>, i: usize, j: usize) -> i32 {
-        | xs[i][j]
-        |}
-        |""".stripMargin)
-
-    inside(cpg.call.nameExact(Operators.indexAccess).l.sortBy(_.code.length)) { case inner :: outer :: Nil =>
-      inner.code shouldBe "xs[i]"
-      outer.code shouldBe "xs[i][j]"
-
-      inside(outer.argument.l) { case (innerArg: Call) :: (indexArg: Identifier) :: Nil =>
-        innerArg shouldBe inner
-        innerArg.argumentIndex shouldBe 1
-        // TODO: innerArg.typeFullName shouldBe
-
-        indexArg.code shouldBe "j"
-        indexArg.argumentIndex shouldBe 2
-      // TODO: indexArg.typeFullName shouldBe
-      }
-    }
-  }
-
   "test 23" in {
     val cpg = code("""
         |struct Point {
@@ -464,113 +241,6 @@ class SimpleAstCreationPassTest extends Rust2CpgSuite {
     }
   }
 
-  "test 30" in {
-    val cpg = code("""
-        |fn foo(xs: Vec<i32>) {
-        | xs.push(1);
-        |}
-        |""".stripMargin)
-
-    inside(cpg.call.nameExact("push").l) { case push :: Nil =>
-      push.code shouldBe "xs.push(1)"
-      // TODO push.methodFullName shouldBe
-      push.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-      // TODO push.typeFullName shouldBe
-
-      inside(push.receiver.l) { case (receiver: Identifier) :: Nil =>
-        receiver.code shouldBe "xs"
-        receiver.argumentIndex shouldBe 0
-      // TODO receiver.typeFullName shouldBe
-      }
-
-      inside(push.argument.l) { case (receiver: Identifier) :: (lit: Literal) :: Nil =>
-        receiver shouldBe push.receiver.head
-
-        lit.code shouldBe "1"
-        lit.argumentIndex shouldBe 1
-        lit.typeFullName shouldBe "i32"
-      }
-    }
-  }
-
-  "test 31" in {
-    val cpg = code("""
-        |fn foo() {
-        | String::from(" hello ").trim().to_string();
-        |}
-        |""".stripMargin)
-
-    inside(cpg.call.nameExact("trim").l) { case trim :: Nil =>
-      trim.code shouldBe """String::from(" hello ").trim()"""
-      trim.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-      trim.arguments(1) shouldBe empty
-      // TODO trim.methodFullName shouldBe
-
-      inside(trim.receiver.l) { case (from: Call) :: Nil =>
-        from.name shouldBe "from"
-        from.code shouldBe """String::from(" hello ")"""
-        from.argumentIndex shouldBe 0
-      }
-    }
-
-    inside(cpg.call.nameExact("to_string").l) { case toString :: Nil =>
-      toString.code shouldBe """String::from(" hello ").trim().to_string()"""
-      toString.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-      toString.arguments(1) shouldBe empty
-      // TODO toString.methodFullName shouldBe
-
-      inside(toString.receiver.l) { case (trim: Call) :: Nil =>
-        trim.name shouldBe "trim"
-        trim.code shouldBe """String::from(" hello ").trim()"""
-        trim.argumentIndex shouldBe 0
-      }
-    }
-  }
-
-  "test 32" in {
-    val cpg = code("""
-        |fn main(x: i32, b: bool, p: *const i32) {
-        | let a = -x;
-        | let c = !b;
-        | let d = *p;
-        |}
-        |""".stripMargin)
-
-    inside(cpg.call.nameExact(Operators.minus).l) { case minus :: Nil =>
-      minus.code shouldBe "-x"
-      minus.methodFullName shouldBe Operators.minus
-      minus.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-
-      inside(minus.argument.l) { case (x: Identifier) :: Nil =>
-        x.code shouldBe "x"
-        x.argumentIndex shouldBe 1
-      // TODO x.typeFullName shouldBe
-      }
-    }
-
-    inside(cpg.call.nameExact(Operators.logicalNot).l) { case logicalNot :: Nil =>
-      logicalNot.code shouldBe "!b"
-      logicalNot.methodFullName shouldBe Operators.logicalNot
-
-      inside(logicalNot.argument.l) { case (b: Identifier) :: Nil =>
-        b.code shouldBe "b"
-        b.argumentIndex shouldBe 1
-      // TODO b.typeFullName shouldBe
-      }
-    }
-
-    inside(cpg.call.nameExact(Operators.indirection).l) { case indirection :: Nil =>
-      indirection.code shouldBe "*p"
-      indirection.methodFullName shouldBe Operators.indirection
-
-      inside(indirection.argument.l) { case (p: Identifier) :: Nil =>
-        p.code shouldBe "p"
-        p.argumentIndex shouldBe 1
-      // TODO p.typeFullName shouldBe
-      }
-    }
-  }
-
   "test 33" in {
     val cpg = code("""
         |fn main(b: bool) {
@@ -585,10 +255,10 @@ class SimpleAstCreationPassTest extends Rust2CpgSuite {
         condition.code shouldBe "!b"
         condition.name shouldBe Operators.logicalNot
         condition.methodFullName shouldBe Operators.logicalNot
-        // TODO condition.typeFullName shouldBe "bool"
+        condition.typeFullName shouldBe "bool"
 
         inside(condition.argument.l) { case (b: Identifier) :: Nil =>
-          // TODO b.typeFullName shouldBe "bool"
+          b.typeFullName shouldBe "bool"
           b.code shouldBe "b"
           b.name shouldBe b.code
         }


### PR DESCRIPTION
Split of #5971 with only typeFullNames + test cleanups.

* In general, calls are STATIC_DISPATCH even when they are methods, since that's what's faithful. `dyn SomeType` would be DYNAMIC_DISPATCH, but I haven't tackled those yet. So, currently, only unresolved methods are DYNAMIC_DISPATCH.
* Some `typeFullName` are missing in this PR, viz. `typeFullNameForNameRef` and `typeFullNameForType`, but it's already a 500+ line diff.