### PR TITLE
[pysrc2cpg] Always set parameter index.

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/NodeBuilder.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/NodeBuilder.scala
@@ -145,7 +145,7 @@ class NodeBuilder(diffGraph: DiffGraphBuilder) {
     name: String,
     isVariadic: Boolean,
     lineAndColumn: LineAndColumn,
-    index: Option[Int] = None,
+    index: Int,
     typeHint: Option[ast.iexpr] = None
   ): nodes.NewMethodParameterIn = {
     val methodParameterNode = nodes
@@ -154,12 +154,12 @@ class NodeBuilder(diffGraph: DiffGraphBuilder) {
       .code(name)
       .evaluationStrategy(EvaluationStrategies.BY_SHARING)
       .typeFullName(extractTypesFromHint(typeHint).getOrElse(Constants.ANY))
+      .index(index)
       .isVariadic(isVariadic)
       .lineNumber(lineAndColumn.line)
       .columnNumber(lineAndColumn.column)
       .offset(lineAndColumn.offset)
       .offsetEnd(lineAndColumn.endOffset)
-    index.foreach(idx => methodParameterNode.index(idx))
     addNodeToDiff(methodParameterNode)
   }
 

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
@@ -505,7 +505,7 @@ class PythonAstVisitor(
       parameterProvider = () =>
         MethodParameters(
           0,
-          nodeBuilder.methodParameterNode("cls", isVariadic = false, lineAndColOf(classDef), Option(0)) :: Nil
+          nodeBuilder.methodParameterNode("cls", isVariadic = false, lineAndColOf(classDef), 0) :: Nil
         ),
       bodyProvider = () => classDef.body.map(convert),
       None,
@@ -665,7 +665,7 @@ class PythonAstVisitor(
       parameterProvider = () => {
         MethodParameters(
           0,
-          nodeBuilder.methodParameterNode("cls", isVariadic = false, lineAndColumn, Option(0)) :: Nil ++
+          nodeBuilder.methodParameterNode("cls", isVariadic = false, lineAndColumn, 0) :: Nil ++
             convert(parameters, 1)
         )
       },
@@ -809,7 +809,7 @@ class PythonAstVisitor(
       parameterProvider = () => {
         MethodParameters(
           0,
-          nodeBuilder.methodParameterNode("cls", isVariadic = false, lineAndColumn, Some(0)) :: Nil ++
+          nodeBuilder.methodParameterNode("cls", isVariadic = false, lineAndColumn, 0) :: Nil ++
             convert(parametersWithoutSelf, 1)
         )
       },
@@ -2132,43 +2132,31 @@ class PythonAstVisitor(
     parameters.posonlyargs.map(convertPosOnlyArg(_, autoIncIndex)) ++
       parameters.args.map(convertNormalArg(_, autoIncIndex)) ++
       parameters.vararg.map(convertVarArg(_, autoIncIndex)) ++
-      parameters.kwonlyargs.map(convertKeywordOnlyArg) ++
-      parameters.kw_arg.map(convertKwArg)
+      parameters.kwonlyargs.map(convertKeywordOnlyArg(_, autoIncIndex)) ++
+      parameters.kw_arg.map(convertKwArg(_, autoIncIndex))
   }
 
   // TODO for now the different arg convert functions are all the same but
   // will all be slightly different in the future when we can represent the
   // different types in the cpg.
   private def convertPosOnlyArg(arg: ast.Arg, index: AutoIncIndex): nodes.NewMethodParameterIn = {
-    nodeBuilder.methodParameterNode(
-      arg.arg,
-      isVariadic = false,
-      lineAndColOf(arg),
-      Option(index.getAndInc),
-      arg.annotation
-    )
+    nodeBuilder.methodParameterNode(arg.arg, isVariadic = false, lineAndColOf(arg), index.getAndInc, arg.annotation)
   }
 
   private def convertNormalArg(arg: ast.Arg, index: AutoIncIndex): nodes.NewMethodParameterIn = {
-    nodeBuilder.methodParameterNode(
-      arg.arg,
-      isVariadic = false,
-      lineAndColOf(arg),
-      Option(index.getAndInc),
-      arg.annotation
-    )
+    nodeBuilder.methodParameterNode(arg.arg, isVariadic = false, lineAndColOf(arg), index.getAndInc, arg.annotation)
   }
 
   private def convertVarArg(arg: ast.Arg, index: AutoIncIndex): nodes.NewMethodParameterIn = {
-    nodeBuilder.methodParameterNode(arg.arg, isVariadic = true, lineAndColOf(arg), Option(index.getAndInc))
+    nodeBuilder.methodParameterNode(arg.arg, isVariadic = true, lineAndColOf(arg), index.getAndInc)
   }
 
-  private def convertKeywordOnlyArg(arg: ast.Arg): nodes.NewMethodParameterIn = {
-    nodeBuilder.methodParameterNode(arg.arg, isVariadic = false, lineAndColOf(arg))
+  private def convertKeywordOnlyArg(arg: ast.Arg, index: AutoIncIndex): nodes.NewMethodParameterIn = {
+    nodeBuilder.methodParameterNode(arg.arg, isVariadic = false, lineAndColOf(arg), index.getAndInc)
   }
 
-  private def convertKwArg(arg: ast.Arg): nodes.NewMethodParameterIn = {
-    nodeBuilder.methodParameterNode(arg.arg, isVariadic = false, lineAndColOf(arg))
+  private def convertKwArg(arg: ast.Arg, index: AutoIncIndex): nodes.NewMethodParameterIn = {
+    nodeBuilder.methodParameterNode(arg.arg, isVariadic = false, lineAndColOf(arg), index.getAndInc)
   }
 
   def convert(keyword: ast.Keyword): NewNode = unhandled(keyword)

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/MethodCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/MethodCpgTests.scala
@@ -54,4 +54,21 @@ class MethodCpgTests extends PySrc2CpgFixture with Matchers {
     )
   }
 
+  "test method parameter index" in {
+    val cpg = code("""
+        |def method(posOnlyParam, /, normalParam, *varargParam, keywordOnlyParam, **extraKeyWordParam):
+        |  pass
+        |""".stripMargin)
+
+    val method = cpg.method.name("method").head
+    inside(method.parameter.l) {
+      case posOnlyParam :: normalParam :: varargParam :: keywordOnlyParam :: extraKeyWordParam :: Nil =>
+        posOnlyParam.index shouldBe 1
+        normalParam.index shouldBe 2
+        varargParam.index shouldBe 3
+        keywordOnlyParam.index shouldBe 4
+        extraKeyWordParam.index shouldBe 5
+    }
+  }
+
 }


### PR DESCRIPTION
This now adheres to the CPG spec which always asks for a parameter
index. The fact that certain parameters in Python cannot be passed by
index between callsite and method is untouched by this and currently not
explicitly encoded.
