### PR TITLE
[rust2cpg] support ArrayExpr syntax.

### DIFF
--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustOperators.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustOperators.scala
@@ -1,0 +1,8 @@
+package io.joern.rust2cpg.astcreation
+
+object RustOperators {
+
+  val tupleLiteral  = "<operator>.tupleLiteral"
+  val repeatInArray = "<operator>.repeatInArray"
+
+}

--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
@@ -74,7 +74,7 @@ trait RustVisitor(implicit withValidationMode: ValidationMode) { this: AstCreato
 
   @tailrec
   private def visitExpr(expr: Expr): Ast = expr match {
-    case x: ArrayExpr                   => notHandledYet(x)
+    case arrayExpr: ArrayExpr           => visitArrayExpr(arrayExpr)
     case x: AsmExpr                     => notHandledYet(x)
     case awaitExpr: AwaitExpr           => visitAwaitExpr(awaitExpr)
     case binExpr: BinExpr               => visitBinExpr(binExpr)
@@ -626,6 +626,23 @@ trait RustVisitor(implicit withValidationMode: ValidationMode) { this: AstCreato
       val argAsts      = tupleExpr.expr.map(visitExpr)
       callAst(callNode, argAsts)
     }
+  }
+
+  // ArrayExpr =
+  //  Attr* '[' (
+  //    (Expr (',' Expr)* ','?)?
+  //  | Expr ';' Expr
+  //  )']'
+  private def visitArrayExpr(arrayExpr: ArrayExpr): Ast = {
+    val typeFullName = typeFullNameForExpr(arrayExpr)
+    val callNode     = operatorCallNode(arrayExpr, code(arrayExpr), Operators.arrayInitializer, Some(typeFullName))
+
+    // In `[value; count]`, we drop `count`.
+    val isRepeatForm = arrayExpr.semicolonToken.isDefined
+    val elems        = if (isRepeatForm) arrayExpr.expr.take(1) else arrayExpr.expr
+    val elemAsts     = elems.map(visitExpr)
+
+    callAst(callNode, elemAsts)
   }
 
   // FieldExpr =

--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
@@ -622,7 +622,7 @@ trait RustVisitor(implicit withValidationMode: ValidationMode) { this: AstCreato
       Ast(literalNode(tupleExpr, code(tupleExpr), "()"))
     } else {
       val typeFullName = typeFullNameForTupleExpr(tupleExpr)
-      val callNode     = operatorCallNode(tupleExpr, code(tupleExpr), "<operator>.tupleLiteral", Some(typeFullName))
+      val callNode     = operatorCallNode(tupleExpr, code(tupleExpr), RustOperators.tupleLiteral, Some(typeFullName))
       val argAsts      = tupleExpr.expr.map(visitExpr)
       callAst(callNode, argAsts)
     }
@@ -635,14 +635,11 @@ trait RustVisitor(implicit withValidationMode: ValidationMode) { this: AstCreato
   //  )']'
   private def visitArrayExpr(arrayExpr: ArrayExpr): Ast = {
     val typeFullName = typeFullNameForExpr(arrayExpr)
-    val callNode     = operatorCallNode(arrayExpr, code(arrayExpr), Operators.arrayInitializer, Some(typeFullName))
-
-    // In `[value; count]`, we drop `count`.
     val isRepeatForm = arrayExpr.semicolonToken.isDefined
-    val elems        = if (isRepeatForm) arrayExpr.expr.take(1) else arrayExpr.expr
-    val elemAsts     = elems.map(visitExpr)
+    val operator     = if (isRepeatForm) RustOperators.repeatInArray else Operators.arrayInitializer
+    val callNode     = operatorCallNode(arrayExpr, code(arrayExpr), operator, Some(typeFullName))
 
-    callAst(callNode, elemAsts)
+    callAst(callNode, arrayExpr.expr.map(visitExpr))
   }
 
   // FieldExpr =

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/ArrayTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/ArrayTests.scala
@@ -1,5 +1,6 @@
 package io.joern.rust2cpg.passes.ast
 
+import io.joern.rust2cpg.astcreation.RustOperators
 import io.joern.rust2cpg.testfixtures.Rust2CpgSuite
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.*
@@ -78,23 +79,28 @@ class ArrayTests extends Rust2CpgSuite(noSysRoot = true) {
         |}
         |""".stripMargin)
 
-    "lower to an arrayInitializer call" in {
-      inside(cpg.call.nameExact(Operators.arrayInitializer).l) { case array :: Nil =>
+    "lower to a repeatInArray call" in {
+      inside(cpg.call.nameExact(RustOperators.repeatInArray).l) { case array :: Nil =>
         array.code shouldBe "[0; 5]"
-        array.methodFullName shouldBe Operators.arrayInitializer
+        array.methodFullName shouldBe RustOperators.repeatInArray
         array.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
       }
     }
 
-    "type the arrayInitializer as [i32; 5]" in {
-      cpg.call.nameExact(Operators.arrayInitializer).typeFullName.l shouldBe List("[i32; 5]")
+    "type the repeatInArray as [i32; 5]" in {
+      cpg.call.nameExact(RustOperators.repeatInArray).typeFullName.l shouldBe List("[i32; 5]")
     }
 
-    "have the repeated value as its only argument" in {
-      inside(cpg.call.nameExact(Operators.arrayInitializer).argument.l) { case (value: Literal) :: Nil =>
-        value.code shouldBe "0"
-        value.argumentIndex shouldBe 1
-        value.typeFullName shouldBe "i32"
+    "have the repeated value and the count as arguments" in {
+      inside(cpg.call.nameExact(RustOperators.repeatInArray).argument.l) {
+        case (value: Literal) :: (count: Literal) :: Nil =>
+          value.code shouldBe "0"
+          value.argumentIndex shouldBe 1
+          value.typeFullName shouldBe "i32"
+
+          count.code shouldBe "5"
+          count.argumentIndex shouldBe 2
+          count.typeFullName shouldBe "usize"
       }
     }
   }

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/ArrayTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/ArrayTests.scala
@@ -1,0 +1,148 @@
+package io.joern.rust2cpg.passes.ast
+
+import io.joern.rust2cpg.testfixtures.Rust2CpgSuite
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.*
+
+class ArrayTests extends Rust2CpgSuite(noSysRoot = true) {
+
+  "an array literal" should {
+    val cpg = code("""
+        |fn main() {
+        | let xs = [1, 2, 3];
+        |}
+        |""".stripMargin)
+
+    "lower to an arrayInitializer call" in {
+      inside(cpg.call.nameExact(Operators.arrayInitializer).l) { case array :: Nil =>
+        array.code shouldBe "[1, 2, 3]"
+        array.methodFullName shouldBe Operators.arrayInitializer
+        array.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+      }
+    }
+
+    "type the arrayInitializer as [i32; 3]" in {
+      cpg.call.nameExact(Operators.arrayInitializer).typeFullName.l shouldBe List("[i32; 3]")
+    }
+
+    "have the i32 literals as arguments" in {
+      inside(cpg.call.nameExact(Operators.arrayInitializer).argument.l) {
+        case (one: Literal) :: (two: Literal) :: (three: Literal) :: Nil =>
+          one.code shouldBe "1"
+          one.argumentIndex shouldBe 1
+          one.typeFullName shouldBe "i32"
+
+          two.code shouldBe "2"
+          two.argumentIndex shouldBe 2
+          two.typeFullName shouldBe "i32"
+
+          three.code shouldBe "3"
+          three.argumentIndex shouldBe 3
+          three.typeFullName shouldBe "i32"
+      }
+    }
+
+    "have the arrayInitializer as the assignment's second argument" in {
+      inside(cpg.assignment.argument(2).l) { case (rhs: Call) :: Nil =>
+        rhs.name shouldBe Operators.arrayInitializer
+        rhs.code shouldBe "[1, 2, 3]"
+      }
+    }
+  }
+
+  "an empty array literal" should {
+    val cpg = code("""
+        |fn main() {
+        | let xs: [i32; 0] = [];
+        |}
+        |""".stripMargin)
+
+    "lower to an arrayInitializer call with no arguments" in {
+      inside(cpg.call.nameExact(Operators.arrayInitializer).l) { case array :: Nil =>
+        array.code shouldBe "[]"
+        array.methodFullName shouldBe Operators.arrayInitializer
+        array.argument shouldBe empty
+      }
+    }
+
+    "type the arrayInitializer as [i32; 0]" in {
+      cpg.call.nameExact(Operators.arrayInitializer).typeFullName.l shouldBe List("[i32; 0]")
+    }
+  }
+
+  "a repeat array literal" should {
+    val cpg = code("""
+        |fn main() {
+        | let xs = [0; 5];
+        |}
+        |""".stripMargin)
+
+    "lower to an arrayInitializer call" in {
+      inside(cpg.call.nameExact(Operators.arrayInitializer).l) { case array :: Nil =>
+        array.code shouldBe "[0; 5]"
+        array.methodFullName shouldBe Operators.arrayInitializer
+        array.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+      }
+    }
+
+    "type the arrayInitializer as [i32; 5]" in {
+      cpg.call.nameExact(Operators.arrayInitializer).typeFullName.l shouldBe List("[i32; 5]")
+    }
+
+    "have the repeated value as its only argument" in {
+      inside(cpg.call.nameExact(Operators.arrayInitializer).argument.l) { case (value: Literal) :: Nil =>
+        value.code shouldBe "0"
+        value.argumentIndex shouldBe 1
+        value.typeFullName shouldBe "i32"
+      }
+    }
+  }
+
+  "a nested array literal" should {
+    val cpg = code("""
+        |fn main() {
+        | let grid = [[1, 2], [3, 4]];
+        |}
+        |""".stripMargin)
+
+    "lower as three arrayInitializer calls" in {
+      cpg.call.nameExact(Operators.arrayInitializer).code.l shouldBe List("[[1, 2], [3, 4]]", "[1, 2]", "[3, 4]")
+    }
+
+    "have the inner arrays as arguments of the outer" in {
+      inside(cpg.call.nameExact(Operators.arrayInitializer).codeExact("[[1, 2], [3, 4]]").argument.l) {
+        case (first: Call) :: (second: Call) :: Nil =>
+          first.name shouldBe Operators.arrayInitializer
+          first.code shouldBe "[1, 2]"
+          first.argumentIndex shouldBe 1
+
+          second.name shouldBe Operators.arrayInitializer
+          second.code shouldBe "[3, 4]"
+          second.argumentIndex shouldBe 2
+      }
+    }
+  }
+
+  "an array literal of calls" should {
+    val cpg = code("""
+        |fn f() -> i32 { 1 }
+        |fn g() -> i32 { 2 }
+        |fn main() {
+        | let xs = [f(), g()];
+        |}
+        |""".stripMargin)
+
+    "have the calls as arguments" in {
+      inside(cpg.call.nameExact(Operators.arrayInitializer).argument.l) { case (callF: Call) :: (callG: Call) :: Nil =>
+        callF.name shouldBe "f"
+        callF.code shouldBe "f()"
+        callF.argumentIndex shouldBe 1
+
+        callG.name shouldBe "g"
+        callG.code shouldBe "g()"
+        callG.argumentIndex shouldBe 2
+      }
+    }
+  }
+}


### PR DESCRIPTION
Motivated by the `vec!`'s test from #6020.

Lowers `[x, y, ..., z]` and `[x; count]` as an `<operator>.arrayInitializer` of `x, y, ...,z` expressions. In particular, `count` gets dropped.