### PR TITLE
[rust2cpg] lower tuple-like struct calls

### DIFF
--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/AstCreator.scala
@@ -174,4 +174,14 @@ class AstCreator(val config: Config, val parseResult: ParseResult)(implicit with
     }
   }
 
+  // A tuple-like constructor call like `Foo(x, y)` has matching methodFullName/typeFullName
+  // from rust_ast_gen. In other words, it's as if there was a function named `Foo(x:X,y:Y) -> Foo`.
+  // TODO: this doesn't account for generics yet.
+  protected def isStructCtorCall(callExpr: RustNodeSyntax.CallExpr): Boolean = {
+    (callExpr.methodFullName, callExpr.typeFullName) match {
+      case (Some(methodFullName), Some(typeFullName)) => methodFullName == typeFullName
+      case _                                          => false
+    }
+  }
+
 }

--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
@@ -298,18 +298,69 @@ trait RustVisitor(implicit withValidationMode: ValidationMode) { this: AstCreato
   // CallExpr =
   //  Attr* Expr ArgList
   private def visitCallExpr(callExpr: CallExpr): Ast = {
-    viewExprAsPathExpr(callExpr.expr) match {
-      case Some(nameRefs) =>
-        val name           = code(nameRefs.last)
-        val methodFullName = methodFullNameForCallExpr(callExpr, nameRefs)
-        val typeFullName   = typeFullNameForExpr(callExpr)
-        val dispatch       = DispatchTypes.STATIC_DISPATCH
-        val call =
-          callNode(callExpr, code(callExpr), name, methodFullName, dispatch, None, Some(typeFullName))
-        val args = callExpr.argList.expr.map(visitExpr)
-        callAst(call, args)
-      case None => notHandledYet(callExpr)
+    if (isStructCtorCall(callExpr)) {
+      lowerStructCtorCall(callExpr)
+    } else {
+      viewExprAsPathExpr(callExpr.expr) match {
+        case Some(nameRefs) =>
+          val name           = code(nameRefs.last)
+          val methodFullName = methodFullNameForCallExpr(callExpr, nameRefs)
+          val typeFullName   = typeFullNameForExpr(callExpr)
+          val dispatch       = DispatchTypes.STATIC_DISPATCH
+          val call =
+            callNode(callExpr, code(callExpr), name, methodFullName, dispatch, None, Some(typeFullName))
+          val args = callExpr.argList.expr.map(visitExpr)
+          callAst(call, args)
+        case None => notHandledYet(callExpr)
+      }
     }
+  }
+
+  // Lowers a tuple-like struct call e.g. `Foo(x,y)` into an alloc-followed-by-field-assignments-block:
+  // BLOCK
+  //   LOCAL tmp
+  //   tmp = <operator>.alloc
+  //   tmp.0 = x
+  //   tmp.1 = y
+  //   tmp
+  // We perform this lowering regardless of where the struct is defined (internal/external).
+  // For internal structs, it would be easy to add a fake "<init>" method that performs the assignments.
+  // But to do the same for external structs, we would have to track them all, and visit the file
+  // more than once.
+  private def lowerStructCtorCall(callExpr: CallExpr): Ast = {
+    // LOCAL tmp
+    val typeFullName = typeFullNameForExpr(callExpr)
+    val local        = localNode(callExpr, name = "tmp", code = "tmp", typeFullName)
+
+    // tmp = <operator>.alloc
+    val allocAssignAst = {
+      val tmp       = identifierNode(callExpr, name = "tmp", code = "tmp", typeFullName)
+      val tmpAst    = Ast(tmp).withRefEdge(tmp, local)
+      val allocCall = operatorCallNode(callExpr, Operators.alloc, Operators.alloc, Some(typeFullName))
+      val assign    = assignmentNode(callExpr, s"tmp = ${Operators.alloc}")
+      callAst(assign, Seq(tmpAst, Ast(allocCall)))
+    }
+
+    // tmp.0 = x; tmp.1 = y; etc.
+    val fieldAssignAsts = callExpr.argList.expr.zipWithIndex.map { case (argExpr, i) =>
+      val argAst      = visitExpr(argExpr)
+      val argType     = typeFullNameForExpr(argExpr)
+      val tmp         = identifierNode(argExpr, "tmp", "tmp", typeFullName)
+      val baseAst     = Ast(tmp).withRefEdge(tmp, local)
+      val fieldAccess = fieldAccessAst(argExpr, argExpr, baseAst, s"tmp.$i", i.toString, argType)
+      val assign      = assignmentNode(argExpr, s"tmp.$i = ${code(argExpr)}")
+      callAst(assign, Seq(fieldAccess, argAst))
+    }
+
+    // tmp
+    val retAst = {
+      val tmp = identifierNode(callExpr, name = "tmp", code = "tmp", typeFullName)
+      Ast(tmp).withRefEdge(tmp, local)
+    }
+
+    // BLOCK { ... }
+    val block = blockNode(callExpr, code(callExpr), typeFullName)
+    Ast(block).withChildren(Seq(Ast(local), allocAssignAst) ++ fieldAssignAsts ++ Seq(retAst))
   }
 
   private def viewExprAsNameRef(expr: Expr): Option[NameRef] = {

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/StructTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/StructTests.scala
@@ -225,4 +225,156 @@ class StructTests extends Rust2CpgSuite(noSysRoot = true) {
       }
     }
   }
+
+  "an internal tuple-struct call" should {
+    val cpg = code("""
+        |struct Foo(i32, bool);
+        |fn main() {
+        | Foo(1, true);
+        |}
+        |""".stripMargin)
+
+    "lower into a block with appropriate type and number of children" in {
+      inside(cpg.method.name("main").body.astChildren.isBlock.l) { case block :: Nil =>
+        block.code shouldBe "Foo(1, true)"
+        block.typeFullName shouldBe "rust2cpgtest::Foo"
+        block.astChildren.size shouldBe 5 // 1 (local) + 1 (.alloc) + 2 (tmp.i = arg) + 1 (ident)
+      }
+    }
+
+    "the block's first child is a LOCAL declaration" in {
+      inside(cpg.block.codeExact("Foo(1, true)").astChildren.order(1).l) { case (local: Local) :: Nil =>
+        local.name shouldBe "tmp"
+        local.typeFullName shouldBe "rust2cpgtest::Foo"
+      }
+    }
+
+    "the block's second child is an alloc assignment" in {
+      inside(cpg.block.codeExact("Foo(1, true)").astChildren.order(2).l) { case (assign: Call) :: Nil =>
+        assign.code shouldBe s"tmp = ${Operators.alloc}"
+
+        inside(assign.argument(1)) { case tmp: Identifier =>
+          tmp.typeFullName shouldBe "rust2cpgtest::Foo"
+          tmp.name shouldBe "tmp"
+          tmp.code shouldBe "tmp"
+        }
+
+        inside(assign.argument(2)) { case alloc: Call =>
+          alloc.methodFullName shouldBe Operators.alloc
+          alloc.name shouldBe Operators.alloc
+          alloc.argument shouldBe empty
+        }
+      }
+    }
+
+    "the block's third child is a field assignment" in {
+      inside(cpg.block.codeExact("Foo(1, true)").astChildren.order(3).l) { case (assign: Call) :: Nil =>
+        assign.code shouldBe "tmp.0 = 1"
+
+        inside(assign.argument(1)) { case fieldAccess: Call =>
+          fieldAccess.code shouldBe "tmp.0"
+          fieldAccess.methodFullName shouldBe Operators.fieldAccess
+          fieldAccess.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+
+          inside(fieldAccess.argument(1)) { case tmp: Identifier =>
+            tmp.code shouldBe "tmp"
+            tmp.typeFullName shouldBe "rust2cpgtest::Foo"
+          }
+
+          inside(fieldAccess.argument(2)) { case zero: FieldIdentifier =>
+            zero.code shouldBe "0"
+            zero.canonicalName shouldBe "0"
+          }
+        }
+
+        inside(assign.argument(2)) { case lit: Literal =>
+          lit.code shouldBe "1"
+          lit.typeFullName shouldBe "i32"
+        }
+      }
+    }
+
+    "the block's fourth child is a field assignment" in {
+      inside(cpg.block.codeExact("Foo(1, true)").astChildren.order(4).l) { case (assign: Call) :: Nil =>
+        assign.code shouldBe "tmp.1 = true"
+
+        inside(assign.argument(1)) { case fieldAccess: Call =>
+          fieldAccess.code shouldBe "tmp.1"
+          fieldAccess.methodFullName shouldBe Operators.fieldAccess
+          fieldAccess.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+
+          inside(fieldAccess.argument(1)) { case tmp: Identifier =>
+            tmp.code shouldBe "tmp"
+            tmp.typeFullName shouldBe "rust2cpgtest::Foo"
+          }
+
+          inside(fieldAccess.argument(2)) { case one: FieldIdentifier =>
+            one.code shouldBe "1"
+            one.canonicalName shouldBe "1"
+          }
+        }
+
+        inside(assign.argument(2)) { case lit: Literal =>
+          lit.code shouldBe "true"
+          lit.typeFullName shouldBe "bool"
+        }
+      }
+    }
+
+    "the block's fifth child is an identifier" in {
+      inside(cpg.block.codeExact("Foo(1, true)").astChildren.order(5).l) { case (ident: Identifier) :: Nil =>
+        ident.name shouldBe "tmp"
+        ident.typeFullName shouldBe "rust2cpgtest::Foo"
+      }
+    }
+  }
+
+  "an internal empty tuple-struct call" should {
+    val cpg = code("""
+        |struct Empty();
+        |fn main() {
+        | Empty();
+        |}
+        |""".stripMargin)
+
+    "lower into a block with appropriate type and number of children" in {
+      inside(cpg.method.name("main").body.astChildren.isBlock.l) { case block :: Nil =>
+        block.code shouldBe "Empty()"
+        block.typeFullName shouldBe "rust2cpgtest::Empty"
+        block.astChildren.size shouldBe 3 // 1 (local) + 1 (.alloc) + 1 (ident)
+      }
+    }
+
+    "the block's first child is a LOCAL declaration" in {
+      inside(cpg.block.codeExact("Empty()").astChildren.order(1).l) { case (local: Local) :: Nil =>
+        local.name shouldBe "tmp"
+        local.typeFullName shouldBe "rust2cpgtest::Empty"
+      }
+    }
+
+    "the block's second child is an alloc assignment" in {
+      inside(cpg.block.codeExact("Empty()").astChildren.order(2).l) { case (assign: Call) :: Nil =>
+        assign.code shouldBe s"tmp = ${Operators.alloc}"
+
+        inside(assign.argument(1)) { case tmp: Identifier =>
+          tmp.typeFullName shouldBe "rust2cpgtest::Empty"
+          tmp.name shouldBe "tmp"
+          tmp.code shouldBe "tmp"
+        }
+
+        inside(assign.argument(2)) { case alloc: Call =>
+          alloc.methodFullName shouldBe Operators.alloc
+          alloc.name shouldBe Operators.alloc
+          alloc.argument shouldBe empty
+        }
+      }
+    }
+
+    "the block's third child is an identifier" in {
+      inside(cpg.block.codeExact("Empty()").astChildren.order(3).l) { case (ident: Identifier) :: Nil =>
+        ident.name shouldBe "tmp"
+        ident.typeFullName shouldBe "rust2cpgtest::Empty"
+      }
+    }
+  }
 }


### PR DESCRIPTION
Rewrites tuple-like struct literals into a block with alloc + field access assignments.

Originally, I was thinking of adding an `<init>` to the structs (TYPE_DECLS) and rewrite the calls to use such method. This would work ok for parsed struct declarations, but not so for externally-defined structs. In rust, a declaration `struct Foo(i32,bool)` (implicitly) introduces a function `Foo(x:i32,y:bool) -> Foo`. So, the original rewrite would create a call with a non-existing methodFullName, viz. `Foo::<init>`.

The alternative approach here is to lower both internal/external struct initializations as a block, in which we allocate a tmp with the appropriate type, and set each field accordingly.

This doesn't handle generic structs yet. (And I couldn't find any non-generic stdlib struct to use to test this.) The current `isStructCtorCall` predicate needs to be updated. I could perhaps do some string trimming to remove generics and compare stripped types, but I believe it's saner to maybe signal these cases from rust_ast_gen properly. So, I would leave generics pending until the next rust_ast_gen release.