### PR TITLE
[pysrc2cpg] Use Reader interface instead of InputStream

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pythonparser/CharStreamImpl.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pythonparser/CharStreamImpl.scala
@@ -2,16 +2,14 @@ package io.joern.pythonparser
 
 import io.joern.pythonparser.CharStreamImpl.{defaultInputBufferSize, defaultMinimumReadSize}
 
-import java.io.{IOException, InputStream, InputStreamReader}
+import java.io.{IOException, Reader}
 
 object CharStreamImpl {
   private val defaultInputBufferSize = 4096
   private val defaultMinimumReadSize = 2048
 }
 
-class CharStreamImpl(inputStream: InputStream, inputBufferSize: Int, minimumReadSize: Int) extends CharStream {
-  private val inputReader = new InputStreamReader(inputStream)
-
+class CharStreamImpl(inputReader: Reader, inputBufferSize: Int, minimumReadSize: Int) extends CharStream {
   private var inputBuffer       = new Array[Char](inputBufferSize)
   private var posToLine         = new Array[Int](inputBufferSize)
   private var posToColumn       = new Array[Int](inputBufferSize)
@@ -29,8 +27,8 @@ class CharStreamImpl(inputStream: InputStream, inputBufferSize: Int, minimumRead
   posToLine(0) = 1
   posToColumn(0) = 0
 
-  def this(inputStream: InputStream) = {
-    this(inputStream, defaultInputBufferSize, defaultMinimumReadSize)
+  def this(inputReader: Reader) = {
+    this(inputReader, defaultInputBufferSize, defaultMinimumReadSize)
   }
 
   def getBeginPos: Int = inputBufferOffset + tokenBeginPos - 1

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pythonparser/PyParser.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pythonparser/PyParser.scala
@@ -4,19 +4,18 @@ import io.joern.pythonparser.PythonParser
 import io.joern.pythonparser.PythonParserConstants
 import io.joern.pythonparser.ast.{ErrorStatement, iast}
 
-import java.io.{BufferedReader, ByteArrayInputStream, InputStream, Reader}
-import java.nio.charset.StandardCharsets
+import java.io.{Reader, StringReader}
 import scala.jdk.CollectionConverters.*
 
 class PyParser {
   private var pythonParser: PythonParser = scala.compiletime.uninitialized
 
   def parse(code: String): iast = {
-    parse(new ByteArrayInputStream(code.getBytes(StandardCharsets.UTF_8)))
+    parse(StringReader(code))
   }
 
-  def parse(inputStream: InputStream): iast = {
-    pythonParser = new PythonParser(new CharStreamImpl(inputStream))
+  def parse(inputReader: Reader): iast = {
+    pythonParser = new PythonParser(new CharStreamImpl(inputReader))
     // We start in INDENT_CHECK lexer state because we want to detect indentations
     // also for the first line.
     pythonParser.token_source.SwitchTo(PythonParserConstants.INDENT_CHECK)


### PR DESCRIPTION
We do this to avoid miss matches between the character encoding
when transforming from string to input stream and from input stream
to character stream.
So far we used UTF8 when transforming from string to byte input stream
and the system encoding when going from input stream to character stream
which could cause miss matches on those rare systems which do not use
UTF8 as standard character encoding.
