### PR TITLE
[kotlin2cpg] Emit JUMP_ARGUMENT edges for labeled break/continue statements

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForStatementsCreator.scala
@@ -8,6 +8,7 @@ import io.shiftleft.codepropertygraph.generated.ControlStructureTypes
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.AstNodeNew
+import io.shiftleft.codepropertygraph.generated.nodes.NewJumpLabel
 import io.shiftleft.codepropertygraph.generated.nodes.NewLocal
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
 import org.jetbrains.kotlin.psi.KtBlockExpression
@@ -530,12 +531,40 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
 
   def astForBreak(expr: KtBreakExpression): Ast = {
     val node = controlStructureNode(expr, ControlStructureTypes.BREAK, code(expr))
-    Ast(node)
+    Option(expr.getLabelName) match {
+      case Some(labelName) =>
+        val jumpLabelNode = NewJumpLabel()
+          .parserTypeName(expr.getClass.getSimpleName)
+          .name(labelName)
+          .code(labelName)
+          .lineNumber(line(expr))
+          .columnNumber(column(expr))
+          .order(1)
+        Ast(node)
+          .withChild(Ast(jumpLabelNode))
+          .withJumpArgumentEdge(node, jumpLabelNode)
+      case None =>
+        Ast(node)
+    }
   }
 
   def astForContinue(expr: KtContinueExpression): Ast = {
     val node = controlStructureNode(expr, ControlStructureTypes.CONTINUE, code(expr))
-    Ast(node)
+    Option(expr.getLabelName) match {
+      case Some(labelName) =>
+        val jumpLabelNode = NewJumpLabel()
+          .parserTypeName(expr.getClass.getSimpleName)
+          .name(labelName)
+          .code(labelName)
+          .lineNumber(line(expr))
+          .columnNumber(column(expr))
+          .order(1)
+        Ast(node)
+          .withChild(Ast(jumpLabelNode))
+          .withJumpArgumentEdge(node, jumpLabelNode)
+      case None =>
+        Ast(node)
+    }
   }
 
   def astForThrowExpression(

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForStatementsCreator.scala
@@ -8,7 +8,6 @@ import io.shiftleft.codepropertygraph.generated.ControlStructureTypes
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.AstNodeNew
-import io.shiftleft.codepropertygraph.generated.nodes.NewJumpLabel
 import io.shiftleft.codepropertygraph.generated.nodes.NewLocal
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
 import org.jetbrains.kotlin.psi.KtBlockExpression
@@ -529,43 +528,11 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
     else astForTryAsExpression(expr, argIdx, argNameMaybe, annotations)
   }
 
-  def astForBreak(expr: KtBreakExpression): Ast = {
-    val node = controlStructureNode(expr, ControlStructureTypes.BREAK, code(expr))
-    Option(expr.getLabelName) match {
-      case Some(labelName) =>
-        val jumpLabelNode = NewJumpLabel()
-          .parserTypeName(expr.getClass.getSimpleName)
-          .name(labelName)
-          .code(labelName)
-          .lineNumber(line(expr))
-          .columnNumber(column(expr))
-          .order(1)
-        Ast(node)
-          .withChild(Ast(jumpLabelNode))
-          .withJumpArgumentEdge(node, jumpLabelNode)
-      case None =>
-        Ast(node)
-    }
-  }
+  def astForBreak(expr: KtBreakExpression): Ast =
+    breakAst(expr, code(expr), Option(expr.getLabelName))
 
-  def astForContinue(expr: KtContinueExpression): Ast = {
-    val node = controlStructureNode(expr, ControlStructureTypes.CONTINUE, code(expr))
-    Option(expr.getLabelName) match {
-      case Some(labelName) =>
-        val jumpLabelNode = NewJumpLabel()
-          .parserTypeName(expr.getClass.getSimpleName)
-          .name(labelName)
-          .code(labelName)
-          .lineNumber(line(expr))
-          .columnNumber(column(expr))
-          .order(1)
-        Ast(node)
-          .withChild(Ast(jumpLabelNode))
-          .withJumpArgumentEdge(node, jumpLabelNode)
-      case None =>
-        Ast(node)
-    }
-  }
+  def astForContinue(expr: KtContinueExpression): Ast =
+    continueAst(expr, code(expr), Option(expr.getLabelName))
 
   def astForThrowExpression(
     expr: KtThrowExpression,

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ControlStructureTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ControlStructureTests.scala
@@ -1,7 +1,7 @@
 package io.joern.kotlin2cpg.querying
 
 import io.joern.kotlin2cpg.testfixtures.KotlinCode2CpgFixture
-import io.shiftleft.codepropertygraph.generated.nodes.{Block, Call, ControlStructure, Identifier, Local}
+import io.shiftleft.codepropertygraph.generated.nodes.{Block, Call, ControlStructure, Identifier, JumpLabel, Local}
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, EdgeTypes, Operators}
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.codepropertygraph.generated.nodes.Literal
@@ -717,4 +717,79 @@ class ControlStructureTests extends KotlinCode2CpgFixture(withOssDataflow = fals
   }
 
   // TODO: also add test for the loop range, when it is with downTo or whatever
+
+  "CPG for code with labeled break statement" should {
+    val cpg = code("""
+        |package mypkg
+        |fun foo() {
+        |  outer@ for (i in 0..10) {
+        |    for (j in 0..10) {
+        |      if (j == 5) break@outer
+        |    }
+        |  }
+        |}""".stripMargin)
+
+    "should contain a BREAK with a JUMP_LABEL child" in {
+      val List(breakNode) = cpg.controlStructure.isBreak.l
+      breakNode.code shouldBe "break@outer"
+      val List(jumpLabel) = breakNode.astChildren.collectAll[JumpLabel].l
+      jumpLabel.name shouldBe "outer"
+      jumpLabel.order shouldBe 1
+    }
+
+    "should have a JUMP_ARGUMENT edge from break to the JUMP_LABEL" in {
+      val List(breakNode) = cpg.controlStructure.isBreak.l
+      val List(jumpLabel) = breakNode.jumpArgumentOut.collectAll[JumpLabel].l
+      jumpLabel.name shouldBe "outer"
+    }
+  }
+
+  "CPG for code with labeled continue statement" should {
+    val cpg = code("""
+        |package mypkg
+        |fun foo() {
+        |  outer@ for (i in 0..10) {
+        |    for (j in 0..10) {
+        |      if (j == 3) continue@outer
+        |    }
+        |  }
+        |}""".stripMargin)
+
+    "should contain a CONTINUE with a JUMP_LABEL child" in {
+      val List(continueNode) = cpg.controlStructure.isContinue.l
+      continueNode.code shouldBe "continue@outer"
+      val List(jumpLabel) = continueNode.astChildren.collectAll[JumpLabel].l
+      jumpLabel.name shouldBe "outer"
+      jumpLabel.order shouldBe 1
+    }
+
+    "should have a JUMP_ARGUMENT edge from continue to the JUMP_LABEL" in {
+      val List(continueNode) = cpg.controlStructure.isContinue.l
+      val List(jumpLabel)    = continueNode.jumpArgumentOut.collectAll[JumpLabel].l
+      jumpLabel.name shouldBe "outer"
+    }
+  }
+
+  "CPG for code with unlabeled break/continue" should {
+    val cpg = code("""
+        |package mypkg
+        |fun foo() {
+        |  for (i in 0..10) {
+        |    if (i == 5) break
+        |    if (i == 3) continue
+        |  }
+        |}""".stripMargin)
+
+    "should have no JUMP_LABEL child and no JUMP_ARGUMENT edge on break" in {
+      val List(breakNode) = cpg.controlStructure.isBreak.l
+      breakNode.astChildren.collectAll[JumpLabel].size shouldBe 0
+      breakNode.jumpArgumentOut.size shouldBe 0
+    }
+
+    "should have no JUMP_LABEL child and no JUMP_ARGUMENT edge on continue" in {
+      val List(continueNode) = cpg.controlStructure.isContinue.l
+      continueNode.astChildren.collectAll[JumpLabel].size shouldBe 0
+      continueNode.jumpArgumentOut.size shouldBe 0
+    }
+  }
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstCreatorBase.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstCreatorBase.scala
@@ -251,11 +251,39 @@ abstract class AstCreatorBase[Node, NodeProcessor](filename: String)(implicit wi
   def breakAst(node: Node, codeStr: String, labelName: Option[String]): Ast =
     labeledJumpAst(node, ControlStructureTypes.BREAK, codeStr, labelName)
 
+  /** Creates an AST for a break statement. When `labelNumber` is present a `Literal` child is created at order 1 and
+    * connected to the break node via a `JUMP_ARGUMENT` edge.
+    */
+  def breakAst(node: Node, codeStr: String, labelNumber: Option[Int])(implicit dummy: DummyImplicit): Ast =
+    integerJumpAst(node, ControlStructureTypes.BREAK, codeStr, labelNumber)
+
+  /** Creates an AST for a break statement without a jump argument. */
+  def breakAst(node: Node, codeStr: String): Ast =
+    jumpAst(node, ControlStructureTypes.BREAK, codeStr)
+
   /** Creates an AST for a continue statement. When `labelName` is present a `JumpLabel` child is created at order 1 and
     * connected to the continue node via a `JUMP_ARGUMENT` edge.
     */
   def continueAst(node: Node, codeStr: String, labelName: Option[String]): Ast =
     labeledJumpAst(node, ControlStructureTypes.CONTINUE, codeStr, labelName)
+
+  /** Creates an AST for a continue statement. When `labelNumber` is present a `Literal` child is created at order 1 and
+    * connected to the continue node via a `JUMP_ARGUMENT` edge.
+    */
+  def continueAst(node: Node, codeStr: String, labelNumber: Option[Int])(implicit dummy: DummyImplicit): Ast =
+    integerJumpAst(node, ControlStructureTypes.CONTINUE, codeStr, labelNumber)
+
+  /** Creates an AST for a continue statement without a jump argument. */
+  def continueAst(node: Node, codeStr: String): Ast =
+    jumpAst(node, ControlStructureTypes.CONTINUE, codeStr)
+
+  def labeledJumpAst(node: Node, jumpType: String, codeStr: String, labelNumber: Option[Int])(implicit
+    dummy: DummyImplicit
+  ): Ast =
+    integerJumpAst(node, jumpType, codeStr, labelNumber)
+
+  def labeledJumpAst(node: Node, jumpType: String, codeStr: String): Ast =
+    jumpAst(node, jumpType, codeStr)
 
   def labeledJumpAst(node: Node, jumpType: String, codeStr: String, labelName: Option[String]): Ast = {
     val jumpNode = NewControlStructure()
@@ -280,6 +308,39 @@ abstract class AstCreatorBase[Node, NodeProcessor](filename: String)(implicit wi
         Ast(jumpNode)
     }
   }
+
+  def integerJumpAst(node: Node, jumpType: String, codeStr: String, labelNumber: Option[Int]): Ast = {
+    val jumpNode = NewControlStructure()
+      .parserTypeName(node.getClass.getSimpleName)
+      .controlStructureType(jumpType)
+      .code(codeStr)
+      .lineNumber(line(node))
+      .columnNumber(column(node))
+    labelNumber match {
+      case Some(number) =>
+        val integerJump = NewLiteral()
+          .code(number.toString)
+          .typeFullName(Defines.Any)
+          .lineNumber(line(node))
+          .columnNumber(column(node))
+          .order(1)
+        Ast(jumpNode)
+          .withChild(Ast(integerJump))
+          .withJumpArgumentEdge(jumpNode, integerJump)
+      case None =>
+        Ast(jumpNode)
+    }
+  }
+
+  private def jumpAst(node: Node, jumpType: String, codeStr: String): Ast =
+    Ast(
+      NewControlStructure()
+        .parserTypeName(node.getClass.getSimpleName)
+        .controlStructureType(jumpType)
+        .code(codeStr)
+        .lineNumber(line(node))
+        .columnNumber(column(node))
+    )
 
   /** For the given try body, catch ASTs and finally AST, create a try-catch-finally AST with orders set correctly for
     * the ossdataflow engine.

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstCreatorBase.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstCreatorBase.scala
@@ -245,6 +245,42 @@ abstract class AstCreatorBase[Node, NodeProcessor](filename: String)(implicit wi
     }
   }
 
+  /** Creates an AST for a break statement. When `labelName` is present a `JumpLabel` child is created at order 1 and
+    * connected to the break node via a `JUMP_ARGUMENT` edge.
+    */
+  def breakAst(node: Node, codeStr: String, labelName: Option[String]): Ast =
+    labeledJumpAst(node, ControlStructureTypes.BREAK, codeStr, labelName)
+
+  /** Creates an AST for a continue statement. When `labelName` is present a `JumpLabel` child is created at order 1 and
+    * connected to the continue node via a `JUMP_ARGUMENT` edge.
+    */
+  def continueAst(node: Node, codeStr: String, labelName: Option[String]): Ast =
+    labeledJumpAst(node, ControlStructureTypes.CONTINUE, codeStr, labelName)
+
+  def labeledJumpAst(node: Node, jumpType: String, codeStr: String, labelName: Option[String]): Ast = {
+    val jumpNode = NewControlStructure()
+      .parserTypeName(node.getClass.getSimpleName)
+      .controlStructureType(jumpType)
+      .code(codeStr)
+      .lineNumber(line(node))
+      .columnNumber(column(node))
+    labelName match {
+      case Some(name) =>
+        val jumpLabelNode = NewJumpLabel()
+          .parserTypeName(node.getClass.getSimpleName)
+          .name(name)
+          .code(name)
+          .lineNumber(line(node))
+          .columnNumber(column(node))
+          .order(1)
+        Ast(jumpNode)
+          .withChild(Ast(jumpLabelNode))
+          .withJumpArgumentEdge(jumpNode, jumpLabelNode)
+      case None =>
+        Ast(jumpNode)
+    }
+  }
+
   /** For the given try body, catch ASTs and finally AST, create a try-catch-finally AST with orders set correctly for
     * the ossdataflow engine.
     */


### PR DESCRIPTION
Kotlin2cpg of: https://github.com/ShiftLeftSecurity/codescience/issues/8864