### PR TITLE
[rubysrc2cpg] Correctly handle access modifier calls

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstCreatorHelper.scala
@@ -7,6 +7,7 @@ import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.{
   IfExpression,
   IndexAccess,
   InstanceFieldIdentifier,
+  LiteralExpr,
   MemberAccess,
   MemberCall,
   RubyExpression,
@@ -302,6 +303,8 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
 
     StatementList(tmpAssignment :: ifStmt :: Nil)(originSpan)
   }
+
+  def symbolName(expr: RubyExpression): String = expr.text.stripPrefix(":")
 
   protected def isErbCall(callName: String): Boolean = ErbTemplateCallNames.contains(callName)
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -54,7 +54,8 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
     case node: DefaultMultipleAssignment        => astForDefaultMultipleAssignmentExpr(node)
     case node: MultipleAssignment               => blockAst(blockNode(node), astsForStatement(node).toList)
     case node: ReturnExpression                 => astForReturnExpression(node)
-    case node: AccessModifier                   => astForSimpleIdentifier(node.toSimpleIdentifier)
+    case node: AccessModifier                   => astForAccessModifierCall(node)
+    case node: MethodAccessModifier             => astForMethodAccessModifierExpr(node)
     case node: ArrayPattern                     => astForArrayPattern(node)
     case node: DummyNode                        => Ast(node.node)
     case node: DummyAst                         => node.ast
@@ -671,6 +672,21 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
   }
 
   protected def astForMandatoryParameter(node: RubyExpression): Ast = handleVariableOccurrence(node)
+
+  protected def astForAccessModifierCall(node: RubyExpression & AccessModifier): Ast = {
+    val operatorName = node match {
+      case _: PublicModifier    => RubyOperators.publicModifier
+      case _: PrivateModifier   => RubyOperators.privateModifier
+      case _: ProtectedModifier => RubyOperators.protectedModifier
+    }
+    val argAsts = node.arguments.map(astForExpression)
+    val call    = callNode(node, code(node), operatorName, operatorName, DispatchTypes.STATIC_DISPATCH)
+    callAst(call, argAsts)
+  }
+
+  protected def astForMethodAccessModifierExpr(node: RubyExpression & MethodAccessModifier): Ast = {
+    blockAst(blockNode(node), astForMethodAccessModifier(node).toList)
+  }
 
   protected def astForSimpleCall(node: SimpleCall): Ast = {
     node.target match {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -158,7 +158,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
       // <main> functions are private functions on the Object class
       else if (isSurroundedByProgramScope) ModifierTypes.PRIVATE
       // Else, use whatever modifier has been user-defined (or is default for current scope)
-      else currentAccessModifier
+      else scope.visibilityForMethod(methodName).getOrElse(currentAccessModifier)
     val modifiers = mutable.Buffer(ModifierTypes.VIRTUAL, accessModifier)
     if (isClosure) modifiers.addOne(ModifierTypes.LAMBDA)
     if (isConstructor) modifiers.addOne(ModifierTypes.CONSTRUCTOR)
@@ -200,21 +200,10 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
       case x: PublicMethodModifier  => (RubyOperators.publicClassMethod, x: RubyExpression)
     }
 
-    val originalAccessModifier = currentAccessModifier
-    popAccessModifier()
-
-    node match {
-      case _: PrivateMethodModifier => pushAccessModifier(ModifierTypes.PRIVATE)
-      case _: PublicMethodModifier  => pushAccessModifier(ModifierTypes.PUBLIC)
-    }
-
     val methodAsts = node.arguments.flatMap {
       case m: ProcedureDeclaration => astsForStatement(m)
       case _                       => Nil
     }
-
-    popAccessModifier()
-    pushAccessModifier(originalAccessModifier)
 
     val argAsts = node.arguments.map(astForExpression)
     val call    = callNode(expr, code(expr), operatorName, operatorName, DispatchTypes.STATIC_DISPATCH)
@@ -489,7 +478,10 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
             parameterAsts ++ anonProcParam,
             stmtBlockAst,
             methodReturnNode(node, Defines.Any),
-            modifierNode(node, ModifierTypes.VIRTUAL) :: modifierNode(node, currentAccessModifier) :: Nil
+            modifierNode(node, ModifierTypes.VIRTUAL) :: modifierNode(
+              node,
+              scope.visibilityForMethod(node.methodName).getOrElse(currentAccessModifier)
+            ) :: Nil
           )
 
         _methodAst :: methodTypeDeclAst :: Nil foreach (Ast.storeInDiffGraph(_, diffGraph))

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -3,6 +3,7 @@ package io.joern.rubysrc2cpg.astcreation
 import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.*
 import io.joern.rubysrc2cpg.datastructures.{ConstructorScope, MethodScope}
 import io.joern.rubysrc2cpg.passes.Defines
+import io.joern.rubysrc2cpg.passes.Defines.RubyOperators
 import io.joern.x2cpg.AstNodeBuilder.{bindingNode, closureBindingNode}
 import io.joern.x2cpg.{Ast, AstEdge, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.nodes.*
@@ -194,28 +195,30 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
   }
 
   protected def astForMethodAccessModifier(node: MethodAccessModifier): Seq[Ast] = {
+    val (operatorName, expr) = node match {
+      case x: PrivateMethodModifier => (RubyOperators.privateClassMethod, x: RubyExpression)
+      case x: PublicMethodModifier  => (RubyOperators.publicClassMethod, x: RubyExpression)
+    }
+
     val originalAccessModifier = currentAccessModifier
     popAccessModifier()
 
     node match {
-      case _: PrivateMethodModifier =>
-        pushAccessModifier(ModifierTypes.PRIVATE)
-      case _: PublicMethodModifier =>
-        pushAccessModifier(ModifierTypes.PUBLIC)
+      case _: PrivateMethodModifier => pushAccessModifier(ModifierTypes.PRIVATE)
+      case _: PublicMethodModifier  => pushAccessModifier(ModifierTypes.PUBLIC)
     }
 
-    val methodAst = node.method match {
+    val methodAsts = node.arguments.flatMap {
       case m: ProcedureDeclaration => astsForStatement(m)
-      case x                       =>
-        // Not sure how we should represent dynamically setting access modifiers based on method refs
-        logger.debug(s"Unhandled method reference from AST type ${x.getClass}")
-        Nil
+      case _                       => Nil
     }
 
     popAccessModifier()
     pushAccessModifier(originalAccessModifier)
 
-    methodAst
+    val argAsts = node.arguments.map(astForExpression)
+    val call    = callNode(expr, code(expr), operatorName, operatorName, DispatchTypes.STATIC_DISPATCH)
+    methodAsts :+ callAst(call, argAsts)
   }
 
   private def transformAsClosureBody(originNode: RubyExpression, refs: List[Ast], baseStmtBlockAst: Ast): Ast = {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -2,12 +2,10 @@ package io.joern.rubysrc2cpg.astcreation
 
 import io.joern.rubysrc2cpg.astcreation.RubyIntermediateAst.*
 import io.joern.rubysrc2cpg.datastructures.BlockScope
-import io.joern.rubysrc2cpg.parser.RubyJsonHelpers
 import io.joern.rubysrc2cpg.passes.Defines
-import io.joern.rubysrc2cpg.passes.Defines.prefixAsKernelDefined
-import io.joern.x2cpg.datastructures.MethodLike
+import io.joern.rubysrc2cpg.passes.Defines.RubyOperators
 import io.joern.x2cpg.{Ast, ValidationMode}
-import io.shiftleft.codepropertygraph.generated.nodes.{NewBlock, NewControlStructure}
+import io.shiftleft.codepropertygraph.generated.nodes.NewControlStructure
 import io.shiftleft.codepropertygraph.generated.{
   ControlStructureTypes,
   DispatchTypes,
@@ -50,22 +48,30 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
   }
 
   private def astForAccessModifier(node: AccessModifier): Seq[Ast] = {
-    scope.surroundingAstLabel match {
-      case Some(x) if x == NodeTypes.METHOD =>
-        val simpleIdent = node.toSimpleIdentifier
-        astForSimpleCall(SimpleCall(simpleIdent, List.empty)(simpleIdent.span)) :: Nil
-      case _ =>
-        registerAccessModifier(node)
+    val (operatorName, expr) = node match {
+      case x: PublicModifier    => (RubyOperators.publicModifier, x: RubyExpression)
+      case x: PrivateModifier   => (RubyOperators.privateModifier, x: RubyExpression)
+      case x: ProtectedModifier => (RubyOperators.protectedModifier, x: RubyExpression)
     }
+
+    scope.surroundingAstLabel match {
+      case Some(x) if x == NodeTypes.METHOD => // no scope state change inside a method
+      case _ if node.arguments.nonEmpty     => // targeted modifier, no scope change
+      case _                                => registerAccessModifier(node)
+    }
+
+    val argAsts = node.arguments.map(astForExpression)
+    val call    = callNode(expr, code(expr), operatorName, operatorName, DispatchTypes.STATIC_DISPATCH)
+    callAst(call, argAsts) :: Nil
   }
 
   /** Registers the currently set access modifier for the current type (until it is reset later).
     */
   private def registerAccessModifier(node: AccessModifier): Seq[Ast] = {
     val modifier = node match {
-      case PrivateModifier()   => ModifierTypes.PRIVATE
-      case ProtectedModifier() => ModifierTypes.PROTECTED
-      case PublicModifier()    => ModifierTypes.PUBLIC
+      case _: PrivateModifier   => ModifierTypes.PRIVATE
+      case _: ProtectedModifier => ModifierTypes.PROTECTED
+      case _: PublicModifier    => ModifierTypes.PUBLIC
     }
     popAccessModifier()          // pop off the current modifier in scope
     pushAccessModifier(modifier) // push new one on
@@ -185,23 +191,6 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
       case ret: ReturnExpression => astForReturnExpression(ret) :: Nil
       case node: (MethodDeclaration | SingletonMethodDeclaration) =>
         (astsForStatement(node) :+ astForReturnMethodDeclarationSymbolName(node)).toList
-      case node: MethodAccessModifier =>
-        val simpleIdent = node.toSimpleIdentifier
-
-        val methodIdentName = node.method match {
-          case x: StaticLiteral     => x.span.text
-          case x: MethodDeclaration => x.methodName
-          case x =>
-            logger.warn(s"Unknown node type for method identifier name: ${x.getClass} (${this.relativeFileName})")
-            x.span.text
-        }
-
-        val methodIdent = SimpleIdentifier(None)(simpleIdent.span.spanStart(methodIdentName))
-
-        val simpleCall = SimpleCall(simpleIdent, List(methodIdent))(
-          simpleIdent.span.spanStart(s"${simpleIdent.span.text} ${methodIdent.span.text}")
-        )
-        astForReturnExpression(ReturnExpression(List(simpleCall))(node.span)) :: Nil
       case node: FieldsDeclaration =>
         val nilReturnSpan    = node.span.spanStart("return nil")
         val nilReturnLiteral = StaticLiteral(Defines.prefixAsCoreType(Defines.NilClass))(nilReturnSpan)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
@@ -338,7 +338,7 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
           m.body.asInstanceOf[StatementList].statements
         case other => other :: Nil
       }
-      .sortBy(_.line.getOrElse(0))
+      .sortBy(el => (el.line.getOrElse(0), el.column.getOrElse(0)))
 
     var currentModifier = ModifierTypes.PUBLIC
     val visibilityMap   = mutable.LinkedHashMap.empty[String, String]

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
@@ -349,9 +349,9 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
       case node: AccessModifier =>
         val modifier = accessModifierType(node)
         node.arguments.foreach {
-          case lit: StaticLiteral => visibilityMap.put(lit.span.text.stripPrefix(":"), modifier)
+          case lit: StaticLiteral => visibilityMap.put(symbolName(lit), modifier)
           case arr: ArrayLiteral =>
-            arr.elements.foreach(el => visibilityMap.put(el.span.text.stripPrefix(":"), modifier))
+            arr.elements.foreach(el => visibilityMap.put(symbolName(el), modifier))
           case _ =>
         }
       case node: MethodAccessModifier =>
@@ -361,9 +361,9 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
         }
         node.arguments.foreach {
           case proc: ProcedureDeclaration => visibilityMap.put(proc.methodName, modifier)
-          case lit: StaticLiteral         => visibilityMap.put(lit.span.text.stripPrefix(":"), modifier)
+          case lit: StaticLiteral         => visibilityMap.put(symbolName(lit), modifier)
           case arr: ArrayLiteral =>
-            arr.elements.foreach(el => visibilityMap.put(el.span.text.stripPrefix(":"), modifier))
+            arr.elements.foreach(el => visibilityMap.put(symbolName(el), modifier))
           case _ =>
         }
       case node: ProcedureDeclaration if !visibilityMap.contains(node.methodName) =>

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
@@ -362,8 +362,9 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
         node.arguments.foreach {
           case proc: ProcedureDeclaration => visibilityMap.put(proc.methodName, modifier)
           case lit: StaticLiteral         => visibilityMap.put(lit.span.text.stripPrefix(":"), modifier)
-          case arr: ArrayLiteral => arr.elements.foreach(e => visibilityMap.put(e.span.text.stripPrefix(":"), modifier))
-          case _                 =>
+          case arr: ArrayLiteral =>
+            arr.elements.foreach(el => visibilityMap.put(el.span.text.stripPrefix(":"), modifier))
+          case _ =>
         }
       case node: ProcedureDeclaration if !visibilityMap.contains(node.methodName) =>
         visibilityMap.put(node.methodName, currentModifier)

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForTypesCreator.scala
@@ -130,23 +130,23 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
       .fullName(s"$classFullName<class>")
       .inheritsFromTypeFullName(inheritsFrom.map(x => s"$x<class>"))
 
+    val classBody     = node.body.asInstanceOf[StatementList]
+    val visibilityMap = computeVisibilityMap(classBody)
+
     val (classModifiers, singletonModifiers) = node match {
       case _: ModuleDeclaration =>
-        scope.pushNewScope(ModuleScope(classFullName))
+        scope.pushNewScope(ModuleScope(classFullName, visibilityMap))
         (
           ModifierTypes.VIRTUAL :: Nil map (modifierNode(node, _)) map Ast.apply,
           ModifierTypes.VIRTUAL :: ModifierTypes.FINAL :: Nil map (modifierNode(node, _)) map Ast.apply
         )
       case _: TypeDeclaration =>
-        scope.pushNewScope(TypeScope(classFullName, List.empty))
+        scope.pushNewScope(TypeScope(classFullName, List.empty, visibilityMap))
         (
           ModifierTypes.VIRTUAL :: Nil map (modifierNode(node, _)) map Ast.apply,
           ModifierTypes.VIRTUAL :: Nil map (modifierNode(node, _)) map Ast.apply
         )
     }
-
-    val classBody =
-      node.body.asInstanceOf[StatementList] // for now (bodyStatement is a superset of stmtList)
 
     val statementsToForwardUpTheAst = mutable.ArrayBuffer.empty[Ast]
     def separateStatementsFromBody(ss: List[RubyExpression]) = {
@@ -323,6 +323,53 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
       StatementList(assignment :: Nil)(node.span.spanStart(s"return $fieldName"))
     )(node.span.spanStart(code))
     astForMethodDeclaration(methodDecl, useSurroundingTypeFullName = true)
+  }
+
+  private def computeVisibilityMap(classBody: StatementList): Map[String, String] = {
+    def accessModifierType(node: AccessModifier): String = node match {
+      case _: PublicModifier    => ModifierTypes.PUBLIC
+      case _: PrivateModifier   => ModifierTypes.PRIVATE
+      case _: ProtectedModifier => ModifierTypes.PROTECTED
+    }
+
+    val allStatements = classBody.statements
+      .flatMap {
+        case m: MethodDeclaration if m.methodName == Defines.TypeDeclBody =>
+          m.body.asInstanceOf[StatementList].statements
+        case other => other :: Nil
+      }
+      .sortBy(_.line.getOrElse(0))
+
+    var currentModifier = ModifierTypes.PUBLIC
+    val visibilityMap   = mutable.LinkedHashMap.empty[String, String]
+
+    allStatements.foreach {
+      case node: AccessModifier if node.arguments.isEmpty =>
+        currentModifier = accessModifierType(node)
+      case node: AccessModifier =>
+        val modifier = accessModifierType(node)
+        node.arguments.foreach {
+          case lit: StaticLiteral => visibilityMap.put(lit.span.text.stripPrefix(":"), modifier)
+          case arr: ArrayLiteral =>
+            arr.elements.foreach(el => visibilityMap.put(el.span.text.stripPrefix(":"), modifier))
+          case _ =>
+        }
+      case node: MethodAccessModifier =>
+        val modifier = node match {
+          case _: PrivateMethodModifier => ModifierTypes.PRIVATE
+          case _: PublicMethodModifier  => ModifierTypes.PUBLIC
+        }
+        node.arguments.foreach {
+          case proc: ProcedureDeclaration => visibilityMap.put(proc.methodName, modifier)
+          case lit: StaticLiteral         => visibilityMap.put(lit.span.text.stripPrefix(":"), modifier)
+          case arr: ArrayLiteral => arr.elements.foreach(e => visibilityMap.put(e.span.text.stripPrefix(":"), modifier))
+          case _                 =>
+        }
+      case node: ProcedureDeclaration if !visibilityMap.contains(node.methodName) =>
+        visibilityMap.put(node.methodName, currentModifier)
+      case _ =>
+    }
+    visibilityMap.toMap
   }
 
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -516,32 +516,39 @@ object RubyIntermediateAst {
 
   sealed trait AccessModifier extends AllowedTypeDeclarationChild {
     def toSimpleIdentifier: SimpleIdentifier
+    def arguments: List[RubyExpression]
   }
 
   sealed trait MethodAccessModifier extends AllowedTypeDeclarationChild {
     def toSimpleIdentifier: SimpleIdentifier
-    def method: RubyExpression
+    def arguments: List[RubyExpression]
   }
 
-  final case class PublicModifier()(span: TextSpan) extends RubyExpression(span) with AccessModifier {
+  final case class PublicModifier(arguments: List[RubyExpression] = Nil)(span: TextSpan)
+      extends RubyExpression(span)
+      with AccessModifier {
     override def toSimpleIdentifier: SimpleIdentifier = SimpleIdentifier(None)(span)
   }
 
-  final case class PrivateModifier()(span: TextSpan) extends RubyExpression(span) with AccessModifier {
+  final case class PrivateModifier(arguments: List[RubyExpression] = Nil)(span: TextSpan)
+      extends RubyExpression(span)
+      with AccessModifier {
     override def toSimpleIdentifier: SimpleIdentifier = SimpleIdentifier(None)(span)
   }
 
-  final case class ProtectedModifier()(span: TextSpan) extends RubyExpression(span) with AccessModifier {
+  final case class ProtectedModifier(arguments: List[RubyExpression] = Nil)(span: TextSpan)
+      extends RubyExpression(span)
+      with AccessModifier {
     override def toSimpleIdentifier: SimpleIdentifier = SimpleIdentifier(None)(span)
   }
 
-  final case class PrivateMethodModifier(method: RubyExpression)(span: TextSpan)
+  final case class PrivateMethodModifier(arguments: List[RubyExpression])(span: TextSpan)
       extends RubyExpression(span)
       with MethodAccessModifier {
     override def toSimpleIdentifier: SimpleIdentifier = SimpleIdentifier(None)(span.spanStart("private_class_method"))
   }
 
-  final case class PublicMethodModifier(method: RubyExpression)(span: TextSpan)
+  final case class PublicMethodModifier(arguments: List[RubyExpression])(span: TextSpan)
       extends RubyExpression(span)
       with MethodAccessModifier {
     override def toSimpleIdentifier: SimpleIdentifier = SimpleIdentifier(None)(span.spanStart("public_class_method"))

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/RubyIntermediateAst.scala
@@ -514,12 +514,12 @@ object RubyIntermediateAst {
       extends RubyExpression(span)
       with RubyCall
 
-  sealed trait AccessModifier extends AllowedTypeDeclarationChild {
+  sealed trait AccessModifier {
     def toSimpleIdentifier: SimpleIdentifier
     def arguments: List[RubyExpression]
   }
 
-  sealed trait MethodAccessModifier extends AllowedTypeDeclarationChild {
+  sealed trait MethodAccessModifier {
     def toSimpleIdentifier: SimpleIdentifier
     def arguments: List[RubyExpression]
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
@@ -90,9 +90,9 @@ class RubyScope(summary: RubyProgramSummary, projectRoot: Option[String])
     popScope().foreach {
       case TypeScope(fullName, fields, visMap) =>
         pushNewScope(TypeScope(fullName, fields :+ field, visMap))
-      case x =>
+      case scope =>
         pushField(field)
-        pushNewScope(x)
+        pushNewScope(scope)
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/RubyScope.scala
@@ -88,8 +88,8 @@ class RubyScope(summary: RubyProgramSummary, projectRoot: Option[String])
 
   def pushField(field: FieldDecl): Unit = {
     popScope().foreach {
-      case TypeScope(fullName, fields) =>
-        pushNewScope(TypeScope(fullName, fields :+ field))
+      case TypeScope(fullName, fields, visMap) =>
+        pushNewScope(TypeScope(fullName, fields :+ field, visMap))
       case x =>
         pushField(field)
         pushNewScope(x)
@@ -97,7 +97,7 @@ class RubyScope(summary: RubyProgramSummary, projectRoot: Option[String])
   }
 
   def getFieldsInScope: List[FieldDecl] =
-    stack.collect { case ScopeElement(TypeScope(_, fields), _) => fields }.flatten
+    stack.collect { case ScopeElement(TypeScope(_, fields, _), _) => fields }.flatten
 
   def findFieldInScope(fieldName: String): Option[FieldDecl] = {
     getFieldsInScope.find(_.name == fieldName)
@@ -112,7 +112,7 @@ class RubyScope(summary: RubyProgramSummary, projectRoot: Option[String])
       case n: ProgramScope =>
         typesInScope.addAll(summary.typesUnderNamespace(n.fullName))
         n
-      case TypeScope(name, _) =>
+      case TypeScope(name, _, _) =>
         typesInScope.addAll(summary.matchingTypes(name))
         scopeNode
       case _ => scopeNode
@@ -328,6 +328,11 @@ class RubyScope(summary: RubyProgramSummary, projectRoot: Option[String])
 
   def surroundingTypeFullName: Option[String] = stack.collectFirst { case ScopeElement(x: TypeLikeScope, _) =>
     x.fullName
+  }
+
+  def visibilityForMethod(methodName: String): Option[String] = stack.collectFirst {
+    case ScopeElement(x: TypeScope, _) if x.visibilityMap.contains(methodName)   => x.visibilityMap(methodName)
+    case ScopeElement(x: ModuleScope, _) if x.visibilityMap.contains(methodName) => x.visibilityMap(methodName)
   }
 
   /** Searches the surrounding classes for a class that matches the given value. Returns it if found.

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/ScopeElement.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/datastructures/ScopeElement.scala
@@ -95,14 +95,15 @@ case class ProgramScope(fileName: String) extends TypeLikeScope {
   * @param fullName
   *   the type full name.
   */
-case class ModuleScope(fullName: String) extends TypeLikeScope
+case class ModuleScope(fullName: String, visibilityMap: Map[String, String] = Map.empty) extends TypeLikeScope
 
 /** A class or interface.
   *
   * @param fullName
   *   the type full name.
   */
-case class TypeScope(fullName: String, fields: List[FieldDecl]) extends TypeLikeScope
+case class TypeScope(fullName: String, fields: List[FieldDecl], visibilityMap: Map[String, String] = Map.empty)
+    extends TypeLikeScope
 
 /** Represents scope objects that map to a method node.
   */

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyJsonToNodeCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyJsonToNodeCreator.scala
@@ -179,10 +179,13 @@ class RubyJsonToNodeCreator(
   }
 
   private def visitAccessModifier(obj: Obj): RubyExpression = {
+    val args =
+      if (obj.contains(ParserKeys.Arguments)) obj.visitArray(ParserKeys.Arguments)
+      else Nil
     obj(ParserKeys.Name).str match {
-      case "public"    => PublicModifier()(obj.toTextSpan)
-      case "private"   => PrivateModifier()(obj.toTextSpan)
-      case "protected" => ProtectedModifier()(obj.toTextSpan)
+      case "public"    => PublicModifier(args)(obj.toTextSpan)
+      case "private"   => PrivateModifier(args)(obj.toTextSpan)
+      case "protected" => ProtectedModifier(args)(obj.toTextSpan)
       case modifierName =>
         logger.warn(s"Unknown modifier type $modifierName")
         defaultResult(Option(obj.toTextSpan))
@@ -697,16 +700,11 @@ class RubyJsonToNodeCreator(
   }
 
   private def visitMethodAccessModifier(obj: Obj): RubyExpression = {
-    val body = obj.visitArray(ParserKeys.Arguments) match {
-      case head :: Nil => head
-      case xs          => xs.head
-    }
+    val args = obj.visitArray(ParserKeys.Arguments)
 
     obj(ParserKeys.Name).str match {
-      case "public_class_method" =>
-        PublicMethodModifier(body)(obj.toTextSpan)
-      case "private_class_method" =>
-        PrivateMethodModifier(body)(obj.toTextSpan)
+      case "public_class_method"  => PublicMethodModifier(args)(obj.toTextSpan)
+      case "private_class_method" => PrivateMethodModifier(args)(obj.toTextSpan)
       case modifierName =>
         logger.warn(s"Unknown modifier type $modifierName")
         defaultResult(Option(obj.toTextSpan))

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/Defines.scala
@@ -49,15 +49,20 @@ object Defines {
   }
 
   object RubyOperators {
-    val backticks: String = "<operator>.backticks"
-    val hashInitializer   = "<operator>.hashInitializer"
-    val association       = "<operator>.association"
-    val splat             = "<operator>.splat"
-    val regexpMatch       = "=~"
-    val regexpNotMatch    = "!~"
-    val templateOutRaw    = "<operator>.templateOutRaw"
-    val templateOutEscape = "<operator>.templateOutEscape"
-    val bufferAppend      = "<operator>.joernBufferAppend"
+    val backticks: String  = "<operator>.backticks"
+    val hashInitializer    = "<operator>.hashInitializer"
+    val association        = "<operator>.association"
+    val splat              = "<operator>.splat"
+    val regexpMatch        = "=~"
+    val regexpNotMatch     = "!~"
+    val templateOutRaw     = "<operator>.templateOutRaw"
+    val templateOutEscape  = "<operator>.templateOutEscape"
+    val bufferAppend       = "<operator>.joernBufferAppend"
+    val publicModifier     = "<operator>.publicModifier"
+    val privateModifier    = "<operator>.privateModifier"
+    val protectedModifier  = "<operator>.protectedModifier"
+    val privateClassMethod = "<operator>.privateClassMethod"
+    val publicClassMethod  = "<operator>.publicClassMethod"
 
     val regexMethods = Set("match") // TODO: Figure out how to model these, "sub", "gsub")
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/AccessModifierTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/AccessModifierTests.scala
@@ -1,9 +1,10 @@
 package io.joern.rubysrc2cpg.querying
 
 import io.joern.rubysrc2cpg.passes.Defines
+import io.joern.rubysrc2cpg.passes.Defines.RubyOperators
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
 import io.shiftleft.codepropertygraph.generated.Operators
-import io.shiftleft.codepropertygraph.generated.nodes.Call
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, Literal}
 import io.shiftleft.semanticcpg.language.*
 
 class AccessModifierTests extends RubyCode2CpgFixture {
@@ -102,6 +103,256 @@ class AccessModifierTests extends RubyCode2CpgFixture {
     indexAccess.name shouldBe Operators.indexAccess
     indexAccess.methodFullName shouldBe Operators.indexAccess
     indexAccess.code shouldBe "<tmp-0>[:private]"
+  }
+
+  // TODO: enable and fix once method definitions correctly return symbols
+  "a bare access modifier at type level should create an operator call" ignore {
+    val cpg = code("""
+        |class Foo
+        | private
+        |
+        | def bar
+        | end
+        |end
+        |""".stripMargin)
+
+    inside(cpg.call.nameExact(RubyOperators.privateModifier).l) { case modifierCall :: Nil =>
+      modifierCall.methodFullName shouldBe RubyOperators.privateModifier
+      modifierCall.code shouldBe "private"
+    }
+
+    cpg.method("bar").head.isPrivate.size shouldBe 1
+  }
+
+  "protected modifier should create its own distinct operator call" ignore {
+    val cpg = code("""
+        |class Foo
+        | protected
+        |
+        | def bar
+        | end
+        |end
+        |""".stripMargin)
+
+    inside(cpg.call.nameExact(RubyOperators.protectedModifier).l) { case modifierCall :: Nil =>
+      modifierCall.methodFullName shouldBe RubyOperators.protectedModifier
+      modifierCall.code shouldBe "protected"
+    }
+
+    cpg.method("bar").head.isProtected.size shouldBe 1
+  }
+
+  "private_class_method with a method declaration should create an operator call" ignore {
+    val cpg = code("""
+        |class Foo
+        | private_class_method def self.bar(x)
+        |   x
+        | end
+        |end
+        |""".stripMargin)
+
+    inside(cpg.call.nameExact(RubyOperators.privateClassMethod).l) { case modifierCall :: Nil =>
+      modifierCall.methodFullName shouldBe RubyOperators.privateClassMethod
+      modifierCall.argument.size shouldBe 1
+      modifierCall.argument.head.code shouldBe "bar"
+
+      inside(modifierCall.argument.l) { case (sym: Literal) :: Nil =>
+        sym.code shouldBe ":bar"
+      }
+    }
+  }
+
+  "public with a symbol argument should create an operator call with the symbol as argument" in {
+    val cpg = code("""
+        |class Foo
+        |  def bar
+        |  end
+        |
+        |  public :bar
+        |end
+        |""".stripMargin)
+
+    inside(cpg.call.nameExact(RubyOperators.publicModifier).l) { case modifierCall :: Nil =>
+      modifierCall.methodFullName shouldBe RubyOperators.publicModifier
+      modifierCall.code shouldBe "public :bar"
+
+      inside(modifierCall.argument.l) { case (sym: Literal) :: Nil =>
+        sym.code shouldBe ":bar"
+      }
+    }
+
+    cpg.method("bar").head.isPublic.size shouldBe 1
+  }
+
+  "private with a symbol argument should create an operator call with the symbol as argument" in {
+    val cpg = code("""
+        |class Foo
+        |  def bar
+        |  end
+        |
+        |  private :bar
+        |end
+        |""".stripMargin)
+
+    inside(cpg.call.nameExact(RubyOperators.privateModifier).l) { case modifierCall :: Nil =>
+      modifierCall.methodFullName shouldBe RubyOperators.privateModifier
+      modifierCall.code shouldBe "private :bar"
+
+      inside(modifierCall.argument.l) { case (sym: Literal) :: Nil =>
+        sym.code shouldBe ":bar"
+      }
+    }
+  }
+
+  "protected with a symbol argument should create an operator call with the symbol as argument" in {
+    val cpg = code("""
+        |class Foo
+        |  def bar
+        |  end
+        |
+        |  protected :bar
+        |end
+        |""".stripMargin)
+
+    inside(cpg.call.nameExact(RubyOperators.protectedModifier).l) { case modifierCall :: Nil =>
+      modifierCall.methodFullName shouldBe RubyOperators.protectedModifier
+      modifierCall.code shouldBe "protected :bar"
+
+      inside(modifierCall.argument.l) { case (sym: Literal) :: Nil =>
+        sym.code shouldBe ":bar"
+      }
+    }
+  }
+
+  "private_class_method with a symbol argument should create an operator call" in {
+    val cpg = code("""
+        |class Foo
+        |  def self.bar
+        |  end
+        |
+        |  private_class_method :bar
+        |end
+        |""".stripMargin)
+
+    inside(cpg.call.nameExact(RubyOperators.privateClassMethod).l) { case modifierCall :: Nil =>
+      modifierCall.methodFullName shouldBe RubyOperators.privateClassMethod
+      modifierCall.code shouldBe "private_class_method :bar"
+
+      inside(modifierCall.argument.l) { case (sym: Literal) :: Nil =>
+        sym.code shouldBe ":bar"
+      }
+    }
+  }
+
+  "public_class_method with a symbol argument should create an operator call" in {
+    val cpg = code("""
+        |class Foo
+        |  private_class_method def self.bar
+        |  end
+        |
+        |  public_class_method :bar
+        |end
+        |""".stripMargin)
+
+    inside(cpg.call.nameExact(RubyOperators.publicClassMethod).l) { case modifierCall :: Nil =>
+      modifierCall.methodFullName shouldBe RubyOperators.publicClassMethod
+      modifierCall.code shouldBe "public_class_method :bar"
+
+      inside(modifierCall.argument.l) { case (sym: Literal) :: Nil =>
+        sym.code shouldBe ":bar"
+      }
+    }
+  }
+
+  "private with multiple symbol arguments should pass all arguments to the operator call" in {
+    val cpg = code("""
+        |class Foo
+        |  def bar; end
+        |  def baz; end
+        |  private :bar, :baz
+        |end
+        |""".stripMargin)
+
+    inside(cpg.call.nameExact(RubyOperators.privateModifier).l) { case modifierCall :: Nil =>
+      modifierCall.code shouldBe "private :bar, :baz"
+
+      inside(modifierCall.argument.l) { case (sym1: Literal) :: (sym2: Literal) :: Nil =>
+        sym1.code shouldBe ":bar"
+        sym2.code shouldBe ":baz"
+      }
+    }
+  }
+
+  // TODO: MethodDeclaration as argument to AccessModifier needs handling in astForAccessModifier
+  "private def bar should create an operator call with the method definition as argument" ignore {
+    val cpg = code("""
+        |class Foo
+        |  private def bar
+        |  end
+        |end
+        |""".stripMargin)
+
+    inside(cpg.call.nameExact(RubyOperators.privateModifier).l) { case modifierCall :: Nil =>
+      modifierCall.methodFullName shouldBe RubyOperators.privateModifier
+      modifierCall.argument.size shouldBe 1
+    }
+
+    cpg.method("bar").head.isPrivate.size shouldBe 1
+  }
+
+  "targeted private :bar should not change default visibility for subsequent methods" in {
+    val cpg = code("""
+        |class Foo
+        |  def bar; end
+        |  private :bar
+        |  def baz; end
+        |end
+        |""".stripMargin)
+
+    inside(cpg.call.nameExact(RubyOperators.privateModifier).l) { case modifierCall :: Nil =>
+      modifierCall.code shouldBe "private :bar"
+
+      inside(modifierCall.argument.l) { case (sym: Literal) :: Nil =>
+        sym.code shouldBe ":bar"
+      }
+    }
+
+    cpg.method("baz").head.isPublic.size shouldBe 1
+  }
+
+  "private_class_method with multiple symbol arguments should pass all arguments" in {
+    val cpg = code("""
+        |class Foo
+        |  def self.bar; end
+        |  def self.baz; end
+        |  private_class_method :bar, :baz
+        |end
+        |""".stripMargin)
+
+    inside(cpg.call.nameExact(RubyOperators.privateClassMethod).l) { case modifierCall :: Nil =>
+      modifierCall.code shouldBe "private_class_method :bar, :baz"
+
+      inside(modifierCall.argument.l) { case (sym1: Literal) :: (sym2: Literal) :: Nil =>
+        sym1.code shouldBe ":bar"
+        sym2.code shouldBe ":baz"
+      }
+    }
+  }
+
+  "private inside a method body should create an operator call without changing scope state" in {
+    val cpg = code("""
+        |class Foo
+        |  def foo
+        |    private
+        |  end
+        |end
+        |""".stripMargin)
+
+    cpg.method("foo").head.isPublic.size shouldBe 1
+
+    inside(cpg.method("foo").body.ast.isCall.nameExact(RubyOperators.privateModifier).l) { case modifierCall :: Nil =>
+      modifierCall.argument.size shouldBe 0
+    }
   }
 
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/AccessModifierTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/AccessModifierTests.scala
@@ -105,13 +105,28 @@ class AccessModifierTests extends RubyCode2CpgFixture {
     indexAccess.code shouldBe "<tmp-0>[:private]"
   }
 
-  // TODO: enable and fix once method definitions correctly return symbols
-  "a bare access modifier at type level should create an operator call" ignore {
+  "a bare access modifier at type level should create an operator call" in {
     val cpg = code("""
         |class Foo
         | private
         |
         | def bar
+        | end
+        |end
+        |""".stripMargin)
+
+    inside(cpg.call.nameExact(RubyOperators.privateModifier).l) { case modifierCall :: Nil =>
+      modifierCall.methodFullName shouldBe RubyOperators.privateModifier
+      modifierCall.code shouldBe "private"
+    }
+
+    cpg.method("bar").head.isPrivate.size shouldBe 1
+  }
+
+  "a bare access modifier at type level and on the same line as a method decl should create an operator call" in {
+    val cpg = code("""
+        |class Foo
+        | private; def bar
         | end
         |end
         |""".stripMargin)

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/AccessModifierTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/AccessModifierTests.scala
@@ -3,7 +3,7 @@ package io.joern.rubysrc2cpg.querying
 import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.rubysrc2cpg.passes.Defines.RubyOperators
 import io.joern.rubysrc2cpg.testfixtures.RubyCode2CpgFixture
-import io.shiftleft.codepropertygraph.generated.Operators
+import io.shiftleft.codepropertygraph.generated.{ModifierTypes, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Literal}
 import io.shiftleft.semanticcpg.language.*
 
@@ -300,45 +300,6 @@ class AccessModifierTests extends RubyCode2CpgFixture {
     cpg.method("bar").head.isPrivate.size shouldBe 1
   }
 
-  "targeted private :bar should not change default visibility for subsequent methods" in {
-    val cpg = code("""
-        |class Foo
-        |  def bar; end
-        |  private :bar
-        |  def baz; end
-        |end
-        |""".stripMargin)
-
-    inside(cpg.call.nameExact(RubyOperators.privateModifier).l) { case modifierCall :: Nil =>
-      modifierCall.code shouldBe "private :bar"
-
-      inside(modifierCall.argument.l) { case (sym: Literal) :: Nil =>
-        sym.code shouldBe ":bar"
-      }
-    }
-
-    cpg.method("baz").head.isPublic.size shouldBe 1
-  }
-
-  "private_class_method with multiple symbol arguments should pass all arguments" in {
-    val cpg = code("""
-        |class Foo
-        |  def self.bar; end
-        |  def self.baz; end
-        |  private_class_method :bar, :baz
-        |end
-        |""".stripMargin)
-
-    inside(cpg.call.nameExact(RubyOperators.privateClassMethod).l) { case modifierCall :: Nil =>
-      modifierCall.code shouldBe "private_class_method :bar, :baz"
-
-      inside(modifierCall.argument.l) { case (sym1: Literal) :: (sym2: Literal) :: Nil =>
-        sym1.code shouldBe ":bar"
-        sym2.code shouldBe ":baz"
-      }
-    }
-  }
-
   "private inside a method body should create an operator call without changing scope state" in {
     val cpg = code("""
         |class Foo
@@ -351,7 +312,220 @@ class AccessModifierTests extends RubyCode2CpgFixture {
     cpg.method("foo").head.isPublic.size shouldBe 1
 
     inside(cpg.method("foo").body.ast.isCall.nameExact(RubyOperators.privateModifier).l) { case modifierCall :: Nil =>
-      modifierCall.argument.size shouldBe 0
+      modifierCall.name shouldBe RubyOperators.privateModifier
+    }
+  }
+
+  "targeted private :bar" should {
+    val cpg = code("""
+        |class Foo
+        |  def bar; end
+        |  private :bar
+        |  def baz; end
+        |end
+        |""".stripMargin)
+
+    "correctly represent the operator call" in {
+      inside(cpg.call.nameExact(RubyOperators.privateModifier).l) { case modifierCall :: Nil =>
+        modifierCall.code shouldBe "private :bar"
+
+        inside(modifierCall.argument.l) { case (sym: Literal) :: Nil =>
+          sym.code shouldBe ":bar"
+        }
+      }
+    }
+
+    "make bar private" in {
+      cpg.method("bar").head.isPrivate.size shouldBe 1
+    }
+
+    "not change default visibility for subsequent methods" in {
+      cpg.method("baz").head.isPublic.size shouldBe 1
+    }
+  }
+
+  "retroactive protected :bar" should {
+    val cpg = code("""
+        |class Foo
+        |  def bar; end
+        |  protected :bar
+        |end
+        |""".stripMargin)
+
+    "correctly represent the operator call" in {
+      inside(cpg.call.nameExact(RubyOperators.protectedModifier).l) { case modifierCall :: Nil =>
+        modifierCall.code shouldBe "protected :bar"
+
+        inside(modifierCall.argument.l) { case (sym: Literal) :: Nil =>
+          sym.code shouldBe ":bar"
+        }
+      }
+    }
+
+    "make bar protected" in {
+      cpg.method("bar").head.isProtected.size shouldBe 1
+    }
+  }
+
+  "private_class_method :bar" should {
+    val cpg = code("""
+        |class Foo
+        |  def self.bar; end
+        |  private_class_method :bar
+        |end
+        |""".stripMargin)
+
+    "correctly represent the operator call" in {
+      inside(cpg.call.nameExact(RubyOperators.privateClassMethod).l) { case modifierCall :: Nil =>
+        modifierCall.code shouldBe "private_class_method :bar"
+
+        inside(modifierCall.argument.l) { case (sym: Literal) :: Nil =>
+          sym.code shouldBe ":bar"
+        }
+      }
+    }
+
+    "make singleton method bar private" in {
+      cpg.method("bar").head.isPrivate.size shouldBe 1
+    }
+  }
+
+  "public_class_method :bar after private_class_method" should {
+    val cpg = code("""
+        |class Foo
+        |  private_class_method def self.bar; end
+        |  public_class_method :bar
+        |end
+        |""".stripMargin)
+
+    "correctly represent the operator call" in {
+      inside(cpg.call.nameExact(RubyOperators.publicClassMethod).l) { case modifierCall :: Nil =>
+        modifierCall.code shouldBe "public_class_method :bar"
+
+        inside(modifierCall.argument.l) { case (sym: Literal) :: Nil =>
+          sym.code shouldBe ":bar"
+        }
+      }
+    }
+
+    "restore singleton method to public" in {
+      cpg.method("bar").head.isPublic.size shouldBe 1
+    }
+  }
+
+  "private with multiple symbol arguments" should {
+    val cpg = code("""
+        |class Foo
+        |  def bar; end
+        |  def baz; end
+        |  private :bar, :baz
+        |end
+        |""".stripMargin)
+
+    "correctly represent the operator call" in {
+      inside(cpg.call.nameExact(RubyOperators.privateModifier).l) { case modifierCall :: Nil =>
+        modifierCall.code shouldBe "private :bar, :baz"
+
+        inside(modifierCall.argument.l) { case (sym1: Literal) :: (sym2: Literal) :: Nil =>
+          sym1.code shouldBe ":bar"
+          sym2.code shouldBe ":baz"
+        }
+      }
+    }
+
+    "make both methods private" in {
+      cpg.method("bar").head.isPrivate.size shouldBe 1
+      cpg.method("baz").head.isPrivate.size shouldBe 1
+    }
+  }
+
+  "private_class_method with multiple symbol arguments" should {
+    val cpg = code("""
+        |class Foo
+        |  def self.bar; end
+        |  def self.baz; end
+        |  private_class_method :bar, :baz
+        |end
+        |""".stripMargin)
+
+    "correctly represent the operator call" in {
+      inside(cpg.call.nameExact(RubyOperators.privateClassMethod).l) { case modifierCall :: Nil =>
+        modifierCall.code shouldBe "private_class_method :bar, :baz"
+
+        inside(modifierCall.argument.l) { case (sym1: Literal) :: (sym2: Literal) :: Nil =>
+          sym1.code shouldBe ":bar"
+          sym2.code shouldBe ":baz"
+        }
+      }
+    }
+
+    "make both singleton methods private" in {
+      cpg.method("bar").head.isPrivate.size shouldBe 1
+      cpg.method("baz").head.isPrivate.size shouldBe 1
+    }
+  }
+
+  "private_class_method with an array literal" should {
+    val cpg = code("""
+        |class Foo
+        |  def self.bar; end
+        |  def self.baz; end
+        |  private_class_method %i[
+        |    bar
+        |    baz
+        |  ]
+        |end
+        |""".stripMargin)
+
+    "correctly represent the access modifier call" in {
+      inside(cpg.call.nameExact(RubyOperators.privateClassMethod).l) { case modifierCall :: Nil =>
+        modifierCall.methodFullName shouldBe RubyOperators.privateClassMethod
+      }
+    }
+
+    "make both singleton methods private" in {
+      cpg.method("bar").head.isPrivate.size shouldBe 1
+      cpg.method("baz").head.isPrivate.size shouldBe 1
+    }
+
+    "not produce orphaned tmp identifiers" in {
+      cpg.identifier.nameExact("<tmp-0>").method.size should not be 0
+    }
+  }
+
+  "visibility can be re-opened: private then public" in {
+    val cpg = code("""
+        |class Foo
+        |  private
+        |  def bar; end
+        |  public
+        |  def baz; end
+        |end
+        |""".stripMargin)
+
+    cpg.method("bar").head.isPrivate.size shouldBe 1
+    cpg.method("baz").head.isPublic.size shouldBe 1
+  }
+
+  "access modifier operator calls" should {
+    val cpg = code("""
+        |class Foo
+        |  def bar; end
+        |  private :bar
+        |  private_class_method :bar
+        |end
+        |""".stripMargin)
+
+    "be inside the <body> method, not direct TYPE_DECL children" in {
+      val bodyMethod = cpg.typeDecl.name("Foo").method.nameExact(Defines.TypeDeclBody).head
+
+      inside(bodyMethod.body.ast.isCall.nameExact(RubyOperators.privateModifier).l) { case modifierCall :: Nil =>
+        modifierCall.code shouldBe "private :bar"
+      }
+
+      inside(bodyMethod.body.ast.isCall.nameExact(RubyOperators.privateClassMethod).l) { case modifierCall :: Nil =>
+        modifierCall.code shouldBe "private_class_method :bar"
+      }
     }
   }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ClassTests.scala
@@ -1121,14 +1121,12 @@ class ClassTests extends RubyCode2CpgFixture {
     inside(cpg.typeDecl.name("Foo").astChildren.isMethod.l) { case lambdaMethod :: _ :: _ :: _ :: Nil =>
       val List(lambdaReturn) = lambdaMethod.body.astChildren.isReturn.l
 
-      lambdaReturn.code shouldBe "private_class_method :case_sensitive_find_by"
+      val List(modifierCall) = lambdaReturn.ast.isCall.nameExact(RubyDefines.RubyOperators.privateClassMethod).l
+      modifierCall.methodFullName shouldBe RubyDefines.RubyOperators.privateClassMethod
+      modifierCall.code shouldBe "private_class_method :case_sensitive_find_by"
 
-      val List(returnCall) = lambdaReturn.astChildren.isCall.l
-      returnCall.code shouldBe "private_class_method :case_sensitive_find_by"
-
-      val List(_, methodNameArg) = returnCall.argument.l
-      methodNameArg.code shouldBe "self.:case_sensitive_find_by"
-
+      val List(methodNameArg) = modifierCall.argument.l
+      methodNameArg.code shouldBe ":case_sensitive_find_by"
     }
   }
 
@@ -1172,7 +1170,11 @@ class ClassTests extends RubyCode2CpgFixture {
         |
         |""".stripMargin)
 
-    cpg.typeDecl("Foo").astChildren.whereNot(_.or(_.isMethod, _.isModifier, _.isTypeDecl, _.isMember)).size shouldBe 0
+    cpg
+      .typeDecl("Foo")
+      .astChildren
+      .whereNot(_.or(_.isMethod, _.isModifier, _.isTypeDecl, _.isMember, _.isCall))
+      .size shouldBe 0
   }
 
   "Proc-param in method with instance field assignment and instance field argument" in {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -993,17 +993,23 @@ class MethodTests extends RubyCode2CpgFixture {
         |    end
         |""".stripMargin)
 
-    inside(cpg.method.name("notifiable").body.astChildren.isReturn.astChildren.isCall.name("public").l) {
-      case publicCall :: Nil =>
-        publicCall.code shouldBe "public"
-
-        val List(selfArg) = publicCall.argument.l
+    inside(
+      cpg.method
+        .name("notifiable")
+        .body
+        .astChildren
+        .isReturn
+        .astChildren
+        .isCall
+        .name(RubyOperators.publicModifier)
+        .l
+    ) { case publicCall :: Nil =>
+      publicCall.code shouldBe "public"
     }
 
-    inside(cpg.method.name("not_notifiable").body.astChildren.isCall.name("public").l) { case publicCall :: Nil =>
-      publicCall.code shouldBe "public"
-
-      val List(selfArg) = publicCall.argument.l
+    inside(cpg.method.name("not_notifiable").body.astChildren.isCall.name(RubyOperators.publicModifier).l) {
+      case publicCall :: Nil =>
+        publicCall.code shouldBe "public"
     }
   }
 


### PR DESCRIPTION
This PR addresses a few things in regard to access modifiers. 

### Access modifiers modelled as operator calls
Each access modifier has its own operator call name.
This also allows us to remove the special implicit return handling.

### Incorrect access modifier arguments
1. Normal access modifiers' arguments were previously not captured in the CPG.
2. Method access modifiers' arguments, if any, were limited to the first argument, even when the argument was a list. 

### Access modifiers not placed in class `<body>` method
Access modifiers were not placed as children of the `<body>` method as they were seen as declarative statements and not calls. Since it's been established that these are calls, they have now been moved to be in the class `<body>` method.
However, doing this means the ordering of statements is lost. Ordering is important for access modifier calls that aren't targeted. Example:

```rb
class Test
  def foo; end
  private
  def bar; end
end
```

In the above example, `foo` is public and `bar` is private. Method declarations are not placed in the `<body>` method. Since my change move the access modifier inside the `<body>` method, the ordering is lost. 
This is remedied by using the statement line numbers to re-order the statements before traversing them. 