### PR TITLE
[rubysrc2cpg] chore: default case for single assignment

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -173,8 +173,6 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
           case x =>
             astsForStatement(transform(expr))
         }
-      case node: SingleAssignment =>
-        astForSingleAssignment(node) :: List(astForReturnExpression(ReturnExpression(List(node.lhs))(node.span)))
       case node: DefaultMultipleAssignment =>
         astsForStatement(node) ++ astsForImplicitReturnStatement(ArrayLiteral(node.assignments.map(_.lhs))(node.span))
       case ret: ReturnExpression => astForReturnExpression(ret) :: Nil

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DoBlockTests.scala
@@ -419,7 +419,7 @@ class DoBlockTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     inside(cpg.method.isLambda.body.astChildren.isCall.name(Operators.assignment).l) {
-      case groupedParam :: countAssignment :: _ :: Nil =>
+      case groupedParam :: countAssignment :: Nil =>
         inside(groupedParam.argument.l) {
           case (labelIdAssign: Call) :: (dateAssign: Call) :: (tmp0Splat: Call) :: Nil =>
             inside(labelIdAssign.argument.l) { case (lhs: Identifier) :: (rhs: Call) :: Nil =>


### PR DESCRIPTION
Use the default case for handling a single assignment as an implicit return