### PR TITLE
[x2cpg] Switch over to Json for http server protocol

### DIFF
--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/io/C2CpgHTTPServerTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/io/C2CpgHTTPServerTests.scala
@@ -51,7 +51,7 @@ class C2CpgHTTPServerTests extends AnyWordSpec with Matchers with BeforeAndAfter
           val input  = projectUnderTest.toAbsolutePath.toString
           val output = cpgOutFile.toString
           val client = FrontendHTTPClient(port)
-          val req    = client.buildRequest(Array(s"input=$input", s"output=$output"))
+          val req    = client.buildRequest("input" -> Some(input), "output" -> Some(output))
           client.sendRequest(req) match {
             case Failure(exception) => fail(exception.getMessage)
             case Success(out) =>
@@ -71,7 +71,7 @@ class C2CpgHTTPServerTests extends AnyWordSpec with Matchers with BeforeAndAfter
             val input  = projectUnderTest.toAbsolutePath.toString
             val output = cpgOutFile.toString
             val client = FrontendHTTPClient(port)
-            val req    = client.buildRequest(Array(s"input=$input", s"output=$output"))
+            val req    = client.buildRequest("input" -> Some(input), "output" -> Some(output))
             client.sendRequest(req) match {
               case Failure(exception) => fail(exception.getMessage)
               case Success(out) =>

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/io/CSharp2CpgHTTPServerTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/io/CSharp2CpgHTTPServerTests.scala
@@ -44,7 +44,7 @@ class CSharp2CpgHTTPServerTests extends CSharpCode2CpgFixture with BeforeAndAfte
           val input  = projectUnderTest.toAbsolutePath.toString
           val output = cpgOutFile.toString
           val client = FrontendHTTPClient(port)
-          val req    = client.buildRequest(Array(s"input=$input", s"output=$output"))
+          val req    = client.buildRequest("input" -> Some(input), "output" -> Some(output))
           client.sendRequest(req) match {
             case Failure(exception) => fail(exception.getMessage)
             case Success(out) =>
@@ -64,7 +64,7 @@ class CSharp2CpgHTTPServerTests extends CSharpCode2CpgFixture with BeforeAndAfte
             val input  = projectUnderTest.toAbsolutePath.toString
             val output = cpgOutFile.toString
             val client = FrontendHTTPClient(port)
-            val req    = client.buildRequest(Array(s"input=$input", s"output=$output"))
+            val req    = client.buildRequest("input" -> Some(input), "output" -> Some(output))
             client.sendRequest(req) match {
               case Failure(exception) => fail(exception.getMessage)
               case Success(out) =>

--- a/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/io/GoSrc2CpgHTTPServerTests.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/test/scala/io/joern/go2cpg/io/GoSrc2CpgHTTPServerTests.scala
@@ -50,7 +50,7 @@ class GoSrc2CpgHTTPServerTests extends AnyWordSpec with Matchers with BeforeAndA
           val input  = projectUnderTest.toAbsolutePath.toString
           val output = cpgOutFile.toString
           val client = FrontendHTTPClient(port)
-          val req    = client.buildRequest(Array(s"input=$input", s"output=$output"))
+          val req    = client.buildRequest("input" -> Some(input), "output" -> Some(output))
           client.sendRequest(req) match {
             case Failure(exception) => fail(exception.getMessage)
             case Success(out) =>
@@ -70,7 +70,7 @@ class GoSrc2CpgHTTPServerTests extends AnyWordSpec with Matchers with BeforeAndA
             val input  = projectUnderTest.toAbsolutePath.toString
             val output = cpgOutFile.toString
             val client = FrontendHTTPClient(port)
-            val req    = client.buildRequest(Array(s"input=$input", s"output=$output"))
+            val req    = client.buildRequest("input" -> Some(input), "output" -> Some(output))
             client.sendRequest(req) match {
               case Failure(exception) => fail(exception.getMessage)
               case Success(out) =>

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/io/JavaSrc2CpgHTTPServerTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/io/JavaSrc2CpgHTTPServerTests.scala
@@ -51,7 +51,7 @@ class JavaSrc2CpgHTTPServerTests extends AnyWordSpec with Matchers with BeforeAn
           val input  = projectUnderTest.toAbsolutePath.toString
           val output = cpgOutFile.toString
           val client = FrontendHTTPClient(port)
-          val req    = client.buildRequest(Array(s"input=$input", s"output=$output"))
+          val req    = client.buildRequest("input" -> Some(input), "output" -> Some(output))
           client.sendRequest(req) match {
             case Failure(exception) => fail(exception.getMessage)
             case Success(out) =>
@@ -71,7 +71,7 @@ class JavaSrc2CpgHTTPServerTests extends AnyWordSpec with Matchers with BeforeAn
             val input  = projectUnderTest.toAbsolutePath.toString
             val output = cpgOutFile.toString
             val client = FrontendHTTPClient(port)
-            val req    = client.buildRequest(Array(s"input=$input", s"output=$output"))
+            val req    = client.buildRequest("input" -> Some(input), "output" -> Some(output))
             client.sendRequest(req) match {
               case Failure(exception) => fail(exception.getMessage)
               case Success(out) =>

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/io/Jimple2CpgHTTPServerTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/io/Jimple2CpgHTTPServerTests.scala
@@ -52,7 +52,7 @@ class Jimple2CpgHTTPServerTests extends JimpleCode2CpgFixture with BeforeAndAfte
           val input  = projectUnderTest.toAbsolutePath.toString
           val output = cpgOutFile.toString
           val client = FrontendHTTPClient(port)
-          val req    = client.buildRequest(Array(s"input=$input", s"output=$output"))
+          val req    = client.buildRequest("input" -> Some(input), "output" -> Some(output))
           client.sendRequest(req) match {
             case Failure(exception) => fail(exception.getMessage)
             case Success(out) =>
@@ -72,7 +72,7 @@ class Jimple2CpgHTTPServerTests extends JimpleCode2CpgFixture with BeforeAndAfte
             val input  = projectUnderTest.toAbsolutePath.toString
             val output = cpgOutFile.toString
             val client = FrontendHTTPClient(port)
-            val req    = client.buildRequest(Array(s"input=$input", s"output=$output"))
+            val req    = client.buildRequest("input" -> Some(input), "output" -> Some(output))
             client.sendRequest(req) match {
               case Failure(exception) => fail(exception.getMessage)
               case Success(out) =>

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/io/JsSrc2CpgHTTPServerTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/io/JsSrc2CpgHTTPServerTests.scala
@@ -49,7 +49,7 @@ class JsSrc2CpgHTTPServerTests extends AnyWordSpec with Matchers with BeforeAndA
           val input  = projectUnderTest.absolutePathAsString
           val output = cpgOutFile.toString
           val client = FrontendHTTPClient(port)
-          val req    = client.buildRequest(Array(s"input=$input", s"output=$output"))
+          val req    = client.buildRequest("input" -> Some(input), "output" -> Some(output))
           client.sendRequest(req) match {
             case Failure(exception) => fail(exception.getMessage)
             case Success(out) =>
@@ -69,7 +69,7 @@ class JsSrc2CpgHTTPServerTests extends AnyWordSpec with Matchers with BeforeAndA
             val input  = projectUnderTest.absolutePathAsString
             val output = cpgOutFile.toString
             val client = FrontendHTTPClient(port)
-            val req    = client.buildRequest(Array(s"input=$input", s"output=$output"))
+            val req    = client.buildRequest("input" -> Some(input), "output" -> Some(output))
             client.sendRequest(req) match {
               case Failure(exception) => fail(exception.getMessage)
               case Success(out) =>

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/io/Kotlin2CpgHTTPServerTests.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/io/Kotlin2CpgHTTPServerTests.scala
@@ -50,7 +50,7 @@ class Kotlin2CpgHTTPServerTests extends AnyWordSpec with Matchers with BeforeAnd
           val input  = projectUnderTest.absolutePathAsString
           val output = cpgOutFile.toString
           val client = FrontendHTTPClient(port)
-          val req    = client.buildRequest(Array(s"input=$input", s"output=$output"))
+          val req    = client.buildRequest("input" -> Some(input), "output" -> Some(output))
           client.sendRequest(req) match {
             case Failure(exception) => fail(exception.getMessage)
             case Success(out) =>
@@ -70,7 +70,8 @@ class Kotlin2CpgHTTPServerTests extends AnyWordSpec with Matchers with BeforeAnd
             val input  = projectUnderTest.absolutePathAsString
             val output = cpgOutFile.toString
             val client = FrontendHTTPClient(port)
-            val req    = client.buildRequest(Array(s"input=$input", s"output=$output", "no-default-exclude"))
+            val req =
+              client.buildRequest("input" -> Some(input), "output" -> Some(output), "no-default-exclude" -> None)
             client.sendRequest(req) match {
               case Failure(exception) => fail(exception.getMessage)
               case Success(out) =>

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/io/Php2CpgHTTPServerTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/io/Php2CpgHTTPServerTests.scala
@@ -49,7 +49,7 @@ class Php2CpgHTTPServerTests extends AnyWordSpec with Matchers with BeforeAndAft
           val input  = projectUnderTest.toAbsolutePath.toString
           val output = cpgOutFile.toString
           val client = FrontendHTTPClient(port)
-          val req    = client.buildRequest(Array(s"input=$input", s"output=$output"))
+          val req    = client.buildRequest("input" -> Some(input), "output" -> Some(output))
           client.sendRequest(req) match {
             case Failure(exception) => fail(exception.getMessage)
             case Success(out) =>
@@ -68,7 +68,7 @@ class Php2CpgHTTPServerTests extends AnyWordSpec with Matchers with BeforeAndAft
             val input  = projectUnderTest.toAbsolutePath.toString
             val output = cpgOutFile.toString
             val client = FrontendHTTPClient(port)
-            val req    = client.buildRequest(Array(s"input=$input", s"output=$output"))
+            val req    = client.buildRequest("input" -> Some(input), "output" -> Some(output))
             client.sendRequest(req) match {
               case Failure(exception) => fail(exception.getMessage)
               case Success(out) =>

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/io/PySrc2CpgHTTPServerTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/io/PySrc2CpgHTTPServerTests.scala
@@ -48,7 +48,7 @@ class PySrc2CpgHTTPServerTests extends AnyWordSpec with Matchers with BeforeAndA
           val input  = projectUnderTest.toAbsolutePath.toString
           val output = cpgOutFile.toString
           val client = FrontendHTTPClient(port)
-          val req    = client.buildRequest(Array(s"input=$input", s"output=$output"))
+          val req    = client.buildRequest("input" -> Some(input), "output" -> Some(output))
           client.sendRequest(req) match {
             case Failure(exception) => fail(exception.getMessage)
             case Success(out) =>
@@ -68,7 +68,7 @@ class PySrc2CpgHTTPServerTests extends AnyWordSpec with Matchers with BeforeAndA
             val input  = projectUnderTest.toAbsolutePath.toString
             val output = cpgOutFile.toString
             val client = FrontendHTTPClient(port)
-            val req    = client.buildRequest(Array(s"input=$input", s"output=$output"))
+            val req    = client.buildRequest("input" -> Some(input), "output" -> Some(output))
             client.sendRequest(req) match {
               case Failure(exception) => fail(exception.getMessage)
               case Success(out) =>

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/io/RubySrc2CpgHTTPServerTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/io/RubySrc2CpgHTTPServerTests.scala
@@ -49,7 +49,7 @@ class RubySrc2CpgHTTPServerTests extends AnyWordSpec with Matchers with BeforeAn
           val input  = projectUnderTest.toAbsolutePath.toString
           val output = cpgOutFile.toString
           val client = FrontendHTTPClient(port)
-          val req    = client.buildRequest(Array(s"input=$input", s"output=$output"))
+          val req    = client.buildRequest("input" -> Some(input), "output" -> Some(output))
           client.sendRequest(req) match {
             case Failure(exception) => fail(exception.getMessage)
             case Success(out) =>
@@ -69,7 +69,7 @@ class RubySrc2CpgHTTPServerTests extends AnyWordSpec with Matchers with BeforeAn
             val input  = projectUnderTest.toAbsolutePath.toString
             val output = cpgOutFile.toString
             val client = FrontendHTTPClient(port)
-            val req    = client.buildRequest(Array(s"input=$input", s"output=$output"))
+            val req    = client.buildRequest("input" -> Some(input), "output" -> Some(output))
             client.sendRequest(req) match {
               case Failure(exception) => fail(exception.getMessage)
               case Success(out) =>

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/io/SwiftSrc2CpgHTTPServerTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/io/SwiftSrc2CpgHTTPServerTests.scala
@@ -48,7 +48,7 @@ class SwiftSrc2CpgHTTPServerTests extends AnyWordSpec with Matchers with BeforeA
           val input  = projectUnderTest.toAbsolutePath.toString
           val output = cpgOutFile.toString
           val client = FrontendHTTPClient(port)
-          val req    = client.buildRequest(Array(s"input=$input", s"output=$output"))
+          val req    = client.buildRequest("input" -> Some(input), "output" -> Some(output))
           client.sendRequest(req) match {
             case Failure(exception) => fail(exception.getMessage)
             case Success(out) =>
@@ -68,7 +68,7 @@ class SwiftSrc2CpgHTTPServerTests extends AnyWordSpec with Matchers with BeforeA
             val input  = projectUnderTest.toAbsolutePath.toString
             val output = cpgOutFile.toString
             val client = FrontendHTTPClient(port)
-            val req    = client.buildRequest(Array(s"input=$input", s"output=$output"))
+            val req    = client.buildRequest("input" -> Some(input), "output" -> Some(output))
             client.sendRequest(req) match {
               case Failure(exception) => fail(exception.getMessage)
               case Success(out) =>

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/server/FrontendHTTPClient.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/server/FrontendHTTPClient.scala
@@ -26,20 +26,23 @@ case class FrontendHTTPClient(port: Int) {
   /** Builds an HTTP POST request with the given arguments.
     *
     * The request is sent to the configured host and port, with a URI path defined by `FrontendHTTPDefaults.route`. The
-    * request body is constructed from the `args` array, which is concatenated into a single string separated by "&" and
-    * sent as `application/x-www-form-urlencoded`.
+    * request body is a JSON object. Arguments with values are encoded as strings and flags are encoded as null.
     *
     * @param args
     *   An array of arguments to be included in the POST request body.
     * @return
     *   The constructed `HttpRequest` object.
     */
-  def buildRequest(args: Array[String]): HttpRequest = {
+  def buildRequest(args: (String, Option[String])*): HttpRequest = {
+    val body = ujson.Obj.from(args.map {
+      case (key, Some(value)) => key -> ujson.Str(value)
+      case (key, None)        => key -> ujson.Null
+    })
     HttpRequest
       .newBuilder()
       .uri(URI.create(s"http://localhost:$port/run"))
-      .header("Content-Type", "application/x-www-form-urlencoded")
-      .POST(BodyPublishers.ofString(args.mkString("&")))
+      .header("Content-Type", "application/json")
+      .POST(BodyPublishers.ofString(body.render()))
       .build()
   }
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/server/FrontendHTTPServer.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/server/FrontendHTTPServer.scala
@@ -152,6 +152,7 @@ class FrontendHTTPServer(executor: ExecutorService, handleRequest: Array[String]
         case (key, anything) =>
           logger.warn("Ignoring HTTP request argument {} with unsupported json type {}", key, anything.getClass)
           None
+      }
     }
 
     private def sendResponse(exchange: HttpExchange, statusCode: Int, body: String): Unit = {

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/server/FrontendHTTPServer.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/server/FrontendHTTPServer.scala
@@ -4,7 +4,7 @@ import io.joern.x2cpg.X2CpgConfig
 import org.slf4j.LoggerFactory
 
 import com.sun.net.httpserver.{HttpExchange, HttpHandler, HttpServer}
-import java.net.{InetSocketAddress, URLDecoder}
+import java.net.InetSocketAddress
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.{ExecutorService, Executors, TimeUnit}
@@ -88,9 +88,10 @@ class FrontendHTTPServer(executor: ExecutorService, handleRequest: Array[String]
     /** Handles POST requests to the "/run" endpoint.
       *
       * The request is expected to include `input`, `output`, and (optionally) frontend arguments (unbounded). The
-      * request is expected to be sent `application/x-www-form-urlencoded`. The provided `X2CpgFrontend` is run with
-      * these input/output/arguments and the resulting CPG output path is returned in the response and status code 200.
-      * In case of a failure, status code 400 is sent together with a response containing the reason.
+      * request is expected to be sent as a JSON object. String values become option values and null values become
+      * flags. The provided `X2CpgFrontend` is run with these input/output/arguments and the resulting CPG output path
+      * is returned in the response and status code 200. In case of a failure, status code 400 is sent together with a
+      * response containing the reason.
       */
     override def handle(exchange: HttpExchange): Unit = {
       if (exchange.getRequestMethod != "POST") {
@@ -110,22 +111,27 @@ class FrontendHTTPServer(executor: ExecutorService, handleRequest: Array[String]
           _.mkString
         }.getOrElse("")
 
-        val params = parseFormUrlEncoded(requestBody)
+        Try {
+          val params = parseFromJson(requestBody)
 
-        val outputDir = params.getOrElse("output", X2CpgConfig.defaultOutputPath)
-        val arguments = params.flatMap {
-          case ("input", value)                      => List(value)
-          case (arg, value) if value.strip().isEmpty => List(s"--$arg")
-          case (arg, value)                          => List(s"--$arg", value)
-        }.toArray
+          var outputDir = X2CpgConfig.defaultOutputPath
+          val arguments = params.flatMap {
+            case ("output", Some(value)) =>
+              outputDir = value
+              List("--output", value)
+            case ("input", Some(value)) => List(value)
+            case (arg, None)            => List(s"--$arg")
+            case (arg, Some(value))     => List(s"--$arg", value)
+          }.toArray
 
-        logger.debug("Got POST with arguments: " + arguments.mkString(" "))
-
-        Try(handleRequest(arguments)) match {
+          logger.debug("Got POST with arguments: " + arguments.mkString(" "))
+          handleRequest(arguments)
+          outputDir
+        } match {
           case Failure(exception) =>
             exception.printStackTrace()
             sendResponse(exchange, 400, exception.getMessage)
-          case Success(_) =>
+          case Success(outputDir) =>
             sendResponse(exchange, 200, outputDir)
         }
       } finally {
@@ -138,19 +144,14 @@ class FrontendHTTPServer(executor: ExecutorService, handleRequest: Array[String]
       }
     }
 
-    /** Parses an application/x-www-form-urlencoded body (e.g. "key1=val1&key2=val2") into key-value pairs. */
-    private def parseFormUrlEncoded(body: String): Map[String, String] = {
-      if (body.isEmpty) return Map.empty
-
-      def decode(s: String): String = URLDecoder.decode(s, StandardCharsets.UTF_8)
-
-      val pairs = body.split("&")
-      pairs.map { pair =>
-        val keyAndValue = pair.split("=", 2) // limit 2 so value may contain '='
-        val key         = decode(keyAndValue(0))
-        val value       = if (keyAndValue.length > 1) decode(keyAndValue(1)) else ""
-        key -> value
-      }.toMap
+    private def parseFromJson(body: String): List[(String, Option[String])] = {
+      val list = ujson.read(body).obj.toList
+      list.flatMap {
+        case (key, ujson.Str(value)) => Some((key, Some(value)))
+        case (key, ujson.Null)       => Some((key, None))
+        case (key, anything) =>
+          logger.warn("Ignoring HTTP request argument {} with unsupported json type {}", key, anything.getClass)
+          None
     }
 
     private def sendResponse(exchange: HttpExchange, statusCode: Int, body: String): Unit = {

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/server/FrontendHTTPServerTests.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/server/FrontendHTTPServerTests.scala
@@ -25,7 +25,7 @@ class FrontendHTTPServerTests extends AnyWordSpec with Matchers {
     val builder = HttpRequest
       .newBuilder()
       .uri(URI.create(s"http://localhost:$port/run"))
-      .header("Content-Type", "application/x-www-form-urlencoded")
+      .header("Content-Type", "application/json")
 
     val req = method match {
       case "POST" => builder.POST(BodyPublishers.ofString(body)).build()
@@ -109,7 +109,7 @@ class FrontendHTTPServerTests extends AnyWordSpec with Matchers {
       try {
         sender.submit(new Runnable {
           override def run(): Unit = {
-            try post(port, "input=/tmp/in&output=/tmp/out")
+            try post(port, """{"input":"/tmp/in","output":"/tmp/out"}""")
             catch { case _: Throwable => () }
           }
         })
@@ -193,7 +193,7 @@ class FrontendHTTPServerTests extends AnyWordSpec with Matchers {
         (1 to 2).foreach { _ =>
           senders.submit(new Runnable {
             override def run(): Unit = {
-              try post(port, "input=/tmp/in&output=/tmp/out")
+              try post(port, """{"input":"/tmp/in","output":"/tmp/out"}""")
               catch { case _: Throwable => () }
             }
           })
@@ -221,7 +221,7 @@ class FrontendHTTPServerTests extends AnyWordSpec with Matchers {
     "invoke the handler with the parsed arguments and respond with 200 + the output path" in {
       val captured = new AtomicReference[Array[String]](Array.empty)
       withServer(args => captured.set(args)) { (_, port) =>
-        val resp = post(port, "input=/tmp/in&output=/tmp/out&flag=")
+        val resp = post(port, """{"input":"/tmp/in","output":"/tmp/out","flag":null}""")
         resp.statusCode() shouldBe 200
         resp.body() shouldBe "/tmp/out"
         val args = captured.get().toSet
@@ -232,19 +232,19 @@ class FrontendHTTPServerTests extends AnyWordSpec with Matchers {
       }
     }
 
-    "URL-decode keys and values in the form-encoded body" in {
+    "preserve spaces and punctuation in JSON values" in {
       val captured = new AtomicReference[Array[String]](Array.empty)
       withServer(args => captured.set(args)) { (_, port) =>
-        val resp = post(port, "input=%2Ftmp%2Fa%20b&output=%2Ftmp%2Fout")
+        val resp = post(port, """{"input":"/tmp/a b=c&d","output":"/tmp/out"}""")
         resp.statusCode() shouldBe 200
         resp.body() shouldBe "/tmp/out"
-        captured.get().toSet should contain("/tmp/a b")
+        captured.get().toSet should contain("/tmp/a b=c&d")
       }
     }
 
     "fall back to the default output path when none is provided" in {
       withServer(_ => ()) { (_, port) =>
-        val resp = post(port, "input=/tmp/in")
+        val resp = post(port, """{"input":"/tmp/in"}""")
         resp.statusCode() shouldBe 200
         resp.body() shouldBe io.joern.x2cpg.X2CpgConfig.defaultOutputPath
       }
@@ -252,18 +252,16 @@ class FrontendHTTPServerTests extends AnyWordSpec with Matchers {
 
     "respond with 400 and the exception message when the handler throws" in {
       withServer(_ => throw new RuntimeException("boom")) { (_, port) =>
-        val resp = post(port, "input=/tmp/in&output=/tmp/out")
+        val resp = post(port, """{"input":"/tmp/in","output":"/tmp/out"}""")
         resp.statusCode() shouldBe 400
         resp.body() shouldBe "boom"
       }
     }
 
-    "tolerate an empty request body" in {
-      val captured = new AtomicReference[Array[String]](Array.empty)
-      withServer(args => captured.set(args)) { (_, port) =>
-        val resp = post(port, "")
-        resp.statusCode() shouldBe 200
-        captured.get() shouldBe empty
+    "reject malformed JSON" in {
+      withServer(_ => ()) { (_, port) =>
+        val resp = post(port, "{")
+        resp.statusCode() shouldBe 400
       }
     }
   }
@@ -274,7 +272,7 @@ class FrontendHTTPServerTests extends AnyWordSpec with Matchers {
       val captured = new AtomicReference[Array[String]](Array.empty)
       withServer(args => captured.set(args)) { (_, port) =>
         val client = FrontendHTTPClient(port)
-        val req    = client.buildRequest(Array("input=/tmp/in", "output=/tmp/out"))
+        val req    = client.buildRequest("input" -> Some("/tmp/in"), "output" -> Some("/tmp/out"))
         client.sendRequest(req).get shouldBe "/tmp/out"
         captured.get().toSet should contain("/tmp/in")
       }
@@ -283,7 +281,7 @@ class FrontendHTTPServerTests extends AnyWordSpec with Matchers {
     "return a Failure when the handler throws" in {
       withServer(_ => throw new RuntimeException("nope")) { (_, port) =>
         val client = FrontendHTTPClient(port)
-        val req    = client.buildRequest(Array("input=/tmp/in"))
+        val req    = client.buildRequest("input" -> Some("/tmp/in"))
         val result = client.sendRequest(req)
         result.isFailure shouldBe true
         result.failed.get.getMessage should include("400")


### PR DESCRIPTION
Is an adaptation of the existing [markus/frontendHttpServerJsonParameter](https://github.com/joernio/joern/compare/master...markus/frontendHttpServerJsonParameter)

Basically fixes the tests that were still using url encoding in FrontendHttpServerTests.