### PR TITLE
[rust2cpg] dispatch based on receiver's type.

### DIFF
--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/Rust2Cpg.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/Rust2Cpg.scala
@@ -1,8 +1,7 @@
 package io.joern.rust2cpg
 
 import io.joern.rust2cpg.astgen.RustAstGenRunner
-import io.joern.rust2cpg.passes.AstCreationPass
-import io.joern.rust2cpg.passes.RustTypeNodePass
+import io.joern.rust2cpg.passes.{AstCreationPass, RustTypeNodePass}
 import io.joern.x2cpg.X2Cpg.withNewEmptyCpg
 import io.joern.x2cpg.X2CpgFrontend
 import io.joern.x2cpg.passes.frontend.MetaDataPass

--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustFullNames.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustFullNames.scala
@@ -61,7 +61,9 @@ trait RustFullNames { this: AstCreator =>
   }
 
   protected def methodFullNameForMethodCallExpr(methodCallExpr: RustNodeSyntax.MethodCallExpr): String = {
-    methodCallExpr.methodFullName.getOrElse(Defines.DynamicCallUnknownFullName)
+    methodCallExpr.methodFullName.getOrElse(
+      combineRustFullName(Defines.UnresolvedNamespace, code(methodCallExpr.nameRef))
+    )
   }
 
   protected def typeFullNameForType(typ: RustNodeSyntax.Type): String = {

--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
@@ -667,16 +667,20 @@ trait RustVisitor(implicit withValidationMode: ValidationMode) { this: AstCreato
     val methodName     = code(methodCallExpr.nameRef)
     val methodFullName = methodFullNameForMethodCallExpr(methodCallExpr)
     val typeFullName   = typeFullNameForExpr(methodCallExpr)
-    // TODO: should also be DYNAMIC_DISPATCH when the type is `dyn`.
-    val dispatch =
-      if (methodFullName == Defines.DynamicCallUnknownFullName) DispatchTypes.DYNAMIC_DISPATCH
-      else DispatchTypes.STATIC_DISPATCH
+    val receiverType   = typeFullNameForExpr(methodCallExpr.expr)
+    val dispatch = if (isTraitObject(receiverType)) DispatchTypes.DYNAMIC_DISPATCH else DispatchTypes.STATIC_DISPATCH
     val call =
       callNode(methodCallExpr, code(methodCallExpr), methodName, methodFullName, dispatch, None, Some(typeFullName))
     val receiverAst = visitExpr(methodCallExpr.expr)
     val args        = methodCallExpr.argList.expr.map(visitExpr)
     callAst(call, args, base = Some(receiverAst))
   }
+
+  // TODO: not accounting for the Deref trait. Depending on how it gets supported, this might need to change.
+  // Currently, only `dyn` are considered dynamically dispatched. We may want to extend rust_ast_gen with semantic
+  // information later.
+  private def isTraitObject(receiverType: String): Boolean =
+    receiverType.stripPrefix("&").stripPrefix("mut ").startsWith("dyn ")
 
   // AwaitExpr =
   //  Attr* Expr '.' 'await'

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/TypeNodePassTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/TypeNodePassTests.scala
@@ -1,6 +1,7 @@
 package io.joern.rust2cpg.passes
 
 import io.joern.rust2cpg.testfixtures.Rust2CpgSuite
+import io.joern.x2cpg.Defines
 import io.shiftleft.semanticcpg.language.*
 
 class TypeNodePassTests extends Rust2CpgSuite(noSysRoot = true) {
@@ -21,6 +22,19 @@ class TypeNodePassTests extends Rust2CpgSuite(noSysRoot = true) {
           typ.fullName shouldBe "usize"
           typ.isExternal shouldBe true
         }
+      }
+    }
+
+    "create the ANY TYPE_DECL" in {
+      val cpg = code("""
+          |fn foo() {
+          | let x = bar();
+          |}
+          |""".stripMargin)
+      inside(cpg.method.name("foo").block.local.name("x").typ.referencedTypeDecl.l) { case typ :: Nil =>
+        typ.name shouldBe Defines.Any
+        typ.fullName shouldBe Defines.Any
+        typ.isExternal shouldBe true
       }
     }
 

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/CallTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/CallTests.scala
@@ -56,12 +56,12 @@ class CallTests extends Rust2CpgSuite(noSysRoot = true) {
         |}
         |""".stripMargin)
 
-    "have DynamicCallUnknownFullName for the inner method call" in {
-      cpg.call.nameExact("chain").methodFullName.l shouldBe List(Defines.DynamicCallUnknownFullName)
+    "have an unresolved-namespace methodFullName for the inner method call" in {
+      cpg.call.nameExact("chain").methodFullName.l shouldBe List(s"${Defines.UnresolvedNamespace}::chain")
     }
 
-    "have DynamicCallUnknownFullName for the outer method call" in {
-      cpg.call.nameExact("tail").methodFullName.l shouldBe List(Defines.DynamicCallUnknownFullName)
+    "have an unresolved-namespace methodFullName for the outer method call" in {
+      cpg.call.nameExact("tail").methodFullName.l shouldBe List(s"${Defines.UnresolvedNamespace}::tail")
     }
 
     "have an unresolved-namespace methodFullName for the function call" in {
@@ -72,12 +72,25 @@ class CallTests extends Rust2CpgSuite(noSysRoot = true) {
       cpg.call.nameExact("external").dispatchType.l shouldBe List(DispatchTypes.STATIC_DISPATCH)
     }
 
-    "have DYNAMIC_DISPATCH for each method call in the chain" in {
-      cpg.call.nameExact("chain", "tail").dispatchType.toSet shouldBe Set(DispatchTypes.DYNAMIC_DISPATCH)
+    "have STATIC_DISPATCH for each method call in the chain" in {
+      cpg.call.nameExact("chain", "tail").dispatchType.toSet shouldBe Set(DispatchTypes.STATIC_DISPATCH)
     }
 
     "have Any as typeFullName for each call in the chain" in {
       cpg.call.nameExact("external", "chain", "tail").typeFullName.toSet shouldBe Set(Defines.Any)
+    }
+
+    "create an external method stub for each call" in {
+      cpg.method.fullNameExact(s"${Defines.UnresolvedNamespace}::external").isExternal.l shouldBe List(true)
+      cpg.method.fullNameExact(s"${Defines.UnresolvedNamespace}::chain").isExternal.l shouldBe List(true)
+      cpg.method.fullNameExact(s"${Defines.UnresolvedNamespace}::tail").isExternal.l shouldBe List(true)
+    }
+
+    "resolve the unknown call type to an external TYPE_DECL" in {
+      inside(cpg.call.nameExact("chain").typ.referencedTypeDecl.l) { case typeDecl :: Nil =>
+        typeDecl.fullName shouldBe Defines.Any
+        typeDecl.isExternal shouldBe true
+      }
     }
   }
 
@@ -99,11 +112,11 @@ class CallTests extends Rust2CpgSuite(noSysRoot = true) {
         |}
         |""".stripMargin)
 
-    "have DynamicCallUnknownFullName as methodFullName" in {
+    "have an unresolved-namespace methodFullName" in {
       inside(cpg.call.nameExact("push").l) { case push :: Nil =>
         push.code shouldBe "xs.push(1)"
-        push.methodFullName shouldBe Defines.DynamicCallUnknownFullName
-        push.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
+        push.methodFullName shouldBe s"${Defines.UnresolvedNamespace}::push"
+        push.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
         push.typeFullName shouldBe Defines.Any
       }
     }
@@ -137,9 +150,9 @@ class CallTests extends Rust2CpgSuite(noSysRoot = true) {
     "lower `trim` as a method call on the result of `from`" in {
       inside(cpg.call.nameExact("trim").l) { case trim :: Nil =>
         trim.code shouldBe """String::from(" hello ").trim()"""
-        trim.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
+        trim.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
         trim.arguments(1) shouldBe empty
-        trim.methodFullName shouldBe Defines.DynamicCallUnknownFullName
+        trim.methodFullName shouldBe s"${Defines.UnresolvedNamespace}::trim"
 
         inside(trim.receiver.l) { case (from: Call) :: Nil =>
           from.name shouldBe "from"
@@ -152,9 +165,9 @@ class CallTests extends Rust2CpgSuite(noSysRoot = true) {
     "lower `to_string` as a method call on the result of `trim`" in {
       inside(cpg.call.nameExact("to_string").l) { case toString :: Nil =>
         toString.code shouldBe """String::from(" hello ").trim().to_string()"""
-        toString.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
+        toString.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
         toString.arguments(1) shouldBe empty
-        toString.methodFullName shouldBe Defines.DynamicCallUnknownFullName
+        toString.methodFullName shouldBe s"${Defines.UnresolvedNamespace}::to_string"
 
         inside(toString.receiver.l) { case (trim: Call) :: Nil =>
           trim.name shouldBe "trim"
@@ -162,6 +175,33 @@ class CallTests extends Rust2CpgSuite(noSysRoot = true) {
           trim.argumentIndex shouldBe 0
         }
       }
+    }
+  }
+
+  "a method call through a `&dyn Trait` receiver" should {
+    val cpg = code("""
+        |trait Greet { fn hello(&self) -> i32; }
+        |fn run(g: &dyn Greet) { g.hello(); }
+        |""".stripMargin)
+
+    "have DYNAMIC_DISPATCH and a resolved methodFullName" in {
+      inside(cpg.call.nameExact("hello").l) { case hello :: Nil =>
+        hello.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
+        hello.methodFullName shouldBe "rust2cpgtest::Greet::hello"
+      }
+    }
+
+    "have the trait object as receiver" in {
+      inside(cpg.call.nameExact("hello").receiver.l) { case (receiver: Identifier) :: Nil =>
+        receiver.name shouldBe "g"
+        receiver.code shouldBe "g"
+        receiver.argumentIndex shouldBe 0
+        receiver.typeFullName shouldBe "&dyn Greet + 'static"
+      }
+    }
+
+    "have the receiver as its only argument" in {
+      cpg.call.nameExact("hello").argument.l shouldBe cpg.call.nameExact("hello").receiver.l
     }
   }
 }


### PR DESCRIPTION
Previously, whenever a call couldn't be resolved it was marked DYNAMIC_DISPATCH. But dynamic dispatch is the exception in Rust. So, 
* it's now marked as dynamically dispatched only when the receiver is a `dyn` (possibly with `&` or `mut`). 
* unresolved methods now have `<unresolvedNamespace>::<method>` full names, instead of `DynamicCallUnknownFullName`.

I need to play with the `Deref` trait a bit more: methods over `Box<dyn Something>` (say) could be considered dynamically dispatched, but that's because there's an implicit `.deref()` call in between, which is currently not present in rust_ast_gen's output. (I would first try to make it explicit, but if that fails we may need to enrich the `isTraitObject` predicate or emit some semantic information from rust_ast_gen to help us here.)

A couple of tests were motivated by a recent buildbot failure in which TYPE_DECLs were missing. This patch doesn't explicitly create them, it turns out they are created during DefaultTestCpg via the overlays, i.e. the tests are in a sense masking this failure. I mainly added them to assert/document the status quo.