### PR TITLE
[rust2cpg] bring TypeNodePass.

### DIFF
--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/Rust2Cpg.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/Rust2Cpg.scala
@@ -2,6 +2,7 @@ package io.joern.rust2cpg
 
 import io.joern.rust2cpg.astgen.RustAstGenRunner
 import io.joern.rust2cpg.passes.AstCreationPass
+import io.joern.rust2cpg.passes.RustTypeNodePass
 import io.joern.x2cpg.X2Cpg.withNewEmptyCpg
 import io.joern.x2cpg.X2CpgFrontend
 import io.joern.x2cpg.passes.frontend.MetaDataPass
@@ -23,6 +24,7 @@ class Rust2Cpg extends X2CpgFrontend {
         val hash         = HashUtil.sha256(astGenResult.parsedFiles.map(Paths.get(_)))
         new MetaDataPass(cpg, Languages.RUST, config.inputPath, Option(hash)).createAndApply()
         new AstCreationPass(cpg, astGenResult.parsedFiles, config)(config.schemaValidation).createAndApply()
+        RustTypeNodePass.withTypesFromCpg(cpg).createAndApply()
       }
     }
   }

--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/Rust2Cpg.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/Rust2Cpg.scala
@@ -24,7 +24,7 @@ class Rust2Cpg extends X2CpgFrontend {
         val hash         = HashUtil.sha256(astGenResult.parsedFiles.map(Paths.get(_)))
         new MetaDataPass(cpg, Languages.RUST, config.inputPath, Option(hash)).createAndApply()
         new AstCreationPass(cpg, astGenResult.parsedFiles, config)(config.schemaValidation).createAndApply()
-        RustTypeNodePass.withTypesFromCpg(cpg).createAndApply()
+        new RustTypeNodePass(cpg).createAndApply()
       }
     }
   }

--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustFullNames.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustFullNames.scala
@@ -11,8 +11,7 @@ import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 // rust_ast_gen-provided methodFullName/typeFullName are always preferred.
 // The fallback is to rely on the current enclosing scope.
 trait RustFullNames { this: AstCreator =>
-
-  private val PathSep = "::"
+  import RustFullNames.PathSep
 
   protected def combineRustFullName(parent: String, child: String): String = {
     s"$parent$PathSep$child"
@@ -47,21 +46,11 @@ trait RustFullNames { this: AstCreator =>
     }
   }
 
-  private def rustAstGenMethodFullName(node: RustNode): Option[String] = {
-    // TODO: move this key into a constant in RustNodeSyntax, or provide the accessor there.
-    node.json.obj.get("methodFullName").flatMap(_.strOpt)
-  }
-
-  private def rustAstGenTypeFullName(node: RustNode): Option[String] = {
-    // TODO: move this key into a constant in RustNodeSyntax, or provide the accessor there.
-    node.json.obj.get("typeFullName").flatMap(_.strOpt)
-  }
-
   protected def methodFullNameForCallExpr(
     callExpr: RustNodeSyntax.CallExpr,
     nameRefs: Seq[RustNodeSyntax.NameRef]
   ): String = {
-    rustAstGenMethodFullName(callExpr).getOrElse {
+    callExpr.methodFullName.getOrElse {
       // TODO: take into account `use` (imports). We are incorrectly assuming here that an
       //  unresolved call e.g. `a::b::c()` has fullName `a::b::c`.
       nameRefs match {
@@ -72,45 +61,79 @@ trait RustFullNames { this: AstCreator =>
   }
 
   protected def methodFullNameForMethodCallExpr(methodCallExpr: RustNodeSyntax.MethodCallExpr): String = {
-    rustAstGenMethodFullName(methodCallExpr).getOrElse(Defines.DynamicCallUnknownFullName)
+    methodCallExpr.methodFullName.getOrElse(Defines.DynamicCallUnknownFullName)
   }
 
-  // TODO
   protected def typeFullNameForType(typ: RustNodeSyntax.Type): String = {
-    text(typ).getOrElse(Defines.Any)
+    typ match {
+      case pathType: RustNodeSyntax.PathType =>
+        typeFullNameForPath(pathType.path)
+      case refType: RustNodeSyntax.RefType =>
+        val mut = Option.when(refType.mutKwToken.isDefined)("mut ").getOrElse("")
+        s"&$mut${typeFullNameForType(refType.`type`)}"
+      case ptrType: RustNodeSyntax.PtrType =>
+        val qualifier = if (ptrType.constKwToken.isDefined) "const " else "mut "
+        s"*$qualifier${typeFullNameForType(ptrType.`type`)}"
+      case sliceType: RustNodeSyntax.SliceType =>
+        s"[${typeFullNameForType(sliceType.`type`)}]"
+      case arrayType: RustNodeSyntax.ArrayType =>
+        s"[${typeFullNameForType(arrayType.`type`)}; ${text(arrayType.constArg).getOrElse("")}]"
+      case tupleType: RustNodeSyntax.TupleType =>
+        s"(${tupleType.`type`.map(typeFullNameForType).mkString(", ")})"
+      case parenType: RustNodeSyntax.ParenType =>
+        typeFullNameForType(parenType.`type`)
+      case _: RustNodeSyntax.NeverType =>
+        "!"
+
+      // TODO: the following are not handled yet.
+      case io.joern.rust2cpg.parser.RustNodeSyntax.DynTraitType(_) =>
+        text(typ).getOrElse(Defines.Any)
+      case io.joern.rust2cpg.parser.RustNodeSyntax.FnPtrType(_) =>
+        text(typ).getOrElse(Defines.Any)
+      case io.joern.rust2cpg.parser.RustNodeSyntax.ForType(_) =>
+        text(typ).getOrElse(Defines.Any)
+      case io.joern.rust2cpg.parser.RustNodeSyntax.ImplTraitType(_) =>
+        text(typ).getOrElse(Defines.Any)
+      case io.joern.rust2cpg.parser.RustNodeSyntax.InferType(_) =>
+        // TODO(rust_ast_gen): is this typeFullName missing on purpose or by accident?
+        //  This corresponds to `_` in something like `let x: Vec<_>`. We currently don't have a
+        //  typeFullName for it, but we have for `x`.
+        text(typ).getOrElse(Defines.Any)
+      case io.joern.rust2cpg.parser.RustNodeSyntax.MacroType(_) =>
+        // TODO: pending macroExpansion from rust_ast_gen.
+        text(typ).getOrElse(Defines.Any)
+    }
   }
 
-  // TODO
   protected def typeFullNameForNameRef(nameRef: RustNodeSyntax.NameRef): String = {
-    Defines.Any
+    nameRef.typeFullName.getOrElse(Defines.Any)
   }
 
   protected def typeFullNameForPath(path: RustNodeSyntax.Path): String = {
-    rustAstGenTypeFullName(path)
-      .orElse(path.pathSegment.nameRef.flatMap(rustAstGenTypeFullName))
-      .getOrElse(Defines.Any)
+    // In a path, only the leaf (NameRef) has typeFullName set (by rust_ast_gen).
+    path.pathSegment.nameRef.flatMap(_.typeFullName).getOrElse(Defines.Any)
   }
 
   protected def typeFullNameForExpr(expr: RustNodeSyntax.Expr): String = {
-    rustAstGenTypeFullName(expr).getOrElse(Defines.Any)
+    expr.typeFullName.getOrElse(Defines.Any)
   }
 
   protected def typeFullNameForTupleExpr(tupleExpr: RustNodeSyntax.TupleExpr): String = {
-    rustAstGenTypeFullName(tupleExpr).getOrElse {
+    tupleExpr.typeFullName.getOrElse {
       val childTypes = tupleExpr.expr.map(typeFullNameForExpr)
       s"(${childTypes.mkString(", ")})"
     }
   }
 
   protected def typeFullNameForLiteral(lit: RustNodeSyntax.Literal): String = {
-    rustAstGenTypeFullName(lit).orElse(lit.value.map(typeFullNameForLiteralToken)).getOrElse(Defines.Any)
+    lit.typeFullName.orElse(lit.value.map(typeFullNameForLiteralToken)).getOrElse(Defines.Any)
   }
 
   protected def typeFullNameForIdentPat(identPat: RustNodeSyntax.IdentPat): String = {
-    rustAstGenTypeFullName(identPat).getOrElse(Defines.Any)
+    identPat.typeFullName.getOrElse(Defines.Any)
   }
 
-  protected def typeFullNameForLiteralToken(tok: RustNodeSyntax.RustToken): String = tok match {
+  private def typeFullNameForLiteralToken(tok: RustNodeSyntax.RustToken): String = tok match {
     case _: RustNodeSyntax.IntNumberToken   => "i32"
     case _: RustNodeSyntax.FloatNumberToken => "f64"
     case _: RustNodeSyntax.StringToken      => "&str"
@@ -123,4 +146,8 @@ trait RustFullNames { this: AstCreator =>
     case _                                  => Defines.Any
   }
 
+}
+
+object RustFullNames {
+  val PathSep = "::"
 }

--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/passes/RustTypeNodePass.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/passes/RustTypeNodePass.scala
@@ -4,20 +4,16 @@ import io.joern.x2cpg.passes.frontend.TypeNodePass
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.joern.rust2cpg.astcreation.RustFullNames
 
-object RustTypeNodePass {
-  def withTypesFromCpg(cpg: Cpg): TypeNodePass = {
-    new TypeNodePass(Set.empty, cpg, getTypesFromCpg = true) {
+class RustTypeNodePass(cpg: Cpg) extends TypeNodePass(Set.empty, cpg, getTypesFromCpg = true) {
 
-      override def fullToShortName(typeName: String): String = {
-        // A path e.g. `x::...::z<...>` or `z<...>` has shortname `z`, without generics.
-        // Any other type shape has matching name/fullName.
-        val isPathLike = typeName.headOption.exists(_.isLetter)
-        if (isPathLike) {
-          typeName.takeWhile(_ != '<').split(RustFullNames.PathSep).lastOption.getOrElse(typeName)
-        } else {
-          typeName
-        }
-      }
+  override def fullToShortName(typeName: String): String = {
+    // A path e.g. `x::...::z<...>` or `z<...>` has shortname `z`, without generics.
+    // Any other type shape has matching name/fullName.
+    val isPathLike = typeName.headOption.exists(_.isLetter)
+    if (isPathLike) {
+      typeName.takeWhile(_ != '<').split(RustFullNames.PathSep).lastOption.getOrElse(typeName)
+    } else {
+      typeName
     }
   }
 }

--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/passes/RustTypeNodePass.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/passes/RustTypeNodePass.scala
@@ -1,0 +1,23 @@
+package io.joern.rust2cpg.passes
+
+import io.joern.x2cpg.passes.frontend.TypeNodePass
+import io.shiftleft.codepropertygraph.generated.Cpg
+import io.joern.rust2cpg.astcreation.RustFullNames
+
+object RustTypeNodePass {
+  def withTypesFromCpg(cpg: Cpg): TypeNodePass = {
+    new TypeNodePass(Set.empty, cpg, getTypesFromCpg = true) {
+
+      override def fullToShortName(typeName: String): String = {
+        // A path e.g. `x::...::z<...>` or `z<...>` has shortname `z`, without generics.
+        // Any other type shape has matching name/fullName.
+        val isPathLike = typeName.headOption.exists(_.isLetter)
+        if (isPathLike) {
+          typeName.takeWhile(_ != '<').split(RustFullNames.PathSep).lastOption.getOrElse(typeName)
+        } else {
+          typeName
+        }
+      }
+    }
+  }
+}

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/TypeNodePassTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/TypeNodePassTests.scala
@@ -1,0 +1,331 @@
+package io.joern.rust2cpg.passes
+
+import io.joern.rust2cpg.testfixtures.Rust2CpgSuite
+import io.shiftleft.semanticcpg.language.*
+
+class TypeNodePassTests extends Rust2CpgSuite(noSysRoot = true) {
+
+  "TypeNodePass" should {
+
+    "create correct types for locals" in {
+      val cpg = code("""
+          |fn foo() {
+          | let x: usize = 10;
+          |}
+          |""".stripMargin)
+      inside(cpg.method.name("foo").block.local.name("x").l) { case local :: Nil =>
+        local.evalType.l shouldBe List("usize")
+
+        inside(local.typ.referencedTypeDecl.l) { case typ :: Nil =>
+          typ.name shouldBe "usize"
+          typ.fullName shouldBe "usize"
+          typ.isExternal shouldBe true
+        }
+      }
+    }
+
+    "create correct types for integer literals" in {
+      val cpg = code("""
+          |fn main() {
+          | let x = 42;
+          |}
+          |""".stripMargin)
+      inside(cpg.literal.l) { case lit :: Nil =>
+        lit.evalType.l shouldBe List("i32")
+
+        inside(lit.typ.referencedTypeDecl.l) { case typ :: Nil =>
+          typ.fullName shouldBe "i32"
+          typ.name shouldBe "i32"
+          typ.isExternal shouldBe true
+        }
+      }
+    }
+
+    "create correct types for byte string literals" in {
+      val cpg = code("""
+          |fn main() {
+          | let s = b"hi";
+          |}
+          |""".stripMargin)
+      inside(cpg.literal.l) { case lit :: Nil =>
+        lit.evalType.l shouldBe List("&[u8; 2]")
+
+        inside(lit.typ.referencedTypeDecl.l) { case typ :: Nil =>
+          typ.fullName shouldBe "&[u8; 2]"
+          typ.name shouldBe "&[u8; 2]"
+          typ.isExternal shouldBe true
+        }
+      }
+    }
+
+    "create correct types for parameters" in {
+      val cpg = code("""
+          |fn id(x: i32) -> i32 {
+          | x
+          |}
+          |""".stripMargin)
+      inside(cpg.method.name("id").parameter.name("x").l) { case param :: Nil =>
+        param.evalType.l shouldBe List("i32")
+
+        inside(param.typ.referencedTypeDecl.l) { case typ :: Nil =>
+          typ.fullName shouldBe "i32"
+          typ.name shouldBe "i32"
+          typ.isExternal shouldBe true
+        }
+      }
+    }
+
+    "create correct types for parameters with struct type" in {
+      val cpg = code("""
+          |struct Foo;
+          |fn foo(y: Foo) {}
+          |""".stripMargin)
+      inside(cpg.method.name("foo").parameter.name("y").l) { case param :: Nil =>
+        param.evalType.l shouldBe List("rust2cpgtest::Foo")
+        param.typ.referencedTypeDecl.l shouldBe cpg.typeDecl.fullNameExact("rust2cpgtest::Foo").l
+      }
+    }
+
+    "create correct types for references" in {
+      val cpg = code("""
+          |fn f(x: &i32) {}
+          |""".stripMargin)
+      inside(cpg.method.name("f").parameter.name("x").l) { case param :: Nil =>
+        param.evalType.l shouldBe List("&i32")
+
+        inside(param.typ.referencedTypeDecl.l) { case typ :: Nil =>
+          typ.fullName shouldBe "&i32"
+          typ.name shouldBe "&i32"
+          typ.isExternal shouldBe true
+        }
+      }
+    }
+
+    "create correct types for references to struct type" in {
+      val cpg = code("""
+          |struct Foo;
+          |fn f(p: &Foo) {}
+          |""".stripMargin)
+      inside(cpg.method.name("f").parameter.name("p").l) { case param :: Nil =>
+        param.evalType.l shouldBe List("&rust2cpgtest::Foo")
+
+        inside(param.typ.referencedTypeDecl.l) { case typ :: Nil =>
+          typ.fullName shouldBe "&rust2cpgtest::Foo"
+          typ.name shouldBe "&rust2cpgtest::Foo"
+          typ.isExternal shouldBe true
+        }
+      }
+    }
+
+    "create correct types for tuples" in {
+      val cpg = code("""
+          |fn f(x: (i32, bool)) {}
+          |""".stripMargin)
+      inside(cpg.method.name("f").parameter.name("x").l) { case param :: Nil =>
+        param.evalType.l shouldBe List("(i32, bool)")
+
+        inside(param.typ.referencedTypeDecl.l) { case typ :: Nil =>
+          typ.fullName shouldBe "(i32, bool)"
+          typ.name shouldBe "(i32, bool)"
+          typ.isExternal shouldBe true
+        }
+      }
+    }
+
+    "create correct types for tuples of struct type" in {
+      val cpg = code("""
+          |struct Foo;
+          |fn f(x: (Foo, i32)) {}
+          |""".stripMargin)
+      inside(cpg.method.name("f").parameter.name("x").l) { case param :: Nil =>
+        param.evalType.l shouldBe List("(rust2cpgtest::Foo, i32)")
+
+        inside(param.typ.referencedTypeDecl.l) { case typ :: Nil =>
+          typ.fullName shouldBe "(rust2cpgtest::Foo, i32)"
+          typ.name shouldBe "(rust2cpgtest::Foo, i32)"
+          typ.isExternal shouldBe true
+        }
+      }
+    }
+
+    "create correct types for arrays" in {
+      val cpg = code("""
+          |fn f(x: [i32; 4]) {}
+          |""".stripMargin)
+      inside(cpg.method.name("f").parameter.name("x").l) { case param :: Nil =>
+        param.evalType.l shouldBe List("[i32; 4]")
+
+        inside(param.typ.referencedTypeDecl.l) { case typ :: Nil =>
+          typ.fullName shouldBe "[i32; 4]"
+          typ.name shouldBe "[i32; 4]"
+          typ.isExternal shouldBe true
+        }
+      }
+    }
+
+    "create correct types for arrays of struct type" in {
+      val cpg = code("""
+          |struct Foo;
+          |fn f(x: [Foo; 4]) {}
+          |""".stripMargin)
+      inside(cpg.method.name("f").parameter.name("x").l) { case param :: Nil =>
+        param.evalType.l shouldBe List("[rust2cpgtest::Foo; 4]")
+
+        inside(param.typ.referencedTypeDecl.l) { case typ :: Nil =>
+          typ.fullName shouldBe "[rust2cpgtest::Foo; 4]"
+          typ.name shouldBe "[rust2cpgtest::Foo; 4]"
+          typ.isExternal shouldBe true
+        }
+      }
+    }
+
+    "create correct types for slices" in {
+      val cpg = code("""
+          |fn f(x: &[i32]) {}
+          |""".stripMargin)
+      inside(cpg.method.name("f").parameter.name("x").l) { case param :: Nil =>
+        param.evalType.l shouldBe List("&[i32]")
+
+        inside(param.typ.referencedTypeDecl.l) { case typ :: Nil =>
+          typ.fullName shouldBe "&[i32]"
+          typ.name shouldBe "&[i32]"
+          typ.isExternal shouldBe true
+        }
+      }
+
+    }
+
+    "create correct types for slices of struct type" in {
+      val cpg = code("""
+          |struct Foo;
+          |fn f(x: &[Foo]) {}
+          |""".stripMargin)
+      inside(cpg.method.name("f").parameter.name("x").l) { case param :: Nil =>
+        param.evalType.l shouldBe List("&[rust2cpgtest::Foo]")
+
+        inside(param.typ.referencedTypeDecl.l) { case typ :: Nil =>
+          typ.fullName shouldBe "&[rust2cpgtest::Foo]"
+          typ.name shouldBe "&[rust2cpgtest::Foo]"
+          typ.isExternal shouldBe true
+        }
+      }
+    }
+
+    "create correct types for raw pointers" in {
+      val cpg = code("""
+          |fn f(p: *const i32) {}
+          |""".stripMargin)
+      inside(cpg.method.name("f").parameter.name("p").l) { case param :: Nil =>
+        param.evalType.l shouldBe List("*const i32")
+
+        inside(param.typ.referencedTypeDecl.l) { case typ :: Nil =>
+          typ.fullName shouldBe "*const i32"
+          typ.name shouldBe "*const i32"
+          typ.isExternal shouldBe true
+        }
+      }
+    }
+
+    "create correct types for raw pointers to struct type" in {
+      val cpg = code("""
+          |struct Foo;
+          |fn f(p: *const Foo) {}
+          |""".stripMargin)
+      inside(cpg.method.name("f").parameter.name("p").l) { case param :: Nil =>
+        param.evalType.l shouldBe List("*const rust2cpgtest::Foo")
+
+        inside(param.typ.referencedTypeDecl.l) { case typ :: Nil =>
+          typ.fullName shouldBe "*const rust2cpgtest::Foo"
+          typ.name shouldBe "*const rust2cpgtest::Foo"
+          typ.isExternal shouldBe true
+        }
+      }
+    }
+
+    "create correct types for the never type" in {
+      val cpg = code("""
+          |fn f() -> ! { loop {} }
+          |""".stripMargin)
+      inside(cpg.method.name("f").methodReturn.l) { case ret :: Nil =>
+        ret.evalType.l shouldBe List("!")
+
+        inside(ret.typ.referencedTypeDecl.l) { case typ :: Nil =>
+          typ.fullName shouldBe "!"
+          typ.name shouldBe "!"
+          typ.isExternal shouldBe true
+        }
+      }
+
+    }
+
+    "create correct types for unit returns" in {
+      val cpg = code("""
+          |fn f() {}
+          |""".stripMargin)
+      inside(cpg.method.name("f").methodReturn.l) { case ret :: Nil =>
+        ret.evalType.l shouldBe List("()")
+
+        inside(ret.typ.referencedTypeDecl.l) { case typ :: Nil =>
+          typ.fullName shouldBe "()"
+          typ.name shouldBe "()"
+          typ.isExternal shouldBe true
+        }
+      }
+    }
+  }
+}
+
+class TypeNodePassTestsWithSysroot extends Rust2CpgSuite(noSysRoot = false) {
+
+  "TypeNodePass" should {
+
+    "create correct types for vec! macro locals" in {
+      val cpg = code("""
+          |fn foo() {
+          | let v = vec![1, 2, 3];
+          |}
+          |""".stripMargin)
+      inside(cpg.method.name("foo").block.local.name("v").l) { case local :: Nil =>
+        local.evalType.l shouldBe List("alloc::vec::Vec<i32, alloc::alloc::Global>")
+
+        inside(local.typ.referencedTypeDecl.l) { case typ :: Nil =>
+          typ.fullName shouldBe "alloc::vec::Vec<i32, alloc::alloc::Global>"
+          typ.name shouldBe "Vec"
+          typ.isExternal shouldBe true
+        }
+      }
+    }
+
+    "create correct types for generic Vec parameters" in {
+      val cpg = code("""
+          |fn foo(xs: Vec<i32>) {}
+          |""".stripMargin)
+      inside(cpg.method.name("foo").parameter.name("xs").l) { case param :: Nil =>
+        param.evalType.l shouldBe List("alloc::vec::Vec<i32>")
+
+        inside(param.typ.referencedTypeDecl.l) { case typ :: Nil =>
+          typ.fullName shouldBe "alloc::vec::Vec<i32>"
+          typ.name shouldBe "Vec"
+          typ.isExternal shouldBe true
+        }
+      }
+    }
+
+    "create correct types for String locals" in {
+      val cpg = code("""
+          |fn foo() {
+          | let s = String::new();
+          |}
+          |""".stripMargin)
+      inside(cpg.method.name("foo").block.local.name("s").l) { case local :: Nil =>
+        local.evalType.l shouldBe List("alloc::string::String")
+
+        inside(local.typ.referencedTypeDecl.l) { case typ :: Nil =>
+          typ.fullName shouldBe "alloc::string::String"
+          typ.name shouldBe "String"
+          typ.isExternal shouldBe true
+        }
+      }
+    }
+  }
+}

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/MethodReturnTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/MethodReturnTests.scala
@@ -78,4 +78,15 @@ class MethodReturnTests extends Rust2CpgSuite(noSysRoot = true) {
       }
     }
   }
+
+  "a struct return type" should {
+    val cpg = code("""
+        |struct Foo;
+        |fn make() -> Foo { Foo }
+        |""".stripMargin)
+
+    "have correct typeFullName for METHOD_RETURN" in {
+      cpg.method.name("make").methodReturn.typeFullName.l shouldBe List("rust2cpgtest::Foo")
+    }
+  }
 }

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/StructTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/StructTests.scala
@@ -191,6 +191,19 @@ class StructTests extends Rust2CpgSuite(noSysRoot = true) {
     }
   }
 
+  "a struct-typed member" should {
+    val cpg = code("""
+        |struct Foo { x: i32 }
+        |struct Bar { baz: Foo }
+        |""".stripMargin)
+
+    "have correct typeFullName for `baz`" in {
+      inside(cpg.typeDecl.nameExact("Bar").member.nameExact("baz").l) { case baz :: Nil =>
+        baz.typeFullName shouldBe "rust2cpgtest::Foo"
+      }
+    }
+  }
+
   "a tuple-struct positional field access" should {
     val cpg = code("""
         |struct Pair(i32, bool);


### PR DESCRIPTION
* replaces the `rustAstGen{MethodFullName,TypeFullName}` helpers by their `RustNode.{methodFullName,typeFullName}` counterparts now that they are auto-generated.
* expands `typeFullNameForType` but there are still a few cases to be worked.
* brings RustTypeNodePass to create the missing `TYPE` nodes.