### PR TITLE
[swiftsrc2cpg] Implement de-sugaring for var/let tuple pattern assignments

### DIFF
--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForDeclSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForDeclSyntaxCreator.scala
@@ -1249,89 +1249,153 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     else { VariableScopeManager.ScopeType.MethodScope }
 
     val bindingAsts = variableDecl.bindings.children.flatMap { binding =>
-      val namesWithNode = binding.pattern match {
-        case expr: ExpressionPatternSyntax =>
-          notHandledYet(expr)
-          Seq((code(expr), expr))
-        case ident: IdentifierPatternSyntax =>
-          Seq((code(ident.identifier), ident))
-        case isType: IsTypePatternSyntax =>
-          notHandledYet(isType)
-          Seq((code(isType), isType))
-        case missing: MissingPatternSyntax =>
-          Seq((code(missing.placeholder), missing))
-        case tuple: TuplePatternSyntax =>
-          tuple.elements.children.map(c => (code(c.pattern), c))
-        case valueBinding: ValueBindingPatternSyntax =>
-          Seq((code(valueBinding.pattern), valueBinding))
-        case w: WildcardPatternSyntax =>
-          Seq((scopeLocalUniqueName("wildcard"), w))
+      val maybeTuplePattern: Option[TuplePatternSyntax] = binding.pattern match {
+        case tp: TuplePatternSyntax => Some(tp)
+        case vb: ValueBindingPatternSyntax =>
+          vb.pattern match {
+            case tp: TuplePatternSyntax => Some(tp)
+            case _                      => None
+          }
+        case _ => None
       }
 
-      namesWithNode.map { case (name, node) =>
-        val cleanedName    = AstCreatorHelper.cleanName(name)
-        val tpeFromTypeMap = fullnameProvider.typeFullname(node)
-        val tpeFromAst     = binding.typeAnnotation.map(t => AstCreatorHelper.cleanType(code(t.`type`)))
-        val typeFullName   = tpeFromTypeMap.orElse(tpeFromAst).getOrElse(Defines.Any)
-        registerType(typeFullName)
+      maybeTuplePattern match {
+        case Some(tuplePat) if binding.initializer.isDefined =>
+          // De-sugar: let/var (a, b) = source
+          //   => <tmp>N = source
+          //      a = <tmp>N.0
+          //      b = <tmp>N.1
+          //      (wildcards produce no local and no assignment)
+          val tmpName      = scopeLocalUniqueName("tmp")
+          val tmpLocalNode = localNode(binding, tmpName, tmpName, Defines.Any).order(0)
+          diffGraph.addEdge(localAstParentStack.head, tmpLocalNode, EdgeTypes.AST)
+          scope.addVariable(tmpName, tmpLocalNode, Defines.Any, VariableScopeManager.ScopeType.BlockScope)
 
-        if (!isTypeDeclMember) {
-          val nLocalNode = localNode(binding, cleanedName, cleanedName, typeFullName).order(0)
-          scope.addVariable(cleanedName, nLocalNode, typeFullName, scopeType)
-          diffGraph.addEdge(localAstParentStack.head, nLocalNode, EdgeTypes.AST)
-        }
+          val tmpIdentNode = identifierNode(binding, tmpName, tmpName, Defines.Any)
+          scope.addVariableReference(tmpName, tmpIdentNode, Defines.Any, EvaluationStrategies.BY_REFERENCE)
+          val initAst = astForNode(binding.initializer.get.value)
+          val tmpAssign = createAssignmentCallAst(
+            binding,
+            Ast(tmpIdentNode),
+            initAst,
+            s"$tmpName = ${code(binding.initializer.get.value)}"
+          )
+          val elemAssigns = astsForBindingTuplePattern(tuplePat, tmpName, List.empty, binding)
+          tmpAssign +: elemAssigns
+        case Some(tuplePat) =>
+          // No initializer: declare locals for every leaf, recursing into nested tuples.
+          def registerTupleLocals(pat: PatternSyntax): Seq[Ast] = pat match {
+            case innerTuple: TuplePatternSyntax =>
+              innerTuple.elements.children.flatMap(elem => registerTupleLocals(elem.pattern)).toSeq
+            case vb: ValueBindingPatternSyntax => registerTupleLocals(vb.pattern)
+            case _: WildcardPatternSyntax      => Seq.empty
+            case leafPat =>
+              val cleanedName  = AstCreatorHelper.cleanName(code(leafPat))
+              val typeFullName = fullnameProvider.typeFullname(leafPat).getOrElse(Defines.Any)
+              registerType(typeFullName)
+              val nLocalNode = localNode(binding, cleanedName, cleanedName, typeFullName).order(0)
+              scope.addVariable(cleanedName, nLocalNode, typeFullName, scopeType)
+              diffGraph.addEdge(localAstParentStack.head, nLocalNode, EdgeTypes.AST)
+              Seq.empty
+          }
+          registerTupleLocals(tuplePat)
+        case _ =>
+          val namesWithNode = binding.pattern match {
+            case expr: ExpressionPatternSyntax =>
+              notHandledYet(expr)
+              Seq((code(expr), expr))
+            case ident: IdentifierPatternSyntax =>
+              Seq((code(ident.identifier), ident))
+            case isType: IsTypePatternSyntax =>
+              notHandledYet(isType)
+              Seq((code(isType), isType))
+            case missing: MissingPatternSyntax =>
+              Seq((code(missing.placeholder), missing))
+            case valueBinding: ValueBindingPatternSyntax =>
+              Seq((code(valueBinding.pattern), valueBinding))
+            case w: WildcardPatternSyntax =>
+              Seq((scopeLocalUniqueName("wildcard"), w))
+            case other =>
+              notHandledYet(other)
+              Seq((code(other), other))
+          }
 
-        binding.accessorBlock.map(_.accessors).collect {
-          case accessorList: AccessorDeclListSyntax =>
-            accessorList.children.foreach(astForAccessor(_, name, typeFullName))
-          case block: CodeBlockItemListSyntax =>
-            astForAccessorBlock(block, name, typeFullName, binding)
-        }
+          namesWithNode.map { case (name, node) =>
+            val cleanedName    = AstCreatorHelper.cleanName(name)
+            val tpeFromTypeMap = fullnameProvider.typeFullname(node)
+            val tpeFromAst =
+              binding.typeAnnotation.map(typeAnnotation => AstCreatorHelper.cleanType(code(typeAnnotation.`type`)))
+            val typeFullName =
+              tpeFromTypeMap.orElse(tpeFromAst).getOrElse(Defines.Any)
+            registerType(typeFullName)
 
-        val initAsts = binding.initializer.map(astForNode).toSeq
-        if (initAsts.isEmpty) {
-          Ast()
-        } else {
-          val patternAst = if (!isTypeDeclMember) {
-            val attributeAsts = variableDecl.attributes.children.map(astForNode)
-            val modifiers =
-              variableDecl.modifiers.children.flatMap(c => astForNode(c).root.map(_.asInstanceOf[NewModifier]))
-
-            val patternIdentifier = identifierNode(binding.pattern, cleanedName).typeFullName(typeFullName)
-            scope.addVariableReference(cleanedName, patternIdentifier, typeFullName, EvaluationStrategies.BY_REFERENCE)
-            modifiers.foreach { mod =>
-              diffGraph.addEdge(patternIdentifier, mod, EdgeTypes.AST)
+            if (!isTypeDeclMember) {
+              val nLocalNode = localNode(binding, cleanedName, cleanedName, typeFullName).order(0)
+              scope.addVariable(cleanedName, nLocalNode, typeFullName, scopeType)
+              diffGraph.addEdge(localAstParentStack.head, nLocalNode, EdgeTypes.AST)
             }
-            attributeAsts.foreach { attrAst =>
-              Ast.storeInDiffGraph(attrAst, diffGraph)
-              attrAst.root.foreach { attr => diffGraph.addEdge(patternIdentifier, attr, EdgeTypes.AST) }
+
+            binding.accessorBlock.map(_.accessors).collect {
+              case accessorList: AccessorDeclListSyntax =>
+                accessorList.children.foreach(astForAccessor(_, name, typeFullName))
+              case block: CodeBlockItemListSyntax =>
+                astForAccessorBlock(block, name, typeFullName, binding)
             }
-            Ast(patternIdentifier)
-          } else {
-            val tpe = fullNameOfEnclosingTypeDecl()
-            val selfNode = if (scope.isInStaticMethodScope) {
-              typeRefNode(node, "Self", tpe)
+
+            val initAsts = binding.initializer.map(astForNode).toSeq
+            if (initAsts.isEmpty) {
+              Ast()
             } else {
-              val selfIdNode = identifierNode(node, "self", "self", tpe)
-              scope.addVariableReference("self", selfIdNode, selfIdNode.typeFullName, EvaluationStrategies.BY_REFERENCE)
-              selfIdNode
+              val patternAst = if (!isTypeDeclMember) {
+                val attributeAsts = variableDecl.attributes.children.map(astForNode)
+                val modifiers =
+                  variableDecl.modifiers.children.flatMap(astForNode(_).root.map(_.asInstanceOf[NewModifier]))
+                val patternIdentifier = identifierNode(binding.pattern, cleanedName).typeFullName(typeFullName)
+                scope.addVariableReference(
+                  cleanedName,
+                  patternIdentifier,
+                  typeFullName,
+                  EvaluationStrategies.BY_REFERENCE
+                )
+                modifiers.foreach { mod =>
+                  diffGraph.addEdge(patternIdentifier, mod, EdgeTypes.AST)
+                }
+                attributeAsts.foreach { attrAst =>
+                  Ast.storeInDiffGraph(attrAst, diffGraph)
+                  attrAst.root.foreach { attr => diffGraph.addEdge(patternIdentifier, attr, EdgeTypes.AST) }
+                }
+                Ast(patternIdentifier)
+              } else {
+                val tpe = fullNameOfEnclosingTypeDecl()
+                val selfNode = if (scope.isInStaticMethodScope) {
+                  typeRefNode(node, "Self", tpe)
+                } else {
+                  val selfIdNode = identifierNode(node, "self", "self", tpe)
+                  scope.addVariableReference(
+                    "self",
+                    selfIdNode,
+                    selfIdNode.typeFullName,
+                    EvaluationStrategies.BY_REFERENCE
+                  )
+                  selfIdNode
+                }
+                fieldAccessAst(node, node, Ast(selfNode), s"${selfNode.code}.$name", name, typeFullName)
+              }
+
+              val initCode = binding.initializer.map(init => s" ${code(init).strip()}").getOrElse("")
+              val typeCode = binding.typeAnnotation.map(typeAnnotation => code(typeAnnotation).strip()).getOrElse("")
+
+              val rhsAst = initAsts match {
+                case Nil         => Ast()
+                case head :: Nil => head
+                case others =>
+                  val block = blockNode(node, code(node), Defines.Any)
+                  blockAst(block, others.toList)
+              }
+
+              createAssignmentCallAst(binding, patternAst, rhsAst, s"$kind $cleanedName$typeCode$initCode".strip())
             }
-            fieldAccessAst(node, node, Ast(selfNode), s"${selfNode.code}.$name", name, typeFullName)
           }
-
-          val initCode = binding.initializer.fold("")(i => s" ${code(i).strip()}")
-          val typeCode = binding.typeAnnotation.fold("")(t => code(t).strip())
-
-          val rhsAst = initAsts match {
-            case Nil         => Ast()
-            case head :: Nil => head
-            case others =>
-              val block = blockNode(node, code(node), Defines.Any)
-              blockAst(block, others.toList)
-          }
-
-          createAssignmentCallAst(binding, patternAst, rhsAst, s"$kind $cleanedName$typeCode$initCode".strip())
-        }
       }
     }
 

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForDeclSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForDeclSyntaxCreator.scala
@@ -1249,6 +1249,9 @@ trait AstForDeclSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
     else { VariableScopeManager.ScopeType.MethodScope }
 
     val bindingAsts = variableDecl.bindings.children.flatMap { binding =>
+      // Detect a tuple pattern at the binding root.
+      // All non-tuple cases (IdentifierPattern, WildcardPattern, etc.) return None and are
+      // handled by the fallthrough `case _` branch below.
       val maybeTuplePattern: Option[TuplePatternSyntax] = binding.pattern match {
         case tp: TuplePatternSyntax => Some(tp)
         case vb: ValueBindingPatternSyntax =>

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/ExpressionTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/ExpressionTests.scala
@@ -1,8 +1,6 @@
 package io.joern.swiftsrc2cpg.passes.ast
 
 import io.joern.swiftsrc2cpg.testfixtures.SwiftSrc2CpgSuite
-import io.joern.x2cpg.frontendspecific.swiftsrc2cpg.Defines
-
 import io.shiftleft.codepropertygraph.generated.*
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.*
@@ -578,7 +576,7 @@ class ExpressionTests extends SwiftSrc2CpgSuite {
           |let (ids, (actions, tracking)) = state.withCriticalRegion { ($0.valueObservers(for: keyPath), $0.didSet(keyPath: keyPath)) }
           |""".stripMargin)
       val closureMethods = cpg.method.name("<lambda>.*").l
-      closureMethods.name.l shouldBe List("<lambda>0", "<lambda>1")
+      closureMethods.name.l shouldBe List("<lambda>0")
       cpg.identifier.name.toSet should contain("$0")
     }
 

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/SimpleAstCreationPassTest.scala
@@ -72,21 +72,6 @@ class SimpleAstCreationPassTest extends SwiftSrc2CpgSuite {
       localD.typeFullName shouldBe Defines.String
     }
 
-    "have correct structure for tuple variable declarations" in {
-      val cpg = code("""
-        |var (a, b): Int = foo()
-        |""".stripMargin)
-      val List(method)           = cpg.method.nameExact("<global>").l
-      val List(assignA, assignB) = method.assignment.l
-      assignA.code shouldBe "var a: Int = foo()"
-      assignB.code shouldBe "var b: Int = foo()"
-      val List(localA, localB) = method.block.local.l
-      localA.name shouldBe "a"
-      localA.typeFullName shouldBe "Swift.Int"
-      localB.name shouldBe "b"
-      localB.typeFullName shouldBe "Swift.Int"
-    }
-
     "have corresponding type decl with correct bindings for function" in {
       val cpg            = code("func method() {}")
       val List(typeDecl) = cpg.typeDecl.nameExact("method").l

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/VarLetTupleTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/VarLetTupleTests.scala
@@ -156,5 +156,39 @@ class VarLetTupleTests extends SwiftSrc2CpgSuite {
       methodBlock.ast.isCall.nameExact(Operators.assignment).l shouldBe List.empty
     }
 
+    "testSingleWildcard" in {
+      val cpg = code("""
+      |func test() {
+      |  let _ = foo()
+      |}
+      |""".stripMargin)
+      val List(methodBlock) = cpg.method.nameExact("test").block.l
+      // A synthetic local is created for the wildcard binding
+      methodBlock.local.nameNot("self").name.loneElement shouldBe "<wildcard>0"
+      // The foo() call is not dropped
+      val List(wildcardAssign) = methodBlock.astChildren.isCall.nameExact(Operators.assignment).l
+      wildcardAssign.argument(1).code shouldBe "<wildcard>0"
+      val fooCall = wildcardAssign.argument(2)
+      fooCall.isCall shouldBe true
+      fooCall.code shouldBe "foo()"
+    }
+
+    "testAllWildcardTuple" in {
+      val cpg = code("""
+      |func test() {
+      |  let (_, _) = foo()
+      |}
+      |""".stripMargin)
+      val List(methodBlock) = cpg.method.nameExact("test").block.l
+      // Only <tmp>0 — no locals for wildcards
+      methodBlock.local.nameNot("self").name.loneElement shouldBe "<tmp>0"
+      // The foo() call is not dropped
+      val List(tmpAssign) = methodBlock.astChildren.isCall.nameExact(Operators.assignment).l
+      tmpAssign.argument(1).code shouldBe "<tmp>0"
+      val fooCall = tmpAssign.argument(2)
+      fooCall.isCall shouldBe true
+      fooCall.code shouldBe "foo()"
+    }
+
   }
 }

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/VarLetTupleTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/VarLetTupleTests.scala
@@ -1,0 +1,160 @@
+package io.joern.swiftsrc2cpg.passes.ast
+
+import io.joern.swiftsrc2cpg.testfixtures.SwiftSrc2CpgSuite
+import io.shiftleft.codepropertygraph.generated.*
+import io.shiftleft.semanticcpg.language.*
+
+class VarLetTupleTests extends SwiftSrc2CpgSuite {
+
+  "VarLetTupleTests" should {
+
+    "testLetTupleBasic" in {
+      val cpg = code("""
+      |func test() {
+      |  let (a, b) = foo()
+      |}
+      |""".stripMargin)
+      val List(methodBlock) = cpg.method.nameExact("test").block.l
+      // <tmp>0, a, b all live in the method block
+      methodBlock.local.nameNot("self").name.sorted shouldBe Seq("<tmp>0", "a", "b")
+
+      // The 3 desugared assignments are wrapped in a block
+      val List(varDeclBlock) = methodBlock.astChildren.isBlock.l
+
+      // <tmp>0 = foo()
+      val List(tmpAssign) =
+        varDeclBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact("<tmp>0 = foo()").l
+      tmpAssign.argument(1).code shouldBe "<tmp>0"
+      tmpAssign.argument(2).code shouldBe "foo()"
+
+      // a = <tmp>0.0  — rhs is a field access: <tmp>0.<field>0
+      val List(aAssign) = varDeclBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact("a = <tmp>0.0").l
+      aAssign.argument(1).code shouldBe "a"
+      val List(aFieldAccess) = aAssign.arguments(2).isCall.nameExact(Operators.fieldAccess).l
+      aFieldAccess.argument(1).code shouldBe "<tmp>0"
+      aFieldAccess.argument(2).code shouldBe "0"
+
+      // b = <tmp>0.1  — rhs is a field access: <tmp>0.<field>1
+      val List(bAssign) = varDeclBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact("b = <tmp>0.1").l
+      bAssign.argument(1).code shouldBe "b"
+      val List(bFieldAccess) = bAssign.arguments(2).isCall.nameExact(Operators.fieldAccess).l
+      bFieldAccess.argument(1).code shouldBe "<tmp>0"
+      bFieldAccess.argument(2).code shouldBe "1"
+    }
+
+    "testVarTupleBasic" in {
+      val cpg = code("""
+      |func test() {
+      |  var (a, b) = foo()
+      |}
+      |""".stripMargin)
+      val List(methodBlock) = cpg.method.nameExact("test").block.l
+      methodBlock.local.nameNot("self").name.sorted shouldBe Seq("<tmp>0", "a", "b")
+
+      val List(varDeclBlock) = methodBlock.astChildren.isBlock.l
+
+      val List(tmpAssign) =
+        varDeclBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact("<tmp>0 = foo()").l
+      tmpAssign.argument(1).code shouldBe "<tmp>0"
+      tmpAssign.argument(2).code shouldBe "foo()"
+
+      val List(aAssign) = varDeclBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact("a = <tmp>0.0").l
+      aAssign.argument(1).code shouldBe "a"
+      val List(aFieldAccess) = aAssign.arguments(2).isCall.nameExact(Operators.fieldAccess).l
+      aFieldAccess.argument(1).code shouldBe "<tmp>0"
+      aFieldAccess.argument(2).code shouldBe "0"
+
+      val List(bAssign) = varDeclBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact("b = <tmp>0.1").l
+      bAssign.argument(1).code shouldBe "b"
+      val List(bFieldAccess) = bAssign.arguments(2).isCall.nameExact(Operators.fieldAccess).l
+      bFieldAccess.argument(1).code shouldBe "<tmp>0"
+      bFieldAccess.argument(2).code shouldBe "1"
+    }
+
+    "testLetTupleWithWildcard" in {
+      val cpg = code("""
+      |func test() {
+      |  let (a, _) = foo()
+      |}
+      |""".stripMargin)
+      val List(methodBlock) = cpg.method.nameExact("test").block.l
+      // Only <tmp>0 and a — no local for the wildcard
+      methodBlock.local.nameNot("self").name.sorted shouldBe Seq("<tmp>0", "a")
+
+      val List(varDeclBlock) = methodBlock.astChildren.isBlock.l
+
+      val List(aAssign) = varDeclBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact("a = <tmp>0.0").l
+      aAssign.argument(1).code shouldBe "a"
+      val List(aFieldAccess) = aAssign.arguments(2).isCall.nameExact(Operators.fieldAccess).l
+      aFieldAccess.argument(1).code shouldBe "<tmp>0"
+      aFieldAccess.argument(2).code shouldBe "0"
+
+      // No assignment for the wildcard element
+      varDeclBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact("_ = <tmp>0.1").l shouldBe empty
+    }
+
+    "testLetTupleNested" in {
+      val cpg = code("""
+      |func test() {
+      |  let (a, (b, c)) = foo()
+      |}
+      |""".stripMargin)
+      val List(methodBlock) = cpg.method.nameExact("test").block.l
+      methodBlock.local.nameNot("self").name.sorted shouldBe Seq("<tmp>0", "a", "b", "c")
+
+      val List(varDeclBlock) = methodBlock.astChildren.isBlock.l
+
+      // a = <tmp>0.0
+      val List(aAssign) = varDeclBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact("a = <tmp>0.0").l
+      aAssign.argument(1).code shouldBe "a"
+      val List(aFieldAccess) = aAssign.arguments(2).isCall.nameExact(Operators.fieldAccess).l
+      aFieldAccess.argument(1).code shouldBe "<tmp>0"
+      aFieldAccess.argument(2).code shouldBe "0"
+
+      // b = <tmp>0.1.0 — nested field access: (<tmp>0.1).0
+      val List(bAssign) = varDeclBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact("b = <tmp>0.1.0").l
+      bAssign.argument(1).code shouldBe "b"
+      val List(bOuterAccess) = bAssign.arguments(2).isCall.nameExact(Operators.fieldAccess).l
+      bOuterAccess.code shouldBe "<tmp>0.1.0"
+      bOuterAccess.argument(2).code shouldBe "0"
+      val List(bInnerAccess) = bOuterAccess.arguments(1).isCall.nameExact(Operators.fieldAccess).l
+      bInnerAccess.argument(1).code shouldBe "<tmp>0"
+      bInnerAccess.argument(2).code shouldBe "1"
+
+      // c = <tmp>0.1.1
+      val List(cAssign) = varDeclBlock.astChildren.isCall.nameExact(Operators.assignment).codeExact("c = <tmp>0.1.1").l
+      cAssign.argument(1).code shouldBe "c"
+      val List(cOuterAccess) = cAssign.arguments(2).isCall.nameExact(Operators.fieldAccess).l
+      cOuterAccess.code shouldBe "<tmp>0.1.1"
+      cOuterAccess.argument(2).code shouldBe "1"
+      val List(cInnerAccess) = cOuterAccess.arguments(1).isCall.nameExact(Operators.fieldAccess).l
+      cInnerAccess.argument(1).code shouldBe "<tmp>0"
+      cInnerAccess.argument(2).code shouldBe "1"
+    }
+
+    "testLetTupleNoInitializer" in {
+      val cpg = code("""
+      |func test() {
+      |  var (a, b): (Int, String)
+      |}
+      |""".stripMargin)
+      val List(methodBlock) = cpg.method.nameExact("test").block.l
+      // All 2 leaf locals declared, no tmp, no assignments
+      methodBlock.local.name.sorted shouldBe Seq("a", "b")
+      methodBlock.ast.isCall.nameExact(Operators.assignment).l shouldBe List.empty
+    }
+
+    "testLetTupleNoInitializerNested" in {
+      val cpg = code("""
+      |func test() {
+      |  var (a, (b, c)): (Int, (Bool, String))
+      |}
+      |""".stripMargin)
+      val List(methodBlock) = cpg.method.nameExact("test").block.l
+      // All 3 leaf locals declared, no tmp, no assignments
+      methodBlock.local.name.sorted shouldBe Seq("a", "b", "c")
+      methodBlock.ast.isCall.nameExact(Operators.assignment).l shouldBe List.empty
+    }
+
+  }
+}


### PR DESCRIPTION
- `var/let (a, b) = source` is de-sugared into a temporary variable holding the RHS (evaluated once) followed by individual field-access assignments:

```
var/let (a, b) = source =>
  <tmp>0 = source
  a = <tmp>0.0
  b = <tmp>0.1
```

- Wildcard elements are dropped. No local and no assignment is emitted for them.

- Nested tuple patterns are handled recursively, e.g.:

```
let (a, (b, c)) = source =>  
  <tmp>0 = source
  a = <tmp>0.0
  b = <tmp>0.1.0
  c = <tmp>0.1.1
```

sptests is happy (builders/82/builds/693).