### PR TITLE
publish linterRules

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,6 @@ lazy val abap2cpg          = Projects.abap2cpg
 lazy val rust2cpg          = Projects.rust2cpg
 lazy val linterRules       = Projects.linterRules
 
-// aggregate project which doesn't include the helper project `linterRules` - we don't want to include it in any standard task
 lazy val root = project
   .in(file("."))
   .aggregate(
@@ -51,7 +50,8 @@ lazy val root = project
     swiftsrc2cpg,
     csharpsrc2cpg,
     abap2cpg,
-    rust2cpg
+    rust2cpg,
+    linterRules
   )
   .dependsOn(linterRules % ScalafixConfig)
 

--- a/linter-rules/build.sbt
+++ b/linter-rules/build.sbt
@@ -1,4 +1,6 @@
 name := "linter-rules"
+//scalafix otherwise gets unhappy because of circular dependency
+disablePlugins(ScalafixPlugin)
 
 libraryDependencies +=
   "ch.epfl.scala" % "scalafix-core_2.13" % _root_.scalafix.sbt.BuildInfo.scalafixVersion

--- a/linter-rules/src/main/scala/fix/SingleLetterIdentifiers.scala
+++ b/linter-rules/src/main/scala/fix/SingleLetterIdentifiers.scala
@@ -60,6 +60,8 @@ class SingleLetterIdentifiers extends SyntacticRule("SingleLetterIdentifiers") {
             Patch.empty
         }
 
+      /* There is some consideration whether to allow single-letter case identifiers.
+         This very linter-rule serves as proof that such a rule would be needlessly intrusive.
       // case x =>
       case c: Case =>
         c.pat match {
@@ -68,6 +70,7 @@ class SingleLetterIdentifiers extends SyntacticRule("SingleLetterIdentifiers") {
           case _ =>
             Patch.empty
         }
+       */
     }
 
     Patch.fromIterable(patches)

--- a/linter-rules/src/main/scala/fix/SingleLetterIdentifiers.scala
+++ b/linter-rules/src/main/scala/fix/SingleLetterIdentifiers.scala
@@ -60,8 +60,6 @@ class SingleLetterIdentifiers extends SyntacticRule("SingleLetterIdentifiers") {
             Patch.empty
         }
 
-      /* There is some consideration whether to allow single-letter case identifiers.
-         This very linter-rule serves as proof that such a rule would be needlessly intrusive.
       // case x =>
       case c: Case =>
         c.pat match {
@@ -70,7 +68,6 @@ class SingleLetterIdentifiers extends SyntacticRule("SingleLetterIdentifiers") {
           case _ =>
             Patch.empty
         }
-       */
     }
 
     Patch.fromIterable(patches)


### PR DESCRIPTION
We plan to also use the joern linter-rules in downstream closed-source codescience. Hence, this PR would publish them along the other joern subprojects.

@max-leuthaeuser : your linter rule that checks for single-letter identifiers in `case c: Case` uses itself single-letter identifiers, and you @ml86 personally approved that.

I applaud this level of trolling. You made your point, let's allow single-letter case matching, and leave the old code commented-out in order to make the next reader smile.