### PR TITLE
Revert optional parameter index intergration PR

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name                     := "joern"
 ThisBuild / organization := "io.joern"
 ThisBuild / scalaVersion := "3.7.4"
 
-val cpgVersion = "1.7.66"
+val cpgVersion = "1.7.65"
 
 lazy val joerncli          = Projects.joerncli
 lazy val querydb           = Projects.querydb

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/Path.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/language/Path.scala
@@ -42,8 +42,7 @@ object Path {
             val methodName = method.name
             val statement = cfgNode match {
               case _: MethodParameterIn =>
-                val paramsPretty =
-                  method.parameter.toList.sortBy(_.index.getOrElse(Int.MaxValue)).map(_.code).mkString(", ")
+                val paramsPretty = method.parameter.toList.sortBy(_.index).map(_.code).mkString(", ")
                 s"$methodName($paramsPretty)"
               case _ => cfgNode.statement.repr
             }

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
@@ -41,11 +41,11 @@ class ReachingDefFlowGraph(val method: Method) extends FlowGraph[CfgNode] {
   val entryNode: CfgNode = method
   val exitNode: CfgNode  = method.methodReturn
 
-  private val params           = method.parameter.sortBy(_.index.getOrElse(Int.MaxValue))
+  private val params           = method.parameter.sortBy(_.index)
   private val firstParam       = params.headOption
   private val lastParam        = params.lastOption
   private val firstOutputParam = firstParam.flatMap(_.asOutput.headOption)
-  private val lastOutputParam  = method.parameter.sortBy(_.index.getOrElse(Int.MaxValue)).asOutput.lastOption
+  private val lastOutputParam  = method.parameter.sortBy(_.index).asOutput.lastOption
 
   private val lastActualCfgNode = exitNode.cfgIn.nextOption
 
@@ -109,13 +109,13 @@ class ReachingDefFlowGraph(val method: Method) extends FlowGraph[CfgNode] {
     n.out(EdgeTypes.CFG).map(_.asInstanceOf[CfgNode]).l
 
   private def nextParamOrBody(param: MethodParameterIn): List[CfgNode] = {
-    val nextParam = param.method.parameter.indexIfPresent(param.index.map(_ + 1)).headOption
+    val nextParam = param.method.parameter.index(param.index + 1).headOption
     if (nextParam.isDefined) { nextParam.toList }
     else { param.method.cfgFirst.l }
   }
 
   private def nextParamOutOrExit(paramOut: MethodParameterOut): List[CfgNode] = {
-    val nextParam = paramOut.method.parameter.indexIfPresent(paramOut.index.map(_ + 1)).asOutput.headOption
+    val nextParam = paramOut.method.parameter.index(paramOut.index + 1).asOutput.headOption
     if (nextParam.isDefined) { nextParam.toList }
     else { List(exitNode) }
   }
@@ -131,13 +131,13 @@ class ReachingDefFlowGraph(val method: Method) extends FlowGraph[CfgNode] {
   }
 
   private def previousParamOrEntry(param: MethodParameterIn): List[CfgNode] = {
-    val prevParam = param.method.parameter.indexIfPresent(param.index.map(_ - 1)).headOption
+    val prevParam = param.method.parameter.index(param.index - 1).headOption
     if (prevParam.isDefined) { prevParam.toList }
     else { List(method) }
   }
 
   private def previousOutputParamOrLastNodeOfBody(paramOut: MethodParameterOut): List[CfgNode] = {
-    val prevParam = paramOut.method.parameter.indexIfPresent(paramOut.index.map(_ - 1)).asOutput.headOption
+    val prevParam = paramOut.method.parameter.index(paramOut.index - 1).asOutput.headOption
     if (prevParam.isDefined) { prevParam.toList }
     else { lastActualCfgNode.toList }
   }

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/slicing/UsageSlicing.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/slicing/UsageSlicing.scala
@@ -280,7 +280,7 @@ object UsageSlicing {
                 slices.get(resolvedMethod).flatMap { calleeSlices =>
                   calleeSlices.find { s =>
                     s.targetObj match {
-                      case p: ParamDef => p.position.contains(argIdx)
+                      case p: ParamDef => p.position == argIdx
                       case _           => false
                     }
                   }

--- a/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/slicing/package.scala
+++ b/dataflowengineoss/src/main/scala/io/joern/dataflowengineoss/slicing/package.scala
@@ -254,18 +254,18 @@ package object slicing {
   /** Represents data introduced via a parameter.
     *
     * @param position
-    *   the index of the parameter, or None if the parameter has no positional index (e.g. keyword-only params).
+    *   the index of the parameter.
     */
   case class ParamDef(
     name: String,
     typeFullName: String,
-    position: Option[Int],
+    position: Integer,
     lineNumber: Option[Int] = None,
     columnNumber: Option[Int] = None,
     label: String = "PARAM"
   ) extends DefComponent
       derives ReadWriter {
-    override def toString: String = super.toString + position.map(pos => s" @ pos #$pos").getOrElse("")
+    override def toString: String = super.toString + s" @ pos #$position"
   }
 
   /** Represents data introduced by the return value of a call.

--- a/joern-cli/frontends/abap2cpg/src/test/scala/io/joern/abap2cpg/passes/AbapIntegrationTests.scala
+++ b/joern-cli/frontends/abap2cpg/src/test/scala/io/joern/abap2cpg/passes/AbapIntegrationTests.scala
@@ -252,7 +252,7 @@ class AbapIntegrationTests extends Abap2CpgSuite {
 
     "set order equal to index on parsed method parameters" in {
       val cpg = code(abapCode, fileName)
-      cpg.parameter.filter(!_.method.isExternal).l.foreach(p => p.index shouldBe Some(p.order))
+      cpg.parameter.filter(!_.method.isExternal).l.foreach(p => p.order shouldBe p.index)
     }
 
     "set isVariadic to false on all parameters" in {

--- a/joern-cli/frontends/abap2cpg/src/test/scala/io/joern/abap2cpg/passes/AstCreatorTests.scala
+++ b/joern-cli/frontends/abap2cpg/src/test/scala/io/joern/abap2cpg/passes/AstCreatorTests.scala
@@ -186,7 +186,7 @@ class AstCreatorTests extends AbapCpgFixture {
     "set index starting at 1 for first parameter" in {
       val cpg   = cpgForProgram(programWithMethod("MY_METHOD", importing = Seq(Parameter("IV_INPUT", "string"))))
       val param = cpg.method.nameExact("MY_METHOD").parameter.nameExact("IV_INPUT").head
-      param.index shouldBe Some(1)
+      param.index shouldBe 1
     }
 
     "set order equal to index" in {
@@ -218,11 +218,11 @@ class AstCreatorTests extends AbapCpgFixture {
     "set sequential indices for multiple parameters" in {
       val cpg =
         cpgForProgram(programWithMethod("MY_METHOD", importing = Seq(Parameter("IV_A", "i"), Parameter("IV_B", "i"))))
-      val params = cpg.method.nameExact("MY_METHOD").parameter.l.sortBy(_.order)
+      val params = cpg.method.nameExact("MY_METHOD").parameter.l.sortBy(_.index)
       params(0).name shouldBe "IV_A"
-      params(0).index shouldBe Some(1)
+      params(0).index shouldBe 1
       params(1).name shouldBe "IV_B"
-      params(1).index shouldBe Some(2)
+      params(1).index shouldBe 2
     }
   }
 
@@ -256,8 +256,8 @@ class AstCreatorTests extends AbapCpgFixture {
         programWithMethod("MY_METHOD", importing = Seq(Parameter("IV_FIRST", "string"), Parameter("IV_SECOND", "int")))
       )
       val params = cpg.method.nameExact("MY_METHOD").parameter.l
-      params.find(_.name == "IV_FIRST").flatMap(_.index) shouldBe Some(1)
-      params.find(_.name == "IV_SECOND").flatMap(_.index) shouldBe Some(2)
+      params.find(_.name == "IV_FIRST").map(_.index) shouldBe Some(1)
+      params.find(_.name == "IV_SECOND").map(_.index) shouldBe Some(2)
     }
 
     "create a method return node" in {

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForFunctionsCreator.scala
@@ -358,8 +358,7 @@ trait AstForFunctionsCreator { this: AstCreator =>
     }
     variadicParam.map { p =>
       p.isVariadic = false
-      // C/C++ parameters always have positional indices; None is not expected here.
-      val index = p.index.get + 1
+      val index = p.index + 1
       new FunctionDeclNodePass.ParameterInfo(
         s"<param>$index",
         s"<param>$index...",

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/cpp/features17/Cpp17FeaturesTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/cpp/features17/Cpp17FeaturesTests.scala
@@ -135,7 +135,7 @@ class Cpp17FeaturesTests extends AstC2CpgSuite(fileSuffix = FileDefaults.CppExt)
       argsParam.name shouldBe "args"
       argsParam.typeFullName shouldBe "Args"
       argsParam.isVariadic shouldBe true
-      argsParam.index shouldBe Some(1)
+      argsParam.index shouldBe 1
       val List(retExpr) = cpg.method.nameExact("logicalAnd").ast.isReturn.astChildren.isCall.l
       retExpr.name shouldBe "<operator>.fold"
       retExpr.typeFullName shouldBe "bool"
@@ -161,7 +161,7 @@ class Cpp17FeaturesTests extends AstC2CpgSuite(fileSuffix = FileDefaults.CppExt)
       argsParam.name shouldBe "args"
       argsParam.typeFullName shouldBe "Args"
       argsParam.isVariadic shouldBe true
-      argsParam.index shouldBe Some(1)
+      argsParam.index shouldBe 1
       val List(retExpr) = cpg.method.nameExact("sum").ast.isReturn.astChildren.isCall.l
       retExpr.name shouldBe "<operator>.fold"
       retExpr.typeFullName shouldBe "Args"

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/AstCreationPassTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/AstCreationPassTests.scala
@@ -42,12 +42,12 @@ class AstCreationPassTests extends AstC2CpgSuite {
       a1.name shouldBe "a"
       a1.code shouldBe "const char *a"
       a1.typeFullName shouldBe "char*"
-      a1.index shouldBe Some(1)
+      a1.index shouldBe 1
       a1.isVariadic shouldBe false
       ellipsis1.name shouldBe "<param>2"
       ellipsis1.code shouldBe "<param>2..."
       ellipsis1.typeFullName shouldBe "char*"
-      ellipsis1.index shouldBe Some(2)
+      ellipsis1.index shouldBe 2
       ellipsis1.isVariadic shouldBe true
 
       val List(bar) = cpg.method("bar").l
@@ -57,12 +57,12 @@ class AstCreationPassTests extends AstC2CpgSuite {
       a2.name shouldBe "a"
       a2.code shouldBe "const char *a"
       a2.typeFullName shouldBe "char*"
-      a2.index shouldBe Some(1)
+      a2.index shouldBe 1
       a2.isVariadic shouldBe false
       ellipsis2.name shouldBe "<param>2"
       ellipsis2.code shouldBe "<param>2..."
       ellipsis2.typeFullName shouldBe "char*"
-      ellipsis2.index shouldBe Some(2)
+      ellipsis2.index shouldBe 2
       ellipsis2.isVariadic shouldBe true
     }
 
@@ -89,12 +89,12 @@ class AstCreationPassTests extends AstC2CpgSuite {
       a1.name shouldBe "a"
       a1.code shouldBe "const char *a"
       a1.typeFullName shouldBe "char*"
-      a1.index shouldBe Some(1)
+      a1.index shouldBe 1
       a1.isVariadic shouldBe false
       ellipsis1.name shouldBe "<param>2"
       ellipsis1.code shouldBe "<param>2..."
       ellipsis1.typeFullName shouldBe "char*"
-      ellipsis1.index shouldBe Some(2)
+      ellipsis1.index shouldBe 2
       ellipsis1.isVariadic shouldBe true
 
       val List(bar) = cpg.method("bar").l
@@ -104,12 +104,12 @@ class AstCreationPassTests extends AstC2CpgSuite {
       a2.name shouldBe "a"
       a2.code shouldBe "const char *a"
       a2.typeFullName shouldBe "char*"
-      a2.index shouldBe Some(1)
+      a2.index shouldBe 1
       a2.isVariadic shouldBe false
       ellipsis2.name shouldBe "<param>2"
       ellipsis2.code shouldBe "<param>2..."
       ellipsis2.typeFullName shouldBe "char*"
-      ellipsis2.index shouldBe Some(2)
+      ellipsis2.index shouldBe 2
       ellipsis2.isVariadic shouldBe true
     }
 
@@ -144,12 +144,12 @@ class AstCreationPassTests extends AstC2CpgSuite {
           x.code shouldBe "int x"
           x.typeFullName shouldBe "int"
           x.isVariadic shouldBe false
-          x.index shouldBe Some(1)
+          x.index shouldBe 1
           args.name shouldBe "args"
           args.code shouldBe "int*... args"
           args.typeFullName shouldBe "int*"
           args.isVariadic shouldBe true
-          args.index shouldBe Some(2)
+          args.index shouldBe 2
         }
       }
     }
@@ -163,17 +163,17 @@ class AstCreationPassTests extends AstC2CpgSuite {
           x.code shouldBe "int x"
           x.typeFullName shouldBe "int"
           x.isVariadic shouldBe false
-          x.index shouldBe Some(1)
+          x.index shouldBe 1
           args.name shouldBe "args"
           args.code shouldBe "int args"
           args.typeFullName shouldBe "int"
           args.isVariadic shouldBe false
-          args.index shouldBe Some(2)
+          args.index shouldBe 2
           param3.name shouldBe "<param>3"
           param3.code shouldBe "<param>3..."
           param3.typeFullName shouldBe "int"
           param3.isVariadic shouldBe true
-          param3.index shouldBe Some(3)
+          param3.index shouldBe 3
         }
       }
     }

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/MethodTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/MethodTests.scala
@@ -92,7 +92,7 @@ class MethodTests extends C2CpgSuite {
 
     "should be correct for pointer dereference parameter" in {
       inside(cpg.method("foo").parameter.l) { case List(data) =>
-        data.index shouldBe Some(1)
+        data.index shouldBe 1
         data.name shouldBe "data"
         data.code shouldBe "int &data"
         data.typeFullName shouldBe "int&"

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/types/ClassTypeTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/types/ClassTypeTests.scala
@@ -181,11 +181,11 @@ class ClassTypeTests extends C2CpgSuite(FileDefaults.CppExt) {
       val List(thisP, p1, p2) = constructor.parameter.l
       thisP.name shouldBe Defines.This
       thisP.typeFullName shouldBe "FooT*"
-      thisP.index shouldBe Some(0)
+      thisP.index shouldBe 0
       p1.typ.fullName shouldBe "std.string&"
-      p1.index shouldBe Some(1)
+      p1.index shouldBe 1
       p2.typ.fullName shouldBe "Bar.SomeClass&"
-      p2.index shouldBe Some(2)
+      p2.index shouldBe 2
     }
   }
 

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/ExtensionMethodTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/ExtensionMethodTests.scala
@@ -26,7 +26,7 @@ class ExtensionMethodTests extends CSharpCode2CpgFixture {
     }
 
     "have correct parameters" in {
-      inside(cpg.method.nameExact("DoStuff").parameter.l) { case myClass :: Nil =>
+      inside(cpg.method.nameExact("DoStuff").parameter.sortBy(_.index).l) { case myClass :: Nil =>
         myClass.typeFullName shouldBe "MyClass"
         myClass.code shouldBe "this MyClass myClass"
         myClass.name shouldBe "myClass"

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/LambdaTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/LambdaTests.scala
@@ -23,7 +23,7 @@ class LambdaTests extends CSharpCode2CpgFixture {
         inside(anon.parameter.l) { case x :: Nil =>
           x.name shouldBe "x"
           x.typeFullName shouldBe DotNetTypeMap(BuiltinTypes.Int)
-          x.index shouldBe Some(1)
+          x.index shouldBe 1
         }
 
       }
@@ -65,11 +65,11 @@ class LambdaTests extends CSharpCode2CpgFixture {
         inside(anon.parameter.l) { case x :: y :: Nil =>
           x.name shouldBe "x"
           x.typeFullName shouldBe DotNetTypeMap(BuiltinTypes.Int)
-          x.index shouldBe Some(1)
+          x.index shouldBe 1
 
           y.name shouldBe "y"
           y.typeFullName shouldBe DotNetTypeMap(BuiltinTypes.Int)
-          y.index shouldBe Some(2)
+          y.index shouldBe 2
         }
 
       }

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/ParameterTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/ParameterTests.scala
@@ -15,7 +15,7 @@ class ParameterTests extends CSharpCode2CpgFixture {
       args.name shouldBe "args"
       args.typeFullName shouldBe "System.String[]"
       args.code shouldBe "string[] args"
-      args.index shouldBe Some(1)
+      args.index shouldBe 1
       args.isVariadic shouldBe false
     }
 
@@ -47,19 +47,19 @@ class ParameterTests extends CSharpCode2CpgFixture {
       thisNode.name shouldBe "this"
       thisNode.typeFullName shouldBe "HelloWorld.Program"
       thisNode.code shouldBe "this"
-      thisNode.index shouldBe Some(0)
+      thisNode.index shouldBe 0
       thisNode.isVariadic shouldBe false
 
       a.name shouldBe "a"
       a.typeFullName shouldBe "System.String"
       a.code shouldBe "string a"
-      a.index shouldBe Some(1)
+      a.index shouldBe 1
       a.isVariadic shouldBe false
 
       b.name shouldBe "b"
       b.typeFullName shouldBe "System.Int32"
       b.code shouldBe "int b"
-      b.index shouldBe Some(2)
+      b.index shouldBe 2
       b.isVariadic shouldBe false
     }
 

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/PropertySetterTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/PropertySetterTests.scala
@@ -28,12 +28,12 @@ class PropertySetterTests extends CSharpCode2CpgFixture {
     }
 
     "have correct parameters" in {
-      inside(cpg.method.nameExact("set_MyProperty").parameter.sortBy(_.order).l) { case thisArg :: valueArg :: Nil =>
-        thisArg.index shouldBe Some(0)
+      inside(cpg.method.nameExact("set_MyProperty").parameter.sortBy(_.index).l) { case thisArg :: valueArg :: Nil =>
+        thisArg.index shouldBe 0
         thisArg.name shouldBe "this"
         thisArg.typeFullName shouldBe "C"
 
-        valueArg.index shouldBe Some(1)
+        valueArg.index shouldBe 1
         valueArg.name shouldBe "value"
         valueArg.typeFullName shouldBe "System.Int32"
       }
@@ -70,8 +70,8 @@ class PropertySetterTests extends CSharpCode2CpgFixture {
     }
 
     "have correct parameters" in {
-      inside(cpg.method.nameExact("set_MyProperty").parameter.l) { case valueArg :: Nil =>
-        valueArg.index shouldBe Some(1)
+      inside(cpg.method.nameExact("set_MyProperty").parameter.sortBy(_.index).l) { case valueArg :: Nil =>
+        valueArg.index shouldBe 1
         valueArg.name shouldBe "value"
         valueArg.typeFullName shouldBe "System.Int32"
       }

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/TypeDeclMembersAndMemberMethodsTest.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/passes/ast/TypeDeclMembersAndMemberMethodsTest.scala
@@ -158,9 +158,9 @@ class TypeDeclMembersAndMemberMethodsTest extends GoCodeToCpgSuite {
       cpg.parameter.name("re").size shouldBe 2
       val List(thisParam, thisParamsec) = cpg.parameter.name("re").l
       thisParam.order shouldBe 0
-      thisParam.index shouldBe Some(0)
+      thisParam.index shouldBe 0
       thisParamsec.order shouldBe 0
-      thisParamsec.index shouldBe Some(0)
+      thisParamsec.index shouldBe 0
     }
 
     "Traversal from 'this'/receiver parameter to method node" in {

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
@@ -321,7 +321,7 @@ class NewCallTests extends JavaSrcCode2CpgFixture {
       inside(cpg.method.name("test").call.name("foo").argument(0).outE.collectAll[Ref].l) { case List(ref) =>
         inside(ref.dst) { case param: MethodParameterIn =>
           param.name shouldBe "this"
-          param.index shouldBe Some(0)
+          param.index shouldBe 0
           param.method.fullName shouldBe "Foo.test:void()"
         }
       }
@@ -340,7 +340,7 @@ class NewCallTests extends JavaSrcCode2CpgFixture {
       inside(cpg.method.name("test").call.name("foo").argument(0).outE.collectAll[Ref].l) { case List(ref) =>
         inside(ref.dst) { case param: MethodParameterIn =>
           param.name shouldBe "this"
-          param.index shouldBe Some(0)
+          param.index shouldBe 0
           param.method.fullName shouldBe "Foo.test:void()"
         }
       }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CapturingTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CapturingTests.scala
@@ -284,7 +284,7 @@ class CapturingTests extends JavaSrcCode2CpgFixture with Inside {
                 thisId.name shouldBe "this"
                 inside(thisId.refsTo.l) { case List(thisParam: MethodParameterIn) =>
                   thisParam.name shouldBe "this"
-                  thisParam.index shouldBe Some(0)
+                  thisParam.index shouldBe 0
                   thisParam.method shouldBe constructor
                 }
 
@@ -294,7 +294,7 @@ class CapturingTests extends JavaSrcCode2CpgFixture with Inside {
               valueId.name shouldBe "value"
               inside(valueId.refsTo.l) { case List(valueParam: MethodParameterIn) =>
                 valueParam.name shouldBe "value"
-                valueParam.index shouldBe Some(1)
+                valueParam.index shouldBe 1
                 valueParam.method shouldBe constructor
               }
             }
@@ -310,7 +310,7 @@ class CapturingTests extends JavaSrcCode2CpgFixture with Inside {
           thisId.typeFullName shouldBe "Foo.<lambda>0:void().LocalRecord"
           inside(thisId.refsTo.l) { case List(thisParam: MethodParameterIn) =>
             thisParam.name shouldBe "this"
-            thisParam.index shouldBe Some(0)
+            thisParam.index shouldBe 0
             thisParam.method.fullName shouldBe "Foo.<lambda>0:void().LocalRecord.print:void()"
           }
 

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LambdaTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LambdaTests.scala
@@ -280,11 +280,11 @@ class LambdaTests extends JavaSrcCode2CpgFixture {
         thisParam.name shouldBe "this"
         thisParam.code shouldBe "this"
         thisParam.typeFullName shouldBe "Foo"
-        thisParam.index shouldBe Some(0)
+        thisParam.index shouldBe 0
 
         inputParam.name shouldBe "input"
         inputParam.typeFullName shouldBe "java.lang.String"
-        inputParam.index shouldBe Some(1)
+        inputParam.index shouldBe 1
       }
     }
   }
@@ -311,12 +311,12 @@ class LambdaTests extends JavaSrcCode2CpgFixture {
         thisParam.code shouldBe "this"
         thisParam.typeFullName shouldBe "Foo"
         thisParam.order shouldBe 0
-        thisParam.index shouldBe Some(0)
+        thisParam.index shouldBe 0
 
         inputParam.name shouldBe "input"
         inputParam.typeFullName shouldBe "java.lang.String"
         inputParam.order shouldBe 1
-        inputParam.index shouldBe Some(1)
+        inputParam.index shouldBe 1
       }
     }
   }
@@ -353,7 +353,7 @@ class LambdaTests extends JavaSrcCode2CpgFixture {
         thisClosureBinding.closureBindingId shouldBe Some("Test0.java:<lambda>0:this")
         inside(thisClosureBinding._refOut.l) { case List(capturedParam: MethodParameterIn) =>
           capturedParam.name shouldBe "this"
-          capturedParam.index shouldBe Some(0)
+          capturedParam.index shouldBe 0
           capturedParam.method.fullName shouldBe "Test.test:void()"
         }
       }
@@ -418,7 +418,7 @@ class LambdaTests extends JavaSrcCode2CpgFixture {
         thisClosureBinding.closureBindingId shouldBe Some("Test0.java:<lambda>0:this")
         inside(thisClosureBinding._refOut.l) { case List(capturedParam: MethodParameterIn) =>
           capturedParam.name shouldBe "this"
-          capturedParam.index shouldBe Some(0)
+          capturedParam.index shouldBe 0
           capturedParam.method.fullName shouldBe "Test.test:void().LocalClass.localClassMethod:void()"
         }
       }
@@ -488,7 +488,7 @@ class LambdaTests extends JavaSrcCode2CpgFixture {
         thisClosureBinding.closureBindingId shouldBe Some("Test0.java:<lambda>0:this")
         inside(thisClosureBinding._refOut.l) { case List(capturedParam: MethodParameterIn) =>
           capturedParam.name shouldBe "this"
-          capturedParam.index shouldBe Some(0)
+          capturedParam.index shouldBe 0
           capturedParam.method.fullName shouldBe "Test.test:void().LocalClass.localClassMethod:void()"
         }
       }
@@ -536,7 +536,7 @@ class LambdaTests extends JavaSrcCode2CpgFixture {
         inputParam.name shouldBe "input"
         inputParam.typeFullName shouldBe "java.lang.String"
         inputParam.order shouldBe 1
-        inputParam.index shouldBe Some(1)
+        inputParam.index shouldBe 1
       }
     }
   }
@@ -666,13 +666,13 @@ class LambdaTests extends JavaSrcCode2CpgFixture {
           input.code shouldBe "java.lang.Integer input"
           input.typeFullName shouldBe "java.lang.Integer"
           input.order shouldBe 1
-          input.index shouldBe Some(1)
+          input.index shouldBe 1
 
           moreInput.name shouldBe "moreInput"
           moreInput.code shouldBe "java.lang.Integer moreInput"
           moreInput.typeFullName shouldBe "java.lang.Integer"
           moreInput.order shouldBe 2
-          moreInput.index shouldBe Some(2)
+          moreInput.index shouldBe 2
         }
       }
     }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LocalClassTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LocalClassTests.scala
@@ -107,20 +107,20 @@ class LocalClassTests extends JavaSrcCode2CpgFixture {
         case List(thisParam, outerClassParam, capturedLocalParam, capturedParamParam) =>
           thisParam.name shouldBe "this"
           thisParam.typeFullName shouldBe "foo.Foo.enclosingMethod:void(int).Local"
-          thisParam.index shouldBe Some(0)
+          thisParam.index shouldBe 0
           thisParam.dynamicTypeHintFullName shouldBe List("foo.Foo.enclosingMethod:void(int).Local")
 
           outerClassParam.name shouldBe "outerClass"
           outerClassParam.typeFullName shouldBe "foo.Foo"
-          outerClassParam.index shouldBe Some(1)
+          outerClassParam.index shouldBe 1
 
           capturedLocalParam.name shouldBe "capturedLocal"
           capturedLocalParam.typeFullName shouldBe "int"
-          capturedLocalParam.index shouldBe Some(2)
+          capturedLocalParam.index shouldBe 2
 
           capturedParamParam.name shouldBe "capturedParam"
           capturedParamParam.typeFullName shouldBe "int"
-          capturedParamParam.index shouldBe Some(3)
+          capturedParamParam.index shouldBe 3
       }
     }
 
@@ -252,16 +252,16 @@ class LocalClassTests extends JavaSrcCode2CpgFixture {
         case List(thisParam, capturedLocalParam, capturedParamParam) =>
           thisParam.name shouldBe "this"
           thisParam.typeFullName shouldBe "foo.Foo.enclosingMethod:void(int).Local"
-          thisParam.index shouldBe Some(0)
+          thisParam.index shouldBe 0
           thisParam.dynamicTypeHintFullName shouldBe List("foo.Foo.enclosingMethod:void(int).Local")
 
           capturedLocalParam.name shouldBe "capturedLocal"
           capturedLocalParam.typeFullName shouldBe "int"
-          capturedLocalParam.index shouldBe Some(1)
+          capturedLocalParam.index shouldBe 1
 
           capturedParamParam.name shouldBe "capturedParam"
           capturedParamParam.typeFullName shouldBe "int"
-          capturedParamParam.index shouldBe Some(2)
+          capturedParamParam.index shouldBe 2
       }
     }
 
@@ -339,13 +339,13 @@ class LocalClassTests extends JavaSrcCode2CpgFixture {
     "have an init parameter for the captured outer class" in {
       inside(localDecl.method.nameExact("<init>").parameter.l) { case List(thisParam, outerClassParam) =>
         thisParam.name shouldBe "this"
-        thisParam.index shouldBe Some(0)
+        thisParam.index shouldBe 0
         thisParam.typeFullName shouldBe "foo.Foo.enclosingMethod:void(int).Local"
         thisParam.dynamicTypeHintFullName shouldBe List("foo.Foo.enclosingMethod:void(int).Local")
 
         outerClassParam.name shouldBe "outerClass"
         outerClassParam.typeFullName shouldBe "foo.Foo"
-        outerClassParam.index shouldBe Some(1)
+        outerClassParam.index shouldBe 1
 
       }
     }
@@ -403,7 +403,7 @@ class LocalClassTests extends JavaSrcCode2CpgFixture {
     "not have an init parameter for the outer class" in {
       inside(localDecl.method.nameExact("<init>").parameter.l) { case List(thisParam) =>
         thisParam.name shouldBe "this"
-        thisParam.index shouldBe Some(0)
+        thisParam.index shouldBe 0
         thisParam.typeFullName shouldBe "foo.Foo.enclosingMethod:void(int).Local"
         thisParam.dynamicTypeHintFullName shouldBe List("foo.Foo.enclosingMethod:void(int).Local")
       }
@@ -497,16 +497,16 @@ class LocalClassTests extends JavaSrcCode2CpgFixture {
         case List(thisParam, outerClassParam, capturedLocalParam) =>
           thisParam.name shouldBe "this"
           thisParam.typeFullName shouldBe "foo.Foo.enclosingMethod:void(int).Local"
-          thisParam.index shouldBe Some(0)
+          thisParam.index shouldBe 0
           thisParam.dynamicTypeHintFullName shouldBe List("foo.Foo.enclosingMethod:void(int).Local")
 
           outerClassParam.name shouldBe "outerClass"
           outerClassParam.typeFullName shouldBe "foo.Foo"
-          outerClassParam.index shouldBe Some(1)
+          outerClassParam.index shouldBe 1
 
           capturedLocalParam.name shouldBe "capturedLocal"
           capturedLocalParam.typeFullName shouldBe "int"
-          capturedLocalParam.index shouldBe Some(2)
+          capturedLocalParam.index shouldBe 2
       }
     }
 
@@ -577,19 +577,19 @@ class LocalClassTests extends JavaSrcCode2CpgFixture {
       inside(localConstructor.parameter.l) {
         case List(thisParam, ctxParam, outerClassParam, outerLocalParam, outerParamParam) =>
           thisParam.name shouldBe "this"
-          thisParam.index shouldBe Some(0)
+          thisParam.index shouldBe 0
 
           ctxParam.name shouldBe "ctxParam"
-          ctxParam.index shouldBe Some(1)
+          ctxParam.index shouldBe 1
 
           outerClassParam.name shouldBe "outerClass"
-          outerClassParam.index shouldBe Some(2)
+          outerClassParam.index shouldBe 2
 
           outerLocalParam.name shouldBe "outerLocal"
-          outerLocalParam.index shouldBe Some(3)
+          outerLocalParam.index shouldBe 3
 
           outerParamParam.name shouldBe "outerParam"
-          outerParamParam.index shouldBe Some(4)
+          outerParamParam.index shouldBe 4
       }
     }
 

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LocalRecordTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LocalRecordTests.scala
@@ -70,11 +70,11 @@ class LocalRecordTests extends JavaSrcCode2CpgFixture {
         inside(constructor.parameter.l) { case List(thisParam, valueParam) =>
           thisParam.name shouldBe "this"
           thisParam.typeFullName shouldBe "foo.Foo.enclosingMethod:void().LocalRecord"
-          thisParam.index shouldBe Some(0)
+          thisParam.index shouldBe 0
 
           valueParam.name shouldBe "value"
           valueParam.typeFullName shouldBe "java.lang.String"
-          valueParam.index shouldBe Some(1)
+          valueParam.index shouldBe 1
         }
 
         inside(constructor.body.astChildren.l) { case List(valueAssign: Call) =>

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/MethodParameterTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/MethodParameterTests.scala
@@ -17,7 +17,7 @@ class MethodParameterTests2 extends JavaSrcCode2CpgFixture {
     "have correct parameter properties for 'this'" in {
       val List(param) = cpg.method.name("foo").parameter.name("this").l
       param.order shouldBe 0
-      param.index shouldBe Some(0)
+      param.index shouldBe 0
       param.lineNumber shouldBe Some(3)
       param.columnNumber shouldBe Some(3)
       param.typeFullName shouldBe "Foo"
@@ -27,7 +27,7 @@ class MethodParameterTests2 extends JavaSrcCode2CpgFixture {
     "have correct parameter properties for p1" in {
       val List(param) = cpg.method.name("foo").parameter.name("p1").l
       param.order shouldBe 1
-      param.index shouldBe Some(1)
+      param.index shouldBe 1
       param.lineNumber shouldBe Some(3)
       param.columnNumber shouldBe Some(11)
       param.typeFullName shouldBe "int"
@@ -37,7 +37,7 @@ class MethodParameterTests2 extends JavaSrcCode2CpgFixture {
     "have correct parameter properties for p2" in {
       val List(param) = cpg.method.name("foo").parameter.name("p2").l
       param.order shouldBe 2
-      param.index shouldBe Some(2)
+      param.index shouldBe 2
       param.lineNumber shouldBe Some(3)
       param.columnNumber shouldBe Some(19)
       param.typeFullName shouldBe "int"

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/TypeDeclTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/TypeDeclTests.scala
@@ -373,7 +373,7 @@ class TypeDeclTests extends JavaSrcCode2CpgFixture {
     thisParam.name shouldBe "this"
     thisParam.typeFullName shouldBe typeFullName
     thisParam.order shouldBe 0
-    thisParam.index shouldBe Some(0)
+    thisParam.index shouldBe 0
     thisParam.dynamicTypeHintFullName shouldBe List(typeFullName)
 
     val constructorReturn = constructor.methodReturn

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/MixedAstCreationPassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/MixedAstCreationPassTests.scala
@@ -826,10 +826,10 @@ class MixedAstCreationPassTests extends JsSrc2CpgSuite {
       val List(fooMethod) = program.astChildren.isMethod.nameExact("foo").l
       val List(a)         = fooMethod.parameter.nameExact("param1_0").l
       a.code shouldBe "{ a }"
-      a.index shouldBe Some(1)
+      a.index shouldBe 1
       val List(b) = fooMethod.parameter.nameExact("b").l
       b.code shouldBe "b"
-      b.index shouldBe Some(2)
+      b.index shouldBe 2
     }
 
     "have correct structure for object destruction assignment in call argument" in {
@@ -1255,7 +1255,7 @@ class MixedAstCreationPassTests extends JsSrc2CpgSuite {
       val List(foo) = cpg.method.nameExact("foo").l
 
       val List(paramA) = foo.parameter.nameExact("a").l
-      paramA.index shouldBe Some(1)
+      paramA.index shouldBe 1
 
       val List(block)      = foo.astChildren.isBlock.l
       val List(assignment) = block.astChildren.isCall.l
@@ -1273,10 +1273,10 @@ class MixedAstCreationPassTests extends JsSrc2CpgSuite {
       val cpg          = code("function foo(a = 1, b = 2) {}")
       val List(foo)    = cpg.method.nameExact("foo").l
       val List(paramA) = foo.parameter.nameExact("a").l
-      paramA.index shouldBe Some(1)
+      paramA.index shouldBe 1
 
       val List(paramB) = foo.parameter.nameExact("b").l
-      paramB.index shouldBe Some(2)
+      paramB.index shouldBe 2
 
       val List(block) = foo.astChildren.isBlock.l
 
@@ -1306,9 +1306,9 @@ class MixedAstCreationPassTests extends JsSrc2CpgSuite {
       val cpg          = code("function foo(a, b = 1) {}")
       val List(foo)    = cpg.method.nameExact("foo").l
       val List(paramA) = foo.parameter.nameExact("a").l
-      paramA.index shouldBe Some(1)
+      paramA.index shouldBe 1
       val List(paramB) = foo.parameter.nameExact("b").l
-      paramB.index shouldBe Some(2)
+      paramB.index shouldBe 2
 
       val List(block) = foo.astChildren.isBlock.l
 
@@ -1327,11 +1327,11 @@ class MixedAstCreationPassTests extends JsSrc2CpgSuite {
       val cpg          = code("function foo(a, b = 1, c = 2) {}")
       val List(foo)    = cpg.method.nameExact("foo").l
       val List(paramA) = foo.parameter.nameExact("a").l
-      paramA.index shouldBe Some(1)
+      paramA.index shouldBe 1
       val List(paramB) = foo.parameter.nameExact("b").l
-      paramB.index shouldBe Some(2)
+      paramB.index shouldBe 2
       val List(paramC) = foo.parameter.nameExact("c").l
-      paramC.index shouldBe Some(3)
+      paramC.index shouldBe 3
 
       val List(block) = foo.astChildren.isBlock.l
 

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/SimpleAstCreationPassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/SimpleAstCreationPassTests.scala
@@ -674,11 +674,11 @@ class SimpleAstCreationPassTests extends JsSrc2CpgSuite {
       val List(lambdaBlock) = lambda.astChildren.isBlock.l
 
       val List(param1, param2) = lambda.parameter.l
-      param1.index shouldBe Some(0)
+      param1.index shouldBe 0
       param1.name shouldBe "this"
       param1.code shouldBe "this"
 
-      param2.index shouldBe Some(1)
+      param2.index shouldBe 1
       param2.name shouldBe "param1_0"
       param2.code shouldBe "[, param]"
 
@@ -693,13 +693,13 @@ class SimpleAstCreationPassTests extends JsSrc2CpgSuite {
       val List(lambdaBlock) = lambda.astChildren.isBlock.l
 
       val List(param1, param2) = lambda.parameter.l
-      param1.index shouldBe Some(0)
+      param1.index shouldBe 0
       param1.name shouldBe "this"
       param1.code shouldBe "this"
       param1.typeFullName shouldBe Defines.Any
       param1.dynamicTypeHintFullName shouldBe Seq("Test0.js::program")
 
-      param2.index shouldBe Some(1)
+      param2.index shouldBe 1
       param2.name shouldBe "param1_0"
       param2.code shouldBe "{x, ...rest}"
 
@@ -715,13 +715,13 @@ class SimpleAstCreationPassTests extends JsSrc2CpgSuite {
       val List(lambdaBlock) = lambda.astChildren.isBlock.l
 
       val List(param1, param2) = lambda.parameter.l
-      param1.index shouldBe Some(0)
+      param1.index shouldBe 0
       param1.name shouldBe "this"
       param1.code shouldBe "this"
       param1.typeFullName shouldBe Defines.Any
       param1.dynamicTypeHintFullName shouldBe Seq("Test0.js::program")
 
-      param2.index shouldBe Some(1)
+      param2.index shouldBe 1
       param2.name shouldBe "param1_0"
       param2.code shouldBe "[x, ...rest]"
 
@@ -966,14 +966,14 @@ class SimpleAstCreationPassTests extends JsSrc2CpgSuite {
       val cpg              = code("function method(x, ...args) {}").withConfig(Config())
       val List(method)     = cpg.method.nameExact("method").l
       val List(t, x, args) = method.parameter.l
-      t.index shouldBe Some(0)
+      t.index shouldBe 0
       t.name shouldBe "this"
       t.typeFullName shouldBe Defines.Any
       t.dynamicTypeHintFullName shouldBe Seq("Test0.js::program")
-      x.index shouldBe Some(1)
+      x.index shouldBe 1
       x.name shouldBe "x"
       x.typeFullName shouldBe Defines.Any
-      args.index shouldBe Some(2)
+      args.index shouldBe 2
       args.name shouldBe "args"
       args.code shouldBe "...args"
       args.isVariadic shouldBe true
@@ -986,11 +986,11 @@ class SimpleAstCreationPassTests extends JsSrc2CpgSuite {
       val List(block)  = method.astChildren.isBlock.l
 
       val List(t, x) = method.parameter.l
-      t.index shouldBe Some(0)
+      t.index shouldBe 0
       t.name shouldBe "this"
       t.typeFullName shouldBe Defines.Any
       t.dynamicTypeHintFullName shouldBe Seq("Test0.js::program")
-      x.index shouldBe Some(1)
+      x.index shouldBe 1
       x.name shouldBe "x"
       x.typeFullName shouldBe Defines.Any
 
@@ -1008,11 +1008,11 @@ class SimpleAstCreationPassTests extends JsSrc2CpgSuite {
       val List(block)  = method.astChildren.isBlock.l
 
       val List(t, x) = method.parameter.l
-      t.index shouldBe Some(0)
+      t.index shouldBe 0
       t.name shouldBe "this"
       t.typeFullName shouldBe Defines.Any
       t.dynamicTypeHintFullName shouldBe Seq("Test0.js::program")
-      x.index shouldBe Some(1)
+      x.index shouldBe 1
       x.name shouldBe "x"
       x.typeFullName shouldBe Defines.Any
 
@@ -1031,14 +1031,14 @@ class SimpleAstCreationPassTests extends JsSrc2CpgSuite {
       val List(block)  = method.astChildren.isBlock.l
 
       val List(t, x, y) = method.parameter.l
-      t.index shouldBe Some(0)
+      t.index shouldBe 0
       t.name shouldBe "this"
       t.typeFullName shouldBe Defines.Any
       t.dynamicTypeHintFullName shouldBe Seq("Test0.js::program")
-      x.index shouldBe Some(1)
+      x.index shouldBe 1
       x.name shouldBe "x"
       x.typeFullName shouldBe Defines.Any
-      y.index shouldBe Some(2)
+      y.index shouldBe 2
       y.name shouldBe "y"
       y.typeFullName shouldBe Defines.Any
 

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsAstCreationPassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/TsAstCreationPassTests.scala
@@ -107,7 +107,7 @@ class TsAstCreationPassTests extends JsSrc2CpgSuite(".ts") {
       arg.name shouldBe "arg"
       arg.typeFullName shouldBe Defines.String
       arg.code shouldBe "arg: string"
-      arg.index shouldBe Some(1)
+      arg.index shouldBe 1
       cpg.method("foo").bindingTypeDecl.fullName.l shouldBe List("Test0.ts::program:foo")
       func.astIn.size shouldBe 1
     }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/slicing/JsUsageSliceTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/slicing/JsUsageSliceTests.scala
@@ -138,8 +138,8 @@ class JsUsageSliceTests extends DataFlowCodeToCpgSuite {
     "extract 'y' local variable" in {
       val slice =
         programSlice.objectSlices.find(x => x.fullName == "main.js::program:bar").flatMap(_.slices.headOption).get
-      slice.targetObj shouldBe ParamDef("y", "ANY", Some(1), Option(14), Option(13))
-      slice.definedBy shouldBe Option(ParamDef("y", "ANY", Some(1), Option(14), Option(13)))
+      slice.targetObj shouldBe ParamDef("y", "ANY", 1, Option(14), Option(13))
+      slice.definedBy shouldBe Option(ParamDef("y", "ANY", 1, Option(14), Option(13)))
 
       val inv1 = slice.invokedCalls.find(_.callName == "getA").get
 

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/slicing/TsUsageSliceTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/slicing/TsUsageSliceTests.scala
@@ -123,8 +123,8 @@ class TsUsageSliceTests extends DataFlowCodeToCpgSuite {
           .find(x => x.fullName == "main.ts::program:Game:loop:<lambda>1")
           .flatMap(_.slices.headOption)
           .get
-      slice.definedBy shouldBe Option(ParamDef("time", "ANY", Some(1), Option(68), Option(31)))
-      slice.targetObj shouldBe ParamDef("time", "ANY", Some(1), Option(68), Option(31))
+      slice.definedBy shouldBe Option(ParamDef("time", "ANY", 1, Option(68), Option(31)))
+      slice.targetObj shouldBe ParamDef("time", "ANY", 1, Option(68), Option(31))
 
       val arg1 = slice.argToCalls.find(_.callName == "loop").get
 

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/types/TSTypesTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/types/TSTypesTests.scala
@@ -32,13 +32,13 @@ class TSTypesTests extends JsSrc2CpgSuite {
     method.methodReturn.typeFullName shouldBe Defines.Any
 
     val List(t, x, args) = method.parameter.l
-    t.index shouldBe Some(0)
+    t.index shouldBe 0
     t.name shouldBe "this"
     t.typeFullName shouldBe Defines.Any
-    x.index shouldBe Some(1)
+    x.index shouldBe 1
     x.name shouldBe "x"
     x.typeFullName shouldBe Defines.Any
-    args.index shouldBe Some(2)
+    args.index shouldBe 2
     args.name shouldBe "args"
     args.code shouldBe "...args"
     args.isVariadic shouldBe true

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallableReferenceTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/CallableReferenceTests.scala
@@ -50,7 +50,7 @@ class CallableReferenceTests extends KotlinCode2CpgFixture(withOssDataflow = fal
     }
 
     "have correct parameters with resolved types" in {
-      val params = invokeMethod.parameter.l.sortBy(_.order)
+      val params = invokeMethod.parameter.l.sortBy(_.index)
       params.size shouldBe 3
       params.head.name shouldBe "this"
       params(1).typeFullName shouldBe "int"
@@ -120,7 +120,7 @@ class CallableReferenceTests extends KotlinCode2CpgFixture(withOssDataflow = fal
       constructor.fullName shouldBe "com.test.Handler.process$kotlin.jvm.functions.Function2Impl.invoke:boolean(int,java.lang.String).<init>:void(com.test.Handler)"
       constructor.signature shouldBe "void(com.test.Handler)"
 
-      val ctorParams = constructor.parameter.l.sortBy(_.order)
+      val ctorParams = constructor.parameter.l.sortBy(_.index)
       ctorParams.size shouldBe 2
       ctorParams.head.name shouldBe "this"
       ctorParams.head.typeFullName shouldBe "com.test.Handler.process$kotlin.jvm.functions.Function2Impl.invoke:boolean(int,java.lang.String)"
@@ -153,7 +153,7 @@ class CallableReferenceTests extends KotlinCode2CpgFixture(withOssDataflow = fal
       inside(rhs.refsTo.l) { case List(param: MethodParameterIn) =>
         param.name shouldBe "receiver"
         param.typeFullName shouldBe "com.test.Handler"
-        param.index shouldBe Some(1)
+        param.index shouldBe 1
       }
     }
 
@@ -389,7 +389,7 @@ class CallableReferenceTests extends KotlinCode2CpgFixture(withOssDataflow = fal
       // Check invoke method
       invokeMethod.fullName shouldBe "Counter.increment$kotlin.jvm.functions.Function0Impl.invoke:int().invoke:int()"
       invokeMethod.signature shouldBe "int()"
-      val invokeParams = invokeMethod.parameter.l
+      val invokeParams = invokeMethod.parameter.l.sortBy(_.index)
       invokeParams.size shouldBe 1
       invokeParams.head.name shouldBe "this"
       invokeParams.head.typeFullName shouldBe "Counter.increment$kotlin.jvm.functions.Function0Impl.invoke:int()"
@@ -398,7 +398,7 @@ class CallableReferenceTests extends KotlinCode2CpgFixture(withOssDataflow = fal
       val constructor = syntheticTypeDecl.method.name("<init>").head
       constructor.fullName shouldBe "Counter.increment$kotlin.jvm.functions.Function0Impl.invoke:int().<init>:void(Counter)"
       constructor.signature shouldBe "void(Counter)"
-      val ctorParams = constructor.parameter.l.sortBy(_.order)
+      val ctorParams = constructor.parameter.l.sortBy(_.index)
       ctorParams.size shouldBe 2
       ctorParams.head.name shouldBe "this"
       ctorParams.head.typeFullName shouldBe "Counter.increment$kotlin.jvm.functions.Function0Impl.invoke:int()"
@@ -449,7 +449,7 @@ class CallableReferenceTests extends KotlinCode2CpgFixture(withOssDataflow = fal
       // Check invoke method
       invokeMethod.fullName shouldBe "Handler.process$kotlin.jvm.functions.Function1Impl.invoke:java.lang.String(java.lang.String).invoke:java.lang.String(java.lang.String)"
       invokeMethod.signature shouldBe "java.lang.String(java.lang.String)"
-      val invokeParams = invokeMethod.parameter.l.sortBy(_.order)
+      val invokeParams = invokeMethod.parameter.l.sortBy(_.index)
       invokeParams.size shouldBe 2
       invokeParams.head.name shouldBe "this"
       invokeParams(1).name shouldBe "p1"
@@ -459,7 +459,7 @@ class CallableReferenceTests extends KotlinCode2CpgFixture(withOssDataflow = fal
       val constructor = syntheticTypeDecl.method.name("<init>").head
       constructor.fullName shouldBe "Handler.process$kotlin.jvm.functions.Function1Impl.invoke:java.lang.String(java.lang.String).<init>:void(Handler)"
       constructor.signature shouldBe "void(Handler)"
-      val ctorParams = constructor.parameter.l.sortBy(_.order)
+      val ctorParams = constructor.parameter.l.sortBy(_.index)
       ctorParams.size shouldBe 2
       ctorParams(1).name shouldBe "receiver"
       ctorParams(1).typeFullName shouldBe "Handler"
@@ -506,7 +506,7 @@ class CallableReferenceTests extends KotlinCode2CpgFixture(withOssDataflow = fal
       // Check invoke method
       invokeMethod.fullName shouldBe "com.test.MyClass.method$kotlin.jvm.functions.Function1Impl.invoke:void(int).invoke:void(int)"
       invokeMethod.signature shouldBe "void(int)"
-      val invokeParams = invokeMethod.parameter.l.sortBy(_.order)
+      val invokeParams = invokeMethod.parameter.l.sortBy(_.index)
       invokeParams.size shouldBe 2
       invokeParams.head.name shouldBe "this"
       invokeParams(1).name shouldBe "p1"
@@ -516,7 +516,7 @@ class CallableReferenceTests extends KotlinCode2CpgFixture(withOssDataflow = fal
       val constructor = syntheticTypeDecl.method.name("<init>").head
       constructor.fullName shouldBe "com.test.MyClass.method$kotlin.jvm.functions.Function1Impl.invoke:void(int).<init>:void(com.test.MyClass)"
       constructor.signature shouldBe "void(com.test.MyClass)"
-      val ctorParams = constructor.parameter.l.sortBy(_.order)
+      val ctorParams = constructor.parameter.l.sortBy(_.index)
       ctorParams.size shouldBe 2
       ctorParams(1).name shouldBe "receiver"
       ctorParams(1).typeFullName shouldBe "com.test.MyClass"
@@ -562,7 +562,7 @@ class CallableReferenceTests extends KotlinCode2CpgFixture(withOssDataflow = fal
       val mapMethod = syntheticTypeDecl.method.name("map").head
       mapMethod.fullName shouldBe "com.test.Converter.convertStrings$com.test.MapperImpl.map:java.util.List(java.util.List).map:java.util.List(java.util.List)"
       mapMethod.signature shouldBe "java.util.List(java.util.List)"
-      val mapParams = mapMethod.parameter.l.sortBy(_.order)
+      val mapParams = mapMethod.parameter.l.sortBy(_.index)
       mapParams.size shouldBe 2
       mapParams.head.name shouldBe "this"
       mapParams(1).name shouldBe "items"
@@ -572,7 +572,7 @@ class CallableReferenceTests extends KotlinCode2CpgFixture(withOssDataflow = fal
       val constructor = syntheticTypeDecl.method.name("<init>").head
       constructor.fullName shouldBe "com.test.Converter.convertStrings$com.test.MapperImpl.map:java.util.List(java.util.List).<init>:void(com.test.Converter)"
       constructor.signature shouldBe "void(com.test.Converter)"
-      val ctorParams = constructor.parameter.l.sortBy(_.order)
+      val ctorParams = constructor.parameter.l.sortBy(_.index)
       ctorParams.size shouldBe 2
       ctorParams(1).name shouldBe "receiver"
       ctorParams(1).typeFullName shouldBe "com.test.Converter"

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ExtensionTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/ExtensionTests.scala
@@ -33,9 +33,9 @@ class ExtensionTests extends KotlinCode2CpgFixture(withOssDataflow = false) {
     "should contain a METHOD node for the extension fn with the correct parameter indicies" in {
       val x = cpg.method.fullName.l
       inside(cpg.method.fullName(".*printBaz.*").parameter.l) { case List(thisParam, textParam) =>
-        thisParam.index shouldBe Some(1)
+        thisParam.index shouldBe 1
         thisParam.order shouldBe 1
-        textParam.index shouldBe Some(2)
+        textParam.index shouldBe 2
         textParam.order shouldBe 2
       }
     }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LambdaTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/querying/LambdaTests.scala
@@ -253,7 +253,7 @@ class LambdaTests extends KotlinCode2CpgFixture(withOssDataflow = false, withDef
       val List(p) = cpg.method.fullName(".*lambda.*").parameter.l
       p.code shouldBe "this"
       p.typeFullName shouldBe "java.lang.String"
-      p.index shouldBe Some(1)
+      p.index shouldBe 1
     }
   }
 
@@ -271,10 +271,10 @@ class LambdaTests extends KotlinCode2CpgFixture(withOssDataflow = false, withDef
     val List(thisParam, itParam) = cpg.method.fullName(".*lambda.*").parameter.l
     thisParam.code shouldBe "this"
     thisParam.typeFullName shouldBe "java.lang.String"
-    thisParam.index shouldBe Some(1)
+    thisParam.index shouldBe 1
     itParam.code shouldBe "it"
     itParam.typeFullName shouldBe "int"
-    itParam.index shouldBe Some(2)
+    itParam.index shouldBe 2
   }
 
   "CPG for code containing a lambda with parameter destructuring" should {
@@ -314,7 +314,7 @@ class LambdaTests extends KotlinCode2CpgFixture(withOssDataflow = false, withDef
     "should contain METHOD_PARAMETER_IN nodes for the lambda with the correct properties set" in {
       val List(p1) = cpg.method.fullName(".*lambda.*").parameter.l
       p1.code shouldBe s"${Constants.DestructedParamNamePrefix}1"
-      p1.index shouldBe Some(1)
+      p1.index shouldBe 1
       p1.typeFullName shouldBe "java.util.Map$Entry"
     }
 
@@ -385,7 +385,7 @@ class LambdaTests extends KotlinCode2CpgFixture(withOssDataflow = false, withDef
     "should contain one METHOD_PARAMETER_IN node for the lambda with the correct properties set" in {
       val List(p1) = cpg.method.fullName(".*lambda.*").parameter.l
       p1.code shouldBe s"${Constants.DestructedParamNamePrefix}1"
-      p1.index shouldBe Some(1)
+      p1.index shouldBe 1
       p1.typeFullName shouldBe "java.util.Map$Entry"
     }
 
@@ -641,7 +641,7 @@ class LambdaTests extends KotlinCode2CpgFixture(withOssDataflow = false, withDef
       val List(p) = cpg.method.fullName(".*lambda.*").parameter.l
       p.code shouldBe "arg"
       p.typeFullName shouldBe "java.lang.String"
-      p.index shouldBe Some(1)
+      p.index shouldBe 1
     }
 
     "should contain a CALL node for `takeIf` with the correct properties set" in {
@@ -1164,7 +1164,7 @@ class LambdaTests extends KotlinCode2CpgFixture(withOssDataflow = false, withDef
       m.signature shouldBe "void(java.lang.String)"
       val List(p) = m.parameter.l
       p.name shouldBe "it"
-      p.index shouldBe Some(1)
+      p.index shouldBe 1
     }
   }
 

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/TypeDeclTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/TypeDeclTests.scala
@@ -117,11 +117,11 @@ class TypeDeclTests extends PhpCode2CpgFixture {
           thisParam.code shouldBe "this"
           thisParam.dynamicTypeHintFullName should contain("Foo")
           thisParam.typeFullName shouldBe "Foo"
-          thisParam.index shouldBe Some(0)
+          thisParam.index shouldBe 0
 
           xParam.code shouldBe "$x"
           xParam.typeFullName shouldBe "int"
-          xParam.index shouldBe Some(1)
+          xParam.index shouldBe 1
         }
       }
     }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/FunctionDefCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/FunctionDefCpgTests.scala
@@ -36,12 +36,12 @@ class FunctionDefCpgTests extends PySrc2CpgFixture with Matchers {
     "test method parameter nodes" in {
       val parameter1 = cpg.method.fullName("test.py:<module>.func").parameter.order(1).head
       parameter1.name shouldBe "a"
-      parameter1.index shouldBe Some(1)
+      parameter1.index shouldBe 1
       parameter1.typeFullName shouldBe Constants.ANY
 
       val parameter2 = cpg.method.fullName("test.py:<module>.func").parameter.order(2).head
       parameter2.name shouldBe "b"
-      parameter2.index shouldBe Some(2)
+      parameter2.index shouldBe 2
       parameter2.typeFullName shouldBe Constants.ANY
     }
 
@@ -97,12 +97,12 @@ class FunctionDefCpgTests extends PySrc2CpgFixture with Matchers {
     "test method parameter nodes" in {
       val parameter1 = cpg.method.fullName("test.py:<module>.func").parameter.order(1).head
       parameter1.name shouldBe "a"
-      parameter1.index shouldBe Some(1)
+      parameter1.index shouldBe 1
       parameter1.typeFullName shouldBe Constants.ANY
 
       val parameter2 = cpg.method.fullName("test.py:<module>.func").parameter.order(2).head
       parameter2.name shouldBe "b"
-      parameter2.index shouldBe Some(2)
+      parameter2.index shouldBe 2
       parameter2.typeFullName shouldBe Constants.ANY
     }
   }
@@ -118,17 +118,17 @@ class FunctionDefCpgTests extends PySrc2CpgFixture with Matchers {
     "test method parameter nodes" in {
       val parameter1 = cpg.method.fullName("test.py:<module>.func").parameter.order(1).head
       parameter1.name shouldBe "a"
-      parameter1.index shouldBe Some(1)
+      parameter1.index shouldBe 1
       parameter1.typeFullName shouldBe Constants.ANY
 
       val parameter2 = cpg.method.fullName("test.py:<module>.func").parameter.order(2).head
       parameter2.name shouldBe "b"
-      parameter2.index shouldBe Some(2)
+      parameter2.index shouldBe 2
       parameter2.typeFullName shouldBe Constants.ANY
 
       val parameter3 = cpg.method.fullName("test.py:<module>.func").parameter.order(3).head
       parameter3.name shouldBe "c"
-      parameter3.index shouldBe Some(3)
+      parameter3.index shouldBe 3
       parameter3.typeFullName shouldBe Constants.ANY
     }
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -124,13 +124,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     // For yield statements where there isn't an explicit proc parameter
     val anonProcParam = scope.procParamName.map { p =>
       val nextIndex =
-        parameterAsts
-          .flatMap(_.root)
-          .collect { case m: NewMethodParameterIn => m.index }
-          .flatten
-          .maxOption
-          .map(_ + 1)
-          .getOrElse(1)
+        parameterAsts.flatMap(_.root).lastOption.map { case m: NewMethodParameterIn => m.index + 1 }.getOrElse(0)
 
       Ast(p.index(nextIndex))
     }
@@ -466,13 +460,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
 
         val anonProcParam = scope.procParamName.map { p =>
           val nextIndex =
-            parameterAsts
-              .flatMap(_.root)
-              .collect { case m: NewMethodParameterIn => m.index }
-              .flatten
-              .maxOption
-              .map(_ + 1)
-              .getOrElse(1)
+            parameterAsts.flatMap(_.root).lastOption.map { case m: NewMethodParameterIn => m.index + 1 }.getOrElse(0)
 
           Ast(p.index(nextIndex))
         }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -25,18 +25,18 @@ class MethodTests extends RubyCode2CpgFixture {
       f.numberOfLines shouldBe 1
 
       val List(x) = f.parameter.name("x").l
-      x.index shouldBe Some(1)
+      x.index shouldBe 1
       x.isVariadic shouldBe false
       x.lineNumber shouldBe Some(2)
 
       val List(fSelf) = f.parameter.name(RDefines.Self).l
-      fSelf.index shouldBe Some(0)
+      fSelf.index shouldBe 0
       fSelf.isVariadic shouldBe false
       fSelf.lineNumber shouldBe Some(2)
       fSelf.referencingIdentifiers.size shouldBe 0
 
       val List(mSelf) = cpg.method.isModule.parameter.name(RDefines.Self).l
-      mSelf.index shouldBe Some(0)
+      mSelf.index shouldBe 0
       mSelf.isVariadic shouldBe false
       mSelf.lineNumber shouldBe Some(2)
       mSelf.referencingIdentifiers.size shouldBe 3
@@ -185,11 +185,11 @@ class MethodTests extends RubyCode2CpgFixture {
         inside(funcF.parameter.l) { case thisParam :: xParam :: Nil =>
           thisParam.code shouldBe RDefines.Self
           thisParam.typeFullName shouldBe s"Test0.rb:$Main.C<class>"
-          thisParam.index shouldBe Some(0)
+          thisParam.index shouldBe 0
           thisParam.isVariadic shouldBe false
 
           xParam.code shouldBe "x"
-          xParam.index shouldBe Some(1)
+          xParam.index shouldBe 1
           xParam.isVariadic shouldBe false
 
         }
@@ -213,11 +213,11 @@ class MethodTests extends RubyCode2CpgFixture {
         inside(funcF.parameter.l) { case thisParam :: xParam :: Nil =>
           thisParam.code shouldBe RDefines.Self
           thisParam.typeFullName shouldBe s"Test0.rb:$Main.C<class>"
-          thisParam.index shouldBe Some(0)
+          thisParam.index shouldBe 0
           thisParam.isVariadic shouldBe false
 
           xParam.code shouldBe "x"
-          xParam.index shouldBe Some(1)
+          xParam.index shouldBe 1
           xParam.isVariadic shouldBe false
         }
       }
@@ -659,10 +659,10 @@ class MethodTests extends RubyCode2CpgFixture {
     inside(cpg.method.name("foo").l) { case fooMethod :: Nil =>
       inside(fooMethod.method.parameter.l) { case selfArg :: splatArg :: normalArg :: Nil =>
         splatArg.code shouldBe "*x"
-        splatArg.index shouldBe Some(1)
+        splatArg.index shouldBe 1
 
         normalArg.code shouldBe "y"
-        normalArg.index shouldBe Some(2)
+        normalArg.index shouldBe 2
       }
     }
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ProcParameterAndYieldTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ProcParameterAndYieldTests.scala
@@ -16,7 +16,7 @@ class ProcParameterAndYieldTests extends RubyCode2CpgFixture with Inspectors {
     val bParam = foo.parameter.last
     bParam.name shouldBe "b"
     bParam.code shouldBe "&b"
-    bParam.index shouldBe Some(1)
+    bParam.index shouldBe 1
 
     inside(foo.call.nameExact("call").argument.l) { case selfBase :: Nil =>
       selfBase.code shouldBe "b"
@@ -31,7 +31,7 @@ class ProcParameterAndYieldTests extends RubyCode2CpgFixture with Inspectors {
     val bParam = foo.parameter.last
     bParam.name shouldBe "b"
     bParam.code shouldBe "&b"
-    bParam.index shouldBe Some(1)
+    bParam.index shouldBe 1
 
     inside(foo.call.nameExact("call").argument.l) { case selfBase :: Nil =>
       selfBase.code shouldBe "b"
@@ -50,12 +50,12 @@ class ProcParameterAndYieldTests extends RubyCode2CpgFixture with Inspectors {
     val fooParam = foo.parameter.last
     fooParam.name shouldBe "<proc-param-0>"
     fooParam.code shouldBe "&<proc-param-0>"
-    fooParam.index shouldBe Some(1)
+    fooParam.index shouldBe 1
 
     val barParam = bar.parameter.last
     barParam.name shouldBe "<proc-param-1>"
     barParam.code shouldBe "&<proc-param-1>"
-    barParam.index shouldBe Some(1)
+    barParam.index shouldBe 1
 
     foo.call.nameExact("call").argument.isIdentifier.name.l shouldBe List("<proc-param-0>")
     bar.call.nameExact("call").argument.isIdentifier.name.l shouldBe List("<proc-param-1>")
@@ -69,11 +69,11 @@ class ProcParameterAndYieldTests extends RubyCode2CpgFixture with Inspectors {
     val List(xParam, procParam) = foo.parameter.l.takeRight(2)
 
     xParam.name shouldBe "x"
-    xParam.index shouldBe Some(1)
+    xParam.index shouldBe 1
 
     procParam.name shouldBe "<proc-param-0>"
     procParam.code shouldBe "&<proc-param-0>"
-    procParam.index shouldBe Some(2)
+    procParam.index shouldBe 2
 
     inside(foo.call.nameExact("call").argument.l) { case selfBase :: x :: Nil =>
       selfBase.code shouldBe "<proc-param-0>"
@@ -130,7 +130,7 @@ class ProcParameterAndYieldTests extends RubyCode2CpgFixture with Inspectors {
       // for the `MethodScope` which is why the procParam for this ConstructorScope is [1] instead of [0]
       procParam.name shouldBe "<proc-param-1>"
       procParam.code shouldBe "&<proc-param-1>"
-      procParam.index shouldBe Some(1)
+      procParam.index shouldBe 1
     }
 
     inside(initMethod.call.nameExact("call").argument.l) { case selfBase :: selfParam :: Nil =>

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/MethodTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/MethodTests.scala
@@ -37,7 +37,7 @@ class MethodTests extends Rust2CpgSuite(noSysRoot = true) {
     "have the parameter at index 1 with its declared type" in {
       inside(cpg.method.name("id").parameter.sortBy(_.order).l) { case (param: MethodParameterIn) :: Nil =>
         param.name shouldBe "x"
-        param.index shouldBe Some(1)
+        param.index shouldBe 1
         param.typeFullName shouldBe "i32"
       }
     }
@@ -62,15 +62,15 @@ class MethodTests extends Rust2CpgSuite(noSysRoot = true) {
     "preserve their order and declared types" in {
       inside(cpg.method.name("foo").parameter.sortBy(_.order).l) { case p1 :: p2 :: p3 :: Nil =>
         p1.name shouldBe "p1"
-        p1.index shouldBe Some(1)
+        p1.index shouldBe 1
         p1.typeFullName shouldBe "i32"
 
         p2.name shouldBe "p2"
-        p2.index shouldBe Some(2)
+        p2.index shouldBe 2
         p2.typeFullName shouldBe "i64"
 
         p3.name shouldBe "p3"
-        p3.index shouldBe Some(3)
+        p3.index shouldBe 3
         p3.typeFullName shouldBe "f32"
       }
     }

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/InitDeinitTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/InitDeinitTests.scala
@@ -31,12 +31,12 @@ class InitDeinitTests extends SwiftCompilerSrc2CpgSuite {
       val List(paramA) = constructorA.parameter.l
       val List(paramB) = constructorB.parameter.l
 
-      paramA.index shouldBe Some(0)
+      paramA.index shouldBe 0
       paramA.order shouldBe 0
       paramA.name shouldBe "self"
       paramA.typeFullName shouldBe "Sources/main.swift:<global>.FooStructConstructorA"
 
-      paramB.index shouldBe Some(0)
+      paramB.index shouldBe 0
       paramB.order shouldBe 0
       paramB.name shouldBe "self"
       paramB.typeFullName shouldBe "SwiftTest.FooStructConstructorA"
@@ -62,12 +62,12 @@ class InitDeinitTests extends SwiftCompilerSrc2CpgSuite {
       val List(paramA) = constructorA.parameter.l
       val List(paramB) = constructorB.parameter.l
 
-      paramA.index shouldBe Some(0)
+      paramA.index shouldBe 0
       paramA.order shouldBe 0
       paramA.name shouldBe "self"
       paramA.typeFullName shouldBe "Sources/main.swift:<global>.FooStructConstructorA"
 
-      paramB.index shouldBe Some(0)
+      paramB.index shouldBe 0
       paramB.order shouldBe 0
       paramB.name shouldBe "self"
       paramB.typeFullName shouldBe "SwiftTest.FooStructConstructorA"
@@ -90,12 +90,12 @@ class InitDeinitTests extends SwiftCompilerSrc2CpgSuite {
       val List(paramA) = deinitA.parameter.l
       val List(paramB) = deinitB.parameter.l
 
-      paramA.index shouldBe Some(0)
+      paramA.index shouldBe 0
       paramA.order shouldBe 0
       paramA.name shouldBe "self"
       paramA.typeFullName shouldBe "Sources/main.swift:<global>.FooStructDeinitializerA"
 
-      paramB.index shouldBe Some(0)
+      paramB.index shouldBe 0
       paramB.order shouldBe 0
       paramB.name shouldBe "self"
       paramB.typeFullName shouldBe "SwiftTest.FooStructDeinitializerA"
@@ -121,12 +121,12 @@ class InitDeinitTests extends SwiftCompilerSrc2CpgSuite {
       val List(paramA) = constructorA.parameter.l
       val List(paramB) = constructorB.parameter.l
 
-      paramA.index shouldBe Some(0)
+      paramA.index shouldBe 0
       paramA.order shouldBe 0
       paramA.name shouldBe "self"
       paramA.typeFullName shouldBe "Sources/main.swift:<global>.BarUnion"
 
-      paramB.index shouldBe Some(0)
+      paramB.index shouldBe 0
       paramB.order shouldBe 0
       paramB.name shouldBe "self"
       paramB.typeFullName shouldBe "SwiftTest.BarUnion"
@@ -153,12 +153,12 @@ class InitDeinitTests extends SwiftCompilerSrc2CpgSuite {
       val List(paramA) = constructorA.parameter.l
       val List(paramB) = constructorB.parameter.l
 
-      paramA.index shouldBe Some(0)
+      paramA.index shouldBe 0
       paramA.order shouldBe 0
       paramA.name shouldBe "self"
       paramA.typeFullName shouldBe "Sources/main.swift:<global>.BarClass"
 
-      paramB.index shouldBe Some(0)
+      paramB.index shouldBe 0
       paramB.order shouldBe 0
       paramB.name shouldBe "self"
       paramB.typeFullName shouldBe "SwiftTest.BarClass"
@@ -172,12 +172,12 @@ class InitDeinitTests extends SwiftCompilerSrc2CpgSuite {
       val List(deinitParamA) = deinitA.parameter.l
       val List(deinitParamB) = deinitB.parameter.l
 
-      deinitParamA.index shouldBe Some(0)
+      deinitParamA.index shouldBe 0
       deinitParamA.order shouldBe 0
       deinitParamA.name shouldBe "self"
       deinitParamA.typeFullName shouldBe "Sources/main.swift:<global>.BarClass"
 
-      deinitParamB.index shouldBe Some(0)
+      deinitParamB.index shouldBe 0
       deinitParamB.order shouldBe 0
       deinitParamB.name shouldBe "self"
       deinitParamB.typeFullName shouldBe "SwiftTest.BarClass"
@@ -204,22 +204,22 @@ class InitDeinitTests extends SwiftCompilerSrc2CpgSuite {
       val List(paramA, xA) = constructorA.parameter.l
       val List(paramB, xB) = constructorB.parameter.l
 
-      paramA.index shouldBe Some(0)
+      paramA.index shouldBe 0
       paramA.order shouldBe 0
       paramA.name shouldBe "self"
       paramA.typeFullName shouldBe "Sources/main.swift:<global>.BarClass"
 
-      paramB.index shouldBe Some(0)
+      paramB.index shouldBe 0
       paramB.order shouldBe 0
       paramB.name shouldBe "self"
       paramB.typeFullName shouldBe "SwiftTest.BarClass"
 
-      xA.index shouldBe Some(1)
+      xA.index shouldBe 1
       xA.order shouldBe 1
       xA.name shouldBe "a"
       xA.typeFullName shouldBe "Swift.Int"
 
-      xB.index shouldBe Some(1)
+      xB.index shouldBe 1
       xB.order shouldBe 1
       xB.name shouldBe "a"
       xB.typeFullName shouldBe "Swift.Int"
@@ -253,12 +253,12 @@ class InitDeinitTests extends SwiftCompilerSrc2CpgSuite {
       val List(paramA) = constructorA.parameter.l
       val List(paramB) = constructorB.parameter.l
 
-      paramA.index shouldBe Some(0)
+      paramA.index shouldBe 0
       paramA.order shouldBe 0
       paramA.name shouldBe "self"
       paramA.typeFullName shouldBe "Sources/main.swift:<global>.BarProtocol"
 
-      paramB.index shouldBe Some(0)
+      paramB.index shouldBe 0
       paramB.order shouldBe 0
       paramB.name shouldBe "self"
       paramB.typeFullName shouldBe "SwiftTest.BarProtocol"

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/ParameterIndexCompatPass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/ParameterIndexCompatPass.scala
@@ -2,32 +2,20 @@ package io.joern.x2cpg.passes.base
 
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.PropertyNames
+import io.shiftleft.codepropertygraph.generated.PropertyDefaults
 import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language.*
 
 /** Old CPGs use the `order` field to indicate the parameter index while newer CPGs use the `parameterIndex` field. This
-  * pass checks whether `parameterIndex` is not set for any parameter in a method, in which case the value of `order` is
-  * copied over for all parameters of that method.
-  *
-  * If at least one parameter in a method already has an explicit index set, this is treated as a new-style CPG where
-  * some parameters may intentionally have no index (e.g. keyword-only parameters in Python). In that case, the pass
-  * leaves all parameters in that method unchanged.
+  * pass checks whether `parameterIndex` is not set, in which case the value of `order` is copied over.
   */
 class ParameterIndexCompatPass(cpg: Cpg) extends CpgPass(cpg) {
 
   override def run(diffGraph: DiffGraphBuilder): Unit = {
-    cpg.method.foreach { method =>
-      val params        = method.parameter.l
-      val anyIndexIsSet = params.exists(_.index.isDefined)
-      if (!anyIndexIsSet) {
-        // Old-style CPG: no parameter in this method has an explicit index. copy order for all.
-        params.foreach { param =>
-          diffGraph.setNodeProperty(param, PropertyNames.Index, param.order)
-        }
+    cpg.parameter.foreach { param =>
+      if (param.index == PropertyDefaults.Index) {
+        diffGraph.setNodeProperty(param, PropertyNames.Index, param.order)
       }
-      // If at least one parameter already has an explicit index, this is a new-style CPG.
-      // Parameters with index = None are intentionally unindexed (e.g. keyword-only params);
-      // leave them as None.
     }
   }
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/ParameterIndexCompatPass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/ParameterIndexCompatPass.scala
@@ -18,7 +18,7 @@ class ParameterIndexCompatPass(cpg: Cpg) extends CpgPass(cpg) {
   override def run(diffGraph: DiffGraphBuilder): Unit = {
     cpg.method.foreach { method =>
       val params        = method.parameter.l
-      val anyIndexIsSet = params.exists(param => param.index.exists(index => index != -1))
+      val anyIndexIsSet = params.exists(_.index.isDefined)
       if (!anyIndexIsSet) {
         // Old-style CPG: no parameter in this method has an explicit index. copy order for all.
         params.foreach { param =>

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/ExpressionMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/ExpressionMethods.scala
@@ -59,8 +59,7 @@ class ExpressionMethods(val node: Expression) extends AnyVal with NodeExtension 
   def parameter(implicit callResolver: ICallResolver): Iterator[MethodParameterIn] = {
     val predicate: MethodParameterIn => Boolean = node.argumentName match {
       case Some(name) => _.name == name
-      case None =>
-        param => param.index.exists(idx => idx == node.argumentIndex || (param.isVariadic && idx < node.argumentIndex))
+      case None => param => param.index == node.argumentIndex || (param.isVariadic && param.index < node.argumentIndex)
     }
 
     for {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterOutTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterOutTraversal.scala
@@ -13,23 +13,17 @@ class MethodParameterOutTraversal(val traversal: Iterator[MethodParameterOut]) e
 
   /* method parameter indexes are  based, i.e. first parameter has index  (that's how java2cpg generates it) */
   def index(num: Int): Iterator[MethodParameterOut] =
-    traversal.filter(_.index.contains(num))
-
-  def index(num: Option[Int]): Iterator[MethodParameterOut] =
-    traversal.filter(_.index == num)
-
-  def indexIfPresent(num: Option[Int]): Iterator[MethodParameterOut] =
-    num.fold(Iterator.empty[MethodParameterOut])(index)
+    traversal.filter { _.index == num }
 
   /* get all parameters from (and including)
    * method parameter indexes are  based, i.e. first parameter has index  (that's how java2cpg generates it) */
   def indexFrom(num: Int): Iterator[MethodParameterOut] =
-    traversal.filter(_.index.exists(_ >= num))
+    traversal.filter(_.index >= num)
 
   /* get all parameters up to (and including)
    * method parameter indexes are  based, i.e. first parameter has index  (that's how java2cpg generates it) */
   def indexTo(num: Int): Iterator[MethodParameterOut] =
-    traversal.filter(_.index.exists(_ <= num))
+    traversal.filter(_.index <= num)
 
   @Doc(info = "Traverse to arguments (actual parameters) associated with this formal parameter")
   def argument(implicit callResolver: ICallResolver): Iterator[Expression] =

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterTraversal.scala
@@ -18,12 +18,12 @@ class MethodParameterTraversal(val traversal: Iterator[MethodParameterIn]) exten
   /** Traverse to all parameters with index greater or equal than `num` */
   @Doc(info = "Traverse to all parameters with index greater or equal than `num`")
   def indexFrom(num: Int): Iterator[MethodParameterIn] =
-    traversal.filter(_.index.exists(_ >= num))
+    traversal.filter(_.index >= num)
 
   /** Traverse to all parameters with index smaller or equal than `num` */
   @Doc(info = "Traverse to all parameters with index smaller or equal than `num`")
   def indexTo(num: Int): Iterator[MethodParameterIn] =
-    traversal.filter(_.index.exists(_ <= num))
+    traversal.filter(_.index <= num)
 
   /** Traverse to arguments (actual parameters) associated with this formal parameter */
   @Doc(info = "Traverse to arguments (actual parameters) associated with this formal parameter")
@@ -34,8 +34,7 @@ class MethodParameterTraversal(val traversal: Iterator[MethodParameterIn]) exten
       case (arg: Expression) <- call._argumentOut
       if arg.argumentName match {
         case Some(name) => name == paramIn.name
-        case None =>
-          paramIn.index.exists(idx => arg.argumentIndex == idx || (paramIn.isVariadic && arg.argumentIndex > idx))
+        case None => arg.argumentIndex == paramIn.index || (paramIn.isVariadic && arg.argumentIndex > paramIn.index)
       }
     } yield arg
   }


### PR DESCRIPTION
We need to revert the hole optional parameter index feature because loosing a linear numbering of parameters would be a pain in too many place like e.g. the policy data flow semantics in MAP statements and the fingerprints.
