### PR TITLE
[rust2cpg] support `impl X` blocks.

### DIFF
--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/AstCreator.scala
@@ -146,6 +146,27 @@ class AstCreator(val config: Config, val parseResult: ParseResult)(implicit with
     )
   }
 
+  protected def typeDeclForImpl(impl: RustNodeSyntax.Impl): NewTypeDecl = {
+    val implType = typeFullNameForType(impl.typ.last)
+    val name     = implType.split(RustFullNames.PathSep).lastOption.getOrElse(implType)
+    val parent   = methodAstParentStack.head
+    typeDeclNode(
+      node = impl,
+      name = name,
+      fullName = implType,
+      filename = parseResult.filename,
+      code = code(impl),
+      astParentType = parent.label,
+      astParentFullName = parent.properties(PropertyNames.FullName).toString
+    )
+  }
+
+  protected def enclosingTypeDeclFullName: Option[String] = {
+    methodAstParentStack.collectFirst { case typeDecl: NewTypeDecl =>
+      typeDecl.properties(PropertyNames.FullName).toString
+    }
+  }
+
   protected def operatorNameFor(binExpr: RustNodeSyntax.BinExpr): Option[String] = binExpr.op match {
     case Some(_: RustNodeSyntax.Pipe2Token)     => Some(Operators.logicalOr)
     case Some(_: RustNodeSyntax.Amp2Token)      => Some(Operators.logicalAnd)

--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
@@ -470,13 +470,15 @@ trait RustVisitor(implicit withValidationMode: ValidationMode) { this: AstCreato
         s"&$mut$enclosingType"
       case None => enclosingType
     }
+    val evaluationStrategy =
+      if (selfParam.ampToken.isDefined) EvaluationStrategies.BY_SHARING else EvaluationStrategies.BY_VALUE
     val paramNode = parameterInNode(
       node = selfParam,
       name = code(selfParam.name),
       code = code(selfParam),
       index = 0,
       isVariadic = false,
-      evaluationStrategy = EvaluationStrategies.BY_SHARING,
+      evaluationStrategy = evaluationStrategy,
       typeFullName = typeFullName
     )
     Ast(paramNode)

--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
@@ -51,7 +51,7 @@ trait RustVisitor(implicit withValidationMode: ValidationMode) { this: AstCreato
     case x: ExternBlock         => notHandledYet(x) :: Nil
     case x: ExternCrate         => notHandledYet(x) :: Nil
     case fn: Fn                 => visitFn(fn) :: Nil
-    case x: Impl                => notHandledYet(x) :: Nil
+    case impl: Impl             => visitImpl(impl)
     case macroCall: MacroCall   => visitMacroCall(macroCall)
     case macroRules: MacroRules => visitMacroRules(macroRules)
     case macroDef: MacroDef     => visitMacroDef(macroDef)
@@ -341,6 +341,24 @@ trait RustVisitor(implicit withValidationMode: ValidationMode) { this: AstCreato
     returnAst(ret, Seq(exprAst))
   }
 
+  // Impl =
+  //  Attr* Visibility?
+  //  'default'? 'unsafe'?
+  //  'impl' GenericParamList? ('const'? '!'? Type 'for')? Type WhereClause?
+  //  AssocItemList
+  // TODO: support `impl X for Y` and remove the side-effects (storeInDiffGraph).
+  private def visitImpl(impl: Impl): Seq[Ast] = {
+    if (impl.forKwToken.isDefined) {
+      Nil
+    } else {
+      methodAstParentStack.push(typeDeclForImpl(impl))
+      val methodAsts = impl.assocItemList.assocItem.collect { case fn: Fn => visitFn(fn) }
+      methodAstParentStack.pop()
+      methodAsts.foreach(Ast.storeInDiffGraph(_, diffGraph))
+      Nil
+    }
+  }
+
   // BlockExpr =
   //  Attr* Label? (TryBlockModifier | 'unsafe' | ('async' 'move'?) | ('gen' 'move'?) | 'const') StmtList
   private def visitBlockExpr(blockExpr: BlockExpr): Ast = {
@@ -417,7 +435,8 @@ trait RustVisitor(implicit withValidationMode: ValidationMode) { this: AstCreato
   //  )')'
   // | '|' (Param (',' Param)* ','?)? '|'
   private def visitParamList(paramList: ParamList): Seq[Ast] = {
-    paramList.param.zipWithIndex.map { case (param, paramIdx) =>
+    val selfParamAst = paramList.selfParam.map(visitSelfParam).toList
+    val paramAsts = paramList.param.zipWithIndex.map { case (param, paramIdx) =>
       val paramName         = param.pat.collect { case x: IdentPat => x }
       val paramTypeFullName = param.typ.map(typeFullNameForType)
 
@@ -436,6 +455,31 @@ trait RustVisitor(implicit withValidationMode: ValidationMode) { this: AstCreato
         case _ => notHandledYet(param)
       }
     }
+
+    selfParamAst ++ paramAsts
+  }
+
+  // SelfParam =
+  //  Attr* ( ('&' Lifetime?)? 'mut'? Name | 'mut'? Name ':' Type )
+  private def visitSelfParam(selfParam: SelfParam): Ast = {
+    val enclosingType = enclosingTypeDeclFullName.getOrElse(Defines.Any)
+    val typeFullName = selfParam.typ match {
+      case Some(typ) => typeFullNameForType(typ)
+      case None if selfParam.ampToken.isDefined =>
+        val mut = Option.when(selfParam.mutKwToken.isDefined)("mut ").getOrElse("")
+        s"&$mut$enclosingType"
+      case None => enclosingType
+    }
+    val paramNode = parameterInNode(
+      node = selfParam,
+      name = code(selfParam.name),
+      code = code(selfParam),
+      index = 0,
+      isVariadic = false,
+      evaluationStrategy = EvaluationStrategies.BY_SHARING,
+      typeFullName = typeFullName
+    )
+    Ast(paramNode)
   }
 
   // Param =

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/ImplTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/ImplTests.scala
@@ -4,6 +4,9 @@ import io.joern.rust2cpg.testfixtures.Rust2CpgSuite
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EvaluationStrategies}
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.utils.FileUtil.PathExt
+
+import java.nio.file.Paths
 
 class ImplTests extends Rust2CpgSuite(noSysRoot = true) {
 
@@ -129,6 +132,41 @@ class ImplTests extends Rust2CpgSuite(noSysRoot = true) {
         |  fn b(&self) {}
         |}
         |""".stripMargin)
+
+    "merge all methods under the same TYPE_DECL" in {
+      cpg.typeDecl.nameExact("Foo").method.fullName.sorted.l shouldBe List(
+        "rust2cpgtest::Foo::a",
+        "rust2cpgtest::Foo::b"
+      )
+    }
+
+    "not create a duplicate TYPE_DECL" in {
+      cpg.typeDecl.fullNameExact("rust2cpgtest::Foo").size shouldBe 1
+    }
+  }
+
+  "multiple impl blocks for the same type spread across files" should {
+    val cpg = code(
+      """
+        |struct Foo;
+        |mod a;
+        |mod b;
+        |""".stripMargin,
+      fileName = (Paths.get("src") / "lib.rs").toString
+    ).moreCode(
+      """
+          |impl crate::Foo {
+          | fn a(&self) {}
+          |}
+          |""".stripMargin,
+      fileName = (Paths.get("src") / "a.rs").toString
+    ).moreCode(
+      """
+        |impl crate::Foo {
+        | fn b(&self) {}
+        |}""".stripMargin,
+      fileName = (Paths.get("src") / "b.rs").toString
+    )
 
     "merge all methods under the same TYPE_DECL" in {
       cpg.typeDecl.nameExact("Foo").method.fullName.sorted.l shouldBe List(

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/ImplTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/ImplTests.scala
@@ -67,6 +67,24 @@ class ImplTests extends Rust2CpgSuite(noSysRoot = true) {
     }
   }
 
+  "an inherent method with a by-value `self` receiver" should {
+    val cpg = code("""
+        |struct Foo;
+        |impl Foo {
+        |  fn bar(self) {}
+        |}
+        |""".stripMargin)
+
+    "have correct self properties" in {
+      inside(cpg.method.nameExact("bar").parameter.nameExact("self").l) { case self :: Nil =>
+        self.index shouldBe 0
+        self.order shouldBe 0
+        self.evaluationStrategy shouldBe EvaluationStrategies.BY_VALUE
+        self.typeFullName shouldBe "rust2cpgtest::Foo"
+      }
+    }
+  }
+
   "an associated function without a receiver" should {
     val cpg = code("""
         |struct Foo;

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/ImplTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/ImplTests.scala
@@ -1,0 +1,176 @@
+package io.joern.rust2cpg.passes.ast
+
+import io.joern.rust2cpg.testfixtures.Rust2CpgSuite
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EvaluationStrategies}
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.*
+
+class ImplTests extends Rust2CpgSuite(noSysRoot = true) {
+
+  "an inherent method in an impl block" should {
+    val cpg = code("""
+        |struct Foo;
+        |impl Foo {
+        |  fn bar(&self) {}
+        |}
+        |""".stripMargin)
+
+    "have correct fullName" in {
+      cpg.method.nameExact("bar").fullName.l shouldBe List("rust2cpgtest::Foo::bar")
+    }
+
+    "have correct return typeFullName" in {
+      cpg.method.nameExact("bar").methodReturn.typeFullName.l shouldBe List("()")
+    }
+
+    "have correct self properties" in {
+      inside(cpg.method.nameExact("bar").parameter.nameExact("self").l) { case self :: Nil =>
+        self.index shouldBe 0
+        self.order shouldBe 0
+        self.evaluationStrategy shouldBe EvaluationStrategies.BY_SHARING
+        self.typeFullName shouldBe "&rust2cpgtest::Foo"
+      }
+    }
+
+    "be an AST child of the corresponding TYPE_DECL" in {
+      cpg.typeDecl.nameExact("Foo").method.nameExact("bar").fullName.l shouldBe List("rust2cpgtest::Foo::bar")
+    }
+
+    "not create a duplicate TYPE_DECL" in {
+      cpg.typeDecl.fullNameExact("rust2cpgtest::Foo").size shouldBe 1
+    }
+  }
+
+  "an inherent method with a `&mut self` and an explicit parameter" should {
+    val cpg = code("""
+        |struct Foo;
+        |impl Foo {
+        |  fn bar(&mut self, x: i32) {}
+        |}
+        |""".stripMargin)
+
+    "have correct self properties" in {
+      inside(cpg.method.nameExact("bar").parameter.nameExact("self").l) { case self :: Nil =>
+        self.index shouldBe 0
+        self.order shouldBe 0
+        self.evaluationStrategy shouldBe EvaluationStrategies.BY_SHARING
+        self.typeFullName shouldBe "&mut rust2cpgtest::Foo"
+      }
+    }
+
+    "have correct explicit parameter properties" in {
+      inside(cpg.method.nameExact("bar").parameter.nameExact("x").l) { case param :: Nil =>
+        param.index shouldBe 1
+        param.order shouldBe 1
+        param.typeFullName shouldBe "i32"
+      }
+    }
+  }
+
+  "an associated function without a receiver" should {
+    val cpg = code("""
+        |struct Foo;
+        |impl Foo {
+        |  fn new() -> Foo { Foo }
+        |}
+        |""".stripMargin)
+
+    "have no parameters" in {
+      cpg.method.nameExact("new").parameter shouldBe empty
+    }
+
+    "have correct return typeFullName" in {
+      cpg.method.nameExact("new").methodReturn.typeFullName.l shouldBe List("rust2cpgtest::Foo")
+    }
+  }
+
+  "multiple methods in a single impl block" should {
+    val cpg = code("""
+        |struct Foo;
+        |impl Foo {
+        |  fn a(&self) {}
+        |  fn b(&self) {}
+        |}
+        |""".stripMargin)
+
+    "lower each as an AST child of the corresponding TYPE_DECL" in {
+      cpg.typeDecl.nameExact("Foo").method.fullName.sorted.l shouldBe List(
+        "rust2cpgtest::Foo::a",
+        "rust2cpgtest::Foo::b"
+      )
+    }
+  }
+
+  "multiple impl blocks for the same type" should {
+    val cpg = code("""
+        |struct Foo;
+        |impl Foo {
+        |  fn a(&self) {}
+        |}
+        |impl Foo {
+        |  fn b(&self) {}
+        |}
+        |""".stripMargin)
+
+    "merge all methods under the same TYPE_DECL" in {
+      cpg.typeDecl.nameExact("Foo").method.fullName.sorted.l shouldBe List(
+        "rust2cpgtest::Foo::a",
+        "rust2cpgtest::Foo::b"
+      )
+    }
+
+    "not create a duplicate TYPE_DECL" in {
+      cpg.typeDecl.fullNameExact("rust2cpgtest::Foo").size shouldBe 1
+    }
+  }
+
+  "a call to an inherent method" should {
+    val cpg = code("""
+        |struct Foo;
+        |impl Foo { fn bar(&self) {} }
+        |fn run(f: Foo) { f.bar(); }
+        |""".stripMargin)
+
+    "have correct properties and callee" in {
+      inside(cpg.call.nameExact("bar").l) { case call :: Nil =>
+        implicit val callResolver: NoResolve.type = NoResolve
+        call.methodFullName shouldBe "rust2cpgtest::Foo::bar"
+        call.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+        call.callee.l shouldBe cpg.method.fullNameExact("rust2cpgtest::Foo::bar").l
+      }
+    }
+
+    "have correct arguments" in {
+      inside(cpg.call.nameExact("bar").argument.l) { case (base: Identifier) :: Nil =>
+        base.name shouldBe "f"
+        base.argumentIndex shouldBe 0
+        base.typeFullName shouldBe "&rust2cpgtest::Foo"
+      }
+    }
+
+    "have correct self typeFullName" in {
+      cpg.method.nameExact("bar").parameter.nameExact("self").typeFullName.l shouldBe List("&rust2cpgtest::Foo")
+    }
+  }
+
+  "a call to an associated function" should {
+    val cpg = code("""
+        |struct Foo;
+        |impl Foo { fn new() -> Foo { Foo } }
+        |fn run() { Foo::new(); }
+        |""".stripMargin)
+
+    "have correct properties and callee" in {
+      inside(cpg.call.nameExact("new").l) { case call :: Nil =>
+        implicit val callResolver: NoResolve.type = NoResolve
+        call.methodFullName shouldBe "rust2cpgtest::Foo::new"
+        call.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+        call.callee.l shouldBe cpg.method.fullNameExact("rust2cpgtest::Foo::new").l
+      }
+    }
+
+    "have no arguments" in {
+      cpg.call.nameExact("new").argument shouldBe empty
+    }
+  }
+}

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/ImplTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/ImplTests.scala
@@ -1,7 +1,7 @@
 package io.joern.rust2cpg.passes.ast
 
 import io.joern.rust2cpg.testfixtures.Rust2CpgSuite
-import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EvaluationStrategies}
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EvaluationStrategies, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.utils.FileUtil.PathExt
@@ -197,10 +197,15 @@ class ImplTests extends Rust2CpgSuite(noSysRoot = true) {
     }
 
     "have correct arguments" in {
-      inside(cpg.call.nameExact("bar").argument.l) { case (base: Identifier) :: Nil =>
-        base.name shouldBe "f"
+      inside(cpg.call.nameExact("bar").argument.l) { case (base: Call) :: Nil =>
+        base.name shouldBe Operators.addressOf
+        base.code shouldBe "&f"
         base.argumentIndex shouldBe 0
         base.typeFullName shouldBe "&rust2cpgtest::Foo"
+        inside(base.argument.l) { case (inner: Identifier) :: Nil =>
+          inner.name shouldBe "f"
+          inner.typeFullName shouldBe "rust2cpgtest::Foo"
+        }
       }
     }
 


### PR DESCRIPTION
Only `impl X` methods are handled here, and they become child methods to the `X` TYPE_DECL. I intend to remove the ugly `storeInDiffGraph` inside RustVisitor as I tackle the `impl X for Y` variant.