### PR TITLE
[x2cpg] Refactor for consistency and concurrency safety

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/Ast.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/Ast.scala
@@ -64,16 +64,16 @@ object Ast {
     * child among its siblings.
     */
   private def setOrderWhereNotSet(ast: Ast): Unit = {
-    ast.root.collect { case r: AstNodeNew =>
-      if (r.order == PropertyDefaults.Order) {
-        r.order = 1
+    ast.root.collect { case rootNode: AstNodeNew =>
+      if (rootNode.order == PropertyDefaults.Order) {
+        rootNode.order = 1
       }
     }
     val siblings = ast.edges.groupBy(_.src).map { case (_, edgeToChild) => edgeToChild.map(_.dst) }
     siblings.foreach { children =>
-      children.zipWithIndex.collect { case (c: AstNodeNew, i) =>
-        if (c.order == PropertyDefaults.Order) {
-          c.order = i + 1
+      children.zipWithIndex.collect { case (child: AstNodeNew, index) =>
+        if (child.order == PropertyDefaults.Order) {
+          child.order = index + 1
         }
       }
     }
@@ -110,10 +110,10 @@ case class Ast(
   /** AST that results when adding `other` as a child to this AST. `other` is connected to this AST's root node.
     */
   def withChild(other: Ast): Ast = {
-    val newAstEdges = edges ++ other.edges ++ root.toList.flatMap(r =>
-      other.root.toList.map { rc =>
-        Ast.neighbourValidation(r, rc, EdgeTypes.AST)
-        AstEdge(r, rc)
+    val newAstEdges = edges ++ other.edges ++ root.toList.flatMap(thisRoot =>
+      other.root.toList.map { otherRoot =>
+        Ast.neighbourValidation(thisRoot, otherRoot, EdgeTypes.AST)
+        AstEdge(thisRoot, otherRoot)
       }
     )
     mergedWith(other, newAstEdges)
@@ -153,7 +153,7 @@ case class Ast(
       // we do this iteratively as a recursive solution which will fail with
       // a StackOverflowException if there are too many elements in .tail.
       var ast = withChild(asts.head)
-      asts.tail.foreach(c => ast = ast.withChild(c))
+      asts.tail.foreach(child => ast = ast.withChild(child))
       ast
     }
   }
@@ -288,8 +288,8 @@ case class Ast(
     */
   def subTreeCopy(node: AstNodeNew, argIndex: Int = -1, replacementNode: Option[AstNodeNew] = None): Ast = {
     val newNode = replacementNode match {
-      case Some(n) => n
-      case None    => node.copy
+      case Some(replacement) => replacement
+      case None              => node.copy
     }
     if (argIndex != -1) {
       newNode match {
@@ -299,14 +299,14 @@ case class Ast(
     }
 
     val astChildren = edges.filter(_.src == node).map(_.dst)
-    val newChildren = astChildren.map { x =>
-      this.subTreeCopy(x.asInstanceOf[AstNodeNew])
+    val newChildren = astChildren.map { oldChild =>
+      this.subTreeCopy(oldChild.asInstanceOf[AstNodeNew])
     }
 
-    val oldToNew                = astChildren.zip(newChildren).map { case (old, n) => old -> n.root.get }.toMap
-    def newIfExists(x: NewNode) = oldToNew.getOrElse(x, x)
+    val oldToNew = astChildren.zip(newChildren).map { case (old, newChild) => old -> newChild.root.get }.toMap
+    def newIfExists(oldNode: NewNode) = oldToNew.getOrElse(oldNode, oldNode)
     def remap(in: collection.Seq[AstEdge]): collection.Seq[AstEdge] =
-      in.filter(_.src == node).map(x => AstEdge(newNode, newIfExists(x.dst)))
+      in.filter(_.src == node).map(edge => AstEdge(newNode, newIfExists(edge.dst)))
 
     Ast(newNode)
       .copy(

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/Ast.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/Ast.scala
@@ -17,65 +17,35 @@ object Ast {
   def apply(node: NewNode)(implicit withSchemaValidation: ValidationMode): Ast = Ast(Vector.empty :+ node)
   def apply()(implicit withSchemaValidation: ValidationMode): Ast              = new Ast(Vector.empty)
 
+  /** Single source of truth for the non-AST edge collections carried by `Ast`. Each entry pairs the wire-level edge
+    * label with a getter for the corresponding edge collection on an `Ast` instance.
+    */
+  private[x2cpg] val typedEdgeKinds: Seq[(String, Ast => collection.Seq[AstEdge])] = Seq(
+    EdgeTypes.CONDITION    -> (_.conditionEdges),
+    EdgeTypes.TRUE_BODY    -> (_.trueBodyEdges),
+    EdgeTypes.FALSE_BODY   -> (_.falseBodyEdges),
+    EdgeTypes.DO_BODY      -> (_.doBodyEdges),
+    EdgeTypes.TRY_BODY     -> (_.tryBodyEdges),
+    EdgeTypes.CATCH_BODY   -> (_.catchBodyEdges),
+    EdgeTypes.FINALLY_BODY -> (_.finallyBodyEdges),
+    EdgeTypes.FOR_INIT     -> (_.forInitEdges),
+    EdgeTypes.FOR_UPDATE   -> (_.forUpdateEdges),
+    EdgeTypes.FOR_BODY     -> (_.forBodyEdges),
+    EdgeTypes.RECEIVER     -> (_.receiverEdges),
+    EdgeTypes.REF          -> (_.refEdges),
+    EdgeTypes.ARGUMENT     -> (_.argEdges),
+    EdgeTypes.BINDS        -> (_.bindsEdges),
+    EdgeTypes.CAPTURE      -> (_.captureEdges)
+  )
+
   /** Copy nodes/edges of given `AST` into the given `diffGraph`.
     */
   def storeInDiffGraph(ast: Ast, diffGraph: DiffGraphBuilder): Unit = {
-
     setOrderWhereNotSet(ast)
-
-    ast.nodes.foreach { node =>
-      diffGraph.addNode(node)
-    }
-    ast.edges.foreach { edge =>
-      diffGraph.addEdge(edge.src, edge.dst, EdgeTypes.AST)
-    }
-    ast.conditionEdges.foreach { edge =>
-      diffGraph.addEdge(edge.src, edge.dst, EdgeTypes.CONDITION)
-    }
-    ast.trueBodyEdges.foreach { edge =>
-      diffGraph.addEdge(edge.src, edge.dst, EdgeTypes.TRUE_BODY)
-    }
-    ast.falseBodyEdges.foreach { edge =>
-      diffGraph.addEdge(edge.src, edge.dst, EdgeTypes.FALSE_BODY)
-    }
-    ast.doBodyEdges.foreach { edge =>
-      diffGraph.addEdge(edge.src, edge.dst, EdgeTypes.DO_BODY)
-    }
-    ast.tryBodyEdges.foreach { edge =>
-      diffGraph.addEdge(edge.src, edge.dst, EdgeTypes.TRY_BODY)
-    }
-    ast.catchBodyEdges.foreach { edge =>
-      diffGraph.addEdge(edge.src, edge.dst, EdgeTypes.CATCH_BODY)
-    }
-    ast.finallyBodyEdges.foreach { edge =>
-      diffGraph.addEdge(edge.src, edge.dst, EdgeTypes.FINALLY_BODY)
-    }
-    ast.forInitEdges.foreach { edge =>
-      diffGraph.addEdge(edge.src, edge.dst, EdgeTypes.FOR_INIT)
-    }
-    ast.forUpdateEdges.foreach { edge =>
-      diffGraph.addEdge(edge.src, edge.dst, EdgeTypes.FOR_UPDATE)
-    }
-    ast.forBodyEdges.foreach { edge =>
-      diffGraph.addEdge(edge.src, edge.dst, EdgeTypes.FOR_BODY)
-    }
-    ast.receiverEdges.foreach { edge =>
-      diffGraph.addEdge(edge.src, edge.dst, EdgeTypes.RECEIVER)
-    }
-    ast.refEdges.foreach { edge =>
-      diffGraph.addEdge(edge.src, edge.dst, EdgeTypes.REF)
-    }
-
-    ast.argEdges.foreach { edge =>
-      diffGraph.addEdge(edge.src, edge.dst, EdgeTypes.ARGUMENT)
-    }
-
-    ast.bindsEdges.foreach { edge =>
-      diffGraph.addEdge(edge.src, edge.dst, EdgeTypes.BINDS)
-    }
-
-    ast.captureEdges.foreach { edge =>
-      diffGraph.addEdge(edge.src, edge.dst, EdgeTypes.CAPTURE)
+    ast.nodes.foreach(diffGraph.addNode)
+    ast.edges.foreach(edge => diffGraph.addEdge(edge.src, edge.dst, EdgeTypes.AST))
+    typedEdgeKinds.foreach { case (label, getter) =>
+      getter(ast).foreach(edge => diffGraph.addEdge(edge.src, edge.dst, label))
     }
   }
 
@@ -140,36 +110,21 @@ case class Ast(
   /** AST that results when adding `other` as a child to this AST. `other` is connected to this AST's root node.
     */
   def withChild(other: Ast): Ast = {
-    Ast(
-      nodes ++ other.nodes,
-      edges = edges ++ other.edges ++ root.toList.flatMap(r =>
-        other.root.toList.map { rc =>
-          Ast.neighbourValidation(r, rc, EdgeTypes.AST)
-          AstEdge(r, rc)
-        }
-      ),
-      conditionEdges = conditionEdges ++ other.conditionEdges,
-      trueBodyEdges = trueBodyEdges ++ other.trueBodyEdges,
-      falseBodyEdges = falseBodyEdges ++ other.falseBodyEdges,
-      doBodyEdges = doBodyEdges ++ other.doBodyEdges,
-      tryBodyEdges = tryBodyEdges ++ other.tryBodyEdges,
-      catchBodyEdges = catchBodyEdges ++ other.catchBodyEdges,
-      finallyBodyEdges = finallyBodyEdges ++ other.finallyBodyEdges,
-      forInitEdges = forInitEdges ++ other.forInitEdges,
-      forUpdateEdges = forUpdateEdges ++ other.forUpdateEdges,
-      forBodyEdges = forBodyEdges ++ other.forBodyEdges,
-      argEdges = argEdges ++ other.argEdges,
-      receiverEdges = receiverEdges ++ other.receiverEdges,
-      refEdges = refEdges ++ other.refEdges,
-      bindsEdges = bindsEdges ++ other.bindsEdges,
-      captureEdges = captureEdges ++ other.captureEdges
+    val newAstEdges = edges ++ other.edges ++ root.toList.flatMap(r =>
+      other.root.toList.map { rc =>
+        Ast.neighbourValidation(r, rc, EdgeTypes.AST)
+        AstEdge(r, rc)
+      }
     )
+    mergedWith(other, newAstEdges)
   }
 
-  def merge(other: Ast): Ast = {
+  def merge(other: Ast): Ast = mergedWith(other, edges ++ other.edges)
+
+  private def mergedWith(other: Ast, newAstEdges: collection.Seq[AstEdge]): Ast = {
     Ast(
       nodes ++ other.nodes,
-      edges = edges ++ other.edges,
+      edges = newAstEdges,
       conditionEdges = conditionEdges ++ other.conditionEdges,
       trueBodyEdges = trueBodyEdges ++ other.trueBodyEdges,
       falseBodyEdges = falseBodyEdges ++ other.falseBodyEdges,
@@ -293,16 +248,8 @@ case class Ast(
     })
   }
   private def addArgumentIndex(node: NewNode, argIndex: Int): Unit = node match {
-    case n: NewBlock            => n.argumentIndex = argIndex
-    case n: NewCall             => n.argumentIndex = argIndex
-    case n: NewFieldIdentifier  => n.argumentIndex = argIndex
-    case n: NewIdentifier       => n.argumentIndex = argIndex
-    case n: NewMethodRef        => n.argumentIndex = argIndex
-    case n: NewTypeRef          => n.argumentIndex = argIndex
-    case n: NewUnknown          => n.argumentIndex = argIndex
-    case n: NewControlStructure => n.argumentIndex = argIndex
-    case n: NewLiteral          => n.argumentIndex = argIndex
-    case n: NewReturn           => n.argumentIndex = argIndex
+    case expr: ExpressionNew => expr.argumentIndex = argIndex
+    case _                   =>
   }
 
   def withConditionEdges(src: NewNode, dsts: List[NewNode]): Ast = {
@@ -356,44 +303,28 @@ case class Ast(
       this.subTreeCopy(x.asInstanceOf[AstNodeNew])
     }
 
-    val oldToNew = astChildren.zip(newChildren).map { case (old, n) => old -> n.root.get }.toMap
-    def newIfExists(x: NewNode) = {
-      oldToNew.getOrElse(x, x)
-    }
-
-    val newArgEdges       = argEdges.filter(_.src == node).map(x => AstEdge(newNode, newIfExists(x.dst)))
-    val newConditionEdges = conditionEdges.filter(_.src == node).map(x => AstEdge(newNode, newIfExists(x.dst)))
-    val newTrueBodyEdges  = trueBodyEdges.filter(_.src == node).map(x => AstEdge(newNode, newIfExists(x.dst)))
-    val newFalseBodyEdges = falseBodyEdges.filter(_.src == node).map(x => AstEdge(newNode, newIfExists(x.dst)))
-    val newDoBodyEdges    = doBodyEdges.filter(_.src == node).map(x => AstEdge(newNode, newIfExists(x.dst)))
-    val newTryBodyEdges   = tryBodyEdges.filter(_.src == node).map(x => AstEdge(newNode, newIfExists(x.dst)))
-    val newCatchBodyEdges = catchBodyEdges.filter(_.src == node).map(x => AstEdge(newNode, newIfExists(x.dst)))
-    val newFinallyEdges   = finallyBodyEdges.filter(_.src == node).map(x => AstEdge(newNode, newIfExists(x.dst)))
-    val newForInitEdges   = forInitEdges.filter(_.src == node).map(x => AstEdge(newNode, newIfExists(x.dst)))
-    val newForUpdateEdges = forUpdateEdges.filter(_.src == node).map(x => AstEdge(newNode, newIfExists(x.dst)))
-    val newForBodyEdges   = forBodyEdges.filter(_.src == node).map(x => AstEdge(newNode, newIfExists(x.dst)))
-    val newRefEdges       = refEdges.filter(_.src == node).map(x => AstEdge(newNode, newIfExists(x.dst)))
-    val newBindsEdges     = bindsEdges.filter(_.src == node).map(x => AstEdge(newNode, newIfExists(x.dst)))
-    val newReceiverEdges  = receiverEdges.filter(_.src == node).map(x => AstEdge(newNode, newIfExists(x.dst)))
-    val newCaptureEdges   = captureEdges.filter(_.src == node).map(x => AstEdge(newNode, newIfExists(x.dst)))
+    val oldToNew                = astChildren.zip(newChildren).map { case (old, n) => old -> n.root.get }.toMap
+    def newIfExists(x: NewNode) = oldToNew.getOrElse(x, x)
+    def remap(in: collection.Seq[AstEdge]): collection.Seq[AstEdge] =
+      in.filter(_.src == node).map(x => AstEdge(newNode, newIfExists(x.dst)))
 
     Ast(newNode)
       .copy(
-        argEdges = newArgEdges,
-        conditionEdges = newConditionEdges,
-        trueBodyEdges = newTrueBodyEdges,
-        falseBodyEdges = newFalseBodyEdges,
-        doBodyEdges = newDoBodyEdges,
-        tryBodyEdges = newTryBodyEdges,
-        catchBodyEdges = newCatchBodyEdges,
-        finallyBodyEdges = newFinallyEdges,
-        forInitEdges = newForInitEdges,
-        forUpdateEdges = newForUpdateEdges,
-        forBodyEdges = newForBodyEdges,
-        refEdges = newRefEdges,
-        bindsEdges = newBindsEdges,
-        receiverEdges = newReceiverEdges,
-        captureEdges = newCaptureEdges
+        argEdges = remap(argEdges),
+        conditionEdges = remap(conditionEdges),
+        trueBodyEdges = remap(trueBodyEdges),
+        falseBodyEdges = remap(falseBodyEdges),
+        doBodyEdges = remap(doBodyEdges),
+        tryBodyEdges = remap(tryBodyEdges),
+        catchBodyEdges = remap(catchBodyEdges),
+        finallyBodyEdges = remap(finallyBodyEdges),
+        forInitEdges = remap(forInitEdges),
+        forUpdateEdges = remap(forUpdateEdges),
+        forBodyEdges = remap(forBodyEdges),
+        refEdges = remap(refEdges),
+        bindsEdges = remap(bindsEdges),
+        receiverEdges = remap(receiverEdges),
+        captureEdges = remap(captureEdges)
       )
       .withChildren(newChildren)
   }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstNodeBuilder.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstNodeBuilder.scala
@@ -224,7 +224,7 @@ trait AstNodeBuilder[Node, NodeProcessor] { this: NodeProcessor =>
       .evaluationStrategy(evaluationStrategy)
       .lineNumber(line(node))
       .columnNumber(column(node))
-      .typeFullName(typeFullName.getOrElse("ANY"))
+      .typeFullName(typeFullName.getOrElse(Defines.Any))
       .dynamicTypeHintFullName(dynamicTypeHintFullName)
     setOffset(node, node_)
   }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/datastructures/VariableScopeManager.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/datastructures/VariableScopeManager.scala
@@ -39,6 +39,23 @@ object VariableScopeManager {
     case MethodScope, BlockScope, TypeDeclScope
   }
 
+  /** Result of one iteration of the link-creation loop in `createVariableReferenceLinks`.
+    *
+    * Encoding the three outcomes as an ADT makes the loop's invariant structural: every iteration that adds a REF edge
+    * either terminates the chain (`Terminate`) or names the next reference to chain from (`Capture`).
+    */
+  private enum LinkStep {
+
+    /** Add a REF edge from the current reference to `target` and stop walking the scope stack. */
+    case Terminate(target: NewNode)
+
+    /** Add a REF edge from the current reference to `target` and continue walking from `next`. */
+    case Capture(target: NewNode, next: NewNode)
+
+    /** Add no edge and continue walking the scope stack. */
+    case Skip
+  }
+
   /** Case class representing a method scope element.
     *
     * @param methodFullName
@@ -319,45 +336,60 @@ class VariableScopeManager {
     val capturedLocals     = mutable.HashMap.empty[String, NewNode]
 
     resolvedReferences.foreach { case VariableScopeManager.ResolvedReference(variableNodeId, origin) =>
-      var nextReference: NewNode                  = null
       var maybeScopeElement: Option[ScopeElement] = origin.stack
       var currentReference: NewNode               = origin.referenceNode
       var done: Boolean                           = false
       while (!done) {
-        val localOrCapturedLocalNodeOption =
-          if (maybeScopeElement.exists(_.nameToVariableNode.contains(origin.variableName))) {
+        val step = nextLinkStep(diffGraph, filename, capturedLocals, variableNodeId, origin, maybeScopeElement)
+        step match {
+          case LinkStep.Terminate(target) =>
+            transferLineAndColumnInfo(currentReference, target)
+            diffGraph.addEdge(currentReference, target, EdgeTypes.REF)
             done = true
-            Option(variableNodeId)
-          } else {
-            maybeScopeElement.flatMap {
-              case methodScope: VariableScopeManager.MethodScopeElement if methodScope.needsEnclosingScope =>
-                maybeScopeElement = getEnclosingMethodScopeElement(maybeScopeElement)
-                None
-              case methodScope: VariableScopeManager.MethodScopeElement =>
-                val prefix = if (methodScope.methodFullName.startsWith(filename)) { "" }
-                else { s"$filename:" }
-                val id = s"$prefix${methodScope.methodFullName}:${origin.variableName}"
-                capturedLocals.updateWith(id) {
-                  case None =>
-                    val closureBinding = closureBindingNode(id, origin.evaluationStrategy)
-                    methodScope.capturingRefNode.foreach(diffGraph.addEdge(_, closureBinding, EdgeTypes.CAPTURE))
-                    nextReference = closureBinding
-                    val localNode = createLocalForUnresolvedReference(diffGraph, methodScope.scopeNode, origin)
-                    Option(localNode.closureBindingId(id))
-                  case someLocalNode =>
-                    done = true
-                    someLocalNode
-                }
-              case _ => None
-            }
-          }
-
-        localOrCapturedLocalNodeOption.foreach { localOrCapturedLocalNode =>
-          transferLineAndColumnInfo(currentReference, localOrCapturedLocalNode)
-          diffGraph.addEdge(currentReference, localOrCapturedLocalNode, EdgeTypes.REF)
-          currentReference = nextReference
+          case LinkStep.Capture(target, next) =>
+            transferLineAndColumnInfo(currentReference, target)
+            diffGraph.addEdge(currentReference, target, EdgeTypes.REF)
+            currentReference = next
+          case LinkStep.Skip =>
         }
         maybeScopeElement = maybeScopeElement.flatMap(_.surroundingScope)
+      }
+    }
+  }
+
+  /** Decide what to do at the current scope while walking the scope stack for a single resolved reference.
+    *
+    * Returns one of three structurally distinct outcomes — see [[VariableScopeManager.LinkStep]] — so that the loop
+    * body in `createVariableReferenceLinks` cannot accidentally emit a REF edge without either terminating the chain or
+    * naming the next reference to chain from.
+    */
+  private def nextLinkStep(
+    diffGraph: DiffGraphBuilder,
+    filename: String,
+    capturedLocals: mutable.HashMap[String, NewNode],
+    variableNodeId: NewNode,
+    origin: PendingReference,
+    maybeScopeElement: Option[ScopeElement]
+  ): LinkStep = {
+    if (maybeScopeElement.exists(_.nameToVariableNode.contains(origin.variableName))) {
+      LinkStep.Terminate(variableNodeId)
+    } else {
+      maybeScopeElement match {
+        case Some(methodScope: MethodScopeElement) if !methodScope.needsEnclosingScope =>
+          val prefix = if (methodScope.methodFullName.startsWith(filename)) "" else s"$filename:"
+          val id     = s"$prefix${methodScope.methodFullName}:${origin.variableName}"
+          capturedLocals.get(id) match {
+            case Some(existing) =>
+              LinkStep.Terminate(existing)
+            case None =>
+              val closureBinding = closureBindingNode(id, origin.evaluationStrategy)
+              methodScope.capturingRefNode.foreach(diffGraph.addEdge(_, closureBinding, EdgeTypes.CAPTURE))
+              val localNode = createLocalForUnresolvedReference(diffGraph, methodScope.scopeNode, origin)
+              val captured  = localNode.closureBindingId(id)
+              capturedLocals.update(id, captured)
+              LinkStep.Capture(target = captured, next = closureBinding)
+          }
+        case _ => LinkStep.Skip
       }
     }
   }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/frontend/XTypeRecovery.scala
@@ -88,15 +88,22 @@ object XTypeRecoveryConfig {
 
 /** @param config
   *   the user defined config.
-  * @param currentIteration
-  *   the current iteration.
+  * @param initialIteration
+  *   the iteration this state starts at.
   */
-class XTypeRecoveryState(val config: XTypeRecoveryConfig = XTypeRecoveryConfig(), var currentIteration: Int = 0) {
-  def isFinalIteration: Boolean = currentIteration == config.iterations - 1
+class XTypeRecoveryState(val config: XTypeRecoveryConfig = XTypeRecoveryConfig(), initialIteration: Int = 0) {
+  private var iteration: Int = initialIteration
+
+  def currentIteration: Int = iteration
+
+  /** Advances the state to the given iteration. Called from `XTypeRecovery.init`. */
+  private[frontend] def setIteration(value: Int): Unit = iteration = value
+
+  def isFinalIteration: Boolean = iteration == config.iterations - 1
 
   def enableDummyTypesForThisIteration: Boolean = isFinalIteration && config.enabledDummyTypes
 
-  def isFirstIteration: Boolean = currentIteration == 0
+  def isFirstIteration: Boolean = iteration == 0
 }
 
 object XTypeRecoveryPassGenerator {
@@ -217,7 +224,7 @@ abstract class XTypeRecovery[CompilationUnitType <: AstNode](cpg: Cpg, state: XT
   override def isParallel: Boolean = true
   override def init(): Unit = {
     super.init()
-    state.currentIteration = iteration
+    state.setIteration(iteration)
   }
 
   override def generateParts(): Array[AnyRef] = compilationUnits.toArray[AnyRef]

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/KeyPool.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/KeyPool.scala
@@ -50,8 +50,8 @@ class IntervalKeyPool(val first: Long, val last: Long) extends KeyPool {
   */
 class SequenceKeyPool(seq: Seq[Long]) extends KeyPool {
 
-  val seqLen: Int = seq.size
-  var cur         = new AtomicInteger(-1)
+  private val seqLen: Int        = seq.size
+  private val cur: AtomicInteger = new AtomicInteger(-1)
 
   override def next: Long = {
     val i = cur.incrementAndGet()

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/server/FrontendHTTPServer.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/server/FrontendHTTPServer.scala
@@ -6,8 +6,8 @@ import org.slf4j.LoggerFactory
 import com.sun.net.httpserver.{HttpExchange, HttpHandler, HttpServer}
 import java.net.{InetSocketAddress, URLDecoder}
 import java.nio.charset.StandardCharsets
+import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.{ExecutorService, Executors, TimeUnit}
-import scala.compiletime.uninitialized
 import scala.io.Source
 import scala.util.Failure
 import scala.util.Success
@@ -34,6 +34,22 @@ object FrontendHTTPServer {
   * related to `X2CpgMain`. It includes handling request execution either in a single-threaded or multi-threaded manner,
   * depending on the executor configuration.
   *
+  * Concurrency model:
+  *   - `httpServerRef` is the canonical liveness flag. Reads (`isRunning`) and the at-most-once shutdown claim in
+  *     `stop()` go through `AtomicReference`, so cross-thread visibility is guaranteed without holding the intrinsic
+  *     monitor.
+  *   - The intrinsic monitor (`synchronized`) protects `runningRequests` and `lastRequest`, and is used by
+  *     `stopServerAfterTimeout` to `wait`/`notifyAll` on liveness changes. It is held only for short, non-blocking
+  *     critical sections.
+  *   - `stop()` deliberately does NOT hold the monitor while running `server.stop(0)`/`executor.awaitTermination`,
+  *     because in-flight `RunHandler.handle` calls need that same monitor for their `runningRequests -= 1` finally
+  *     block — holding it across shutdown would deadlock against them. A brief `synchronized { notifyAll() }` runs
+  *     before `awaitTermination` so any thread parked in `stopServerAfterTimeout` is released without waiting for the
+  *     executor to drain.
+  *   - `startup()` synchronizes on a dedicated `startupLock` only to make the `require(!isRunning)` precondition and
+  *     the subsequent server bind/start atomic relative to other `startup()` calls. It uses a separate monitor from the
+  *     intrinsic one because it protects unrelated state and never needs to wait on handlers.
+  *
   * @param executor
   *   ExecutorService used to execute HTTP requests.
   * @param handleRequest
@@ -53,10 +69,18 @@ class FrontendHTTPServer(executor: ExecutorService, handleRequest: Array[String]
     */
   private val contextClassLoader: ClassLoader = Thread.currentThread().getContextClassLoader
 
-  private var httpServer: HttpServer = uninitialized
-  private var runningRequests        = 0
-  private var lastRequest            = System.nanoTime()
-  private var isRunning              = false
+  // Atomic so concurrent stop() calls race on a single CAS rather than racing on a `var` write; a non-null value
+  // also serves as the canonical liveness flag, read without holding the monitor via `isRunning`.
+  private val httpServerRef: AtomicReference[HttpServer] = new AtomicReference(null)
+  // Guarded by the intrinsic monitor of `this`. Mutated by RunHandler (in/out of `handle`) and read by
+  // `stopServerAfterTimeout` to decide when the server has been idle long enough to shut down.
+  private var runningRequests = 0
+  private var lastRequest     = System.nanoTime()
+  // Dedicated monitor for `startup()`'s precondition-check + bind/start, kept separate from the intrinsic monitor
+  // of `this` so it does not interact with the request/idle-tracking lock used by handlers and the timeout loop.
+  private val startupLock = new Object
+
+  private def isRunning: Boolean = httpServerRef.get() != null
 
   /** Handler for HTTP requests, providing functionality to handle specific routes. */
   private class RunHandler extends HttpHandler {
@@ -141,39 +165,52 @@ class FrontendHTTPServer(executor: ExecutorService, handleRequest: Array[String]
 
   /** Stops the underlying HTTP server if it is running.
     *
-    * This method checks if the server is running and, if so, stops the server. It also logs a debug message indicating
-    * that the server has been stopped. If the server is not running, this method does nothing.
+    * `httpServerRef.getAndSet(null)` atomically claims the server, so concurrent `stop()` calls run the shutdown
+    * sequence at most once — only the caller that observes a non-null value proceeds. The intrinsic monitor is NOT held
+    * during `server.stop(0)`/`executor.awaitTermination`, because in-flight handlers need that same monitor for their
+    * `runningRequests -= 1` finally block; holding it across shutdown would deadlock. `synchronized { notifyAll() }`
+    * runs before `awaitTermination` so any thread parked in `stopServerAfterTimeout` is released without waiting for
+    * the executor to drain — the loop's `isRunning` predicate already sees `httpServerRef` as `null`.
     */
   def stop(): Unit = {
-    if (isRunning) {
-      httpServer.stop(0)
-      httpServer = null
+    val server = httpServerRef.getAndSet(null)
+    if (server != null) {
+      server.stop(0)
       executor.shutdown()
+      synchronized { notifyAll() }
       executor.awaitTermination(10, TimeUnit.SECONDS)
-      isRunning = false
       logger.debug("Server stopped.")
     }
   }
 
-  /** Starts the server and returns the server's randomly chosen port
+  /** Starts the server and returns the server's randomly chosen port.
+    *
+    * Synchronizes on `startupLock` (not the intrinsic monitor of `this`) to make the `require(!isRunning)` check and
+    * the subsequent bind/start atomic against other `startup()` calls. Using a dedicated lock keeps this independent of
+    * the request/idle-tracking monitor used by handlers and `stopServerAfterTimeout`, since the state being protected
+    * here (the bind sequence) is unrelated.
     */
-  def startup(): Int = {
+  def startup(): Int = startupLock.synchronized {
     require(!isRunning)
 
     // Create server on port 0 (OS chooses random available port)
-    httpServer = HttpServer.create(new InetSocketAddress(0), 0)
-    httpServer.createContext("/run", new RunHandler())
-    httpServer.setExecutor(executor)
-    httpServer.start()
+    val server = HttpServer.create(new InetSocketAddress(0), 0)
+    server.createContext("/run", new RunHandler())
+    server.setExecutor(executor)
+    // Start before publishing so `stop()` never sees an unstarted server.
+    server.start()
+    httpServerRef.set(server)
 
-    isRunning = true
-
-    val port = httpServer.getAddress.getPort
+    val port = server.getAddress.getPort
     logger.debug(s"Server started on port $port")
     port
   }
 
-  /** Stops the server, once it hasn't served any new requests for longer than timeout seconds
+  /** Stops the server, once it hasn't served any new requests for longer than timeout seconds.
+    *
+    * Loops on the intrinsic monitor: `wait` is woken either by a finishing handler (which calls `notifyAll` in its
+    * finally block) or by `stop()`'s trailing `synchronized { notifyAll() }`. The loop predicate uses `isRunning`
+    * (atomic read) so that once `stop()` flips `httpServerRef` to `null` the next iteration exits cleanly.
     */
   def stopServerAfterTimeout(timeoutSeconds: Long): Unit = {
     synchronized {

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/server/FrontendHTTPServerTests.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/server/FrontendHTTPServerTests.scala
@@ -1,0 +1,294 @@
+package io.joern.x2cpg.utils.server
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.net.URI
+import java.net.http.{HttpClient, HttpRequest, HttpResponse}
+import java.net.http.HttpRequest.BodyPublishers
+import java.net.http.HttpResponse.BodyHandlers
+import java.util.concurrent.{CountDownLatch, Executors, TimeUnit}
+import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
+
+class FrontendHTTPServerTests extends AnyWordSpec with Matchers {
+
+  /** Run `body` against a freshly-started server with the given handler, ensuring the server is stopped afterwards. */
+  private def withServer[T](handler: Array[String] => Unit)(body: (FrontendHTTPServer, Int) => T): T = {
+    val server = new FrontendHTTPServer(FrontendHTTPServer.singleThreadExecutor(), handler)
+    val port   = server.startup()
+    try body(server, port)
+    finally server.stop()
+  }
+
+  /** Synchronous HTTP POST helper using the JDK client. */
+  private def post(port: Int, body: String, method: String = "POST"): HttpResponse[String] = {
+    val builder = HttpRequest
+      .newBuilder()
+      .uri(URI.create(s"http://localhost:$port/run"))
+      .header("Content-Type", "application/x-www-form-urlencoded")
+
+    val req = method match {
+      case "POST" => builder.POST(BodyPublishers.ofString(body)).build()
+      case "GET"  => builder.GET().build()
+      case other  => builder.method(other, BodyPublishers.ofString(body)).build()
+    }
+
+    HttpClient.newHttpClient().send(req, BodyHandlers.ofString())
+  }
+
+  "FrontendHTTPServer.startup" should {
+
+    "bind to a random available port and reject a second startup" in {
+      val server = new FrontendHTTPServer(FrontendHTTPServer.singleThreadExecutor(), _ => ())
+      val port   = server.startup()
+      try {
+        port should be > 0
+        an[IllegalArgumentException] should be thrownBy server.startup()
+      } finally server.stop()
+    }
+  }
+
+  "FrontendHTTPServer.stop" should {
+
+    "be a no-op when the server was never started" in {
+      val server = new FrontendHTTPServer(FrontendHTTPServer.singleThreadExecutor(), _ => ())
+      noException should be thrownBy server.stop()
+    }
+
+    "shut down the executor and stop accepting new connections" in {
+      val executor = FrontendHTTPServer.singleThreadExecutor()
+      val server   = new FrontendHTTPServer(executor, _ => ())
+      server.startup()
+      server.stop()
+      executor.isShutdown shouldBe true
+    }
+
+    "be safe under repeated calls (at-most-once shutdown)" in {
+      val server = new FrontendHTTPServer(FrontendHTTPServer.singleThreadExecutor(), _ => ())
+      server.startup()
+      server.stop()
+      noException should be thrownBy server.stop()
+      noException should be thrownBy server.stop()
+    }
+
+    "be safe when called concurrently from multiple threads" in {
+      val server  = new FrontendHTTPServer(FrontendHTTPServer.cachedThreadPoolExecutor(), _ => ())
+      val _       = server.startup()
+      val starter = new CountDownLatch(1)
+      val done    = new CountDownLatch(8)
+      val pool    = Executors.newCachedThreadPool()
+      try {
+        (1 to 8).foreach { _ =>
+          pool.submit(new Runnable {
+            override def run(): Unit = {
+              starter.await()
+              server.stop()
+              done.countDown()
+            }
+          })
+        }
+        starter.countDown()
+        done.await(10, TimeUnit.SECONDS) shouldBe true
+      } finally pool.shutdownNow()
+    }
+
+    "not deadlock when called while a handler is in flight" in {
+      val handlerEntered = new CountDownLatch(1)
+      val releaseHandler = new CountDownLatch(1)
+      val executor       = FrontendHTTPServer.cachedThreadPoolExecutor()
+      val server = new FrontendHTTPServer(
+        executor,
+        _ => {
+          handlerEntered.countDown()
+          releaseHandler.await()
+        }
+      )
+      val port    = server.startup()
+      val sender  = Executors.newSingleThreadExecutor()
+      val stopper = Executors.newSingleThreadExecutor()
+      try {
+        sender.submit(new Runnable {
+          override def run(): Unit = {
+            try post(port, "input=/tmp/in&output=/tmp/out")
+            catch { case _: Throwable => () }
+          }
+        })
+        handlerEntered.await(10, TimeUnit.SECONDS) shouldBe true
+
+        val stopFuture = stopper.submit(new Runnable {
+          override def run(): Unit = server.stop()
+        })
+        // `executor.isShutdown` flips inside `stop()` after `shutdown()` and immediately before `awaitTermination`,
+        // so by the time we observe it the stopper is parked exactly where the would-be deadlock would occur.
+        // Releasing the handler now forces it through its `runningRequests -= 1` finally block, which must not be
+        // blocked by the monitor stop() would have held in a buggy implementation.
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+        while (!executor.isShutdown && System.nanoTime() < deadline) {
+          Thread.`yield`()
+        }
+        executor.isShutdown shouldBe true
+        releaseHandler.countDown()
+        stopFuture.get(15, TimeUnit.SECONDS)
+      } finally {
+        releaseHandler.countDown()
+        sender.shutdownNow()
+        stopper.shutdownNow()
+      }
+    }
+  }
+
+  "FrontendHTTPServer.stopServerAfterTimeout" should {
+
+    "shut down once no requests have been served for the timeout window" in {
+      val server = new FrontendHTTPServer(FrontendHTTPServer.cachedThreadPoolExecutor(), _ => ())
+      server.startup()
+      val timer = Executors.newSingleThreadExecutor()
+      try {
+        val started = System.nanoTime()
+        val f = timer.submit(new Runnable {
+          override def run(): Unit = server.stopServerAfterTimeout(1)
+        })
+        f.get(10, TimeUnit.SECONDS)
+        val elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - started)
+        // Lower bound is intentionally below the 1s timeout to tolerate scheduler jitter on slow CI runners
+        // (some JVMs may return from wait() a few ms early). The upper bound is enforced by `f.get(10s)`.
+        elapsedMs should be >= 800L
+      } finally timer.shutdownNow()
+    }
+
+    "wake from wait() promptly when stop() is called externally" in {
+      val server = new FrontendHTTPServer(FrontendHTTPServer.cachedThreadPoolExecutor(), _ => ())
+      server.startup()
+      val timer = Executors.newSingleThreadExecutor()
+      try {
+        val f = timer.submit(new Runnable {
+          override def run(): Unit = server.stopServerAfterTimeout(60)
+        })
+        Thread.sleep(200)
+        server.stop()
+        f.get(5, TimeUnit.SECONDS)
+      } finally timer.shutdownNow()
+    }
+  }
+
+  "Concurrent requests" should {
+
+    "be tracked correctly so that stopServerAfterTimeout waits for them" in {
+      val inFlight       = new AtomicInteger(0)
+      val handlerEntered = new CountDownLatch(2)
+      val releaseHandler = new CountDownLatch(1)
+      val server = new FrontendHTTPServer(
+        FrontendHTTPServer.cachedThreadPoolExecutor(),
+        _ => {
+          inFlight.incrementAndGet()
+          handlerEntered.countDown()
+          releaseHandler.await()
+          inFlight.decrementAndGet()
+          ()
+        }
+      )
+      val port    = server.startup()
+      val senders = Executors.newCachedThreadPool()
+      try {
+        (1 to 2).foreach { _ =>
+          senders.submit(new Runnable {
+            override def run(): Unit = {
+              try post(port, "input=/tmp/in&output=/tmp/out")
+              catch { case _: Throwable => () }
+            }
+          })
+        }
+        handlerEntered.await(10, TimeUnit.SECONDS) shouldBe true
+        inFlight.get() shouldBe 2
+        releaseHandler.countDown()
+      } finally {
+        senders.shutdownNow()
+        server.stop()
+      }
+    }
+  }
+
+  "RunHandler" should {
+
+    "return 405 for non-POST requests" in {
+      withServer(_ => ()) { (_, port) =>
+        val resp = post(port, "", method = "GET")
+        resp.statusCode() shouldBe 405
+        resp.body() shouldBe "Method Not Allowed"
+      }
+    }
+
+    "invoke the handler with the parsed arguments and respond with 200 + the output path" in {
+      val captured = new AtomicReference[Array[String]](Array.empty)
+      withServer(args => captured.set(args)) { (_, port) =>
+        val resp = post(port, "input=/tmp/in&output=/tmp/out&flag=")
+        resp.statusCode() shouldBe 200
+        resp.body() shouldBe "/tmp/out"
+        val args = captured.get().toSet
+        args should contain("/tmp/in")
+        args should contain("--output")
+        args should contain("/tmp/out")
+        args should contain("--flag")
+      }
+    }
+
+    "URL-decode keys and values in the form-encoded body" in {
+      val captured = new AtomicReference[Array[String]](Array.empty)
+      withServer(args => captured.set(args)) { (_, port) =>
+        val resp = post(port, "input=%2Ftmp%2Fa%20b&output=%2Ftmp%2Fout")
+        resp.statusCode() shouldBe 200
+        resp.body() shouldBe "/tmp/out"
+        captured.get().toSet should contain("/tmp/a b")
+      }
+    }
+
+    "fall back to the default output path when none is provided" in {
+      withServer(_ => ()) { (_, port) =>
+        val resp = post(port, "input=/tmp/in")
+        resp.statusCode() shouldBe 200
+        resp.body() shouldBe io.joern.x2cpg.X2CpgConfig.defaultOutputPath
+      }
+    }
+
+    "respond with 400 and the exception message when the handler throws" in {
+      withServer(_ => throw new RuntimeException("boom")) { (_, port) =>
+        val resp = post(port, "input=/tmp/in&output=/tmp/out")
+        resp.statusCode() shouldBe 400
+        resp.body() shouldBe "boom"
+      }
+    }
+
+    "tolerate an empty request body" in {
+      val captured = new AtomicReference[Array[String]](Array.empty)
+      withServer(args => captured.set(args)) { (_, port) =>
+        val resp = post(port, "")
+        resp.statusCode() shouldBe 200
+        captured.get() shouldBe empty
+      }
+    }
+  }
+
+  "FrontendHTTPClient" should {
+
+    "round-trip a successful request to FrontendHTTPServer" in {
+      val captured = new AtomicReference[Array[String]](Array.empty)
+      withServer(args => captured.set(args)) { (_, port) =>
+        val client = FrontendHTTPClient(port)
+        val req    = client.buildRequest(Array("input=/tmp/in", "output=/tmp/out"))
+        client.sendRequest(req).get shouldBe "/tmp/out"
+        captured.get().toSet should contain("/tmp/in")
+      }
+    }
+
+    "return a Failure when the handler throws" in {
+      withServer(_ => throw new RuntimeException("nope")) { (_, port) =>
+        val client = FrontendHTTPClient(port)
+        val req    = client.buildRequest(Array("input=/tmp/in"))
+        val result = client.sendRequest(req)
+        result.isFailure shouldBe true
+        result.failed.get.getMessage should include("400")
+        result.failed.get.getMessage should include("nope")
+      }
+    }
+  }
+}


### PR DESCRIPTION
Did a small x2cpg cleanup pass. Each commit is independently reviewable.

- Used `Defines.Any` for `parameterIn` fallback type; drop the hardcoded `"ANY"` literal in `AstNodeBuilder.parameterInNode`.
- Made `REF`-link invariant structurally visible in `VariableScopeManager`.
- Fixed `KeyPool` field visibility and mutability.
- Encapsulated `XTypeRecoveryState` iteration counter. Replaced the `public var currentIteration` with a package-private `setIteration` method; reads stay free.
- Collapsed repeated edge handling in `Ast`: Introduced a single `typedEdgeKinds` table so `storeInDiffGraph` / `subTreeCopy` no longer repeat per-edge boilerplate, and share a `mergedWith` helper between `withChild` / `merge`. Public case class signature is unchanged, so all frontends keep working.
- Improved `FrontendHTTPServer` concurrency and add tests: Replace `var httpServer` / `var isRunning` with a single `AtomicReference`, giving at-most-once shutdown via `getAndSet(null)`. Concurrency model documented; new tests cover repeated stop, concurrent stop, stop-while-handler-in-flight, and `stopServerAfterTimeout` idle-shutdown / external-wakeup paths.

Buildbot is also [fine](https://buildbot.global.sltr.io/#/builders/82/builds/630) with it.