### PR TITLE
[x2cpg] Use local gradle at GRADLE_HOME if set

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/GradleDependencies.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/GradleDependencies.scala
@@ -35,6 +35,14 @@ object GradleDependencies {
 
   private val logger = LoggerFactory.getLogger(getClass)
 
+  private def getGradleHome: Option[JFile] = {
+    sys.env
+      .get("GRADLE_HOME")
+      .filterNot(_.isBlank)
+      .map(new JFile(_))
+      .filter(gradleHome => gradleHome.exists && gradleHome.isDirectory)
+  }
+
   // works with Gradle 5.1+ because the script makes use of `task.register`:
   //   https://docs.gradle.org/current/userguide/task_configuration_avoidance.html
   private def getInitScriptContent(
@@ -98,7 +106,9 @@ object GradleDependencies {
   }
 
   private[dependency] def makeConnection(projectDir: JFile): ProjectConnection = {
-    GradleConnector.newConnector().forProjectDirectory(projectDir).connect()
+    val connector = GradleConnector.newConnector().forProjectDirectory(projectDir)
+    getGradleHome.foreach(gradleHome => connector.useInstallation(gradleHome))
+    connector.connect()
   }
 
   private def dependencyMapFromOutputDir(outputDir: Path): List[(String, List[String])] = {

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/GradleDependencies.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/GradleDependencies.scala
@@ -107,7 +107,10 @@ object GradleDependencies {
 
   private[dependency] def makeConnection(projectDir: JFile): ProjectConnection = {
     val connector = GradleConnector.newConnector().forProjectDirectory(projectDir)
-    getGradleHome.foreach(gradleHome => connector.useInstallation(gradleHome))
+    getGradleHome.foreach { gradleHome =>
+      logger.info(s"Using gradle distribution from GRADLE_HOME at ${gradleHome.getAbsolutePath}")
+      connector.useInstallation(gradleHome)
+    }
     connector.connect()
   }
 


### PR DESCRIPTION
By default, the correct gradle distribution will be downloaded when using the gradle tooling API to build the project, unless this distribution has been cached previously. This is an issue in a customer environment where the request is re-routed to a private artifactory where this distribution is not available.

This PR configures the tooling API to use a local gradle distribution if `GRADLE_HOME` is set instead. This does mean that this environment variable may have to be overridden on a per-project basis on a system with multiple projects with conflicting gradle versions.

I did consider adding a fallback to retry the connection with the default fetching behaviour if using `GRADLE_HOME` fails, but since this is under the user's control (they can simply unset the variable), I don't think it's unreasonable to leave that up to the user to configure (but I'm happy to change this PR if there is disagreement).

I tested this locally by removing the cached gradle distribution for `elasticsearch` and then confirmed that dependencies can be fetched with or without an explicit `GRADLE_HOME` set and that the correct distribution is used (by checking paths in logs)