### PR TITLE
[x2cpg][jssrc2cpg][c2cpg][swiftsrc2cpg] Bump validation level + fixes + x2cpg adaptations

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForStatementsCreator.scala
@@ -459,8 +459,6 @@ trait AstForStatementsCreator { this: AstCreator =>
     val testAst =
       createCallAst(testCallNode, base = Some(Ast(hasNextReceiverNode)), receiver = Some(Ast(hasNextReceiverNode)))
 
-    val whileLoopAst = Ast(whileLoopNode).withChild(testAst).withConditionEdge(whileLoopNode, testCallNode)
-
     // while loop variable assignment:
     val whileLoopVariableNode = identifierNode(forStmt, loopVariableName, loopVariableName, idType)
     scope.addVariableReference(loopVariableName, whileLoopVariableNode, idType, EvaluationStrategies.BY_REFERENCE)
@@ -509,13 +507,16 @@ trait AstForStatementsCreator { this: AstCreator =>
     // end surrounding block:
     scope.popScope()
 
-    val whileLoopAstWithBody = whileLoopBlockAst.root match {
-      case Some(blockRoot) => whileLoopAst.withChild(whileLoopBlockAst).withTrueBodyEdge(whileLoopNode, blockRoot)
-      case None            => whileLoopAst.withChild(whileLoopBlockAst)
-    }
+    val whileLoopAst = whileAst(
+      Option(testAst),
+      List(whileLoopBlockAst),
+      code = Option(whileLoopCode),
+      lineNumber = line(forStmt),
+      columnNumber = column(forStmt)
+    )
 
     val blockChildren =
-      List(iteratorAssignmentAst, Ast(loopVariableLocalNode), whileLoopAstWithBody)
+      List(iteratorAssignmentAst, Ast(loopVariableLocalNode), whileLoopAst)
     blockAst(blockNode, blockChildren)
   }
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForStatementsCreator.scala
@@ -259,9 +259,14 @@ trait AstForStatementsCreator { this: AstCreator =>
       case _ =>
         Seq.empty
     }
-    val conditionAst = astForConditionExpression(switchStmt.getControllerExpression)
-    val stmtAsts     = nullSafeAst(switchStmt.getBody)
-    initAsts :+ controlStructureAst(switchNode, Option(conditionAst), stmtAsts)
+    val conditionAst    = astForConditionExpression(switchStmt.getControllerExpression)
+    val stmtAsts        = nullSafeAst(switchStmt.getBody)
+    val astWithChildren = controlStructureAst(switchNode, Option(conditionAst), stmtAsts)
+    val astWithEdge = stmtAsts.headOption.flatMap(_.root) match {
+      case Some(bodyRoot) => astWithChildren.withTrueBodyEdge(switchNode, bodyRoot)
+      case None           => astWithChildren
+    }
+    initAsts :+ astWithEdge
   }
 
   private def astsForCaseStatement(caseStmt: IASTCaseStatement): Seq[Ast] = {
@@ -509,22 +514,26 @@ trait AstForStatementsCreator { this: AstCreator =>
     // end surrounding block:
     scope.popScope()
 
+    val whileLoopAstWithBody = whileLoopBlockAst.root match {
+      case Some(blockRoot) => whileLoopAst.withChild(whileLoopBlockAst).withTrueBodyEdge(whileLoopNode, blockRoot)
+      case None            => whileLoopAst.withChild(whileLoopBlockAst)
+    }
+
     val blockChildren =
-      List(iteratorAssignmentAst, Ast(loopVariableLocalNode), whileLoopAst.withChild(whileLoopBlockAst))
+      List(iteratorAssignmentAst, Ast(loopVariableLocalNode), whileLoopAstWithBody)
     blockAst(blockNode, blockChildren)
   }
 
   private def astForWhile(whileStmt: IASTWhileStatement): Ast = {
     val code       = s"while (${nullSafeCode(whileStmt.getCondition)})"
+    val whileNode  = controlStructureNode(whileStmt, ControlStructureTypes.WHILE, code)
     val compareAst = wrapInNullComparison(whileStmt.getCondition, astForConditionExpression(whileStmt.getCondition))
     val bodyAst    = nullSafeAst(whileStmt.getBody)
-    whileAst(
-      Option(compareAst),
-      bodyAst,
-      code = Option(code),
-      lineNumber = line(whileStmt),
-      columnNumber = column(whileStmt)
-    )
+    val astWithChildren = controlStructureAst(whileNode, Option(compareAst), bodyAst)
+    bodyAst.headOption.flatMap(_.root) match {
+      case Some(bodyRoot) => astWithChildren.withTrueBodyEdge(whileNode, bodyRoot)
+      case None           => astWithChildren
+    }
   }
 
   private def wrapInNullComparison(node: IASTNode, conditionAst: Ast): Ast = {

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForStatementsCreator.scala
@@ -259,14 +259,9 @@ trait AstForStatementsCreator { this: AstCreator =>
       case _ =>
         Seq.empty
     }
-    val conditionAst    = astForConditionExpression(switchStmt.getControllerExpression)
-    val stmtAsts        = nullSafeAst(switchStmt.getBody)
-    val astWithChildren = controlStructureAst(switchNode, Option(conditionAst), stmtAsts)
-    val astWithEdge = stmtAsts.headOption.flatMap(_.root) match {
-      case Some(bodyRoot) => astWithChildren.withTrueBodyEdge(switchNode, bodyRoot)
-      case None           => astWithChildren
-    }
-    initAsts :+ astWithEdge
+    val conditionAst = astForConditionExpression(switchStmt.getControllerExpression)
+    val stmtAsts     = nullSafeAst(switchStmt.getBody)
+    initAsts :+ switchAst(switchNode, conditionAst, stmtAsts)
   }
 
   private def astsForCaseStatement(caseStmt: IASTCaseStatement): Seq[Ast] = {
@@ -526,14 +521,15 @@ trait AstForStatementsCreator { this: AstCreator =>
 
   private def astForWhile(whileStmt: IASTWhileStatement): Ast = {
     val code       = s"while (${nullSafeCode(whileStmt.getCondition)})"
-    val whileNode  = controlStructureNode(whileStmt, ControlStructureTypes.WHILE, code)
     val compareAst = wrapInNullComparison(whileStmt.getCondition, astForConditionExpression(whileStmt.getCondition))
     val bodyAst    = nullSafeAst(whileStmt.getBody)
-    val astWithChildren = controlStructureAst(whileNode, Option(compareAst), bodyAst)
-    bodyAst.headOption.flatMap(_.root) match {
-      case Some(bodyRoot) => astWithChildren.withTrueBodyEdge(whileNode, bodyRoot)
-      case None           => astWithChildren
-    }
+    whileAst(
+      Option(compareAst),
+      bodyAst,
+      code = Option(code),
+      lineNumber = line(whileStmt),
+      columnNumber = column(whileStmt)
+    )
   }
 
   private def wrapInNullComparison(node: IASTNode, conditionAst: Ast): Ast = {

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/AstC2CpgFrontend.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/AstC2CpgFrontend.scala
@@ -46,7 +46,7 @@ trait AstC2CpgFrontend extends LanguageFrontend {
       )
     headerPass.createAndApply()
     new FunctionDeclNodePass(cpg, headerPass.unhandledMethodDeclarations(), config).createAndApply()
-    new PostFrontendValidator(cpg, ValidationLevel.V1).run()
+    new PostFrontendValidator(cpg, ValidationLevel.V2).run()
     cpg
   }
 }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/C2CpgFrontend.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/testfixtures/C2CpgFrontend.scala
@@ -12,7 +12,7 @@ trait C2CpgFrontend extends LanguageFrontend {
     val c2cpg  = new C2Cpg()
     val config = getConfig().getOrElse(Config()).withInputPath(sourceCodePath.getAbsolutePath)
     val res    = c2cpg.createCpg(config).get
-    new PostFrontendValidator(res, ValidationLevel.V1).run()
+    new PostFrontendValidator(res, ValidationLevel.V2).run()
     res
   }
 }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -358,8 +358,6 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     val testCallArgs = List(testNode)
     val testCallAst  = callAst(testCallNode, testCallArgs)
 
-    val whileLoopAst = Ast(whileLoopNode).withChild(testCallAst).withConditionEdge(whileLoopNode, testCallNode)
-
     // while loop variable assignment:
     val whileLoopVariableNode = identifierNode(forInOfStmt, loopVariableName)
 
@@ -396,13 +394,16 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     scope.popScope()
     localAstParentStack.pop()
 
-    val whileLoopAstWithBody = whileLoopBlockAst.root match {
-      case Some(blockRoot) => whileLoopAst.withChild(whileLoopBlockAst).withTrueBodyEdge(whileLoopNode, blockRoot)
-      case None            => whileLoopAst.withChild(whileLoopBlockAst)
-    }
+    val whileLoopAst = whileAst(
+      Option(testCallAst),
+      List(whileLoopBlockAst),
+      code = Option(code(forInOfStmt)),
+      lineNumber = line(forInOfStmt),
+      columnNumber = column(forInOfStmt)
+    )
 
     val blockChildren =
-      List(iteratorAssignmentAst, Ast(resultNode), Ast(loopVariableNode), whileLoopAstWithBody)
+      List(iteratorAssignmentAst, Ast(resultNode), Ast(loopVariableNode), whileLoopAst)
     blockAst(blockNode_, blockChildren)
   }
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -134,14 +134,15 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
   }
 
   protected def astForWhileStatement(whileStmt: BabelNodeInfo): Ast = {
-    val whileNode       = controlStructureNode(whileStmt, ControlStructureTypes.WHILE, code(whileStmt))
-    val testAst         = astForNodeWithFunctionReference(whileStmt.json("test"))
-    val bodyAst         = astForNodeWithFunctionReference(whileStmt.json("body"))
-    val astWithChildren = controlStructureAst(whileNode, Option(testAst), Seq(bodyAst))
-    bodyAst.root match {
-      case Some(bodyRoot) => astWithChildren.withTrueBodyEdge(whileNode, bodyRoot)
-      case None           => astWithChildren
-    }
+    val testAst = astForNodeWithFunctionReference(whileStmt.json("test"))
+    val bodyAst = astForNodeWithFunctionReference(whileStmt.json("body"))
+    whileAst(
+      Option(testAst),
+      Seq(bodyAst),
+      code = Option(code(whileStmt)),
+      lineNumber = line(whileStmt),
+      columnNumber = column(whileStmt)
+    )
   }
 
   protected def astForForStatement(forStmt: BabelNodeInfo): Ast = {
@@ -248,15 +249,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     localAstParentStack.pop()
 
     val switchBlockAst = blockAst(blockNode_, casesAsts.toList)
-    val astWithChildren = Ast(switchNode)
-      .withChild(switchExpressionAst)
-      .withConditionEdge(switchNode, switchExpressionAst.nodes.head)
-      .withChild(switchBlockAst)
-
-    switchBlockAst.root match {
-      case Some(blockRoot) => astWithChildren.withTrueBodyEdge(switchNode, blockRoot)
-      case None            => astWithChildren
-    }
+    switchAst(switchNode, switchExpressionAst, Seq(switchBlockAst))
   }
 
   /** De-sugaring from:

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -134,10 +134,14 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
   }
 
   protected def astForWhileStatement(whileStmt: BabelNodeInfo): Ast = {
-    val whileNode = controlStructureNode(whileStmt, ControlStructureTypes.WHILE, code(whileStmt))
-    val testAst   = astForNodeWithFunctionReference(whileStmt.json("test"))
-    val bodyAst   = astForNodeWithFunctionReference(whileStmt.json("body"))
-    controlStructureAst(whileNode, Option(testAst), Seq(bodyAst))
+    val whileNode       = controlStructureNode(whileStmt, ControlStructureTypes.WHILE, code(whileStmt))
+    val testAst         = astForNodeWithFunctionReference(whileStmt.json("test"))
+    val bodyAst         = astForNodeWithFunctionReference(whileStmt.json("body"))
+    val astWithChildren = controlStructureAst(whileNode, Option(testAst), Seq(bodyAst))
+    bodyAst.root match {
+      case Some(bodyRoot) => astWithChildren.withTrueBodyEdge(whileNode, bodyRoot)
+      case None           => astWithChildren
+    }
   }
 
   protected def astForForStatement(forStmt: BabelNodeInfo): Ast = {
@@ -243,10 +247,16 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     scope.popScope()
     localAstParentStack.pop()
 
-    Ast(switchNode)
+    val switchBlockAst = blockAst(blockNode_, casesAsts.toList)
+    val astWithChildren = Ast(switchNode)
       .withChild(switchExpressionAst)
       .withConditionEdge(switchNode, switchExpressionAst.nodes.head)
-      .withChild(blockAst(blockNode_, casesAsts.toList))
+      .withChild(switchBlockAst)
+
+    switchBlockAst.root match {
+      case Some(blockRoot) => astWithChildren.withTrueBodyEdge(switchNode, blockRoot)
+      case None            => astWithChildren
+    }
   }
 
   /** De-sugaring from:
@@ -393,8 +403,13 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     scope.popScope()
     localAstParentStack.pop()
 
+    val whileLoopAstWithBody = whileLoopBlockAst.root match {
+      case Some(blockRoot) => whileLoopAst.withChild(whileLoopBlockAst).withTrueBodyEdge(whileLoopNode, blockRoot)
+      case None            => whileLoopAst.withChild(whileLoopBlockAst)
+    }
+
     val blockChildren =
-      List(iteratorAssignmentAst, Ast(resultNode), Ast(loopVariableNode), whileLoopAst.withChild(whileLoopBlockAst))
+      List(iteratorAssignmentAst, Ast(resultNode), Ast(loopVariableNode), whileLoopAstWithBody)
     blockAst(blockNode_, blockChildren)
   }
 
@@ -534,7 +549,12 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     scope.popScope()
     localAstParentStack.pop()
 
-    val blockChildren = List(iteratorAssignmentAst, Ast(resultNode), whileLoopAst.withChild(whileLoopBlockAst))
+    val whileLoopAstWithBody = whileLoopBlockAst.root match {
+      case Some(blockRoot) => whileLoopAst.withChild(whileLoopBlockAst).withTrueBodyEdge(whileLoopNode, blockRoot)
+      case None            => whileLoopAst.withChild(whileLoopBlockAst)
+    }
+
+    val blockChildren = List(iteratorAssignmentAst, Ast(resultNode), whileLoopAstWithBody)
     blockAst(blockNode_, blockChildren)
   }
 
@@ -682,10 +702,13 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     scope.popScope()
     localAstParentStack.pop()
 
+    val whileLoopAstWithBody = whileLoopBlockAst.root match {
+      case Some(blockRoot) => whileLoopAst.withChild(whileLoopBlockAst).withTrueBodyEdge(whileLoopNode, blockRoot)
+      case None            => whileLoopAst.withChild(whileLoopBlockAst)
+    }
+
     val blockNodeChildren =
-      List(iteratorAssignmentAst, Ast(resultNode)) ++ loopVariableNodes.map(Ast(_)) :+ whileLoopAst.withChild(
-        whileLoopBlockAst
-      )
+      List(iteratorAssignmentAst, Ast(resultNode)) ++ loopVariableNodes.map(Ast(_)) :+ whileLoopAstWithBody
     blockAst(blockNode_, blockNodeChildren)
   }
 
@@ -832,10 +855,13 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     scope.popScope()
     localAstParentStack.pop()
 
+    val whileLoopAstWithBody = whileLoopBlockAst.root match {
+      case Some(blockRoot) => whileLoopAst.withChild(whileLoopBlockAst).withTrueBodyEdge(whileLoopNode, blockRoot)
+      case None            => whileLoopAst.withChild(whileLoopBlockAst)
+    }
+
     val blockNodeChildren =
-      List(iteratorAssignmentAst, Ast(resultNode)) ++ loopVariableNodes.map(Ast(_)) :+ whileLoopAst.withChild(
-        whileLoopBlockAst
-      )
+      List(iteratorAssignmentAst, Ast(resultNode)) ++ loopVariableNodes.map(Ast(_)) :+ whileLoopAstWithBody
     blockAst(blockNode_, blockNodeChildren)
   }
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -505,8 +505,6 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     val testCallArgs = List(testNode)
     val testCallAst  = callAst(testCallNode, testCallArgs)
 
-    val whileLoopAst = Ast(whileLoopNode).withChild(testCallAst).withConditionEdge(whileLoopNode, testCallNode)
-
     // while loop variable assignment:
     val whileLoopVariableNode = astForNode(idNodeInfo.json)
 
@@ -543,12 +541,15 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     scope.popScope()
     localAstParentStack.pop()
 
-    val whileLoopAstWithBody = whileLoopBlockAst.root match {
-      case Some(blockRoot) => whileLoopAst.withChild(whileLoopBlockAst).withTrueBodyEdge(whileLoopNode, blockRoot)
-      case None            => whileLoopAst.withChild(whileLoopBlockAst)
-    }
+    val whileLoopAst = whileAst(
+      Option(testCallAst),
+      List(whileLoopBlockAst),
+      code = Option(code(forInOfStmt)),
+      lineNumber = line(forInOfStmt),
+      columnNumber = column(forInOfStmt)
+    )
 
-    val blockChildren = List(iteratorAssignmentAst, Ast(resultNode), whileLoopAstWithBody)
+    val blockChildren = List(iteratorAssignmentAst, Ast(resultNode), whileLoopAst)
     blockAst(blockNode_, blockChildren)
   }
 
@@ -658,8 +659,6 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     val testCallArgs = List(testNode)
     val testCallAst  = callAst(testCallNode, testCallArgs)
 
-    val whileLoopAst = Ast(whileLoopNode).withChild(testCallAst).withConditionEdge(whileLoopNode, testCallNode)
-
     // while loop variable assignment:
     val loopVariableAssignmentAsts = loopVariableNames.map { loopVariableName =>
       val whileLoopVariableNode = identifierNode(forInOfStmt, loopVariableName)
@@ -696,13 +695,16 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     scope.popScope()
     localAstParentStack.pop()
 
-    val whileLoopAstWithBody = whileLoopBlockAst.root match {
-      case Some(blockRoot) => whileLoopAst.withChild(whileLoopBlockAst).withTrueBodyEdge(whileLoopNode, blockRoot)
-      case None            => whileLoopAst.withChild(whileLoopBlockAst)
-    }
+    val whileLoopAst = whileAst(
+      Option(testCallAst),
+      List(whileLoopBlockAst),
+      code = Option(code(forInOfStmt)),
+      lineNumber = line(forInOfStmt),
+      columnNumber = column(forInOfStmt)
+    )
 
     val blockNodeChildren =
-      List(iteratorAssignmentAst, Ast(resultNode)) ++ loopVariableNodes.map(Ast(_)) :+ whileLoopAstWithBody
+      List(iteratorAssignmentAst, Ast(resultNode)) ++ loopVariableNodes.map(Ast(_)) :+ whileLoopAst
     blockAst(blockNode_, blockNodeChildren)
   }
 
@@ -811,8 +813,6 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     val testCallArgs = List(testNode)
     val testCallAst  = callAst(testCallNode, testCallArgs)
 
-    val whileLoopAst = Ast(whileLoopNode).withChild(testCallAst).withConditionEdge(whileLoopNode, testCallNode)
-
     // while loop variable assignment:
     val loopVariableAssignmentAsts = loopVariableNames.zipWithIndex.map { case (loopVariableName, index) =>
       val whileLoopVariableNode = identifierNode(forInOfStmt, loopVariableName)
@@ -849,13 +849,16 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     scope.popScope()
     localAstParentStack.pop()
 
-    val whileLoopAstWithBody = whileLoopBlockAst.root match {
-      case Some(blockRoot) => whileLoopAst.withChild(whileLoopBlockAst).withTrueBodyEdge(whileLoopNode, blockRoot)
-      case None            => whileLoopAst.withChild(whileLoopBlockAst)
-    }
+    val whileLoopAst = whileAst(
+      Option(testCallAst),
+      List(whileLoopBlockAst),
+      code = Option(code(forInOfStmt)),
+      lineNumber = line(forInOfStmt),
+      columnNumber = column(forInOfStmt)
+    )
 
     val blockNodeChildren =
-      List(iteratorAssignmentAst, Ast(resultNode)) ++ loopVariableNodes.map(Ast(_)) :+ whileLoopAstWithBody
+      List(iteratorAssignmentAst, Ast(resultNode)) ++ loopVariableNodes.map(Ast(_)) :+ whileLoopAst
     blockAst(blockNode_, blockNodeChildren)
   }
 

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/testfixtures/JsSrc2CpgFrontend.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/testfixtures/JsSrc2CpgFrontend.scala
@@ -12,7 +12,7 @@ trait JsSrc2CpgFrontend extends LanguageFrontend {
     val jssrc2cpg = new JsSrc2Cpg()
     val config    = getConfig().getOrElse(Config(tsTypes = false)).withInputPath(sourceCodePath.getAbsolutePath)
     val res       = jssrc2cpg.createCpg(config).get
-    new PostFrontendValidator(res, ValidationLevel.V1).run()
+    new PostFrontendValidator(res, ValidationLevel.V2).run()
     res
   }
 }

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstCreatorHelper.scala
@@ -152,12 +152,12 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
       val conditionAst = astForNode(guardStmt.conditions)
 
       val thenAst = astsForBlockElements(elementsAfterGuard) ++ deferElementsAstsOrdered match {
-        case Nil => Ast()
+        case Nil =>
+          blockAst(blockNode(guardStmt), List.empty)
         case blockElement :: Nil =>
-          setOrderExplicitly(blockElement, 2)
           blockElement
         case blockChildren =>
-          val block = blockNode(elementsAfterGuard.head).order(2)
+          val block = blockNode(elementsAfterGuard.head)
           blockAst(block, blockChildren)
       }
       val elseAst = astForNode(guardStmt.body)

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForExprSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForExprSyntaxCreator.scala
@@ -498,11 +498,19 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
   }
 
   private def astForIfExprSyntax(node: IfExprSyntax): Ast = {
-    val code         = this.code(node)
-    val ifNode       = controlStructureNode(node, ControlStructureTypes.IF, code)
-    val conditionAst = astForNode(node.conditions)
-    val thenAst      = astForNode(node.body)
-    val elseAst      = node.elseBody.map(astForNode)
+    val code            = this.code(node)
+    val ifNode          = controlStructureNode(node, ControlStructureTypes.IF, code)
+    val conditionAstRaw = astForNode(node.conditions)
+    val conditionAst = conditionAstRaw.root match {
+      case Some(_) => conditionAstRaw
+      case None    => blockAst(blockNode(node.conditions), List.empty)
+    }
+    val bodyAst = astForNode(node.body)
+    val thenAst = bodyAst.root match {
+      case Some(_) => bodyAst
+      case None    => blockAst(blockNode(node.body), List.empty)
+    }
+    val elseAst = node.elseBody.map(astForNode)
     ifThenElseAst(ifNode, Option(conditionAst), thenAst, elseAst)
   }
 
@@ -1060,10 +1068,16 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
       scope.popScope()
       localAstParentStack.pop()
 
-      val switchAst = Ast(switchNode)
+      val switchBlockAst = blockAst(switchBlockNode, casesAsts)
+      val astWithChildren = Ast(switchNode)
         .withChild(condAst)
         .withConditionEdge(switchNode, condIdentNode)
-        .withChild(blockAst(switchBlockNode, casesAsts))
+        .withChild(switchBlockAst)
+
+      val switchAst = switchBlockAst.root match {
+        case Some(blockRoot) => astWithChildren.withTrueBodyEdge(switchNode, blockRoot)
+        case None            => astWithChildren
+      }
 
       scope.popScope()
       localAstParentStack.pop()
@@ -1085,10 +1099,16 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
       scope.popScope()
       localAstParentStack.pop()
 
-      Ast(switchNode)
+      val switchBlockAst = blockAst(blockNode_, casesAsts)
+      val astWithChildren = Ast(switchNode)
         .withChild(switchExpressionAst)
         .withConditionEdge(switchNode, switchExpressionAst.nodes.head)
-        .withChild(blockAst(blockNode_, casesAsts))
+        .withChild(switchBlockAst)
+
+      switchBlockAst.root match {
+        case Some(blockRoot) => astWithChildren.withTrueBodyEdge(switchNode, blockRoot)
+        case None            => astWithChildren
+      }
     }
   }
 

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForExprSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForExprSyntaxCreator.scala
@@ -505,12 +505,8 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
       case Some(_) => conditionAstRaw
       case None    => blockAst(blockNode(node.conditions), List.empty)
     }
-    val bodyAst = astForNode(node.body)
-    val thenAst = bodyAst.root match {
-      case Some(_) => bodyAst
-      case None    => blockAst(blockNode(node.body), List.empty)
-    }
-    val elseAst = node.elseBody.map(astForNode)
+    val thenAst      = astForNode(node.body)
+    val elseAst      = node.elseBody.map(astForNode)
     ifThenElseAst(ifNode, Option(conditionAst), thenAst, elseAst)
   }
 

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForExprSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForExprSyntaxCreator.scala
@@ -1068,21 +1068,13 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
       scope.popScope()
       localAstParentStack.pop()
 
-      val switchBlockAst = blockAst(switchBlockNode, casesAsts)
-      val astWithChildren = Ast(switchNode)
-        .withChild(condAst)
-        .withConditionEdge(switchNode, condIdentNode)
-        .withChild(switchBlockAst)
-
-      val switchAst = switchBlockAst.root match {
-        case Some(blockRoot) => astWithChildren.withTrueBodyEdge(switchNode, blockRoot)
-        case None            => astWithChildren
-      }
+      val switchBlockAst  = blockAst(switchBlockNode, casesAsts)
+      val switchAstResult = switchAst(switchNode, condAst, Seq(switchBlockAst))
 
       scope.popScope()
       localAstParentStack.pop()
 
-      blockAst(outerBlockNode, List(subjectAssignAst, switchAst))
+      blockAst(outerBlockNode, List(subjectAssignAst, switchAstResult))
     } else {
       // The semantics of switch statement children is partially defined by their order value.
       // The blockAst must have order == 2. Only to avoid collision we set switchExpressionAst to 1
@@ -1100,15 +1092,7 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
       localAstParentStack.pop()
 
       val switchBlockAst = blockAst(blockNode_, casesAsts)
-      val astWithChildren = Ast(switchNode)
-        .withChild(switchExpressionAst)
-        .withConditionEdge(switchNode, switchExpressionAst.nodes.head)
-        .withChild(switchBlockAst)
-
-      switchBlockAst.root match {
-        case Some(blockRoot) => astWithChildren.withTrueBodyEdge(switchNode, blockRoot)
-        case None            => astWithChildren
-      }
+      switchAst(switchNode, switchExpressionAst, Seq(switchBlockAst))
     }
   }
 

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForExprSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForExprSyntaxCreator.scala
@@ -505,8 +505,8 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
       case Some(_) => conditionAstRaw
       case None    => blockAst(blockNode(node.conditions), List.empty)
     }
-    val thenAst      = astForNode(node.body)
-    val elseAst      = node.elseBody.map(astForNode)
+    val thenAst = astForNode(node.body)
+    val elseAst = node.elseBody.map(astForNode)
     ifThenElseAst(ifNode, Option(conditionAst), thenAst, elseAst)
   }
 
@@ -1017,7 +1017,8 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
           case other => (List(astForNode(other)), List.empty)
         }
         val needsSyntheticBreak = !s.statements.children.lastOption.exists(_.item.isInstanceOf[FallThroughStmtSyntax])
-        val asts                = flowAst :+ astForNode(s.statements)
+        val statementsAsts      = if (s.statements.children.isEmpty) List.empty else List(astForNode(s.statements))
+        val asts                = flowAst ++ statementsAsts
         val cAsts = if (needsSyntheticBreak) {
           asts :+ Ast(controlStructureNode(s, ControlStructureTypes.BREAK, "break"))
         } else asts

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForStmtSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForStmtSyntaxCreator.scala
@@ -209,8 +209,6 @@ trait AstForStmtSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     val testCallArgs = List(testNode)
     val testCallAst  = callAst(testCallNode, testCallArgs)
 
-    val whileLoopAst = Ast(whileLoopNode).withChild(testCallAst).withConditionEdge(whileLoopNode, testCallNode)
-
     // while loop variable assignment:
     val whileLoopVariableNode = identifierNode(node, loopVariableName)
 
@@ -244,13 +242,16 @@ trait AstForStmtSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     scope.popScope()
     localAstParentStack.pop()
 
-    val whileLoopAstWithBody = whileLoopBlockAst.root match {
-      case Some(blockRoot) => whileLoopAst.withChild(whileLoopBlockAst).withTrueBodyEdge(whileLoopNode, blockRoot)
-      case None            => whileLoopAst.withChild(whileLoopBlockAst)
-    }
+    val whileLoopAst = whileAst(
+      Option(testCallAst),
+      List(whileLoopBlockAst),
+      code = Option(code(node)),
+      lineNumber = line(node),
+      columnNumber = column(node)
+    )
 
     val blockChildren =
-      List(iteratorAssignmentAst, Ast(resultNode), Ast(loopVariableNode), whileLoopAstWithBody)
+      List(iteratorAssignmentAst, Ast(resultNode), Ast(loopVariableNode), whileLoopAst)
     blockAst(blockNode_, blockChildren)
   }
 
@@ -346,8 +347,6 @@ trait AstForStmtSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     val testCallArgs = List(testNode)
     val testCallAst  = callAst(testCallNode, testCallArgs)
 
-    val whileLoopAst = Ast(whileLoopNode).withChild(testCallAst).withConditionEdge(whileLoopNode, testCallNode)
-
     // while loop variable assignment:
     val whileLoopVariableNode = astForNode(id)
 
@@ -381,12 +380,15 @@ trait AstForStmtSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     scope.popScope()
     localAstParentStack.pop()
 
-    val whileLoopAstWithBody = whileLoopBlockAst.root match {
-      case Some(blockRoot) => whileLoopAst.withChild(whileLoopBlockAst).withTrueBodyEdge(whileLoopNode, blockRoot)
-      case None            => whileLoopAst.withChild(whileLoopBlockAst)
-    }
+    val whileLoopAst = whileAst(
+      Option(testCallAst),
+      List(whileLoopBlockAst),
+      code = Option(code(node)),
+      lineNumber = line(node),
+      columnNumber = column(node)
+    )
 
-    val blockChildren = List(iteratorAssignmentAst, Ast(resultNode), whileLoopAstWithBody)
+    val blockChildren = List(iteratorAssignmentAst, Ast(resultNode), whileLoopAst)
     blockAst(blockNode_, blockChildren)
   }
 
@@ -492,8 +494,6 @@ trait AstForStmtSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     val testCallArgs = List(testNode)
     val testCallAst  = callAst(testCallNode, testCallArgs)
 
-    val whileLoopAst = Ast(whileLoopNode).withChild(testCallAst).withConditionEdge(whileLoopNode, testCallNode)
-
     // while loop variable assignment:
     val loopVariableAssignmentAsts = loopVariableNames.zipWithIndex.map { case (loopVariableName, idx) =>
       val whileLoopVariableNode = identifierNode(node, loopVariableName)
@@ -529,13 +529,16 @@ trait AstForStmtSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     scope.popScope()
     localAstParentStack.pop()
 
-    val whileLoopAstWithBody = whileLoopBlockAst.root match {
-      case Some(blockRoot) => whileLoopAst.withChild(whileLoopBlockAst).withTrueBodyEdge(whileLoopNode, blockRoot)
-      case None            => whileLoopAst.withChild(whileLoopBlockAst)
-    }
+    val whileLoopAst = whileAst(
+      Option(testCallAst),
+      List(whileLoopBlockAst),
+      code = Option(code(node)),
+      lineNumber = line(node),
+      columnNumber = column(node)
+    )
 
     val blockNodeChildren =
-      List(iteratorAssignmentAst, Ast(resultNode)) ++ loopVariableNodes.map(Ast(_)) :+ whileLoopAstWithBody
+      List(iteratorAssignmentAst, Ast(resultNode)) ++ loopVariableNodes.map(Ast(_)) :+ whileLoopAst
     blockAst(blockNode_, blockNodeChildren)
   }
 

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForStmtSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForStmtSyntaxCreator.scala
@@ -91,9 +91,17 @@ trait AstForStmtSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
   private def astForForStmtBody(node: ForStmtSyntax): Ast = {
     node.whereClause match {
       case Some(whereClause: WhereClauseSyntax) =>
-        val ifNode  = controlStructureNode(whereClause.condition, ControlStructureTypes.IF, code(whereClause.condition))
-        val testAst = astForNode(whereClause)
-        val consequentAst = astForNode(node.body)
+        val ifNode = controlStructureNode(whereClause.condition, ControlStructureTypes.IF, code(whereClause.condition))
+        val testAstRaw = astForNode(whereClause)
+        val testAst = testAstRaw.root match {
+          case Some(_) => testAstRaw
+          case None    => blockAst(blockNode(whereClause), List.empty)
+        }
+        val consequentAstRaw = astForNode(node.body)
+        val consequentAst = consequentAstRaw.root match {
+          case Some(_) => consequentAstRaw
+          case None    => blockAst(blockNode(node.body), List.empty)
+        }
         ifThenElseAst(ifNode, Option(testAst), consequentAst, None)
       case None => astForNode(node.body)
     }
@@ -240,8 +248,13 @@ trait AstForStmtSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     scope.popScope()
     localAstParentStack.pop()
 
+    val whileLoopAstWithBody = whileLoopBlockAst.root match {
+      case Some(blockRoot) => whileLoopAst.withChild(whileLoopBlockAst).withTrueBodyEdge(whileLoopNode, blockRoot)
+      case None            => whileLoopAst.withChild(whileLoopBlockAst)
+    }
+
     val blockChildren =
-      List(iteratorAssignmentAst, Ast(resultNode), Ast(loopVariableNode), whileLoopAst.withChild(whileLoopBlockAst))
+      List(iteratorAssignmentAst, Ast(resultNode), Ast(loopVariableNode), whileLoopAstWithBody)
     blockAst(blockNode_, blockChildren)
   }
 
@@ -372,7 +385,12 @@ trait AstForStmtSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     scope.popScope()
     localAstParentStack.pop()
 
-    val blockChildren = List(iteratorAssignmentAst, Ast(resultNode), whileLoopAst.withChild(whileLoopBlockAst))
+    val whileLoopAstWithBody = whileLoopBlockAst.root match {
+      case Some(blockRoot) => whileLoopAst.withChild(whileLoopBlockAst).withTrueBodyEdge(whileLoopNode, blockRoot)
+      case None            => whileLoopAst.withChild(whileLoopBlockAst)
+    }
+
+    val blockChildren = List(iteratorAssignmentAst, Ast(resultNode), whileLoopAstWithBody)
     blockAst(blockNode_, blockChildren)
   }
 
@@ -515,10 +533,13 @@ trait AstForStmtSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     scope.popScope()
     localAstParentStack.pop()
 
+    val whileLoopAstWithBody = whileLoopBlockAst.root match {
+      case Some(blockRoot) => whileLoopAst.withChild(whileLoopBlockAst).withTrueBodyEdge(whileLoopNode, blockRoot)
+      case None            => whileLoopAst.withChild(whileLoopBlockAst)
+    }
+
     val blockNodeChildren =
-      List(iteratorAssignmentAst, Ast(resultNode)) ++ loopVariableNodes.map(Ast(_)) :+ whileLoopAst.withChild(
-        whileLoopBlockAst
-      )
+      List(iteratorAssignmentAst, Ast(resultNode)) ++ loopVariableNodes.map(Ast(_)) :+ whileLoopAstWithBody
     blockAst(blockNode_, blockNodeChildren)
   }
 
@@ -544,7 +565,7 @@ trait AstForStmtSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     val code         = this.code(node)
     val ifNode       = controlStructureNode(node, ControlStructureTypes.IF, code)
     val conditionAst = astForNode(node.conditions)
-    val thenAst      = Ast()
+    val thenAst      = blockAst(blockNode(node), List.empty)
     val elseAst      = astForNode(node.body)
     ifThenElseAst(ifNode, Option(conditionAst), thenAst, Option(elseAst))
   }
@@ -604,18 +625,15 @@ trait AstForStmtSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
   }
 
   private def astForWhileStmtSyntax(node: WhileStmtSyntax): Ast = {
-    val code         = this.code(node)
-    val conditionAst = astForNode(node.conditions)
-    val bodyAst      = astForNode(node.body)
-    setOrderExplicitly(conditionAst, 1)
-    setOrderExplicitly(bodyAst, 2)
-    whileAst(
-      Option(conditionAst),
-      Seq(bodyAst),
-      code = Option(code),
-      lineNumber = line(node),
-      columnNumber = column(node)
-    )
+    val code            = this.code(node)
+    val whileNode       = controlStructureNode(node, ControlStructureTypes.WHILE, code)
+    val conditionAst    = astForNode(node.conditions)
+    val bodyAst         = astForNode(node.body)
+    val astWithChildren = controlStructureAst(whileNode, Option(conditionAst), Seq(bodyAst))
+    bodyAst.root match {
+      case Some(bodyRoot) => astWithChildren.withTrueBodyEdge(whileNode, bodyRoot)
+      case None           => astWithChildren
+    }
   }
 
   private def astForYieldStmtSyntax(node: YieldStmtSyntax): Ast = {

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForStmtSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForStmtSyntaxCreator.scala
@@ -625,15 +625,16 @@ trait AstForStmtSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
   }
 
   private def astForWhileStmtSyntax(node: WhileStmtSyntax): Ast = {
-    val code            = this.code(node)
-    val whileNode       = controlStructureNode(node, ControlStructureTypes.WHILE, code)
-    val conditionAst    = astForNode(node.conditions)
-    val bodyAst         = astForNode(node.body)
-    val astWithChildren = controlStructureAst(whileNode, Option(conditionAst), Seq(bodyAst))
-    bodyAst.root match {
-      case Some(bodyRoot) => astWithChildren.withTrueBodyEdge(whileNode, bodyRoot)
-      case None           => astWithChildren
-    }
+    val code         = this.code(node)
+    val conditionAst = astForNode(node.conditions)
+    val bodyAst      = astForNode(node.body)
+    whileAst(
+      Option(conditionAst),
+      Seq(bodyAst),
+      code = Option(code),
+      lineNumber = line(node),
+      columnNumber = column(node)
+    )
   }
 
   private def astForYieldStmtSyntax(node: YieldStmtSyntax): Ast = {

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForStmtSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForStmtSyntaxCreator.scala
@@ -97,12 +97,8 @@ trait AstForStmtSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
           case Some(_) => testAstRaw
           case None    => blockAst(blockNode(whereClause), List.empty)
         }
-        val consequentAstRaw = astForNode(node.body)
-        val consequentAst = consequentAstRaw.root match {
-          case Some(_) => consequentAstRaw
-          case None    => blockAst(blockNode(node.body), List.empty)
-        }
-        ifThenElseAst(ifNode, Option(testAst), consequentAst, None)
+        val thenAst = astForNode(node.body)
+        ifThenElseAst(ifNode, Option(testAst), thenAst, None)
       case None => astForNode(node.body)
     }
   }

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForSyntaxCollectionCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForSyntaxCollectionCreator.scala
@@ -11,7 +11,7 @@ trait AstForSyntaxCollectionCreator(implicit withSchemaValidation: ValidationMod
 
   protected def astForListSyntaxChildren(node: SwiftNode, children: Seq[SwiftNode]): Ast = {
     children.toList match {
-      case Nil         =>
+      case Nil =>
         val blockNode_ = blockNode(node, PropertyDefaults.Code, Defines.Any)
         blockAst(blockNode_, List.empty)
       case head :: Nil =>

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForSyntaxCollectionCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForSyntaxCollectionCreator.scala
@@ -11,8 +11,11 @@ trait AstForSyntaxCollectionCreator(implicit withSchemaValidation: ValidationMod
 
   protected def astForListSyntaxChildren(node: SwiftNode, children: Seq[SwiftNode]): Ast = {
     children.toList match {
-      case Nil         => Ast()
-      case head :: Nil => astForNode(head)
+      case Nil         =>
+        val blockNode_ = blockNode(node, PropertyDefaults.Code, Defines.Any)
+        blockAst(blockNode_, List.empty)
+      case head :: Nil =>
+        astForNode(head)
       case elements =>
         val blockNode_ = blockNode(node, PropertyDefaults.Code, Defines.Any)
         scope.pushNewBlockScope(blockNode_)

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/AvailabilityQueryTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/AvailabilityQueryTests.scala
@@ -14,7 +14,7 @@ class AvailabilityQueryTests extends SwiftSrc2CpgSuite {
     "testAvailabilityQuery1" in {
       val cpg                      = code("if #available(OSX 10.51, *) {}")
       val List(ifControlStructure) = cpg.controlStructure.isIf.l
-      ifControlStructure.whenTrue shouldBe empty
+      ifControlStructure.whenTrue.astChildren shouldBe empty
       val List(condition) = ifControlStructure.condition.isCall.l
       condition.code shouldBe "#available(OSX 10.51, *)"
       val List(arg1, arg2) = condition.argument.isLiteral.l
@@ -28,7 +28,7 @@ class AvailabilityQueryTests extends SwiftSrc2CpgSuite {
     "testAvailabilityQuery2" in {
       val cpg                      = code("if #unavailable(OSX 10.51, *) {}")
       val List(ifControlStructure) = cpg.controlStructure.isIf.l
-      ifControlStructure.whenTrue shouldBe empty
+      ifControlStructure.whenTrue.astChildren shouldBe empty
       val List(condition) = ifControlStructure.condition.isCall.l
       condition.code shouldBe "#unavailable(OSX 10.51, *)"
       val List(arg1, arg2) = condition.argument.isLiteral.l
@@ -42,7 +42,7 @@ class AvailabilityQueryTests extends SwiftSrc2CpgSuite {
     "testAvailabilityQuery5b" in {
       val cpg                      = code("if let _ = Optional(5), #unavailable(OSX 10.52, *) {}")
       val List(ifControlStructure) = cpg.controlStructure.isIf.l
-      ifControlStructure.whenTrue shouldBe empty
+      ifControlStructure.whenTrue.astChildren shouldBe empty
       val List(assignment, unavailable) = ifControlStructure.condition.astChildren.isCall.l
       assignment.code shouldBe "let _ = Optional(5)"
       assignment.name shouldBe Operators.assignment
@@ -54,7 +54,7 @@ class AvailabilityQueryTests extends SwiftSrc2CpgSuite {
     "testAvailabilityQuery6" in {
       val cpg                      = code("if #available(OSX 10.51, *), #available(OSX 10.52, *) {}")
       val List(ifControlStructure) = cpg.controlStructure.isIf.l
-      ifControlStructure.whenTrue shouldBe empty
+      ifControlStructure.whenTrue.astChildren shouldBe empty
       val List(available1, available2) = ifControlStructure.condition.astChildren.isCall.l
       available1.code shouldBe "#available(OSX 10.51, *)"
       available1.name shouldBe "#available"
@@ -66,7 +66,7 @@ class AvailabilityQueryTests extends SwiftSrc2CpgSuite {
     "testAvailabilityQuery10" in {
       val cpg                      = code("if #available(OSX) {}")
       val List(ifControlStructure) = cpg.controlStructure.isIf.l
-      ifControlStructure.whenTrue shouldBe empty
+      ifControlStructure.whenTrue.astChildren shouldBe empty
       val List(condition) = ifControlStructure.condition.isCall.l
       condition.code shouldBe "#available(OSX)"
       val List(arg1) = condition.argument.isLiteral.l
@@ -78,7 +78,7 @@ class AvailabilityQueryTests extends SwiftSrc2CpgSuite {
     "testAvailabilityQuery12" in {
       val cpg                      = code("if #available(OSX 10.51) {}")
       val List(ifControlStructure) = cpg.controlStructure.isIf.l
-      ifControlStructure.whenTrue shouldBe empty
+      ifControlStructure.whenTrue.astChildren shouldBe empty
       val List(condition) = ifControlStructure.condition.isCall.l
       condition.code shouldBe "#available(OSX 10.51)"
       val List(arg1) = condition.argument.isLiteral.l
@@ -90,7 +90,7 @@ class AvailabilityQueryTests extends SwiftSrc2CpgSuite {
     "testAvailabilityQuery13" in {
       val cpg                      = code("if #available(iDishwasherOS 10.51) {}")
       val List(ifControlStructure) = cpg.controlStructure.isIf.l
-      ifControlStructure.whenTrue shouldBe empty
+      ifControlStructure.whenTrue.astChildren shouldBe empty
       val List(condition) = ifControlStructure.condition.isCall.l
       condition.code shouldBe "#available(iDishwasherOS 10.51)"
       val List(arg1) = condition.argument.isLiteral.l
@@ -102,7 +102,7 @@ class AvailabilityQueryTests extends SwiftSrc2CpgSuite {
     "testAvailabilityQuery14" in {
       val cpg                      = code(" if #available(iDishwasherOS 10.51, *) {}")
       val List(ifControlStructure) = cpg.controlStructure.isIf.l
-      ifControlStructure.whenTrue shouldBe empty
+      ifControlStructure.whenTrue.astChildren shouldBe empty
       val List(condition) = ifControlStructure.condition.isCall.l
       condition.code shouldBe "#available(iDishwasherOS 10.51, *)"
       val List(arg1, arg2) = condition.argument.isLiteral.l
@@ -116,7 +116,7 @@ class AvailabilityQueryTests extends SwiftSrc2CpgSuite {
     "testAvailabilityQuery19" in {
       val cpg                      = code("if #available(OSX 10.51, OSX 10.52, *) {}")
       val List(ifControlStructure) = cpg.controlStructure.isIf.l
-      ifControlStructure.whenTrue shouldBe empty
+      ifControlStructure.whenTrue.astChildren shouldBe empty
       val List(condition) = ifControlStructure.condition.isCall.l
       condition.code shouldBe "#available(OSX 10.51, OSX 10.52, *)"
       val List(arg1, arg2, arg3) = condition.argument.isLiteral.l
@@ -132,7 +132,7 @@ class AvailabilityQueryTests extends SwiftSrc2CpgSuite {
     "testAvailabilityQuery24" in {
       val cpg                      = code("if #available(*) {}")
       val List(ifControlStructure) = cpg.controlStructure.isIf.l
-      ifControlStructure.whenTrue shouldBe empty
+      ifControlStructure.whenTrue.astChildren shouldBe empty
       val List(condition) = ifControlStructure.condition.isCall.l
       condition.code shouldBe "#available(*)"
       val List(arg1) = condition.argument.isLiteral.l
@@ -144,7 +144,7 @@ class AvailabilityQueryTests extends SwiftSrc2CpgSuite {
     "testAvailabilityQuery35" in {
       val cpg                      = code("if 1 != 2, #available(iOS 8.0, *) {}")
       val List(ifControlStructure) = cpg.controlStructure.isIf.l
-      ifControlStructure.whenTrue shouldBe empty
+      ifControlStructure.whenTrue.astChildren shouldBe empty
       val List(notEquals, available) = ifControlStructure.condition.astChildren.isCall.l
       notEquals.code shouldBe "1 != 2"
       notEquals.name shouldBe Operators.notEquals
@@ -156,7 +156,7 @@ class AvailabilityQueryTests extends SwiftSrc2CpgSuite {
     "testAvailabilityQuery36" in {
       val cpg                      = code("if case 42 = 42, #available(iOS 8.0, *) {}")
       val List(ifControlStructure) = cpg.controlStructure.isIf.l
-      ifControlStructure.whenTrue shouldBe empty
+      ifControlStructure.whenTrue.astChildren shouldBe empty
       val List(notEquals, available) = ifControlStructure.condition.astChildren.isCall.l
       notEquals.code shouldBe "case 42 = 42"
       notEquals.name shouldBe Operators.equals

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/GuardTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/GuardTests.scala
@@ -24,7 +24,7 @@ class GuardTests extends SwiftSrc2CpgSuite {
       guardIf.code shouldBe "guard {} else {}"
       guardIf.controlStructureType shouldBe ControlStructureTypes.IF
       guardIf.condition.code.l shouldBe List("<lambda>0")
-      guardIf.whenTrue.code.l shouldBe empty
+      guardIf.whenTrue.astChildren.code.l shouldBe empty
       methodBlock.astChildren.isControlStructure.whenFalse.astChildren.code.l shouldBe empty
     }
 

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/testfixtures/SwiftCompilerSrc2CpgFrontend.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/testfixtures/SwiftCompilerSrc2CpgFrontend.scala
@@ -12,7 +12,7 @@ trait SwiftCompilerSrc2CpgFrontend extends LanguageFrontend {
     val pathAsString = sourceCodePath.toPath.resolve("SwiftTest").toAbsolutePath.toString
     val config       = getConfig().getOrElse(Config()).withInputPath(pathAsString)
     val cpg          = new SwiftSrc2Cpg().createCpg(config).get
-    new PostFrontendValidator(cpg, ValidationLevel.V1).run()
+    new PostFrontendValidator(cpg, ValidationLevel.V2).run()
     cpg
   }
 

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/testfixtures/SwiftSrc2CpgFrontend.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/testfixtures/SwiftSrc2CpgFrontend.scala
@@ -12,7 +12,7 @@ trait SwiftSrc2CpgFrontend extends LanguageFrontend {
     val pathAsString = sourceCodePath.getAbsolutePath
     val config       = getConfig().getOrElse(Config()).withInputPath(pathAsString)
     val tmp          = new SwiftSrc2Cpg().createCpg(config).get
-    new PostFrontendValidator(tmp, ValidationLevel.V1).run()
+    new PostFrontendValidator(tmp, ValidationLevel.V2).run()
     tmp
   }
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstCreatorBase.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstCreatorBase.scala
@@ -165,7 +165,11 @@ abstract class AstCreatorBase[Node, NodeProcessor](filename: String)(implicit wi
     if (code.isDefined) {
       whileNode = whileNode.code(code.get)
     }
-    controlStructureAst(whileNode, condition, body)
+    val astWithChildren = controlStructureAst(whileNode, condition, body)
+    body.headOption.flatMap(_.root) match {
+      case Some(bodyRoot) => astWithChildren.withTrueBodyEdge(whileNode, bodyRoot)
+      case None           => astWithChildren
+    }
   }
 
   def doWhileAst(
@@ -186,6 +190,14 @@ abstract class AstCreatorBase[Node, NodeProcessor](filename: String)(implicit wi
     body.headOption.flatMap(_.root) match {
       case Some(doBodyRoot) => astWithChildren.withDoBodyEdge(doWhileNode, doBodyRoot)
       case None             => astWithChildren
+    }
+  }
+
+  def switchAst(switchNode: NewControlStructure, condition: Ast, body: Seq[Ast]): Ast = {
+    val astWithChildren = controlStructureAst(switchNode, Option(condition), body)
+    body.headOption.flatMap(_.root) match {
+      case Some(bodyRoot) => astWithChildren.withTrueBodyEdge(switchNode, bodyRoot)
+      case None           => astWithChildren
     }
   }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/validation/validation.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/validation/validation.scala
@@ -446,22 +446,36 @@ class PostFrontendValidator(cpg: Cpg, fatalValidationLevel: ValidationLevel) ext
                 s"TRY ControlStructure '${controlStructure.code}' is missing TRY_BODY edge (CfgCreator will use legacy order fallback)"
               )
             // CATCH_BODY: CfgCreator falls back to CATCH ControlStructure children, or astChildren.order(2)
+            // but we should not warn if the child at order(2) is a FINALLY control structure (try-finally case)
             val hasCatchFallback =
               controlStructure.astChildren.isControlStructure
                 .filter(_.controlStructureType == ControlStructureTypes.CATCH)
                 .nonEmpty ||
-                controlStructure.astChildren.order(2).nonEmpty
+                (controlStructure.astChildren.order(2).nonEmpty &&
+                  controlStructure.astChildren
+                    .order(2)
+                    .collectFirst {
+                      case cs: nodes.ControlStructure if cs.controlStructureType == ControlStructureTypes.FINALLY => cs
+                    }
+                    .isEmpty)
             if (controlStructure._catchBodyOut.isEmpty && hasCatchFallback)
               registerViolation(
                 CTRL_EDGE_USING_LEGACY,
                 s"TRY ControlStructure '${controlStructure.code}' is missing CATCH_BODY edge (CfgCreator will use legacy order fallback)"
               )
             // FINALLY_BODY: CfgCreator falls back to FINALLY ControlStructure children, or astChildren.order(3)
+            // but we should not warn if the child at order(3) is a CATCH control structure (multiple catches case)
             val hasFinallyFallback =
               controlStructure.astChildren.isControlStructure
                 .filter(_.controlStructureType == ControlStructureTypes.FINALLY)
                 .nonEmpty ||
-                controlStructure.astChildren.order(3).nonEmpty
+                (controlStructure.astChildren.order(3).nonEmpty &&
+                  controlStructure.astChildren
+                    .order(3)
+                    .collectFirst {
+                      case cs: nodes.ControlStructure if cs.controlStructureType == ControlStructureTypes.CATCH => cs
+                    }
+                    .isEmpty)
             if (controlStructure._finallyBodyOut.isEmpty && hasFinallyFallback)
               registerViolation(
                 CTRL_EDGE_USING_LEGACY,


### PR DESCRIPTION
Adds explicit `TRUE_BODY`, `FALSE_BODY`, `DO_BODY` edges to control structures in jssrc2cpg, c2cpg, and swiftsrc2cpg to satisfy `V2` validation.

## Changes

**x2cpg:**
- Created `switchAst` helper in x2cpg
- Added TRUE_BODY edge to `whileAst` helper

**jssrc2cpg:**
- While loops: use `whileAst` helper from x2cpg
- Switch statements: use `switchAst` helper from x2cpg
- For-in/for-of loops: Add `TRUE_BODY` edge to desugared while loop body

**c2cpg:**
- While loops: use `whileAst` helper from x2cpg
- Switch statements: use `switchAst` helper from x2cpg
- ForEach statements: Add `TRUE_BODY` edge to desugared while loop body

**swiftsrc2cpg:**
- Guard statements: Create empty block for `TRUE_BODY` when no following statements
- If expressions: Create empty blocks for `TRUE_BODY` and `CONDITION` when missing
- For loop where clauses: Create empty blocks for `TRUE_BODY` and `CONDITION` when missing
- Updated tests to check `.whenTrue.astChildren` instead of `.whenTrue`

**Validation:**
- Fixed false positive warnings for try-finally (missing `CATCH_BODY` when `FINALLY` at order 2)
- Fixed false positive warnings for multiple catch clauses (missing `FINALLY_BODY` when `CATCH` at order 3)