### PR TITLE
[rust2cpg] add missing control structure edges

### DIFF
--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/AstCreator.scala
@@ -7,7 +7,14 @@ import io.joern.rust2cpg.parser.RustNodeSyntax
 import io.joern.rust2cpg.parser.RustNodeSyntax.RustNode
 import io.joern.x2cpg.datastructures.Stack.*
 import io.joern.x2cpg.{Ast, AstCreatorBase, ValidationMode}
-import io.shiftleft.codepropertygraph.generated.nodes.{NewCall, NewMethod, NewNamespaceBlock, NewNode, NewTypeDecl}
+import io.shiftleft.codepropertygraph.generated.nodes.{
+  NewCall,
+  NewControlStructure,
+  NewMethod,
+  NewNamespaceBlock,
+  NewNode,
+  NewTypeDecl
+}
 import io.shiftleft.codepropertygraph.generated.{NodeTypes, Operators, PropertyDefaults, PropertyNames}
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 import org.slf4j.LoggerFactory
@@ -157,6 +164,14 @@ class AstCreator(val config: Config, val parseResult: ParseResult)(implicit with
     case Some(_: RustNodeSyntax.BangToken)  => Some(Operators.logicalNot)
     case Some(_: RustNodeSyntax.StarToken)  => Some(Operators.indirection)
     case _                                  => None
+  }
+
+  protected def whileBodyAst(whileNode: NewControlStructure, conditionAst: Ast, bodyAst: Ast): Ast = {
+    val ast = controlStructureAst(whileNode, Some(conditionAst), Seq(bodyAst))
+    bodyAst.root match {
+      case Some(bodyRoot) => ast.withTrueBodyEdge(whileNode, bodyRoot)
+      case None           => ast
+    }
   }
 
 }

--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
@@ -518,9 +518,9 @@ trait RustVisitor(implicit withValidationMode: ValidationMode) { this: AstCreato
     val ifNode       = controlStructureNode(ifExpr, ControlStructureTypes.IF, code(ifExpr))
     val conditionAst = visitExpr(ifExpr.expr)
     val thenAst      = visitBlockExpr(ifExpr.thenBranch)
-    val elseAst      = ifExpr.elseBranch.map(visitElseBranch).getOrElse(Ast())
+    val elseAst      = ifExpr.elseBranch.map(visitElseBranch)
 
-    controlStructureAst(ifNode, Some(conditionAst), Seq(thenAst, elseAst))
+    ifThenElseAst(ifNode, Some(conditionAst), thenAst, elseAst)
   }
 
   private def visitElseBranch(elseBranch: IfExpr | BlockExpr): Ast = {
@@ -563,7 +563,7 @@ trait RustVisitor(implicit withValidationMode: ValidationMode) { this: AstCreato
     val conditionAst = visitExpr(whileExpr.expr)
     val bodyAst      = visitBlockExpr(whileExpr.blockExpr)
 
-    controlStructureAst(whileNode, Some(conditionAst), Seq(bodyAst))
+    whileBodyAst(whileNode, conditionAst, bodyAst)
   }
 
   // LoopExpr =
@@ -574,7 +574,7 @@ trait RustVisitor(implicit withValidationMode: ValidationMode) { this: AstCreato
     val conditionAst = Ast(literalNode(loopExpr.loopKwToken, "true", "bool"))
     val bodyAst      = visitBlockExpr(loopExpr.blockExpr)
 
-    controlStructureAst(loopNode, Some(conditionAst), Seq(bodyAst))
+    whileBodyAst(loopNode, conditionAst, bodyAst)
   }
 
   // ForExpr =


### PR DESCRIPTION
To clear the recently introduced `... is missing TRUE_BODY edge (CfgCreator will use legacy order fallback)` warnings.