### PR TITLE
[swiftsrc2cpg] Implement desugaring for optional binding syntax with tuple patterns

### DIFF
--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstCreatorHelper.scala
@@ -124,7 +124,7 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
 
   import AstCreatorHelper.*
 
-  private val optionalBindingNames: mutable.HashMap[String, String] = mutable.HashMap.empty
+  private val optionalBindingNames: mutable.HashMap[String, (String, List[String])] = mutable.HashMap.empty
 
   protected def notHandledYet(node: SwiftNode): Ast = {
     val text =
@@ -288,16 +288,21 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
         // For the de-sugaring of condition ASTs during `buildOptionalBindingCondition`,
         // we replace the identifier names of dependent optional binding variables to model
         // dependencies through the generated &&- and nil-check chain.
-        val identName = optionalBindingNames.getOrElse(name, name)
-        val identNode = identifierNode(node, identName)
-        val tpe = variableOption match {
-          case Some((_, variableTypeName)) if variableTypeName != Defines.Any => variableTypeName
-          case None if identNode.typeFullName != Defines.Any                  => identNode.typeFullName
-          case _                                                              => Defines.Any
+        optionalBindingNames.get(name) match {
+          case Some((baseName, fieldPath)) if fieldPath.nonEmpty =>
+            createFieldAccessChain(baseName, fieldPath, node)
+          case other =>
+            val resolvedName = other.map(_._1).getOrElse(name)
+            val identNode    = identifierNode(node, resolvedName)
+            val tpe = variableOption match {
+              case Some((_, variableTypeName)) if variableTypeName != Defines.Any => variableTypeName
+              case None if identNode.typeFullName != Defines.Any                  => identNode.typeFullName
+              case _                                                              => Defines.Any
+            }
+            identNode.typeFullName = tpe
+            scope.addVariableReference(resolvedName, identNode, tpe, EvaluationStrategies.BY_REFERENCE)
+            Ast(identNode)
         }
-        identNode.typeFullName = tpe
-        scope.addVariableReference(identName, identNode, tpe, EvaluationStrategies.BY_REFERENCE)
-        Ast(identNode)
     }
   }
 
@@ -613,25 +618,111 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
     *   The source-level OptionalBindingConditionSyntax node
     * @param isWildcard
     *   True if the pattern is a wildcard (e.g., `if let _ = foo()`), requiring generated name
+    * @param tuplePattern
+    *   The tuple pattern for tuple optional bindings (e.g., `(a, b)` in `if let (a, b) = foo()`); None for simple
+    *   bindings
     */
   protected case class BindingInfo(
     localName: String,
     tmpName: Option[String],
     binding: OptionalBindingConditionSyntax,
-    isWildcard: Boolean
+    isWildcard: Boolean,
+    tuplePattern: Option[PatternSyntax] = None
   )
+
+  /** Recursively walks a tuple pattern or tuple expression and registers every leaf variable name into
+    * [[optionalBindingNames]] so that identifier resolution in [[astForIdentifier]] does not wrongly treat those names
+    * as implicit `self.member` accesses.
+    *
+    * Handles:
+    *   - `TuplePatternSyntax` — recurse into each element's `.pattern`, accumulating field index path
+    *   - `ExpressionPatternSyntax` wrapping `TupleExprSyntax` — recurse into each element's `.expression`
+    *   - `IdentifierPatternSyntax` — register `code(identifier)` → `(tmpName, fieldPath)`
+    *   - `ValueBindingPatternSyntax(IdentifierPatternSyntax)` — register inner identifier name → `(tmpName, fieldPath)`
+    *   - `WildcardPatternSyntax` — skip (wildcard, nothing to register)
+    *
+    * @param pattern
+    *   The top-level pattern from the binding (either a `TuplePatternSyntax` or `ExpressionPatternSyntax` wrapping a
+    *   `TupleExprSyntax`)
+    * @param tmpName
+    *   The generated temporary name to associate with each bound variable
+    * @param fieldPath
+    *   The accumulated list of field index strings representing the path from `tmpName` to the leaf variable
+    */
+  private def registerTuplePatternBindings(
+    pattern: PatternSyntax,
+    tmpName: String,
+    fieldPath: List[String] = List.empty
+  ): Unit = {
+    def walkExpr(expr: ExprSyntax, currentPath: List[String]): Unit = expr match {
+      case inner: TupleExprSyntax =>
+        inner.elements.children.zipWithIndex.foreach { case (elem, idx) =>
+          walkExpr(elem.expression, currentPath :+ idx.toString)
+        }
+      case patExpr: PatternExprSyntax =>
+        walkPattern(patExpr.pattern, currentPath)
+      case declRef: DeclReferenceExprSyntax =>
+        optionalBindingNames.put(code(declRef), (tmpName, currentPath))
+      case _: DiscardAssignmentExprSyntax =>
+      // skip wildcards
+      case other =>
+        // Unreachable in valid Swift tuple patterns; over-registers at worst, never under-registers
+        optionalBindingNames.put(code(other), (tmpName, currentPath))
+    }
+
+    def walkPattern(pat: PatternSyntax, currentPath: List[String]): Unit = pat match {
+      case tuplePat: TuplePatternSyntax =>
+        tuplePat.elements.children.zipWithIndex.foreach { case (elem, idx) =>
+          walkPattern(elem.pattern, currentPath :+ idx.toString)
+        }
+      case ep: ExpressionPatternSyntax if ep.expression.isInstanceOf[TupleExprSyntax] =>
+        ep.expression.asInstanceOf[TupleExprSyntax].elements.children.zipWithIndex.foreach { case (elem, idx) =>
+          walkExpr(elem.expression, currentPath :+ idx.toString)
+        }
+      case ep: ExpressionPatternSyntax =>
+        walkExpr(ep.expression, currentPath)
+      case ident: IdentifierPatternSyntax =>
+        optionalBindingNames.put(code(ident.identifier), (tmpName, currentPath))
+      case vb: ValueBindingPatternSyntax =>
+        vb.pattern match {
+          case ident: IdentifierPatternSyntax =>
+            optionalBindingNames.put(code(ident.identifier), (tmpName, currentPath))
+          case inner =>
+            walkPattern(inner, currentPath)
+        }
+      case _: WildcardPatternSyntax =>
+      // skip wildcards
+      case _ =>
+    }
+
+    walkPattern(pattern, fieldPath)
+  }
 
   protected def collectBindingInfos(bindings: Seq[OptionalBindingConditionSyntax]): Seq[BindingInfo] = {
     bindings.map { binding =>
-      val (localName, isWildcard) = binding.pattern match {
-        case ident: IdentifierPatternSyntax => (code(ident.identifier), false)
-        case _                              => (scopeLocalUniqueName("wildcard"), true)
+      if (isTupleLikePattern(binding.pattern)) {
+        val tmpName = binding.initializer.map(_ => scopeLocalUniqueName("tmp"))
+        if (tmpName.isDefined) {
+          registerTuplePatternBindings(binding.pattern, tmpName.get)
+        }
+        BindingInfo(
+          scopeLocalUniqueName("tupleWildcard"),
+          tmpName,
+          binding,
+          isWildcard = true,
+          tuplePattern = Some(binding.pattern)
+        )
+      } else {
+        val (localName, isWildcard) = binding.pattern match {
+          case ident: IdentifierPatternSyntax => (code(ident.identifier), false)
+          case _                              => (scopeLocalUniqueName("wildcard"), true)
+        }
+        val tmpName = binding.initializer.map(_ => scopeLocalUniqueName("tmp"))
+        if (!isWildcard && tmpName.isDefined) {
+          optionalBindingNames.put(localName, (tmpName.get, List.empty))
+        }
+        BindingInfo(localName, tmpName, binding, isWildcard, tuplePattern = None)
       }
-      val tmpName = binding.initializer.map(_ => scopeLocalUniqueName("tmp"))
-      if (!isWildcard && tmpName.isDefined) {
-        optionalBindingNames.put(localName, tmpName.get)
-      }
-      BindingInfo(localName, tmpName, binding, isWildcard)
     }
   }
 
@@ -656,18 +747,17 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
     val otherConditions =
       conditionsSeq.filterNot(condElem => condElem.condition.isInstanceOf[OptionalBindingConditionSyntax])
 
-    if (simpleBindings.isEmpty) {
-      // No simple bindings to desugar
+    val allBindings = simpleBindings ++ tupleBindings
+
+    if (allBindings.isEmpty) {
+      // No optional bindings at all — standard handling
       onStandard()
-    } else if (otherConditions.isEmpty && tupleBindings.isEmpty) {
-      // All conditions are simple optional bindings
-      onAllSimple(simpleBindings)
     } else if (otherConditions.isEmpty) {
-      // All conditions are optional bindings (mixed simple + tuple)
-      onMixed(simpleBindings, tupleBindings)
+      // All conditions are optional bindings (simple + tuple merged)
+      onAllSimple(allBindings)
     } else {
-      // Partial: simple bindings + other conditions (and maybe tuple bindings)
-      onPartial(simpleBindings, tupleBindings, otherConditions)
+      // Optional bindings plus other conditions (e.g. boolean guards)
+      onPartial(allBindings, Seq.empty, otherConditions)
     }
   }
 
@@ -810,35 +900,52 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
     bindingInfos: Seq[BindingInfo]
   ): Ast = {
     val bindingsWithInitializer = bindingInfos.filter(info => info.tmpName.isDefined && !info.isWildcard)
+    val tupleBindingsWithInitializer =
+      bindingInfos.filter(info => info.tmpName.isDefined && info.tuplePattern.isDefined)
+    val hasUnwrapping = bindingsWithInitializer.nonEmpty || tupleBindingsWithInitializer.nonEmpty
 
-    if (bindingsWithInitializer.nonEmpty) {
+    if (hasUnwrapping) {
       val bodyBlockNode = blockNode(bodyNode)
       scope.pushNewBlockScope(bodyBlockNode)
       localAstParentStack.push(bodyBlockNode)
 
-      val unwrapAsts = bindingsWithInitializer.map { info =>
-        val binding = info.binding
-        val tmpName = info.tmpName.get
+      val unwrapAsts = bindingInfos.filter(_.tmpName.isDefined).flatMap { info =>
+        info.tuplePattern match {
+          case Some(tp: TuplePatternSyntax) =>
+            astsForBindingTuplePattern(tp, info.tmpName.get, List.empty, info.binding)
+          case Some(ep: ExpressionPatternSyntax) if ep.expression.isInstanceOf[TupleExprSyntax] =>
+            astsForBindingTupleExpr(
+              ep.expression.asInstanceOf[TupleExprSyntax],
+              info.tmpName.get,
+              List.empty,
+              info.binding
+            )
+          case _ if !info.isWildcard =>
+            val binding = info.binding
+            val tmpName = info.tmpName.get
 
-        val typeFullName =
-          binding.typeAnnotation.fold(Defines.Any)(typeAnn => AstCreatorHelper.cleanType(code(typeAnn.`type`)))
-        val kind = code(binding.bindingSpecifier)
-        val scopeType =
-          if (kind == "let") VariableScopeManager.ScopeType.BlockScope
-          else VariableScopeManager.ScopeType.MethodScope
+            val typeFullName =
+              binding.typeAnnotation.fold(Defines.Any)(typeAnn => AstCreatorHelper.cleanType(code(typeAnn.`type`)))
+            val kind = code(binding.bindingSpecifier)
+            val scopeType =
+              if (kind == "let") VariableScopeManager.ScopeType.BlockScope
+              else VariableScopeManager.ScopeType.MethodScope
 
-        val tpeFromTypeMap = fullnameProvider.typeFullname(binding.pattern).getOrElse(typeFullName)
-        registerType(tpeFromTypeMap)
-        val localNode_ = localNode(binding, info.localName, info.localName, tpeFromTypeMap).order(0)
-        scope.addVariable(info.localName, localNode_, tpeFromTypeMap, scopeType)
-        diffGraph.addEdge(bodyBlockNode, localNode_, EdgeTypes.AST)
+            val tpeFromTypeMap = fullnameProvider.typeFullname(binding.pattern).getOrElse(typeFullName)
+            registerType(tpeFromTypeMap)
+            val localNode_ = localNode(binding, info.localName, info.localName, tpeFromTypeMap).order(0)
+            scope.addVariable(info.localName, localNode_, tpeFromTypeMap, scopeType)
+            diffGraph.addEdge(bodyBlockNode, localNode_, EdgeTypes.AST)
 
-        val localIdentNode = identifierNode(binding, info.localName, info.localName, tpeFromTypeMap)
-        scope.addVariableReference(info.localName, localIdentNode, tpeFromTypeMap, EvaluationStrategies.BY_REFERENCE)
+            val localIdentNode = identifierNode(binding, info.localName, info.localName, tpeFromTypeMap)
+            scope
+              .addVariableReference(info.localName, localIdentNode, tpeFromTypeMap, EvaluationStrategies.BY_REFERENCE)
 
-        val tmpIdent = identifierNode(binding, tmpName, tmpName, Defines.Any)
-        scope.addVariableReference(tmpName, tmpIdent, Defines.Any, EvaluationStrategies.BY_REFERENCE)
-        createAssignmentCallAst(binding, Ast(localIdentNode), Ast(tmpIdent), s"${info.localName} = $tmpName")
+            val tmpIdent = identifierNode(binding, tmpName, tmpName, Defines.Any)
+            scope.addVariableReference(tmpName, tmpIdent, Defines.Any, EvaluationStrategies.BY_REFERENCE)
+            List(createAssignmentCallAst(binding, Ast(localIdentNode), Ast(tmpIdent), s"${info.localName} = $tmpName"))
+          case _ => List.empty
+        }
       }
 
       val bodyAsts = astsForBlockElements(bodyStatements.toList)
@@ -857,32 +964,51 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
   }
 
   private def buildUnwrapAssignments(bindingInfos: Seq[BindingInfo]): List[Ast] = {
-    val bindingsWithInitializer = bindingInfos.filter(info => info.tmpName.isDefined && !info.isWildcard)
+    bindingInfos
+      .filter(_.tmpName.isDefined)
+      .flatMap { info =>
+        info.tuplePattern match {
+          case Some(tp: TuplePatternSyntax) =>
+            astsForBindingTuplePattern(tp, info.tmpName.get, List.empty, info.binding)
+          case Some(ep: ExpressionPatternSyntax) if ep.expression.isInstanceOf[TupleExprSyntax] =>
+            astsForBindingTupleExpr(
+              ep.expression.asInstanceOf[TupleExprSyntax],
+              info.tmpName.get,
+              List.empty,
+              info.binding
+            )
+          case _ if !info.isWildcard =>
+            val binding = info.binding
+            val tmpName = info.tmpName.get
 
-    bindingsWithInitializer.map { info =>
-      val binding = info.binding
-      val tmpName = info.tmpName.get
+            val typeFullName =
+              binding.typeAnnotation.fold(Defines.Any)(typeAnn => AstCreatorHelper.cleanType(code(typeAnn.`type`)))
+            val kind = code(binding.bindingSpecifier)
+            val scopeType =
+              if (kind == "let") VariableScopeManager.ScopeType.BlockScope
+              else VariableScopeManager.ScopeType.MethodScope
 
-      val typeFullName =
-        binding.typeAnnotation.fold(Defines.Any)(typeAnn => AstCreatorHelper.cleanType(code(typeAnn.`type`)))
-      val kind = code(binding.bindingSpecifier)
-      val scopeType =
-        if (kind == "let") VariableScopeManager.ScopeType.BlockScope
-        else VariableScopeManager.ScopeType.MethodScope
+            val tpeFromTypeMap = fullnameProvider.typeFullname(binding.pattern).getOrElse(typeFullName)
+            registerType(tpeFromTypeMap)
+            val localNode_ = localNode(binding, info.localName, info.localName, tpeFromTypeMap).order(0)
+            scope.addVariable(info.localName, localNode_, tpeFromTypeMap, scopeType)
+            diffGraph.addEdge(localAstParentStack.head, localNode_, EdgeTypes.AST)
 
-      val tpeFromTypeMap = fullnameProvider.typeFullname(binding.pattern).getOrElse(typeFullName)
-      registerType(tpeFromTypeMap)
-      val localNode_ = localNode(binding, info.localName, info.localName, tpeFromTypeMap).order(0)
-      scope.addVariable(info.localName, localNode_, tpeFromTypeMap, scopeType)
-      diffGraph.addEdge(localAstParentStack.head, localNode_, EdgeTypes.AST)
+            val localIdentNode = identifierNode(binding, info.localName, info.localName, tpeFromTypeMap)
+            scope.addVariableReference(
+              info.localName,
+              localIdentNode,
+              tpeFromTypeMap,
+              EvaluationStrategies.BY_REFERENCE
+            )
 
-      val localIdentNode = identifierNode(binding, info.localName, info.localName, tpeFromTypeMap)
-      scope.addVariableReference(info.localName, localIdentNode, tpeFromTypeMap, EvaluationStrategies.BY_REFERENCE)
-
-      val tmpIdent = identifierNode(binding, tmpName, tmpName, Defines.Any)
-      scope.addVariableReference(tmpName, tmpIdent, Defines.Any, EvaluationStrategies.BY_REFERENCE)
-      createAssignmentCallAst(binding, Ast(localIdentNode), Ast(tmpIdent), s"${info.localName} = $tmpName")
-    }.toList
+            val tmpIdent = identifierNode(binding, tmpName, tmpName, Defines.Any)
+            scope.addVariableReference(tmpName, tmpIdent, Defines.Any, EvaluationStrategies.BY_REFERENCE)
+            List(createAssignmentCallAst(binding, Ast(localIdentNode), Ast(tmpIdent), s"${info.localName} = $tmpName"))
+          case _ => List.empty
+        }
+      }
+      .toList
   }
 
 }

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstCreatorHelper.scala
@@ -124,7 +124,8 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
 
   import AstCreatorHelper.*
 
-  private val optionalBindingNames: mutable.HashMap[String, (String, List[String])] = mutable.HashMap.empty
+  private val optionalBindingNames: mutable.HashMap[String, (baseName: String, fieldPath: List[String])] =
+    mutable.HashMap.empty
 
   protected def notHandledYet(node: SwiftNode): Ast = {
     val text =
@@ -279,7 +280,7 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
           case Some((baseName, fieldPath)) if fieldPath.nonEmpty =>
             createFieldAccessChain(baseName, fieldPath, node)
           case other =>
-            val resolvedName = other.map(_._1).getOrElse(name)
+            val resolvedName = other.map(_.baseName).getOrElse(name)
             val identNode    = identifierNode(node, resolvedName)
             val tpe = variableOption match {
               case Some((_, variableTypeName)) if variableTypeName != Defines.Any => variableTypeName
@@ -662,10 +663,6 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
         tuplePat.elements.children.zipWithIndex.foreach { case (elem, idx) =>
           walkPattern(elem.pattern, currentPath :+ idx.toString)
         }
-      case ep: ExpressionPatternSyntax if ep.expression.isInstanceOf[TupleExprSyntax] =>
-        ep.expression.asInstanceOf[TupleExprSyntax].elements.children.zipWithIndex.foreach { case (elem, idx) =>
-          walkExpr(elem.expression, currentPath :+ idx.toString)
-        }
       case ep: ExpressionPatternSyntax =>
         walkExpr(ep.expression, currentPath)
       case ident: IdentifierPatternSyntax =>
@@ -679,7 +676,8 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
         }
       case _: WildcardPatternSyntax =>
       // skip wildcards
-      case _ =>
+      case other =>
+        logger.debug(s"Unhandled pattern type in tuple binding: ${other.getClass.getSimpleName}")
     }
 
     walkPattern(pattern, fieldPath)
@@ -739,7 +737,7 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
       // No optional bindings at all — standard handling
       onStandard()
     } else if (otherConditions.isEmpty) {
-      // All conditions are optional bindings (simple + tuple merged)
+      // All conditions are optional bindings (simple and tuple-like)
       onAllSimple(allBindings)
     } else {
       // Optional bindings plus other conditions (e.g. boolean guards)
@@ -896,42 +894,7 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
       localAstParentStack.push(bodyBlockNode)
 
       val unwrapAsts = bindingInfos.filter(_.tmpName.isDefined).flatMap { info =>
-        info.tuplePattern match {
-          case Some(tp: TuplePatternSyntax) =>
-            astsForBindingTuplePattern(tp, info.tmpName.get, List.empty, info.binding)
-          case Some(ep: ExpressionPatternSyntax) if ep.expression.isInstanceOf[TupleExprSyntax] =>
-            astsForBindingTupleExpr(
-              ep.expression.asInstanceOf[TupleExprSyntax],
-              info.tmpName.get,
-              List.empty,
-              info.binding
-            )
-          case _ if !info.isWildcard =>
-            val binding = info.binding
-            val tmpName = info.tmpName.get
-
-            val typeFullName =
-              binding.typeAnnotation.fold(Defines.Any)(typeAnn => AstCreatorHelper.cleanType(code(typeAnn.`type`)))
-            val kind = code(binding.bindingSpecifier)
-            val scopeType =
-              if (kind == "let") VariableScopeManager.ScopeType.BlockScope
-              else VariableScopeManager.ScopeType.MethodScope
-
-            val tpeFromTypeMap = fullnameProvider.typeFullname(binding.pattern).getOrElse(typeFullName)
-            registerType(tpeFromTypeMap)
-            val localNode_ = localNode(binding, info.localName, info.localName, tpeFromTypeMap).order(0)
-            scope.addVariable(info.localName, localNode_, tpeFromTypeMap, scopeType)
-            diffGraph.addEdge(bodyBlockNode, localNode_, EdgeTypes.AST)
-
-            val localIdentNode = identifierNode(binding, info.localName, info.localName, tpeFromTypeMap)
-            scope
-              .addVariableReference(info.localName, localIdentNode, tpeFromTypeMap, EvaluationStrategies.BY_REFERENCE)
-
-            val tmpIdent = identifierNode(binding, tmpName, tmpName, Defines.Any)
-            scope.addVariableReference(tmpName, tmpIdent, Defines.Any, EvaluationStrategies.BY_REFERENCE)
-            List(createAssignmentCallAst(binding, Ast(localIdentNode), Ast(tmpIdent), s"${info.localName} = $tmpName"))
-          case _ => List.empty
-        }
+        unwrapAssignmentsForBindingInfo(info, bodyBlockNode)
       }
 
       val bodyAsts = astsForBlockElements(bodyStatements.toList)
@@ -952,49 +915,41 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
   private def buildUnwrapAssignments(bindingInfos: Seq[BindingInfo]): List[Ast] = {
     bindingInfos
       .filter(_.tmpName.isDefined)
-      .flatMap { info =>
-        info.tuplePattern match {
-          case Some(tp: TuplePatternSyntax) =>
-            astsForBindingTuplePattern(tp, info.tmpName.get, List.empty, info.binding)
-          case Some(ep: ExpressionPatternSyntax) if ep.expression.isInstanceOf[TupleExprSyntax] =>
-            astsForBindingTupleExpr(
-              ep.expression.asInstanceOf[TupleExprSyntax],
-              info.tmpName.get,
-              List.empty,
-              info.binding
-            )
-          case _ if !info.isWildcard =>
-            val binding = info.binding
-            val tmpName = info.tmpName.get
-
-            val typeFullName =
-              binding.typeAnnotation.fold(Defines.Any)(typeAnn => AstCreatorHelper.cleanType(code(typeAnn.`type`)))
-            val kind = code(binding.bindingSpecifier)
-            val scopeType =
-              if (kind == "let") VariableScopeManager.ScopeType.BlockScope
-              else VariableScopeManager.ScopeType.MethodScope
-
-            val tpeFromTypeMap = fullnameProvider.typeFullname(binding.pattern).getOrElse(typeFullName)
-            registerType(tpeFromTypeMap)
-            val localNode_ = localNode(binding, info.localName, info.localName, tpeFromTypeMap).order(0)
-            scope.addVariable(info.localName, localNode_, tpeFromTypeMap, scopeType)
-            diffGraph.addEdge(localAstParentStack.head, localNode_, EdgeTypes.AST)
-
-            val localIdentNode = identifierNode(binding, info.localName, info.localName, tpeFromTypeMap)
-            scope.addVariableReference(
-              info.localName,
-              localIdentNode,
-              tpeFromTypeMap,
-              EvaluationStrategies.BY_REFERENCE
-            )
-
-            val tmpIdent = identifierNode(binding, tmpName, tmpName, Defines.Any)
-            scope.addVariableReference(tmpName, tmpIdent, Defines.Any, EvaluationStrategies.BY_REFERENCE)
-            List(createAssignmentCallAst(binding, Ast(localIdentNode), Ast(tmpIdent), s"${info.localName} = $tmpName"))
-          case _ => List.empty
-        }
-      }
+      .flatMap(info => unwrapAssignmentsForBindingInfo(info, localAstParentStack.head))
       .toList
+  }
+
+  private def unwrapAssignmentsForBindingInfo(info: BindingInfo, localParent: NewBlock): List[Ast] = {
+    info.tuplePattern match {
+      case Some(tp: TuplePatternSyntax) =>
+        astsForBindingTuplePattern(tp, info.tmpName.get, List.empty, info.binding)
+      case Some(ep: ExpressionPatternSyntax) if ep.expression.isInstanceOf[TupleExprSyntax] =>
+        astsForBindingTupleExpr(ep.expression.asInstanceOf[TupleExprSyntax], info.tmpName.get, List.empty, info.binding)
+      case _ if !info.isWildcard =>
+        val binding = info.binding
+        val tmpName = info.tmpName.get
+
+        val typeFullName =
+          binding.typeAnnotation.map(typeAnn => AstCreatorHelper.cleanType(code(typeAnn.`type`))).getOrElse(Defines.Any)
+        val kind = code(binding.bindingSpecifier)
+        val scopeType =
+          if (kind == "let") VariableScopeManager.ScopeType.BlockScope
+          else VariableScopeManager.ScopeType.MethodScope
+
+        val tpeFromTypeMap = fullnameProvider.typeFullname(binding.pattern).getOrElse(typeFullName)
+        registerType(tpeFromTypeMap)
+        val localNode_ = localNode(binding, info.localName, info.localName, tpeFromTypeMap).order(0)
+        scope.addVariable(info.localName, localNode_, tpeFromTypeMap, scopeType)
+        diffGraph.addEdge(localParent, localNode_, EdgeTypes.AST)
+
+        val localIdentNode = identifierNode(binding, info.localName, info.localName, tpeFromTypeMap)
+        scope.addVariableReference(info.localName, localIdentNode, tpeFromTypeMap, EvaluationStrategies.BY_REFERENCE)
+
+        val tmpIdent = identifierNode(binding, tmpName, tmpName, Defines.Any)
+        scope.addVariableReference(tmpName, tmpIdent, Defines.Any, EvaluationStrategies.BY_REFERENCE)
+        List(createAssignmentCallAst(binding, Ast(localIdentNode), Ast(tmpIdent), s"${info.localName} = $tmpName"))
+      case _ => List.empty
+    }
   }
 
 }

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstCreatorHelper.scala
@@ -185,19 +185,6 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
           val unwraps = buildUnwrapAssignments(bindingInfos)
           (condAst, unwraps)
         },
-        // Handles mixed optional binding constructs with both simple and tuple patterns.
-        //
-        // De-sugars `guard let a = foo(), let (b, c) = bar() else { exit }` into:
-        //   Condition:  { (<tmp>0 = foo()) != nil }
-        //   Then block: { let a = <tmp>0; let (b, c) = bar() }
-        onMixed = (simpleBindings, tupleBindings) => {
-          val bindingInfos = collectBindingInfos(simpleBindings)
-          val condAst      = buildOptionalBindingCondition(guardStmt, bindingInfos)
-          scope.pushNewBlockScope(thenBlockNode)
-          localAstParentStack.push(thenBlockNode)
-          val unwraps = buildUnwrapAssignments(bindingInfos) ++ tupleBindings.map(astForNode)
-          (condAst, unwraps)
-        },
         // Handles partial optional binding desugaring with other conditions.
         //
         // De-sugars `guard let a = foo(), someCondition else { exit }` into:
@@ -729,7 +716,6 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
   protected def handleOptionalBindingConditions[T](
     conditions: Iterable[ConditionElementSyntax],
     onAllSimple: Seq[OptionalBindingConditionSyntax] => T,
-    onMixed: (Seq[OptionalBindingConditionSyntax], Seq[OptionalBindingConditionSyntax]) => T,
     onPartial: (
       Seq[OptionalBindingConditionSyntax],
       Seq[OptionalBindingConditionSyntax],

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForExprSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForExprSyntaxCreator.scala
@@ -504,8 +504,6 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     handleOptionalBindingConditions(
       node.conditions.children,
       onAllSimple = simpleBindings => astForIfLetExprSyntax(node, ifNode, simpleBindings, node.body, node.elseBody),
-      onMixed = (simpleBindings, tupleBindings) =>
-        astForIfLetExprSyntaxMixed(node, ifNode, simpleBindings, tupleBindings, node.body, node.elseBody),
       onPartial = (simpleBindings, tupleBindings, otherConditions) =>
         astForIfLetExprSyntaxPartial(
           node,
@@ -555,30 +553,6 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     val bindingInfos = collectBindingInfos(optionalBindings)
     val conditionAst = buildOptionalBindingCondition(node, bindingInfos)
     val thenAst      = buildBodyWithUnwrapping(thenBody, thenBody.statements.children, bindingInfos)
-    val elseAst      = elseBody.map(astForNode)
-
-    ifThenElseAst(ifNode, Option(conditionAst), thenAst, elseAst)
-  }
-
-  /** Handles mixed optional binding constructs with both simple and tuple patterns.
-    *
-    * De-sugars `if let a = foo(), let (b, c) = bar() { body }` into:
-    *
-    * Condition: { (<tmp>0 = foo()) != nil }
-    *
-    * Then block: { let a = <tmp>0; let (b, c) = bar(); body }
-    */
-  private def astForIfLetExprSyntaxMixed(
-    node: IfExprSyntax,
-    ifNode: NewControlStructure,
-    simpleBindings: Seq[OptionalBindingConditionSyntax],
-    tupleBindings: Seq[OptionalBindingConditionSyntax],
-    thenBody: CodeBlockSyntax,
-    elseBody: Option[IfExprSyntax | CodeBlockSyntax]
-  ): Ast = {
-    val bindingInfos = collectBindingInfos(simpleBindings)
-    val conditionAst = buildOptionalBindingCondition(node, bindingInfos)
-    val thenAst      = buildBodyWithUnwrapping(thenBody, tupleBindings ++ thenBody.statements.children, bindingInfos)
     val elseAst      = elseBody.map(astForNode)
 
     ifThenElseAst(ifNode, Option(conditionAst), thenAst, elseAst)

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForExprSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForExprSyntaxCreator.scala
@@ -822,8 +822,10 @@ trait AstForExprSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     * identifier/field-identifier nodes so the resulting AST can be safely used as an argument without node-sharing
     * issues.
     */
-  private def createFieldAccessChain(baseName: String, fields: List[String], node: SwiftNode): Ast = {
-    val baseAst = Ast(identifierNode(node, baseName))
+  protected def createFieldAccessChain(baseName: String, fields: List[String], node: SwiftNode): Ast = {
+    val baseNode = identifierNode(node, baseName)
+    val baseAst  = Ast(baseNode)
+    scope.addVariableReference(baseName, baseNode, baseNode.typeFullName, EvaluationStrategies.BY_REFERENCE)
     fields.foldLeft(baseAst) { (accAst, field) =>
       createFieldAccessCallAst(node, accAst, fieldIdentifierNode(node, field, field))
     }

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForStmtSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForStmtSyntaxCreator.scala
@@ -613,12 +613,9 @@ trait AstForStmtSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
   }
 
   private def astForWhileStmtSyntax(node: WhileStmtSyntax): Ast = {
-    val code = this.code(node)
-
     handleOptionalBindingConditions(
       node.conditions.children,
       onAllSimple = simpleBindings => astForWhileLetStmtSyntax(node, simpleBindings),
-      onMixed = (simpleBindings, tupleBindings) => astForWhileLetStmtSyntaxMixed(node, simpleBindings, tupleBindings),
       onPartial = (simpleBindings, tupleBindings, otherConditions) =>
         astForWhileLetStmtSyntaxPartial(node, simpleBindings, tupleBindings, otherConditions),
       onStandard = () => {
@@ -627,7 +624,7 @@ trait AstForStmtSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
         whileAst(
           Option(conditionAst),
           Seq(bodyAst),
-          code = Option(code),
+          code = Option(code(node)),
           lineNumber = line(node),
           columnNumber = column(node)
         )
@@ -662,33 +659,6 @@ trait AstForStmtSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     val bindingInfos = collectBindingInfos(optionalBindings)
     val conditionAst = buildOptionalBindingCondition(node, bindingInfos)
     val bodyAst      = buildBodyWithUnwrapping(node.body, node.body.statements.children, bindingInfos)
-
-    whileAst(
-      Option(conditionAst),
-      Seq(bodyAst),
-      code = Option(code(node)),
-      lineNumber = line(node),
-      columnNumber = column(node)
-    )
-  }
-
-  /** Handles mixed optional binding constructs with both simple and tuple patterns.
-    *
-    * De-sugars `while let a = foo(), let (b, c) = bar() { body }` into:
-    *
-    * Condition: { (<tmp>0 = foo()) != nil }
-    *
-    * Loop body: { let a = <tmp>0; let (b, c) = bar(); body }
-    */
-  private def astForWhileLetStmtSyntaxMixed(
-    node: WhileStmtSyntax,
-    simpleBindings: Seq[OptionalBindingConditionSyntax],
-    tupleBindings: Seq[OptionalBindingConditionSyntax]
-  ): Ast = {
-    val bindingInfos = collectBindingInfos(simpleBindings)
-    val conditionAst = buildOptionalBindingCondition(node, bindingInfos)
-    val bodyAst      = buildBodyWithUnwrapping(node.body, tupleBindings ++ node.body.statements.children, bindingInfos)
-
     whileAst(
       Option(conditionAst),
       Seq(bodyAst),

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/GuardTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/GuardTests.scala
@@ -544,6 +544,145 @@ class GuardTests extends SwiftSrc2CpgSuite {
       elseReturn.code shouldBe "return"
     }
 
+    "testGuardLetPureTuple" in {
+      val cpg = code("""
+      |func test() {
+      |  guard let (a, b) = foo() else { return }
+      |  print(a, b)
+      |}
+      |""".stripMargin)
+      val List(methodBlock) = cpg.method.nameExact("test").block.l
+
+      val List(tmpLocal) = methodBlock.local.nameNot("self", "a", "b").l
+      val tmpName        = tmpLocal.name
+      tmpName shouldBe "<tmp>0"
+
+      val List(guardIf) = methodBlock.astChildren.isControlStructure.controlStructureType(ControlStructureTypes.IF).l
+
+      // Condition: { (<tmp>0 = foo()) != nil }
+      val List(condBlock) = guardIf.condition.isBlock.l
+      val List(condCheck) = condBlock.astChildren.isCall.nameExact(Operators.notEquals).l
+      condCheck.code shouldBe s"($tmpName = foo()) != nil"
+
+      // Then block contains a = <tmp>0.0 and b = <tmp>0.1
+      val List(thenBlock) = guardIf.whenTrue.isBlock.l
+
+      val List(aAssign) = thenBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact(s"a = $tmpName.0").l
+      aAssign.argument(1).code shouldBe "a"
+      aAssign.argument(2).code shouldBe s"$tmpName.0"
+
+      val List(bAssign) = thenBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact(s"b = $tmpName.1").l
+      bAssign.argument(1).code shouldBe "b"
+      bAssign.argument(2).code shouldBe s"$tmpName.1"
+
+      val List(printCall) = thenBlock.astChildren.isCall.nameExact("print").l
+      printCall.code shouldBe "print(a, b)"
+
+      val List(returnNode) = guardIf.whenFalse.isReturn.l
+      returnNode.code shouldBe "return"
+    }
+
+    "testGuardLetMixedWithTuplePattern" in {
+      val cpg = code("""
+      |func test() {
+      |  guard let a = foo(), let (b, c) = bar() else { return }
+      |  print(a, b, c)
+      |}
+      |""".stripMargin)
+      val List(methodBlock) = cpg.method.nameExact("test").block.l
+
+      val List(tmp0Local, tmp1Local) = methodBlock.local.nameNot("self", "a", "b", "c").l
+      val tmp0Name                   = tmp0Local.name
+      val tmp1Name                   = tmp1Local.name
+      tmp0Name shouldBe "<tmp>0"
+      tmp1Name shouldBe "<tmp>1"
+
+      val List(guardIf) = methodBlock.astChildren.isControlStructure.controlStructureType(ControlStructureTypes.IF).l
+
+      // Condition: { (<tmp>0 = foo()) != nil && (<tmp>1 = bar()) != nil }
+      val List(condBlock) = guardIf.condition.isBlock.l
+      val List(andCheck)  = condBlock.astChildren.isCall.nameExact(Operators.logicalAnd).l
+      andCheck.argument(1).code shouldBe s"($tmp0Name = foo()) != nil"
+      andCheck.argument(2).code shouldBe s"($tmp1Name = bar()) != nil"
+
+      // Then block: { a = <tmp>0; b = <tmp>1.0; c = <tmp>1.1; print(a, b, c) }
+      val List(thenBlock) = guardIf.whenTrue.isBlock.l
+
+      val List(aLocal) = thenBlock.astChildren.isLocal.nameExact("a").l
+      aLocal.name shouldBe "a"
+
+      val List(unwrapA) = thenBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact(s"a = $tmp0Name").l
+      unwrapA.argument(1).code shouldBe "a"
+      unwrapA.argument(2).code shouldBe tmp0Name
+
+      val List(bAssign) = thenBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact(s"b = $tmp1Name.0").l
+      bAssign.argument(1).code shouldBe "b"
+      bAssign.argument(2).code shouldBe s"$tmp1Name.0"
+
+      val List(cAssign) = thenBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact(s"c = $tmp1Name.1").l
+      cAssign.argument(1).code shouldBe "c"
+      cAssign.argument(2).code shouldBe s"$tmp1Name.1"
+
+      val List(printCall) = thenBlock.astChildren.isCall.nameExact("print").l
+      printCall.code shouldBe "print(a, b, c)"
+
+      val List(returnNode) = guardIf.whenFalse.isReturn.l
+      returnNode.code shouldBe "return"
+    }
+
+    "testGuardLetTupleWithDependentBinding" in {
+      val cpg = code("""
+      |func test() {
+      |  guard let (a, b) = foo(), let c = a.bar() else { return }
+      |  print(a, b, c)
+      |}
+      |""".stripMargin)
+      val List(methodBlock) = cpg.method.nameExact("test").block.l
+
+      // <tmp>0 is allocated for a.bar(), <tmp>1 for the tuple binding foo()
+      val List(cTmpLocal, tupleTmpLocal) = methodBlock.local.nameNot("self", "a", "b", "c").l
+      cTmpLocal.name shouldBe "<tmp>0"
+      tupleTmpLocal.name shouldBe "<tmp>1"
+
+      val List(guardIf)   = methodBlock.astChildren.isControlStructure.controlStructureType(ControlStructureTypes.IF).l
+      val List(condBlock) = guardIf.condition.isBlock.l
+
+      // Condition: { (<tmp>0 = a.bar()) != nil && (<tmp>1 = foo()) != nil }
+      // where a.bar() structurally uses <tmp>1.0 as the receiver
+      val List(andCheck) = condBlock.astChildren.isCall.nameExact(Operators.logicalAnd).l
+      andCheck.argument(1).code shouldBe "(<tmp>0 = a.bar()) != nil"
+      andCheck.argument(2).code shouldBe "(<tmp>1 = foo()) != nil"
+
+      // The receiver of bar() in the condition is <tmp>1.0 (tuple field access), not a plain 'a'
+      val List(barCall) = condBlock.ast.isCall.nameExact("bar").l
+      barCall.code shouldBe "a.bar()"
+      val List(barReceiver) = barCall.argument.isCall.nameExact(Operators.fieldAccess).l
+      barReceiver.code shouldBe "<tmp>1.0"
+
+      // Then block: { c = <tmp>0; a = <tmp>1.0; b = <tmp>1.1; print(a, b, c) }
+      val List(thenBlock) = guardIf.whenTrue.isBlock.l
+
+      thenBlock.astChildren.isLocal.name.sorted shouldBe Seq("a", "b", "c")
+
+      val List(cAssign) = thenBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact("c = <tmp>0").l
+      cAssign.argument(1).code shouldBe "c"
+      cAssign.argument(2).code shouldBe "<tmp>0"
+
+      val List(aAssign) = thenBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact("a = <tmp>1.0").l
+      aAssign.argument(1).code shouldBe "a"
+      aAssign.argument(2).code shouldBe "<tmp>1.0"
+
+      val List(bAssign) = thenBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact("b = <tmp>1.1").l
+      bAssign.argument(1).code shouldBe "b"
+      bAssign.argument(2).code shouldBe "<tmp>1.1"
+
+      val List(printCall) = thenBlock.astChildren.isCall.nameExact("print").l
+      printCall.code shouldBe "print(a, b, c)"
+
+      val List(returnNode) = guardIf.whenFalse.isReturn.l
+      returnNode.code shouldBe "return"
+    }
+
     "testGuardLetWithOtherConditions" in {
       val cpg = code("""
       |func test(flag: Bool) {

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/GuardTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/GuardTests.scala
@@ -656,8 +656,10 @@ class GuardTests extends SwiftSrc2CpgSuite {
       // The receiver of bar() in the condition is <tmp>1.0 (tuple field access), not a plain 'a'
       val List(barCall) = condBlock.ast.isCall.nameExact("bar").l
       barCall.code shouldBe "a.bar()"
-      val List(barReceiver) = barCall.argument.isCall.nameExact(Operators.fieldAccess).l
+      val List(barReceiver) = barCall.receiver.isCall.nameExact(Operators.fieldAccess).l
       barReceiver.code shouldBe "<tmp>1.0"
+      barReceiver.argumentIndex shouldBe 0
+      barCall.argument(0).code shouldBe "<tmp>1.0"
 
       // Then block: { c = <tmp>0; a = <tmp>1.0; b = <tmp>1.1; print(a, b, c) }
       val List(thenBlock) = guardIf.whenTrue.isBlock.l
@@ -732,6 +734,48 @@ class GuardTests extends SwiftSrc2CpgSuite {
 
       val List(elseReturn) = guardIf.whenFalse.l
       elseReturn.code shouldBe "return"
+    }
+
+    "testGuardLetNestedTuple" in {
+      val cpg = code("""
+      |func test() {
+      |  guard let ((a, b), c) = foo() else { return }
+      |  print(a, b, c)
+      |}
+      |""".stripMargin)
+      val List(methodBlock) = cpg.method.nameExact("test").block.l
+
+      val List(tmpLocal) = methodBlock.local.nameNot("self", "a", "b", "c").l
+      tmpLocal.name shouldBe "<tmp>0"
+
+      val List(guardIf)   = methodBlock.astChildren.isControlStructure.controlStructureType(ControlStructureTypes.IF).l
+      val List(condBlock) = guardIf.condition.isBlock.l
+
+      // Condition: { (<tmp>0 = foo()) != nil }
+      val List(nilCheck) = condBlock.astChildren.isCall.nameExact(Operators.notEquals).l
+      nilCheck.code shouldBe "(<tmp>0 = foo()) != nil"
+
+      // Then block: { a = <tmp>0.0.0; b = <tmp>0.0.1; c = <tmp>0.1; print(a, b, c) }
+      val List(thenBlock) = guardIf.whenTrue.isBlock.l
+      thenBlock.astChildren.isLocal.name.sorted shouldBe Seq("a", "b", "c")
+
+      val List(aAssign) = thenBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact("a = <tmp>0.0.0").l
+      aAssign.argument(1).code shouldBe "a"
+      aAssign.argument(2).code shouldBe "<tmp>0.0.0"
+
+      val List(bAssign) = thenBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact("b = <tmp>0.0.1").l
+      bAssign.argument(1).code shouldBe "b"
+      bAssign.argument(2).code shouldBe "<tmp>0.0.1"
+
+      val List(cAssign) = thenBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact("c = <tmp>0.1").l
+      cAssign.argument(1).code shouldBe "c"
+      cAssign.argument(2).code shouldBe "<tmp>0.1"
+
+      val List(printCall) = thenBlock.astChildren.isCall.nameExact("print").l
+      printCall.code shouldBe "print(a, b, c)"
+
+      val List(returnNode) = guardIf.whenFalse.isReturn.l
+      returnNode.code shouldBe "return"
     }
 
   }

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/MatchingPatternsTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/MatchingPatternsTests.scala
@@ -458,22 +458,32 @@ class MatchingPatternsTests extends SwiftSrc2CpgSuite {
         |  }
         |}
         |""".stripMargin)
-      val List(ifNode)                      = cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).l
-      val condBlock                         = ifNode.condition.isBlock.l.head
-      val tmpName                           = condBlock.ast.isLocal.name.filter(_.startsWith("<tmp>")).loneElement
-      val List(_)                           = condBlock.ast.isLocal.nameExact("a").l
-      val List(_)                           = condBlock.ast.isLocal.nameExact("b").l
-      val List(tmpAssign, assignA, assignB) = condBlock.astChildren.isCall.nameExact(Operators.assignment).l
-      tmpAssign.code shouldBe s"$tmpName = x"
-      tmpAssign.order shouldBe 1
-      assignA.code shouldBe s"a = $tmpName.0"
-      assignA.order shouldBe 2
-      assignB.code shouldBe s"b = $tmpName.1"
-      assignB.order shouldBe 3
-      val isTupleOp         = Defines.createIsTupleOperator(2)
-      val List(isTupleCall) = condBlock.astChildren.isCall.nameExact(isTupleOp).l
-      isTupleCall.code shouldBe s"$isTupleOp($tmpName)"
-      isTupleCall.order shouldBe 4
+      val List(methodBlock) = cpg.method.nameExact("foo").block.l
+      val List(tmpLocal)    = methodBlock.local.nameNot("self", "x").l
+      val tmpName           = tmpLocal.name
+      tmpName shouldBe "<tmp>0"
+
+      val List(ifNode) = cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).l
+
+      // Condition: { (<tmp>0 = x) != nil }
+      val List(condBlock) = ifNode.condition.isBlock.l
+      val List(condCheck) = condBlock.astChildren.isCall.nameExact(Operators.notEquals).l
+      condCheck.code shouldBe s"($tmpName = x) != nil"
+
+      // Then block: { a = <tmp>0.0; b = <tmp>0.1; print(a); print(b) }
+      val List(thenBlock) = ifNode.whenTrue.isBlock.l
+
+      val List(assignA) = thenBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact(s"a = $tmpName.0").l
+      assignA.argument(1).code shouldBe "a"
+      assignA.argument(2).code shouldBe s"$tmpName.0"
+
+      val List(assignB) = thenBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact(s"b = $tmpName.1").l
+      assignB.argument(1).code shouldBe "b"
+      assignB.argument(2).code shouldBe s"$tmpName.1"
+
+      val List(printA, printB) = thenBlock.astChildren.isCall.nameExact("print").l
+      printA.code shouldBe "print(a)"
+      printB.code shouldBe "print(b)"
     }
 
   }

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/StatementTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/StatementTests.scala
@@ -646,8 +646,10 @@ class StatementTests extends SwiftSrc2CpgSuite {
       // The receiver of bar() in the condition is <tmp>1.0 (tuple field access), not a plain 'a'
       val List(barCall) = condBlock.ast.isCall.nameExact("bar").l
       barCall.code shouldBe "a.bar()"
-      val List(barReceiver) = barCall.argument.isCall.nameExact(Operators.fieldAccess).l
+      val List(barReceiver) = barCall.receiver.isCall.nameExact(Operators.fieldAccess).l
       barReceiver.code shouldBe "<tmp>1.0"
+      barReceiver.argumentIndex shouldBe 0
+      barCall.argument(0).code shouldBe "<tmp>1.0"
 
       // Then block: { c = <tmp>0; a = <tmp>1.0; b = <tmp>1.1; print(a, b, c) }
       val List(thenBlock) = ifNode.whenTrue.isBlock.l

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/StatementTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/StatementTests.scala
@@ -469,31 +469,24 @@ class StatementTests extends SwiftSrc2CpgSuite {
       |}
       |""".stripMargin)
       val List(methodBlock) = cpg.method.nameExact("test").block.l
-      // After desugaring: <tmp>0 in method block
-      // FIXME: because optional tuple bindings are not handled yet the default handling
-      // (which is wrong) will not create correct locals and the arguments to print end up
-      // creating locals in the method block.
-      val List(tmp0Local) = methodBlock.local.nameNot("self", "b", "c").l
-      val tmp0Name        = tmp0Local.name
+      // Two tmp locals: <tmp>0 for foo(), <tmp>1 for bar()
+      val List(tmp0Local, tmp1Local) = methodBlock.local.nameNot("self").l
+      val tmp0Name                   = tmp0Local.name
+      val tmp1Name                   = tmp1Local.name
       tmp0Name shouldBe "<tmp>0"
+      tmp1Name shouldBe "<tmp>1"
 
       val List(ifNode) = cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).l
 
-      // Condition: { (<tmp>0 = foo()) != nil } (tuple pattern excluded from condition)
+      // Condition: { (<tmp>0 = foo()) != nil && (<tmp>1 = bar()) != nil }
       val List(condBlock) = ifNode.condition.isBlock.l
+      val List(andCheck)  = condBlock.astChildren.isCall.nameExact(Operators.logicalAnd).l
+      andCheck.argument(1).code shouldBe s"($tmp0Name = foo()) != nil"
+      andCheck.argument(2).code shouldBe s"($tmp1Name = bar()) != nil"
 
-      val List(check1) = condBlock.astChildren.isCall.nameExact(Operators.notEquals).l
-      check1.code shouldBe s"($tmp0Name = foo()) != nil"
-
-      val List(assign1) = check1.argument.assignment.l
-      assign1.code shouldBe s"$tmp0Name = foo()"
-      assign1.argument(1).code shouldBe tmp0Name
-      assign1.argument(2).code shouldBe "foo()"
-
-      // Then block: { a = <tmp>0; let (b, c) = bar(); print(a, b, c) }
+      // Then block: { a = <tmp>0; b = <tmp>1.0; c = <tmp>1.1; print(a, b, c) }
       val List(thenBlock) = ifNode.whenTrue.isBlock.l
 
-      // First child: unwrapping assignment for 'a'
       val List(aLocal) = thenBlock.astChildren.isLocal.nameExact("a").l
       aLocal.name shouldBe "a"
 
@@ -501,13 +494,13 @@ class StatementTests extends SwiftSrc2CpgSuite {
       unwrapA.argument(1).code shouldBe "a"
       unwrapA.argument(2).code shouldBe tmp0Name
 
-      // Second child: tuple binding block for (b, c) = bar()
-      // The tuple binding creates a nested block with tmp assignment + tuple destructuring
-      val List(tupleBindingBlock) = thenBlock.astChildren.isBlock.l
+      val List(bAssign) = thenBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact(s"b = $tmp1Name.0").l
+      bAssign.argument(1).code shouldBe "b"
+      bAssign.argument(2).code shouldBe s"$tmp1Name.0"
 
-      // Inside the tuple binding block, there should be an assignment involving bar()
-      val List(barAssignment) = tupleBindingBlock.astChildren.isCall.nameExact(Operators.assignment).code(".*bar.*").l
-      barAssignment.code should include("bar()")
+      val List(cAssign) = thenBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact(s"c = $tmp1Name.1").l
+      cAssign.argument(1).code shouldBe "c"
+      cAssign.argument(2).code shouldBe s"$tmp1Name.1"
     }
 
     "testWhileLetMixedWithTuplePattern" in {
@@ -518,32 +511,24 @@ class StatementTests extends SwiftSrc2CpgSuite {
       |  }
       |}
       |""".stripMargin)
-      val List(methodBlock) = cpg.method.nameExact("test").block.l
-      // After desugaring: <tmp>0 in method block
-      // FIXME: because optional tuple bindings are not handled yet the default handling
-      // (which is wrong) will not create correct locals and the arguments to print end up
-      // creating locals in the method block.
-      val List(tmp0Local) = methodBlock.local.nameNot("self", "b", "c").l
-      val tmp0Name        = tmp0Local.name
+      val List(methodBlock)          = cpg.method.nameExact("test").block.l
+      val List(tmp0Local, tmp1Local) = methodBlock.local.nameNot("self").l
+      val tmp0Name                   = tmp0Local.name
+      val tmp1Name                   = tmp1Local.name
       tmp0Name shouldBe "<tmp>0"
+      tmp1Name shouldBe "<tmp>1"
 
       val List(whileNode) = cpg.controlStructure.controlStructureType(ControlStructureTypes.WHILE).l
 
-      // Condition: { (<tmp>0 = foo()) != nil } (tuple pattern excluded from condition)
+      // Condition: { (<tmp>0 = foo()) != nil && (<tmp>1 = bar()) != nil }
       val List(condBlock) = whileNode.condition.isBlock.l
+      val List(andCheck)  = condBlock.astChildren.isCall.nameExact(Operators.logicalAnd).l
+      andCheck.argument(1).code shouldBe s"($tmp0Name = foo()) != nil"
+      andCheck.argument(2).code shouldBe s"($tmp1Name = bar()) != nil"
 
-      val List(check1) = condBlock.astChildren.isCall.nameExact(Operators.notEquals).l
-      check1.code shouldBe s"($tmp0Name = foo()) != nil"
-
-      val List(assign1) = check1.argument.assignment.l
-      assign1.code shouldBe s"$tmp0Name = foo()"
-      assign1.argument(1).code shouldBe tmp0Name
-      assign1.argument(2).code shouldBe "foo()"
-
-      // Loop body: { a = <tmp>0; let (b, c) = bar(); print(a, b, c) }
+      // Body: { a = <tmp>0; b = <tmp>1.0; c = <tmp>1.1; print(a, b, c) }
       val List(bodyBlock) = whileNode.whenTrue.isBlock.l
 
-      // First child: unwrapping assignment for 'a'
       val List(aLocal) = bodyBlock.astChildren.isLocal.nameExact("a").l
       aLocal.name shouldBe "a"
 
@@ -551,13 +536,200 @@ class StatementTests extends SwiftSrc2CpgSuite {
       unwrapA.argument(1).code shouldBe "a"
       unwrapA.argument(2).code shouldBe tmp0Name
 
-      // Second child: tuple binding block for (b, c) = bar()
-      // The tuple binding creates a nested block with tmp assignment + tuple destructuring
-      val List(tupleBindingBlock) = bodyBlock.astChildren.isBlock.l
+      val List(bAssign) = bodyBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact(s"b = $tmp1Name.0").l
+      bAssign.argument(1).code shouldBe "b"
+      bAssign.argument(2).code shouldBe s"$tmp1Name.0"
 
-      // Inside the tuple binding block, there should be an assignment involving bar()
-      val List(barAssignment) = tupleBindingBlock.astChildren.isCall.nameExact(Operators.assignment).code(".*bar.*").l
-      barAssignment.code should include("bar()")
+      val List(cAssign) = bodyBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact(s"c = $tmp1Name.1").l
+      cAssign.argument(1).code shouldBe "c"
+      cAssign.argument(2).code shouldBe s"$tmp1Name.1"
+    }
+
+    "testIfLetPureTuple" in {
+      val cpg = code("""
+      |func test() {
+      |  if let (a, b) = foo() {
+      |    print(a, b)
+      |  }
+      |}
+      |""".stripMargin)
+      val List(methodBlock) = cpg.method.nameExact("test").block.l
+      // tmp variable in method block for nil check
+      val List(tmpLocal) = methodBlock.local.nameNot("self").l
+      val tmpName        = tmpLocal.name
+      tmpName shouldBe "<tmp>0"
+
+      val List(ifNode) = cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).l
+
+      // Condition: { (<tmp>0 = foo()) != nil }
+      val List(condBlock) = ifNode.condition.isBlock.l
+      val List(condCheck) = condBlock.astChildren.isCall.nameExact(Operators.notEquals).l
+      condCheck.code shouldBe s"($tmpName = foo()) != nil"
+
+      val List(condAssign) = condCheck.argument.assignment.l
+      condAssign.code shouldBe s"$tmpName = foo()"
+
+      // Then block: { a = <tmp>0.0; b = <tmp>0.1; print(a, b) }
+      val List(thenBlock) = ifNode.whenTrue.isBlock.l
+
+      val List(aAssign) = thenBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact(s"a = $tmpName.0").l
+      aAssign.argument(1).code shouldBe "a"
+      aAssign.argument(2).code shouldBe s"$tmpName.0"
+
+      val List(bAssign) = thenBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact(s"b = $tmpName.1").l
+      bAssign.argument(1).code shouldBe "b"
+      bAssign.argument(2).code shouldBe s"$tmpName.1"
+
+      val List(printCall) = thenBlock.astChildren.isCall.nameExact("print").l
+      printCall.code shouldBe "print(a, b)"
+    }
+
+    "testWhileLetPureTuple" in {
+      val cpg = code("""
+      |func test() {
+      |  while let (a, b) = foo() {
+      |    print(a, b)
+      |  }
+      |}
+      |""".stripMargin)
+      val List(methodBlock) = cpg.method.nameExact("test").block.l
+      val List(tmpLocal)    = methodBlock.local.nameNot("self").l
+      val tmpName           = tmpLocal.name
+      tmpName shouldBe "<tmp>0"
+
+      val List(whileNode) = cpg.controlStructure.controlStructureType(ControlStructureTypes.WHILE).l
+
+      // Condition: { (<tmp>0 = foo()) != nil }
+      val List(condBlock) = whileNode.condition.isBlock.l
+      val List(condCheck) = condBlock.astChildren.isCall.nameExact(Operators.notEquals).l
+      condCheck.code shouldBe s"($tmpName = foo()) != nil"
+
+      // Body: { a = <tmp>0.0; b = <tmp>0.1; print(a, b) }
+      val List(bodyBlock) = whileNode.whenTrue.isBlock.l
+
+      val List(aAssign) = bodyBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact(s"a = $tmpName.0").l
+      aAssign.argument(1).code shouldBe "a"
+      aAssign.argument(2).code shouldBe s"$tmpName.0"
+
+      val List(bAssign) = bodyBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact(s"b = $tmpName.1").l
+      bAssign.argument(1).code shouldBe "b"
+      bAssign.argument(2).code shouldBe s"$tmpName.1"
+
+      val List(printCall) = bodyBlock.astChildren.isCall.nameExact("print").l
+      printCall.code shouldBe "print(a, b)"
+    }
+
+    "testIfLetTupleWithDependentBinding" in {
+      val cpg = code("""
+      |func test() {
+      |  if let (a, b) = foo(), let c = a.bar() {
+      |    print(a, b, c)
+      |  }
+      |}
+      |""".stripMargin)
+      val List(methodBlock) = cpg.method.nameExact("test").block.l
+
+      // <tmp>0 is allocated for a.bar(), <tmp>1 for the tuple binding foo()
+      val List(cTmpLocal, tupleTmpLocal) = methodBlock.local.nameNot("self", "a", "b", "c").l
+      cTmpLocal.name shouldBe "<tmp>0"
+      tupleTmpLocal.name shouldBe "<tmp>1"
+
+      val List(ifNode)    = cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).l
+      val List(condBlock) = ifNode.condition.isBlock.l
+
+      // Condition: { (<tmp>0 = a.bar()) != nil && (<tmp>1 = foo()) != nil }
+      // where a.bar() structurally uses <tmp>1.0 as the receiver
+      val List(andCheck) = condBlock.astChildren.isCall.nameExact(Operators.logicalAnd).l
+      andCheck.argument(1).code shouldBe "(<tmp>0 = a.bar()) != nil"
+      andCheck.argument(2).code shouldBe "(<tmp>1 = foo()) != nil"
+
+      // The receiver of bar() in the condition is <tmp>1.0 (tuple field access), not a plain 'a'
+      val List(barCall) = condBlock.ast.isCall.nameExact("bar").l
+      barCall.code shouldBe "a.bar()"
+      val List(barReceiver) = barCall.argument.isCall.nameExact(Operators.fieldAccess).l
+      barReceiver.code shouldBe "<tmp>1.0"
+
+      // Then block: { c = <tmp>0; a = <tmp>1.0; b = <tmp>1.1; print(a, b, c) }
+      val List(thenBlock) = ifNode.whenTrue.isBlock.l
+
+      thenBlock.astChildren.isLocal.name.sorted shouldBe Seq("a", "b", "c")
+
+      val List(cAssign) = thenBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact("c = <tmp>0").l
+      cAssign.argument(1).code shouldBe "c"
+      cAssign.argument(2).code shouldBe "<tmp>0"
+
+      val List(aAssign) = thenBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact("a = <tmp>1.0").l
+      aAssign.argument(1).code shouldBe "a"
+      aAssign.argument(2).code shouldBe "<tmp>1.0"
+
+      val List(bAssign) = thenBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact("b = <tmp>1.1").l
+      bAssign.argument(1).code shouldBe "b"
+      bAssign.argument(2).code shouldBe "<tmp>1.1"
+
+      val List(printCall) = thenBlock.astChildren.isCall.nameExact("print").l
+      printCall.code shouldBe "print(a, b, c)"
+    }
+
+    "testIfLetNestedWithTuple" in {
+      val cpg = code("""
+      |func test() {
+      |  if let (a, b) = foo() {
+      |    if let c = bar(a) {
+      |      print(a, b, c)
+      |    }
+      |  }
+      |}
+      |""".stripMargin)
+      val List(methodBlock) = cpg.method.nameExact("test").block.l
+
+      // Outer method block: <tmp>0 for foo() tuple binding
+      val List(outerTmpLocal) = methodBlock.local.nameNot("self").l
+      outerTmpLocal.name shouldBe "<tmp>0"
+
+      val List(outerIf) = methodBlock.astChildren.isControlStructure.controlStructureType(ControlStructureTypes.IF).l
+      val List(outerCondBlock) = outerIf.condition.isBlock.l
+
+      // Outer condition: { (<tmp>0 = foo()) != nil }
+      val List(outerCondCheck) = outerCondBlock.astChildren.isCall.nameExact(Operators.notEquals).l
+      outerCondCheck.code shouldBe "(<tmp>0 = foo()) != nil"
+
+      // Outer then block: a = <tmp>0.0; b = <tmp>0.1; then inner if, plus <tmp>1 local for the inner binding
+      val List(outerThenBlock) = outerIf.whenTrue.isBlock.l
+
+      outerThenBlock.astChildren.isLocal.name.sorted shouldBe Seq("<tmp>1", "a", "b")
+
+      val List(aAssign) = outerThenBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact("a = <tmp>0.0").l
+      aAssign.argument(1).code shouldBe "a"
+      aAssign.argument(2).code shouldBe "<tmp>0.0"
+
+      val List(bAssign) = outerThenBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact("b = <tmp>0.1").l
+      bAssign.argument(1).code shouldBe "b"
+      bAssign.argument(2).code shouldBe "<tmp>0.1"
+
+      // Inner if: bar(a) uses 'a' as a plain identifier (not a field access)
+      // because by this point 'a' is already declared as a local in the outer then-block
+      val List(innerIf) = outerThenBlock.astChildren.isControlStructure.controlStructureType(ControlStructureTypes.IF).l
+      val List(innerCondBlock) = innerIf.condition.isBlock.l
+      val List(innerCondCheck) = innerCondBlock.astChildren.isCall.nameExact(Operators.notEquals).l
+      innerCondCheck.code shouldBe "(<tmp>1 = bar(a)) != nil"
+
+      // 'a' in bar(a) is a plain identifier reference, not a field access
+      val List(barCall) = innerCondBlock.ast.isCall.nameExact("bar").l
+      barCall.code shouldBe "bar(a)"
+      val List(aArg) = barCall.argument.isIdentifier.nameNot("self").l
+      aArg.code shouldBe "a"
+
+      // Inner then block: { c = <tmp>1; print(a, b, c) }
+      val List(innerThenBlock) = innerIf.whenTrue.isBlock.l
+
+      innerThenBlock.astChildren.isLocal.name.loneElement shouldBe "c"
+
+      val List(cAssign) = innerThenBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact("c = <tmp>1").l
+      cAssign.argument(1).code shouldBe "c"
+      cAssign.argument(2).code shouldBe "<tmp>1"
+
+      val List(printCall) = innerThenBlock.astChildren.isCall.nameExact("print").l
+      printCall.code shouldBe "print(a, b, c)"
     }
 
     "testGuardLetNestedInIfLetBody" in {


### PR DESCRIPTION
Optional bindings with tuple patterns are now fully de-sugared, consistent with how simple optional bindings work.

- For `if let (a, b) = foo()`:

  Condition: `{ (<tmp>0 = foo()) != nil }`
  Then block: `{ a = <tmp>0.0; b = <tmp>0.1; ... }`

- For `if let a = foo(), let (b, c) = bar()`:

  Condition: `{ (<tmp>0 = foo()) != nil && (<tmp>1 = bar()) != nil }`
  Then block: `{ a = <tmp>0; b = <tmp>1.0; c = <tmp>1.1; ... }`

- For `if let (a, b) = foo(), let c = a.bar()` (dependent bindings):

  Condition: `{ (<tmp>0 = foo()) != nil && (<tmp>1 = <tmp>0.0.bar()) != nil }`
  Then block: `{ a = <tmp>0.0; b = <tmp>0.1; c = <tmp>1; ... }`

The same de-sugaring applies to while-let and guard-let. Nested tuples (e.g. `let ((a, b), c) = foo()`) produce the corresponding nested field accesses (`<tmp>0.0.0`, `<tmp>0.0.1`, `<tmp>0.1`).

buildbot is happy (.../builders/100/builds/90).