### PR TITLE
[rubysrc2cpg] Handle multiple assignment as expression

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
@@ -93,12 +93,9 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
   }
 
   protected def handleVariableOccurrence(node: RubyExpression): Ast = {
-    val name       = code(node)
-    val identifier = identifierNode(node, name, name, Defines.Any)
-    val typeRef    = scope.tryResolveTypeReference(name)
-
     node match {
       case fieldVariable: RubyFieldIdentifier =>
+        val name = code(node)
         scope.findFieldInScope(name) match {
           case None =>
             scope.pushField(FieldDecl(name, Defines.Any, false, false, fieldVariable))
@@ -107,25 +104,31 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
             astForFieldInstance(name, field.node)
         }
       case _ =>
-        scope.lookupVariable(name) match {
-          case None if typeRef.isDefined =>
-            Ast(identifier.typeFullName(typeRef.get.name))
-          case None =>
-            val local = localNode(node, name, name, Defines.Any)
-            scope.addToScope(name, local) match {
-              case BlockScope(block) => diffGraph.addEdge(block, local, EdgeTypes.AST)
-              case _                 =>
-            }
-            Ast(identifier).withRefEdge(identifier, local)
-          case Some(local) =>
-            local match {
-              case x: NewLocal             => identifier.dynamicTypeHintFullName(x.dynamicTypeHintFullName)
-              case x: NewMethodParameterIn => identifier.dynamicTypeHintFullName(x.dynamicTypeHintFullName)
-            }
-            Ast(identifier).withRefEdge(identifier, local)
-        }
+        handleVariableOccurrence(code(node), node)
     }
+  }
 
+  protected def handleVariableOccurrence(name: String, positionNode: RubyExpression): Ast = {
+    val identifier = identifierNode(positionNode, name, name, Defines.Any)
+    val typeRef    = scope.tryResolveTypeReference(name)
+
+    scope.lookupVariable(name) match {
+      case None if typeRef.isDefined =>
+        Ast(identifier.typeFullName(typeRef.get.name))
+      case None =>
+        val local = localNode(positionNode, name, name, Defines.Any)
+        scope.addToScope(name, local) match {
+          case BlockScope(block) => diffGraph.addEdge(block, local, EdgeTypes.AST)
+          case _                 =>
+        }
+        Ast(identifier).withRefEdge(identifier, local)
+      case Some(local) =>
+        local match {
+          case x: NewLocal             => identifier.dynamicTypeHintFullName(x.dynamicTypeHintFullName)
+          case x: NewMethodParameterIn => identifier.dynamicTypeHintFullName(x.dynamicTypeHintFullName)
+        }
+        Ast(identifier).withRefEdge(identifier, local)
+    }
   }
 
   protected def astForIfStatement(builder: (IfExpression, Ast, Ast, Option[Ast]) => Ast)(node: IfExpression): Ast = {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -64,8 +64,8 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
     case node: DummyAst           => node.ast
     case node: EmptyExpression    => Ast()
     case node: Unknown            => astForUnknown(node)
-    case x =>
-      logger.warn(s"Unhandled expression of type ${x.getClass.getSimpleName}")
+    case xs =>
+      logger.warn(s"Unhandled expression of type ${xs.getClass.getSimpleName}")
       astForUnknown(node)
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -51,19 +51,15 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
     case node: RubyCallWithBlock[_]             => astForCallWithBlock(node)
     case node: SelfIdentifier                   => astForSelfIdentifier(node)
     case node: StatementList                    => astForStatementList(node)
-    case node: DefaultMultipleAssignment =>
-      blockAst(
-        blockNode(node, code(node), Defines.Any),
-        astForDefaultMultipleAssignment(node, isExpression = true).toList
-      )
-    case node: MultipleAssignment => blockAst(blockNode(node), astsForStatement(node).toList)
-    case node: ReturnExpression   => astForReturnExpression(node)
-    case node: AccessModifier     => astForSimpleIdentifier(node.toSimpleIdentifier)
-    case node: ArrayPattern       => astForArrayPattern(node)
-    case node: DummyNode          => Ast(node.node)
-    case node: DummyAst           => node.ast
-    case node: EmptyExpression    => Ast()
-    case node: Unknown            => astForUnknown(node)
+    case node: DefaultMultipleAssignment        => astForDefaultMultipleAssignmentExpr(node)
+    case node: MultipleAssignment               => blockAst(blockNode(node), astsForStatement(node).toList)
+    case node: ReturnExpression                 => astForReturnExpression(node)
+    case node: AccessModifier                   => astForSimpleIdentifier(node.toSimpleIdentifier)
+    case node: ArrayPattern                     => astForArrayPattern(node)
+    case node: DummyNode                        => Ast(node.node)
+    case node: DummyAst                         => node.ast
+    case node: EmptyExpression                  => Ast()
+    case node: Unknown                          => astForUnknown(node)
     case xs =>
       logger.warn(s"Unhandled expression of type ${xs.getClass.getSimpleName}")
       astForUnknown(node)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -51,14 +51,19 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
     case node: RubyCallWithBlock[_]             => astForCallWithBlock(node)
     case node: SelfIdentifier                   => astForSelfIdentifier(node)
     case node: StatementList                    => astForStatementList(node)
-    case node: MultipleAssignment               => blockAst(blockNode(node), astsForStatement(node).toList)
-    case node: ReturnExpression                 => astForReturnExpression(node)
-    case node: AccessModifier                   => astForSimpleIdentifier(node.toSimpleIdentifier)
-    case node: ArrayPattern                     => astForArrayPattern(node)
-    case node: DummyNode                        => Ast(node.node)
-    case node: DummyAst                         => node.ast
-    case node: EmptyExpression                  => Ast()
-    case node: Unknown                          => astForUnknown(node)
+    case node: DefaultMultipleAssignment =>
+      blockAst(
+        blockNode(node, code(node), Defines.Any),
+        astForDefaultMultipleAssignment(node, isExpression = true).toList
+      )
+    case node: MultipleAssignment => blockAst(blockNode(node), astsForStatement(node).toList)
+    case node: ReturnExpression   => astForReturnExpression(node)
+    case node: AccessModifier     => astForSimpleIdentifier(node.toSimpleIdentifier)
+    case node: ArrayPattern       => astForArrayPattern(node)
+    case node: DummyNode          => Ast(node.node)
+    case node: DummyAst           => node.ast
+    case node: EmptyExpression    => Ast()
+    case node: Unknown            => astForUnknown(node)
     case x =>
       logger.warn(s"Unhandled expression of type ${x.getClass.getSimpleName}")
       astForUnknown(node)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -35,7 +35,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
       case node: MethodDeclaration          => astForMethodDeclaration(node)
       case node: MethodAccessModifier       => astForMethodAccessModifier(node)
       case node: SingletonMethodDeclaration => astForSingletonMethodDeclaration(node)
-      case node: DefaultMultipleAssignment  => astForDefaultMultipleAssignment(node)
+      case node: DefaultMultipleAssignment  => astForDefaultMultipleAssignment(node, isExpression = false)
       case node: MultipleAssignment         => node.assignments.map(astForExpression)
       case node: BreakExpression            => astForBreakExpression(node) :: Nil
       case node: SingletonStatementList     => astForSingletonStatementList(node)
@@ -221,10 +221,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     returnAst(returnNode(node, code(node)), nodeAst :: Nil)
   }
 
-  protected def astForDefaultMultipleAssignment(
-    node: DefaultMultipleAssignment,
-    isExpression: Boolean = false
-  ): Seq[Ast] = {
+  protected def astForDefaultMultipleAssignment(node: DefaultMultipleAssignment, isExpression: Boolean): Seq[Ast] = {
     if (!isExpression) {
       node.assignments.map(astForExpression)
     } else {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -8,7 +8,15 @@ import io.joern.rubysrc2cpg.passes.Defines.prefixAsKernelDefined
 import io.joern.x2cpg.datastructures.MethodLike
 import io.joern.x2cpg.{Ast, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.nodes.{NewBlock, NewControlStructure}
-import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, ModifierTypes, NodeTypes}
+import io.shiftleft.codepropertygraph.generated.{
+  ControlStructureTypes,
+  DispatchTypes,
+  ModifierTypes,
+  NodeTypes,
+  Operators
+}
+
+import scala.collection.mutable
 
 trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
@@ -27,6 +35,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
       case node: MethodDeclaration          => astForMethodDeclaration(node)
       case node: MethodAccessModifier       => astForMethodAccessModifier(node)
       case node: SingletonMethodDeclaration => astForSingletonMethodDeclaration(node)
+      case node: DefaultMultipleAssignment  => astForDefaultMultipleAssignment(node)
       case node: MultipleAssignment         => node.assignments.map(astForExpression)
       case node: BreakExpression            => astForBreakExpression(node) :: Nil
       case node: SingletonStatementList     => astForSingletonStatementList(node)
@@ -173,8 +182,6 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
           case x =>
             astsForStatement(transform(expr))
         }
-      case node: DefaultMultipleAssignment =>
-        astsForStatement(node) ++ astsForImplicitReturnStatement(ArrayLiteral(node.assignments.map(_.lhs))(node.span))
       case ret: ReturnExpression => astForReturnExpression(ret) :: Nil
       case node: (MethodDeclaration | SingletonMethodDeclaration) =>
         (astsForStatement(node) :+ astForReturnMethodDeclarationSymbolName(node)).toList
@@ -210,8 +217,61 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
   }
 
   private def returnAst(node: RubyExpression): Ast = {
-    val nodeAst = astsForStatement(node)
-    returnAst(returnNode(node, code(node)), nodeAst)
+    val nodeAst = astForExpression(node)
+    returnAst(returnNode(node, code(node)), nodeAst :: Nil)
+  }
+
+  protected def astForDefaultMultipleAssignment(
+    node: DefaultMultipleAssignment,
+    isExpression: Boolean = false
+  ): Seq[Ast] = {
+    if (!isExpression) {
+      node.assignments.map(astForExpression)
+    } else {
+      val assignmentAsts = mutable.ListBuffer.empty[Ast]
+      val returnExprs    = mutable.ListBuffer.empty[RubyExpression]
+
+      node.assignments.foreach { assignment =>
+        if (isSimpleExpression(assignment.lhs)) {
+          assignmentAsts += astForExpression(assignment)
+          returnExprs += assignment.lhs
+        } else {
+          val tmpName  = scope.getNewVarTmp
+          val tmpIdent = SimpleIdentifier()(assignment.span.spanStart(tmpName))
+
+          val tmpLhsAst = handleVariableOccurrence(tmpIdent)
+          val rhsAst    = astForExpression(assignment.rhs)
+          val tmpAssignCall = callNode(
+            assignment,
+            s"$tmpName = ${code(assignment.rhs)}",
+            Operators.assignment,
+            Operators.assignment,
+            DispatchTypes.STATIC_DISPATCH
+          )
+          assignmentAsts += callAst(tmpAssignCall, Seq(tmpLhsAst, rhsAst))
+
+          val lhsAst    = astForExpression(assignment.lhs)
+          val tmpRhsAst = handleVariableOccurrence(tmpIdent)
+          val lhsAssignCall = callNode(
+            assignment,
+            s"${code(assignment.lhs)} = $tmpName",
+            Operators.assignment,
+            Operators.assignment,
+            DispatchTypes.STATIC_DISPATCH
+          )
+          assignmentAsts += callAst(lhsAssignCall, Seq(lhsAst, tmpRhsAst))
+
+          returnExprs += tmpIdent
+        }
+      }
+      assignmentAsts.toSeq :+ astForExpression(ArrayLiteral(returnExprs.toList)(node.span))
+    }
+  }
+
+  private def isSimpleExpression(expr: RubyExpression): Boolean = expr match {
+    case _: RubyIdentifier | _: SelfIdentifier => true
+    case _: LiteralExpr                        => true
+    case _                                     => false
   }
 
   // The evaluation of a MethodDeclaration returns its name in symbol form.

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -221,6 +221,13 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     returnAst(returnNode(node, code(node)), nodeAst :: Nil)
   }
 
+  protected def astForDefaultMultipleAssignmentExpr(node: DefaultMultipleAssignment): Ast = {
+    blockAst(
+      blockNode(node, code(node), Defines.Any),
+      astForDefaultMultipleAssignment(node, isExpression = true).toList
+    )
+  }
+
   protected def astForDefaultMultipleAssignment(node: DefaultMultipleAssignment, isExpression: Boolean): Seq[Ast] = {
     if (!isExpression) {
       node.assignments.map(astForExpression)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -232,18 +232,17 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     if (!isExpression) {
       node.assignments.map(astForExpression)
     } else {
-      val assignmentAsts = mutable.ListBuffer.empty[Ast]
-      val returnExprs    = mutable.ListBuffer.empty[RubyExpression]
+      val assignmentAsts  = mutable.ListBuffer.empty[Ast]
+      val returnExprNames = mutable.ListBuffer.empty[String]
 
       node.assignments.foreach { assignment =>
         if (isSimpleExpression(assignment.lhs)) {
           assignmentAsts += astForExpression(assignment)
-          returnExprs += assignment.lhs
+          returnExprNames += simpleExpressionName(assignment.lhs)
         } else {
-          val tmpName  = scope.getNewVarTmp
-          val tmpIdent = SimpleIdentifier()(assignment.span.spanStart(tmpName))
+          val tmpName = scope.getNewVarTmp
 
-          val tmpLhsAst = handleVariableOccurrence(tmpIdent)
+          val tmpLhsAst = handleVariableOccurrence(tmpName, assignment)
           val rhsAst    = astForExpression(assignment.rhs)
           val tmpAssignCall = callNode(
             assignment,
@@ -255,7 +254,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
           assignmentAsts += callAst(tmpAssignCall, Seq(tmpLhsAst, rhsAst))
 
           val lhsAst    = astForExpression(assignment.lhs)
-          val tmpRhsAst = handleVariableOccurrence(tmpIdent)
+          val tmpRhsAst = handleVariableOccurrence(tmpName, assignment)
           val lhsAssignCall = callNode(
             assignment,
             s"${code(assignment.lhs)} = $tmpName",
@@ -265,10 +264,46 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
           )
           assignmentAsts += callAst(lhsAssignCall, Seq(lhsAst, tmpRhsAst))
 
-          returnExprs += tmpIdent
+          returnExprNames += tmpName
         }
       }
-      assignmentAsts.toSeq :+ astForExpression(ArrayLiteral(returnExprs.toList)(node.span))
+      val arrayTmpName = scope.getNewVarTmp
+
+      val allocCall = callNode(node, Operators.alloc, Operators.alloc, Operators.alloc, DispatchTypes.STATIC_DISPATCH)
+      val arrayAssignCall = callNode(
+        node,
+        s"$arrayTmpName = ${Operators.alloc}",
+        Operators.assignment,
+        Operators.assignment,
+        DispatchTypes.STATIC_DISPATCH
+      )
+      assignmentAsts += callAst(arrayAssignCall, Seq(handleVariableOccurrence(arrayTmpName, node), callAst(allocCall)))
+
+      returnExprNames.toList.zipWithIndex.foreach { case (exprName, idx) =>
+        val idxLiteral = literalNode(node, idx.toString, Defines.prefixAsCoreType(Defines.Integer))
+        val indexAccessCall =
+          callNode(
+            node,
+            s"$arrayTmpName[$idx]",
+            Operators.indexAccess,
+            Operators.indexAccess,
+            DispatchTypes.STATIC_DISPATCH
+          )
+        val indexAccessAst =
+          callAst(indexAccessCall, Seq(handleVariableOccurrence(arrayTmpName, node), Ast(idxLiteral)))
+
+        val elemAssignCall = callNode(
+          node,
+          s"$arrayTmpName[$idx] = $exprName",
+          Operators.assignment,
+          Operators.assignment,
+          DispatchTypes.STATIC_DISPATCH
+        )
+        assignmentAsts += callAst(elemAssignCall, Seq(indexAccessAst, handleVariableOccurrence(exprName, node)))
+      }
+
+      assignmentAsts += handleVariableOccurrence(arrayTmpName, node)
+      assignmentAsts.toSeq
     }
   }
 
@@ -276,6 +311,13 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     case _: RubyIdentifier | _: SelfIdentifier => true
     case _: LiteralExpr                        => true
     case _                                     => false
+  }
+
+  private def simpleExpressionName(expr: RubyExpression): String = expr match {
+    case _: SelfIdentifier => Defines.Self
+    case x: RubyIdentifier => x.span.text
+    case x: LiteralExpr    => x.span.text
+    case x                 => code(x)
   }
 
   // The evaluation of a MethodDeclaration returns its name in symbol form.

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -314,7 +314,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
   }
 
   private def simpleExpressionName(expr: RubyExpression): String = expr match {
-    case _: SelfIdentifier => Defines.Self
+    case _: SelfIdentifier    => Defines.Self
     case node: RubyIdentifier => node.span.text
     case node: LiteralExpr    => node.span.text
     case node                 => code(node)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -315,9 +315,9 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
 
   private def simpleExpressionName(expr: RubyExpression): String = expr match {
     case _: SelfIdentifier => Defines.Self
-    case x: RubyIdentifier => x.span.text
-    case x: LiteralExpr    => x.span.text
-    case x                 => code(x)
+    case node: RubyIdentifier => node.span.text
+    case node: LiteralExpr    => node.span.text
+    case node                 => code(node)
   }
 
   // The evaluation of a MethodDeclaration returns its name in symbol form.

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyJsonHelpers.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyJsonHelpers.scala
@@ -269,9 +269,15 @@ object RubyJsonHelpers {
       case Nil                                                 => List.empty
     }
     val op = "="
+    def arraySpan(elems: List[RubyExpression]): TextSpan =
+      obj.toTextSpan.spanStart(elems.map(_.span.text).mkString("[", ", ", "]"))
+
+    def assignSpan(lhs: RubyExpression, rhs: RubyExpression): TextSpan =
+      lhs.span.spanStart(s"${lhs.span.text} $op ${rhs.span.text}")
+
     lazy val defaultAssignments = lhsNodes
       .zipAll(rhsNodes, defaultResult(), nilResult())
-      .map { case (lhs, rhs) => SingleAssignment(lhs, op, rhs)(obj.toTextSpan) }
+      .map { case (lhs, rhs) => SingleAssignment(lhs, op, rhs)(assignSpan(lhs, rhs)) }
 
     val assignments = if ((lhsNodes ++ rhsNodes).exists(_.isInstanceOf[SplattingRubyNode])) {
       rhsNodes.size - lhsNodes.size match {
@@ -287,9 +293,12 @@ object RubyJsonHelpers {
             .sortBy { x => slurpedLhs.indexOf(x._1) } // groupBy produces a map which discards insertion order
             .map {
               case (SplattingRubyNode(lhs), rhss) =>
-                SingleAssignment(lhs, op, ArrayLiteral(rhss)(obj.toTextSpan))(obj.toTextSpan)
-              case (lhs, rhs :: Nil) => SingleAssignment(lhs, op, rhs)(obj.toTextSpan)
-              case (lhs, rhss)       => SingleAssignment(lhs, op, ArrayLiteral(rhss)(obj.toTextSpan))(obj.toTextSpan)
+                val rhs = ArrayLiteral(rhss)(arraySpan(rhss))
+                SingleAssignment(lhs, op, rhs)(assignSpan(lhs, rhs))
+              case (lhs, rhs :: Nil) => SingleAssignment(lhs, op, rhs)(assignSpan(lhs, rhs))
+              case (lhs, rhss) =>
+                val rhs = ArrayLiteral(rhss)(arraySpan(rhss))
+                SingleAssignment(lhs, op, rhs)(assignSpan(lhs, rhs))
             }
             .toList
         }
@@ -305,9 +314,16 @@ object RubyJsonHelpers {
             .sortBy { x => slurpedRhs.indexOf(x._1) } // groupBy produces a map which discards insertion order
             .flatMap {
               case (SplattingRubyNode(rhs), lhss) =>
-                lhss.map(SingleAssignment(_, op, SplattingRubyNode(rhs)(rhs.span))(obj.toTextSpan))
-              case (rhs, lhs :: Nil) => Seq(SingleAssignment(lhs, op, rhs)(obj.toTextSpan))
-              case (rhs, lhss) => lhss.map(SingleAssignment(_, op, SplattingRubyNode(rhs)(rhs.span))(obj.toTextSpan))
+                lhss.map { lhs =>
+                  val splatRhs = SplattingRubyNode(rhs)(rhs.span)
+                  SingleAssignment(lhs, op, splatRhs)(assignSpan(lhs, splatRhs))
+                }
+              case (rhs, lhs :: Nil) => Seq(SingleAssignment(lhs, op, rhs)(assignSpan(lhs, rhs)))
+              case (rhs, lhss) =>
+                lhss.map { lhs =>
+                  val splatRhs = SplattingRubyNode(rhs)(rhs.span)
+                  SingleAssignment(lhs, op, splatRhs)(assignSpan(lhs, splatRhs))
+                }
             }
             .toList
         }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DestructuredAssignmentsTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DestructuredAssignmentsTests.scala
@@ -368,14 +368,30 @@ class DestructuredAssignmentsTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "create an explicit return of the LHS values as an array" in {
-      val arrayLiteral = cpg.method.name("f").methodReturn.toReturn.astChildren.isBlock.head
+      inside(cpg.method.name("f").methodReturn.toReturn.astChildren.isBlock.l) { case retBlock :: Nil =>
+        retBlock.code shouldBe "a, b = 1, 2"
 
-      arrayLiteral.code shouldBe "a, b = 1, 2"
+        inside(retBlock.astChildren.isCall.nameExact(Operators.assignment).l) {
+          case aAssign :: bAssign :: arrayAlloc :: arrayElem0 :: arrayElem1 :: Nil =>
+            aAssign.code shouldBe "a, b = 1, 2"
+            bAssign.code shouldBe "a, b = 1, 2"
 
-      val asgns = arrayLiteral.astChildren.assignment.where(_.target.isCall.nameExact(Operators.indexAccess)).l
-      inside(asgns.map(_.source)) { case (a: Identifier) :: (b: Identifier) :: Nil =>
-        a.code shouldBe "a"
-        b.code shouldBe "b"
+            arrayAlloc.code shouldBe s"<tmp-0> = ${Operators.alloc}"
+            arrayAlloc.argument(1).code shouldBe "<tmp-0>"
+            arrayAlloc.argument(2).code shouldBe Operators.alloc
+
+            arrayElem0.code shouldBe "<tmp-0>[0] = a"
+            arrayElem0.argument(1).code shouldBe "<tmp-0>[0]"
+            arrayElem0.argument(2).code shouldBe "a"
+
+            arrayElem1.code shouldBe "<tmp-0>[1] = b"
+            arrayElem1.argument(1).code shouldBe "<tmp-0>[1]"
+            arrayElem1.argument(2).code shouldBe "b"
+        }
+
+        inside(retBlock.astChildren.l.last) { case returnedArray: Identifier =>
+          returnedArray.code shouldBe "<tmp-0>"
+        }
       }
     }
 
@@ -389,20 +405,34 @@ class DestructuredAssignmentsTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     "use temporary variables for the complex LHS expressions" in {
-      val retBlock = cpg.method.name("f").methodReturn.toReturn.astChildren.isBlock.head
-      retBlock.code shouldBe "arr[0], arr[1] = 1, 2"
+      inside(cpg.method.name("f").methodReturn.toReturn.astChildren.isBlock.l) { case retBlock :: Nil =>
+        retBlock.code shouldBe "arr[0], arr[1] = 1, 2"
 
-      val directAssignments = retBlock.astChildren.isCall.nameExact(Operators.assignment).l
-      directAssignments.size shouldBe 4
+        inside(retBlock.astChildren.isCall.nameExact(Operators.assignment).l) {
+          case rhsToTmp0 :: lhsFromTmp0 :: rhsToTmp1 :: lhsFromTmp1 :: arrayAlloc :: arrayElem0 :: arrayElem1 :: Nil =>
+            rhsToTmp0.code shouldBe "<tmp-0> = 1"
+            lhsFromTmp0.code shouldBe "arr[0] = <tmp-0>"
 
-      val tmpAssignments = directAssignments.filter(_.argument(1).code.startsWith("<tmp-"))
-      tmpAssignments.size shouldBe 2
-      tmpAssignments.map(_.code).toSet shouldBe Set("<tmp-0> = 1", "<tmp-1> = 2")
+            rhsToTmp1.code shouldBe "<tmp-1> = 2"
+            lhsFromTmp1.code shouldBe "arr[1] = <tmp-1>"
 
-      val lhsAssignments = directAssignments.filter(_.argument(2).code.startsWith("<tmp-"))
-      lhsAssignments.size shouldBe 2
-      lhsAssignments.map(_.code).toSet shouldBe Set("arr[0] = <tmp-0>", "arr[1] = <tmp-1>")
+            arrayAlloc.code shouldBe s"<tmp-2> = ${Operators.alloc}"
+            arrayAlloc.argument(1).code shouldBe "<tmp-2>"
+            arrayAlloc.argument(2).code shouldBe Operators.alloc
+
+            arrayElem0.code shouldBe "<tmp-2>[0] = <tmp-0>"
+            arrayElem0.argument(1).code shouldBe "<tmp-2>[0]"
+            arrayElem0.argument(2).code shouldBe "<tmp-0>"
+
+            arrayElem1.code shouldBe "<tmp-2>[1] = <tmp-1>"
+            arrayElem1.argument(1).code shouldBe "<tmp-2>[1]"
+            arrayElem1.argument(2).code shouldBe "<tmp-1>"
+        }
+
+        inside(retBlock.astChildren.l.last) { case returnedArray: Identifier =>
+          returnedArray.code shouldBe "<tmp-2>"
+        }
+      }
     }
   }
-
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DestructuredAssignmentsTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DestructuredAssignmentsTests.scala
@@ -381,4 +381,28 @@ class DestructuredAssignmentsTests extends RubyCode2CpgFixture {
 
   }
 
+  "multi-assignments with complex LHS as a return value" should {
+    val cpg = code("""
+        |def f(arr)
+        | arr[0], arr[1] = 1, 2
+        |end
+        |""".stripMargin)
+
+    "use temporary variables for the complex LHS expressions" in {
+      val retBlock = cpg.method.name("f").methodReturn.toReturn.astChildren.isBlock.head
+      retBlock.code shouldBe "arr[0], arr[1] = 1, 2"
+
+      val directAssignments = retBlock.astChildren.isCall.nameExact(Operators.assignment).l
+      directAssignments.size shouldBe 4
+
+      val tmpAssignments = directAssignments.filter(_.argument(1).code.startsWith("<tmp-"))
+      tmpAssignments.size shouldBe 2
+      tmpAssignments.map(_.code).toSet shouldBe Set("<tmp-0> = 1", "<tmp-1> = 2")
+
+      val lhsAssignments = directAssignments.filter(_.argument(2).code.startsWith("<tmp-"))
+      lhsAssignments.size shouldBe 2
+      lhsAssignments.map(_.code).toSet shouldBe Set("arr[0] = <tmp-0>", "arr[1] = <tmp-1>")
+    }
+  }
+
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DestructuredAssignmentsTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/DestructuredAssignmentsTests.scala
@@ -16,9 +16,9 @@ class DestructuredAssignmentsTests extends RubyCode2CpgFixture {
 
     "separate the assignments into three separate assignment nodes" in {
       inside(cpg.assignment.l) { case aAssignment :: bAssignment :: cAssignment :: Nil =>
-        aAssignment.code shouldBe "a, b, c = 1, 2, 3"
-        bAssignment.code shouldBe "a, b, c = 1, 2, 3"
-        cAssignment.code shouldBe "a, b, c = 1, 2, 3"
+        aAssignment.code shouldBe "a = 1"
+        bAssignment.code shouldBe "b = 2"
+        cAssignment.code shouldBe "c = 3"
 
         val List(a: Identifier, one: Literal) = aAssignment.argumentOut.toList: @unchecked
         a.name shouldBe "a"
@@ -45,9 +45,9 @@ class DestructuredAssignmentsTests extends RubyCode2CpgFixture {
 
     "separate the assignments into 3 and leave `d` undefined" in {
       inside(cpg.assignment.l) { case aAssignment :: bAssignment :: cAssignment :: Nil =>
-        aAssignment.code shouldBe "a, b, c, d = 1, 2, 3"
-        bAssignment.code shouldBe "a, b, c, d = 1, 2, 3"
-        cAssignment.code shouldBe "a, b, c, d = 1, 2, 3"
+        aAssignment.code shouldBe "a = 1"
+        bAssignment.code shouldBe "b = 2"
+        cAssignment.code shouldBe "c = 3"
 
         val List(a: Identifier, one: Literal) = aAssignment.argumentOut.toList: @unchecked
         a.name shouldBe "a"
@@ -73,29 +73,28 @@ class DestructuredAssignmentsTests extends RubyCode2CpgFixture {
                 |a, b, *c = 1, 2, 3, 4
                 |""".stripMargin)
 
-      inside(cpg.assignment.codeExact("a, b, *c = 1, 2, 3, 4").l) {
-        case aAssignment :: bAssignment :: cAssignment :: _ :: Nil =>
-          aAssignment.code shouldBe "a, b, *c = 1, 2, 3, 4"
-          bAssignment.code shouldBe "a, b, *c = 1, 2, 3, 4"
-          cAssignment.code shouldBe "a, b, *c = 1, 2, 3, 4"
+      inside(cpg.assignment.l) { case aAssignment :: bAssignment :: cAssignment :: _ :: _ :: _ :: _ :: Nil =>
+        aAssignment.code shouldBe "a = 1"
+        bAssignment.code shouldBe "b = 2"
+        cAssignment.code shouldBe "c = [3, 4]"
 
-          val List(a: Identifier, one: Literal) = aAssignment.argumentOut.toList: @unchecked
-          a.name shouldBe "a"
-          one.code shouldBe "1"
+        val List(a: Identifier, one: Literal) = aAssignment.argumentOut.toList: @unchecked
+        a.name shouldBe "a"
+        one.code shouldBe "1"
 
-          val List(b: Identifier, two: Literal) = bAssignment.argumentOut.toList: @unchecked
-          b.name shouldBe "b"
-          two.code shouldBe "2"
+        val List(b: Identifier, two: Literal) = bAssignment.argumentOut.toList: @unchecked
+        b.name shouldBe "b"
+        two.code shouldBe "2"
 
-          val List(c: Identifier, arr: Block) = cAssignment.argumentOut.toList: @unchecked
-          c.name shouldBe "c"
-          arr.code shouldBe "a, b, *c = 1, 2, 3, 4"
+        val List(c: Identifier, arr: Block) = cAssignment.argumentOut.toList: @unchecked
+        c.name shouldBe "c"
+        arr.code shouldBe "[3, 4]"
 
-          val asgns = arr.astChildren.assignment.where(_.target.isCall.nameExact(Operators.indexAccess)).l
-          inside(asgns.map(_.source)) { case (three: Literal) :: (four: Literal) :: Nil =>
-            three.code shouldBe "3"
-            four.code shouldBe "4"
-          }
+        val asgns = arr.astChildren.assignment.where(_.target.isCall.nameExact(Operators.indexAccess)).l
+        inside(asgns.map(_.source)) { case (three: Literal) :: (four: Literal) :: Nil =>
+          three.code shouldBe "3"
+          four.code shouldBe "4"
+        }
 
       }
 
@@ -106,29 +105,28 @@ class DestructuredAssignmentsTests extends RubyCode2CpgFixture {
                 |a, *b, c = 1, 2, 3, 4
                 |""".stripMargin)
 
-      inside(cpg.assignment.codeExact("a, *b, c = 1, 2, 3, 4").l) {
-        case aAssignment :: bAssignment :: _ :: cAssignment :: Nil =>
-          aAssignment.code shouldBe "a, *b, c = 1, 2, 3, 4"
-          bAssignment.code shouldBe "a, *b, c = 1, 2, 3, 4"
-          cAssignment.code shouldBe "a, *b, c = 1, 2, 3, 4"
+      inside(cpg.assignment.l) { case aAssignment :: bAssignment :: _ :: _ :: _ :: _ :: cAssignment :: Nil =>
+        aAssignment.code shouldBe "a = 1"
+        bAssignment.code shouldBe "b = [2, 3]"
+        cAssignment.code shouldBe "c = 4"
 
-          val List(a: Identifier, one: Literal) = aAssignment.argumentOut.toList: @unchecked
-          a.name shouldBe "a"
-          one.code shouldBe "1"
+        val List(a: Identifier, one: Literal) = aAssignment.argumentOut.toList: @unchecked
+        a.name shouldBe "a"
+        one.code shouldBe "1"
 
-          val List(b: Identifier, arr: Block) = bAssignment.argumentOut.toList: @unchecked
-          b.name shouldBe "b"
-          arr.code shouldBe "a, *b, c = 1, 2, 3, 4"
+        val List(b: Identifier, arr: Block) = bAssignment.argumentOut.toList: @unchecked
+        b.name shouldBe "b"
+        arr.code shouldBe "[2, 3]"
 
-          val asgns = arr.astChildren.assignment.where(_.target.isCall.nameExact(Operators.indexAccess)).l
-          inside(asgns.map(_.source)) { case (two: Literal) :: (three: Literal) :: Nil =>
-            two.code shouldBe "2"
-            three.code shouldBe "3"
-          }
+        val asgns = arr.astChildren.assignment.where(_.target.isCall.nameExact(Operators.indexAccess)).l
+        inside(asgns.map(_.source)) { case (two: Literal) :: (three: Literal) :: Nil =>
+          two.code shouldBe "2"
+          three.code shouldBe "3"
+        }
 
-          val List(c: Identifier, four: Literal) = cAssignment.argumentOut.toList: @unchecked
-          c.name shouldBe "c"
-          four.code shouldBe "4"
+        val List(c: Identifier, four: Literal) = cAssignment.argumentOut.toList: @unchecked
+        c.name shouldBe "c"
+        four.code shouldBe "4"
 
       }
 
@@ -139,29 +137,28 @@ class DestructuredAssignmentsTests extends RubyCode2CpgFixture {
                 |*a, b, c = 1, 2, 3, 4
                 |""".stripMargin)
 
-      inside(cpg.assignment.codeExact("*a, b, c = 1, 2, 3, 4").l) {
-        case aAssignment :: _ :: bAssignment :: cAssignment :: Nil =>
-          aAssignment.code shouldBe "*a, b, c = 1, 2, 3, 4"
-          bAssignment.code shouldBe "*a, b, c = 1, 2, 3, 4"
-          cAssignment.code shouldBe "*a, b, c = 1, 2, 3, 4"
+      inside(cpg.assignment.l) { case aAssignment :: _ :: _ :: _ :: _ :: bAssignment :: cAssignment :: Nil =>
+        aAssignment.code shouldBe "a = [1, 2]"
+        bAssignment.code shouldBe "b = 3"
+        cAssignment.code shouldBe "c = 4"
 
-          val List(a: Identifier, arr: Block) = aAssignment.argumentOut.toList: @unchecked
-          a.name shouldBe "a"
-          arr.code shouldBe "*a, b, c = 1, 2, 3, 4"
+        val List(a: Identifier, arr: Block) = aAssignment.argumentOut.toList: @unchecked
+        a.name shouldBe "a"
+        arr.code shouldBe "[1, 2]"
 
-          val asgns = arr.astChildren.assignment.where(_.target.isCall.nameExact(Operators.indexAccess)).l
-          inside(asgns.map(_.source)) { case (one: Literal) :: (two: Literal) :: Nil =>
-            one.code shouldBe "1"
-            two.code shouldBe "2"
-          }
+        val asgns = arr.astChildren.assignment.where(_.target.isCall.nameExact(Operators.indexAccess)).l
+        inside(asgns.map(_.source)) { case (one: Literal) :: (two: Literal) :: Nil =>
+          one.code shouldBe "1"
+          two.code shouldBe "2"
+        }
 
-          val List(b: Identifier, three: Literal) = bAssignment.argumentOut.toList: @unchecked
-          b.name shouldBe "b"
-          three.code shouldBe "3"
+        val List(b: Identifier, three: Literal) = bAssignment.argumentOut.toList: @unchecked
+        b.name shouldBe "b"
+        three.code shouldBe "3"
 
-          val List(c: Identifier, four: Literal) = cAssignment.argumentOut.toList: @unchecked
-          c.name shouldBe "c"
-          four.code shouldBe "4"
+        val List(c: Identifier, four: Literal) = cAssignment.argumentOut.toList: @unchecked
+        c.name shouldBe "c"
+        four.code shouldBe "4"
 
       }
 
@@ -201,12 +198,12 @@ class DestructuredAssignmentsTests extends RubyCode2CpgFixture {
                 |a, b, c = 1, 2, *list
                 |""".stripMargin)
 
-      inside(cpg.assignment.codeExact("a, b, c = 1, 2, *list", "list = [3, 4]").l) {
-        case listAssignment :: aAssignment :: bAssignment :: cAssignment :: Nil =>
+      inside(cpg.assignment.l) {
+        case listAssignment :: _ :: _ :: _ :: _ :: aAssignment :: bAssignment :: cAssignment :: Nil =>
           listAssignment.code shouldBe "list = [3, 4]"
-          aAssignment.code shouldBe "a, b, c = 1, 2, *list"
-          bAssignment.code shouldBe "a, b, c = 1, 2, *list"
-          cAssignment.code shouldBe "a, b, c = 1, 2, *list"
+          aAssignment.code shouldBe "a = 1"
+          bAssignment.code shouldBe "b = 2"
+          cAssignment.code shouldBe "c = *list"
 
           val List(a: Identifier, one: Literal) = aAssignment.argumentOut.toList: @unchecked
           a.name shouldBe "a"
@@ -233,12 +230,12 @@ class DestructuredAssignmentsTests extends RubyCode2CpgFixture {
           |a, b, c = 1, *list
           |""".stripMargin)
 
-      inside(cpg.assignment.codeExact("list = [3, 4]", "a, b, c = 1, *list").l) {
-        case listAssignment :: aAssignment :: bAssignment :: cAssignment :: Nil =>
+      inside(cpg.assignment.l) {
+        case listAssignment :: _ :: _ :: _ :: _ :: aAssignment :: bAssignment :: cAssignment :: Nil =>
           listAssignment.code shouldBe "list = [3, 4]"
-          aAssignment.code shouldBe "a, b, c = 1, *list"
-          bAssignment.code shouldBe "a, b, c = 1, *list"
-          cAssignment.code shouldBe "a, b, c = 1, *list"
+          aAssignment.code shouldBe "a = 1"
+          bAssignment.code shouldBe "b = list"
+          cAssignment.code shouldBe "c = list"
 
           val List(a: Identifier, one: Literal) = aAssignment.argumentOut.toList: @unchecked
           a.name shouldBe "a"
@@ -269,31 +266,30 @@ class DestructuredAssignmentsTests extends RubyCode2CpgFixture {
         |a, *b, c = 1, 2, 3, 4, 5, 6
         |""".stripMargin)
 
-    inside(cpg.assignment.codeExact("a, *b, c = 1, 2, 3, 4, 5, 6").l) {
-      case aAssignment :: bAssignment :: _ :: cAssignment :: Nil =>
-        aAssignment.code shouldBe "a, *b, c = 1, 2, 3, 4, 5, 6"
-        bAssignment.code shouldBe "a, *b, c = 1, 2, 3, 4, 5, 6"
-        cAssignment.code shouldBe "a, *b, c = 1, 2, 3, 4, 5, 6"
+    inside(cpg.assignment.l) { case aAssignment :: bAssignment :: _ :: _ :: _ :: _ :: _ :: _ :: cAssignment :: Nil =>
+      aAssignment.code shouldBe "a = 1"
+      bAssignment.code shouldBe "b = [2, 3, 4, 5]"
+      cAssignment.code shouldBe "c = 6"
 
-        val List(a: Identifier, lit: Literal) = aAssignment.argumentOut.toList: @unchecked
-        a.name shouldBe "a"
-        lit.code shouldBe "1"
+      val List(a: Identifier, lit: Literal) = aAssignment.argumentOut.toList: @unchecked
+      a.name shouldBe "a"
+      lit.code shouldBe "1"
 
-        val List(splat: Identifier, arr: Block) = bAssignment.argumentOut.toList: @unchecked
-        splat.name shouldBe "b"
-        arr.code shouldBe "a, *b, c = 1, 2, 3, 4, 5, 6"
-        val asgns = arr.astChildren.assignment.where(_.target.isCall.nameExact(Operators.indexAccess)).l
-        inside(asgns.map(_.source)) {
-          case (two: Literal) :: (three: Literal) :: (four: Literal) :: (five: Literal) :: Nil =>
-            two.code shouldBe "2"
-            three.code shouldBe "3"
-            four.code shouldBe "4"
-            five.code shouldBe "5"
-        }
+      val List(splat: Identifier, arr: Block) = bAssignment.argumentOut.toList: @unchecked
+      splat.name shouldBe "b"
+      arr.code shouldBe "[2, 3, 4, 5]"
+      val asgns = arr.astChildren.assignment.where(_.target.isCall.nameExact(Operators.indexAccess)).l
+      inside(asgns.map(_.source)) {
+        case (two: Literal) :: (three: Literal) :: (four: Literal) :: (five: Literal) :: Nil =>
+          two.code shouldBe "2"
+          three.code shouldBe "3"
+          four.code shouldBe "4"
+          five.code shouldBe "5"
+      }
 
-        val List(c: Identifier, cLiteral: Literal) = cAssignment.argumentOut.toList: @unchecked
-        c.name shouldBe "c"
-        cLiteral.code shouldBe "6"
+      val List(c: Identifier, cLiteral: Literal) = cAssignment.argumentOut.toList: @unchecked
+      c.name shouldBe "c"
+      cLiteral.code shouldBe "6"
     }
   }
 
@@ -302,9 +298,9 @@ class DestructuredAssignmentsTests extends RubyCode2CpgFixture {
         |*, a = 1, 2, 3
         |""".stripMargin)
 
-    inside(cpg.assignment.codeExact("*, a = 1, 2, 3").l) { case splatAssignment :: _ :: aAssignment :: Nil =>
-      aAssignment.code shouldBe "*, a = 1, 2, 3"
-      splatAssignment.code shouldBe "*, a = 1, 2, 3"
+    inside(cpg.assignment.l) { case splatAssignment :: _ :: _ :: _ :: _ :: aAssignment :: Nil =>
+      splatAssignment.code shouldBe "_ = [1, 2]"
+      aAssignment.code shouldBe "a = 3"
 
       val List(a: Identifier, lit: Literal) = aAssignment.argumentOut.toList: @unchecked
       a.name shouldBe "a"
@@ -312,7 +308,7 @@ class DestructuredAssignmentsTests extends RubyCode2CpgFixture {
 
       val List(splat: Identifier, arr: Block) = splatAssignment.argumentOut.toList: @unchecked
       splat.name shouldBe "_"
-      arr.code shouldBe "*, a = 1, 2, 3"
+      arr.code shouldBe "[1, 2]"
       val asgns = arr.astChildren.assignment.where(_.target.isCall.nameExact(Operators.indexAccess)).l
       inside(asgns.map(_.source)) { case (one: Literal) :: (two: Literal) :: Nil =>
         one.code shouldBe "1"
@@ -326,35 +322,34 @@ class DestructuredAssignmentsTests extends RubyCode2CpgFixture {
         |a, *b, c = 1, 2, *d, *f, 4
         |""".stripMargin)
 
-    inside(cpg.assignment.codeExact("a, *b, c = 1, 2, *d, *f, 4").l) {
-      case aAssignment :: bAssignment :: _ :: cAssignment :: Nil =>
-        aAssignment.code shouldBe "a, *b, c = 1, 2, *d, *f, 4"
-        bAssignment.code shouldBe "a, *b, c = 1, 2, *d, *f, 4"
-        cAssignment.code shouldBe "a, *b, c = 1, 2, *d, *f, 4"
+    inside(cpg.assignment.l) { case aAssignment :: bAssignment :: _ :: _ :: _ :: _ :: _ :: cAssignment :: Nil =>
+      aAssignment.code shouldBe "a = 1"
+      bAssignment.code shouldBe "b = [2, *d, *f]"
+      cAssignment.code shouldBe "c = 4"
 
-        val List(a: Identifier, aLiteral: Literal) = aAssignment.argumentOut.toList: @unchecked
-        a.name shouldBe "a"
-        aLiteral.code shouldBe "1"
+      val List(a: Identifier, aLiteral: Literal) = aAssignment.argumentOut.toList: @unchecked
+      a.name shouldBe "a"
+      aLiteral.code shouldBe "1"
 
-        val List(splat: Identifier, arr: Block) = bAssignment.argumentOut.toList: @unchecked
-        splat.name shouldBe "b"
-        arr.code shouldBe "a, *b, c = 1, 2, *d, *f, 4"
+      val List(splat: Identifier, arr: Block) = bAssignment.argumentOut.toList: @unchecked
+      splat.name shouldBe "b"
+      arr.code shouldBe "[2, *d, *f]"
 
-        val asgns = arr.astChildren.assignment.where(_.target.isCall.nameExact(Operators.indexAccess)).l
-        inside(asgns.map(_.source)) { case (two: Literal) :: (d: Call) :: (f: Call) :: Nil =>
-          two.code shouldBe "2"
+      val asgns = arr.astChildren.assignment.where(_.target.isCall.nameExact(Operators.indexAccess)).l
+      inside(asgns.map(_.source)) { case (two: Literal) :: (d: Call) :: (f: Call) :: Nil =>
+        two.code shouldBe "2"
 
-          d.code shouldBe "*d"
-          d.methodFullName shouldBe RubyOperators.splat
+        d.code shouldBe "*d"
+        d.methodFullName shouldBe RubyOperators.splat
 
-          f.code shouldBe "*f"
-          f.methodFullName shouldBe RubyOperators.splat
+        f.code shouldBe "*f"
+        f.methodFullName shouldBe RubyOperators.splat
 
-        }
+      }
 
-        val List(c: Identifier, cLiteral: Literal) = cAssignment.argumentOut.toList: @unchecked
-        c.name shouldBe "c"
-        cLiteral.code shouldBe "4"
+      val List(c: Identifier, cLiteral: Literal) = cAssignment.argumentOut.toList: @unchecked
+      c.name shouldBe "c"
+      cLiteral.code shouldBe "4"
 
     }
   }
@@ -373,8 +368,8 @@ class DestructuredAssignmentsTests extends RubyCode2CpgFixture {
 
         inside(retBlock.astChildren.isCall.nameExact(Operators.assignment).l) {
           case aAssign :: bAssign :: arrayAlloc :: arrayElem0 :: arrayElem1 :: Nil =>
-            aAssign.code shouldBe "a, b = 1, 2"
-            bAssign.code shouldBe "a, b = 1, 2"
+            aAssign.code shouldBe "a = 1"
+            bAssign.code shouldBe "b = 2"
 
             arrayAlloc.code shouldBe s"<tmp-0> = ${Operators.alloc}"
             arrayAlloc.argument(1).code shouldBe "<tmp-0>"


### PR DESCRIPTION
### Ensure that Ruby's multiple assignments return a value in expression context

If the entrypoint for `DefaultMultipleAssignment` is `astsForStatement`, `astForDefaultMultipleAssignment` is called with `isExpression = false` to avoid unnecessarily generating tmp variables 