### PR TITLE
[rust2cpg] support `mod { }` declarations

### DIFF
--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/AstCreator.scala
@@ -83,6 +83,11 @@ class AstCreator(val config: Config, val parseResult: ParseResult)(implicit with
     s"${parseResult.filename}:$rustNamespaceFullName"
   }
 
+  protected def moduleNamespaceBlockNode(module: RustNodeSyntax.Module): NewNamespaceBlock = {
+    val name = composeRustFullName(code(module.name))
+    namespaceBlockNode(module, name, s"${parseResult.filename}:$name", parseResult.filename)
+  }
+
   protected def globalFakeMethodNode(
     sourceFile: RustNodeSyntax.SourceFile,
     namespaceBlock: NewNamespaceBlock

--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
@@ -56,7 +56,7 @@ trait RustVisitor(implicit withValidationMode: ValidationMode) { this: AstCreato
     case x: MacroCall   => notHandledYet(x) :: Nil
     case x: MacroRules  => notHandledYet(x) :: Nil
     case x: MacroDef    => notHandledYet(x) :: Nil
-    case x: Module      => notHandledYet(x) :: Nil
+    case module: Module => visitModule(module)
     case x: Static      => notHandledYet(x) :: Nil
     case struct: Struct => visitStruct(struct) :: Nil
     case x: Trait       => notHandledYet(x) :: Nil
@@ -127,6 +127,21 @@ trait RustVisitor(implicit withValidationMode: ValidationMode) { this: AstCreato
     case x: RefType       => notHandledYet(x)
     case x: SliceType     => notHandledYet(x)
     case x: TupleType     => notHandledYet(x)
+  }
+
+  // Module =
+  //  Attr* Visibility?
+  //  'mod' Name (ItemList | ';')
+  private def visitModule(module: Module): Seq[Ast] = {
+    module.itemList match {
+      case None => Nil
+      case Some(itemList) =>
+        val namespaceBlock = moduleNamespaceBlockNode(module)
+        methodAstParentStack.push(namespaceBlock)
+        val itemAsts = itemList.item.flatMap(visitItem)
+        methodAstParentStack.pop()
+        Ast(namespaceBlock).withChildren(itemAsts) :: Nil
+    }
   }
 
   // Const =

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/NamespaceBlockTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/NamespaceBlockTests.scala
@@ -76,4 +76,66 @@ class NamespaceBlockTests extends Rust2CpgSuite(noSysRoot = true) {
       }
     }
   }
+
+  "an inline module" should {
+    val libPath = (Paths.get("src") / "lib.rs").toString
+    val cpg = code("""
+        |mod foo {
+        | fn bar() {}
+        |}
+        |""".stripMargin)
+
+    "create a namespace block whose name is crate-prefixed" in {
+      cpg.namespaceBlock.fullName.l should contain(s"$libPath:rust2cpgtest::foo")
+    }
+
+    "name the namespace block with the crate name" in {
+      cpg.namespaceBlock.fullNameExact(s"$libPath:rust2cpgtest::foo").name.l shouldBe List("rust2cpgtest::foo")
+    }
+
+    "own the inner fn as an AST child" in {
+      inside(cpg.namespaceBlock.fullNameExact(s"$libPath:rust2cpgtest::foo").astChildren.isMethod.l) {
+        case bar :: Nil =>
+          bar.name shouldBe "bar"
+          bar.fullName shouldBe "rust2cpgtest::foo::bar"
+      }
+    }
+
+    "parent the inner fn by the module's namespace block" in {
+      inside(cpg.method.nameExact("bar").l) { case bar :: Nil =>
+        bar.astParentType shouldBe NodeTypes.NAMESPACE_BLOCK
+        bar.astParentFullName shouldBe s"$libPath:rust2cpgtest::foo"
+      }
+    }
+  }
+
+  "a nested inline module" should {
+    val libPath = (Paths.get("src") / "lib.rs").toString
+    val cpg = code("""
+        |mod a {
+        | mod b {
+        |   fn c() {}
+        | }
+        |}
+        |""".stripMargin)
+
+    "compose the outer module's name with the crate" in {
+      cpg.namespaceBlock.fullName.l should contain(s"$libPath:rust2cpgtest::a")
+    }
+
+    "compose the inner module's name with its parent module" in {
+      cpg.namespaceBlock.fullName.l should contain(s"$libPath:rust2cpgtest::a::b")
+    }
+
+    "compose the fn's fullName with both modules" in {
+      cpg.method.nameExact("c").fullName.l shouldBe List("rust2cpgtest::a::b::c")
+    }
+
+    "parent the fn by the inner module's namespace block" in {
+      inside(cpg.method.nameExact("c").l) { case cFn :: Nil =>
+        cFn.astParentType shouldBe NodeTypes.NAMESPACE_BLOCK
+        cFn.astParentFullName shouldBe s"$libPath:rust2cpgtest::a::b"
+      }
+    }
+  }
 }


### PR DESCRIPTION
* `mod foo { ... }` is lowered as a traditional namespace block. 
* `mod foo;` is skipped. It's a forward declaration for which we don't have an AST use.