### PR TITLE
[rust2cpg] basic REF linking for identifiers to locals and parameters.

### DIFF
--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/AstCreator.scala
@@ -6,6 +6,7 @@ import io.joern.rust2cpg.parser.RustJsonParser.ParseResult
 import io.joern.rust2cpg.parser.RustNodeSyntax
 import io.joern.rust2cpg.parser.RustNodeSyntax.RustNode
 import io.joern.x2cpg.datastructures.Stack.*
+import io.joern.x2cpg.datastructures.VariableScopeManager
 import io.joern.x2cpg.{Ast, AstCreatorBase, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.nodes.{
   NewCall,
@@ -29,11 +30,13 @@ class AstCreator(val config: Config, val parseResult: ParseResult)(implicit with
   private val logger = LoggerFactory.getLogger(getClass)
 
   protected val methodAstParentStack = new Stack[NewNode]
+  protected val variableScope        = new VariableScopeManager()
 
   override def createAst(): DiffGraphBuilder = {
     val sourceFile = parseResult.ast.asInstanceOf[RustNodeSyntax.SourceFile]
     val ast        = visitSourceFile(sourceFile)
     Ast.storeInDiffGraph(ast, diffGraph)
+    variableScope.createVariableReferenceLinks(diffGraph, parseResult.filename)
     diffGraph
   }
 

--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustFullNames.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustFullNames.scala
@@ -80,11 +80,6 @@ trait RustFullNames { this: AstCreator =>
     text(typ).getOrElse(Defines.Any)
   }
 
-  // TODO
-  protected def typeFullNameForNameRef(nameRef: RustNodeSyntax.NameRef): String = {
-    Defines.Any
-  }
-
   protected def typeFullNameForPath(path: RustNodeSyntax.Path): String = {
     rustAstGenTypeFullName(path)
       .orElse(path.pathSegment.nameRef.flatMap(rustAstGenTypeFullName))

--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
@@ -2,6 +2,7 @@ package io.joern.rust2cpg.astcreation
 
 import io.joern.rust2cpg.parser.RustNodeSyntax.*
 import io.joern.x2cpg.datastructures.Stack.*
+import io.joern.x2cpg.datastructures.VariableScopeManager.ScopeType
 import io.joern.x2cpg.{Ast, Defines, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.{
   ControlStructureTypes,
@@ -184,6 +185,7 @@ trait RustVisitor(implicit withValidationMode: ValidationMode) { this: AstCreato
               case None =>
                 val lhsName = code(identToken)
                 val local   = localNode(identToken, lhsName, lhsName, typeFullName)
+                variableScope.addVariable(local.name, local, local.typeFullName, ScopeType.BlockScope)
                 Ast(local) :: Nil
             }
           case None => notHandledYet(letStmt) :: Nil
@@ -252,10 +254,12 @@ trait RustVisitor(implicit withValidationMode: ValidationMode) { this: AstCreato
     val methodRet       = methodReturnNode(fn, retTypeFullName)
     val methodMods      = Seq[NewModifier]()
 
+    variableScope.pushNewMethodScope(method.fullName, method.name, method, None)
     methodAstParentStack.push(method)
     val paramAsts = visitParamList(fn.paramList)
     val bodyAst   = fn.blockExpr.map(lowerFnBody).getOrElse(blockAst(blockNode(fn)))
     methodAstParentStack.pop()
+    variableScope.popScope()
 
     methodAst(method = method, parameters = paramAsts, body = bodyAst, methodReturn = methodRet, modifiers = methodMods)
   }
@@ -266,9 +270,12 @@ trait RustVisitor(implicit withValidationMode: ValidationMode) { this: AstCreato
   //   RETURN (expr) // if (expr) exists
   // }
   private def lowerFnBody(blockExpr: BlockExpr): Ast = {
+    val block = blockNode(blockExpr)
+    variableScope.pushNewBlockScope(block)
     val stmtAsts   = blockExpr.stmtList.stmt.flatMap(visitStmt)
     val retExprAst = blockExpr.stmtList.expr.map(lowerReturnExpr).toList
-    Ast(blockNode(blockExpr)).withChildren(stmtAsts ++ retExprAst)
+    variableScope.popScope()
+    Ast(block).withChildren(stmtAsts ++ retExprAst)
   }
 
   // Creates:
@@ -370,6 +377,7 @@ trait RustVisitor(implicit withValidationMode: ValidationMode) { this: AstCreato
             evaluationStrategy = EvaluationStrategies.BY_SHARING,
             typeFullName = typeFullName
           )
+          variableScope.addVariable(paramNode.name, paramNode, typeFullName, ScopeType.MethodScope)
           Ast(paramNode)
         case _ => notHandledYet(param)
       }
@@ -394,47 +402,15 @@ trait RustVisitor(implicit withValidationMode: ValidationMode) { this: AstCreato
 
   // Path =
   //  (qualifier:Path '::')? segment:PathSegment
-  private def visitPath(path: Path): Ast = {
-    lowerPathAsFieldAccess(path)
-  }
-
-  // TODO
-  private def lowerPathAsFieldAccess(path: Path): Ast = {
-    val lhs = path.path.map(lowerPathAsFieldAccess)
-    val rhs = visitPathSegment(path.pathSegment)
-
-    val name         = code(path.pathSegment)
-    val typeFullName = typeFullNameForPath(path)
-
-    lhs match {
-      case None      => Ast(identifierNode(path.pathSegment, name, code(path), typeFullName))
-      case Some(lhs) => notHandledYet(path)
-    }
-  }
-
-  // PathSegment =
-  //  '::'? NameRef
-  // | NameRef GenericArgList?
-  // | NameRef ParenthesizedArgList RetType?
-  // | NameRef ReturnTypeSyntax
-  // | TypeAnchor
-  private def visitPathSegment(pathSegment: PathSegment): Ast = {
-    pathSegment.nameRef match {
-      case Some(nameRef) => visitNameRef(nameRef)
-      case None          => notHandledYet(pathSegment)
-    }
-  }
-
-  // NameRef =
-  //  '#ident' | '@int_number' | 'self' | 'super' | 'crate' | 'Self'
-  private def visitNameRef(nameRef: NameRef): Ast = {
-    nameRef.identToken match {
-      case Some(ident) =>
-        val typeFullName = typeFullNameForNameRef(nameRef)
-        val name         = code(ident)
-        Ast(identifierNode(nameRef, name, code(nameRef), typeFullName))
-      case None => notHandledYet(nameRef)
-    }
+  private def visitPath(path: Path): Ast = path.path match {
+    case None =>
+      // TODO: this doesn't yet account for imported items, i.e. we are assuming that identifiers denote variables.
+      val name         = code(path.pathSegment)
+      val typeFullName = typeFullNameForPath(path)
+      val ident        = identifierNode(path.pathSegment, name, code(path), typeFullName)
+      variableScope.addVariableReference(name, ident, typeFullName, EvaluationStrategies.BY_REFERENCE)
+      Ast(ident)
+    case Some(_) => notHandledYet(path)
   }
 
   // BinExpr =

--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
@@ -3,6 +3,7 @@ package io.joern.rust2cpg.astcreation
 import io.joern.rust2cpg.parser.RustNodeSyntax.*
 import io.joern.x2cpg.datastructures.Stack.*
 import io.joern.x2cpg.datastructures.VariableScopeManager.ScopeType
+import io.joern.x2cpg.datastructures.VariableScopeManager.ScopeType.BlockScope
 import io.joern.x2cpg.{Ast, Defines, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.{
   ControlStructureTypes,
@@ -181,15 +182,33 @@ trait RustVisitor(implicit withValidationMode: ValidationMode) { this: AstCreato
           case Some(identToken) =>
             val typeFullName = letStmt.`type`.map(typeFullNameForType).getOrElse(typeFullNameForIdentPat(identPat))
             letStmt.expr match {
-              case Some(rhsExpr) => lowerIdentifierDecl(identToken, rhsExpr, typeFullName, code(letStmt))
+              case Some(rhsExpr) =>
+                if (variableScope.variableIsInCurrentScope(code(identToken))) {
+                  // Shadowing: only create the assignment.
+                  val rhsAst  = visitExpr(rhsExpr)
+                  val lhsNode = identifierNode(identToken, code(identToken), code(identToken), typeFullName)
+                  val lhsAst  = Ast(lhsNode)
+                  variableScope.addVariableReference(
+                    lhsNode.name,
+                    lhsNode,
+                    lhsNode.typeFullName,
+                    EvaluationStrategies.BY_REFERENCE
+                  )
+                  callAst(assignmentNode(letStmt, code(letStmt)), Seq(lhsAst, rhsAst)) :: Nil
+                } else {
+                  // A fresh identifier in the current scope. Create a LOCAL and the assignment.
+                  lowerIdentifierDecl(identToken, rhsExpr, typeFullName, code(letStmt))
+                }
               case None =>
                 val lhsName = code(identToken)
                 val local   = localNode(identToken, lhsName, lhsName, typeFullName)
                 variableScope.addVariable(local.name, local, local.typeFullName, ScopeType.BlockScope)
                 Ast(local) :: Nil
             }
+          // TODO: should actually be unreachable. The other scenario from `identPat.name` is `self`, which isn't valid.
           case None => notHandledYet(letStmt) :: Nil
         }
+      // TODO: support other LHS patterns other than identifiers.
       case _ => notHandledYet(letStmt) :: Nil
     }
   }
@@ -206,9 +225,12 @@ trait RustVisitor(implicit withValidationMode: ValidationMode) { this: AstCreato
     val lhsName = code(lhsToken)
 
     val local = localNode(lhsToken, lhsName, code(lhsToken), typeFullName)
-    val ident = identifierNode(lhsToken, lhsName, code(lhsToken), typeFullName)
+    variableScope.addVariable(local.name, local, local.typeFullName, BlockScope)
 
-    val lhsAst        = Ast(ident).withRefEdge(ident, local)
+    val ident = identifierNode(lhsToken, lhsName, code(lhsToken), typeFullName)
+    variableScope.addVariableReference(ident.name, ident, ident.typeFullName, EvaluationStrategies.BY_REFERENCE)
+
+    val lhsAst        = Ast(ident)
     val rhsAst        = visitExpr(rhsExpr)
     val localAst      = Ast(local)
     val assignmentAst = callAst(assignmentNode(lhsToken, declCode), Seq(lhsAst, rhsAst))
@@ -289,8 +311,10 @@ trait RustVisitor(implicit withValidationMode: ValidationMode) { this: AstCreato
   // BlockExpr =
   //  Attr* Label? (TryBlockModifier | 'unsafe' | ('async' 'move'?) | ('gen' 'move'?) | 'const') StmtList
   private def visitBlockExpr(blockExpr: BlockExpr): Ast = {
-    val stmts = visitStmtList(blockExpr.stmtList)
     val block = blockNode(blockExpr)
+    variableScope.pushNewBlockScope(block)
+    val stmts = visitStmtList(blockExpr.stmtList)
+    variableScope.popScope()
     Ast(block).withChildren(stmts)
   }
 

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/ControlStructureTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/ControlStructureTests.scala
@@ -32,6 +32,11 @@ class ControlStructureTests extends Rust2CpgSuite(noSysRoot = true) {
       cpg.ifBlock.condition.isCall.argument.isIdentifier.name.l shouldBe List("x", "y")
     }
 
+    "have x and y reference the parameters" in {
+      cpg.identifier("x").refsTo.l shouldBe cpg.parameter("x").l
+      cpg.identifier("y").refsTo.l shouldBe cpg.parameter("y").l
+    }
+
     "place foo in the then-branch" in {
       cpg.ifBlock.whenTrue.isBlock.astChildren.isCall.name.l shouldBe List("foo")
     }

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/DeclarationTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/DeclarationTests.scala
@@ -231,4 +231,64 @@ class DeclarationTests extends Rust2CpgSuite(noSysRoot = true) {
       cpg.method("main").assignment.target.isIdentifier.name("x").refsTo.l shouldBe cpg.method("main").local.name("x").l
     }
   }
+
+  "two consecutive `let x = ...`" should {
+    val cpg = code("""
+        |fn main() {
+        | let x = 123;    // 3
+        | let x = x + 1;  // 4
+        | let y = x;      // 5
+        |}
+        |""".stripMargin)
+
+    "have exactly one LOCAL i32 for `x`" in {
+      inside(cpg.method.name("main").block.local.name("x").l) { case local :: Nil =>
+        local.typeFullName shouldBe "i32"
+        local.code shouldBe "x"
+        local.lineNumber shouldBe Some(3)
+      }
+    }
+
+    "`x+1` refs `x` on line 3" in {
+      inside(cpg.assignment.lineNumber(4).argument(2).astChildren.isIdentifier.name("x").l) { case xUse :: Nil =>
+        xUse.refsTo.l shouldBe cpg.local("x").lineNumber(3).l
+      }
+    }
+
+    "`x` on line 4 refs `x` on line 3" in {
+      inside(cpg.assignment.lineNumber(4).argument(1).isIdentifier.name("x").l) { case xLhs :: Nil =>
+        xLhs.refsTo.l shouldBe cpg.local("x").lineNumber(3).l
+      }
+    }
+
+  }
+
+  "shadowed `let x` via nested block" should {
+    val cpg = code("""
+        |fn main() {
+        | let x = 1;     // 3
+        | {
+        |   let x = 2;   // 5
+        |   let y = x;   // 6
+        | }
+        | let z = x;     // 8
+        |}
+        |""".stripMargin)
+
+    "have a distinct LOCAL `x` per block" in {
+      cpg.method("main").local.name("x").lineNumber.sorted.l shouldBe List(3, 5)
+    }
+
+    "have the inner `y = x` ref the inner `x`" in {
+      inside(cpg.assignment.lineNumber(6).argument(2).isIdentifier.name("x").l) { case xUse :: Nil =>
+        xUse.refsTo.l shouldBe cpg.local("x").lineNumber(5).l
+      }
+    }
+
+    "have the outer `z = x` ref the outer `x`" in {
+      inside(cpg.assignment.lineNumber(8).argument(2).isIdentifier.name("x").l) { case xUse :: Nil =>
+        xUse.refsTo.l shouldBe cpg.local("x").lineNumber(3).l
+      }
+    }
+  }
 }

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/DeclarationTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/DeclarationTests.scala
@@ -226,5 +226,9 @@ class DeclarationTests extends Rust2CpgSuite(noSysRoot = true) {
         local.code shouldBe "x"
       }
     }
+
+    "have the LHS of the assignment reference the declaration" in {
+      cpg.method("main").assignment.target.isIdentifier.name("x").refsTo.l shouldBe cpg.method("main").local.name("x").l
+    }
   }
 }

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/MethodTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/MethodTests.scala
@@ -49,8 +49,8 @@ class MethodTests extends Rust2CpgSuite(noSysRoot = true) {
         inside(ret.astChildren.l) { case (ident: Identifier) :: Nil =>
           ident.name shouldBe "x"
           ident.code shouldBe "x"
-        // TODO: update once typeFullNames are recorded.
-        //  ident.typeFullName shouldBe "i32"
+          ident.typeFullName shouldBe "i32"
+          ident.refsTo.l shouldBe cpg.method.name("id").parameter.l
         }
       }
     }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/datastructures/VariableScopeManager.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/datastructures/VariableScopeManager.scala
@@ -198,6 +198,18 @@ class VariableScopeManager {
     getEnclosingMethodScopeElement(stack).exists(_.nameToVariableNode.contains(identifier))
   }
 
+  /** Checks if a variable is in the current (i.e. innermost) scope only.
+    *
+    * @param identifier
+    *   The name of the variable.
+    *
+    * @return
+    *   True if the variable is in the current scope, false otherwise.
+    */
+  def variableIsInCurrentScope(identifier: String): Boolean = {
+    stack.exists(_.nameToVariableNode.contains(identifier))
+  }
+
   /** Checks whether a variable with the given identifier is declared in the type decl scope.
     *
     * This method inspects the current scope stack:


### PR DESCRIPTION
Brings in VariableScopeManager to batch-create REF edges once the visitor has finished.