### PR TITLE
[pysrc2cpg] Temp variable naming improvements

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ContextStack.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ContextStack.scala
@@ -169,15 +169,16 @@ class ContextStack {
     val context  = stack.head
     val nameBase = prefix.map(prefixValue => s"${prefixValue}_tmp").getOrElse("tmp")
 
-    var result: String = ""
-    while (result == "" || context.reservedNames.contains(result)) {
+    var unusedName = Option.empty[String]
+    while (unusedName.forall(context.reservedNames.contains)) {
       val counter = context.tmpCounters.getOrElse(nameBase, 0)
-      result = s"$nameBase$counter"
+      unusedName = Some(s"$nameBase$counter")
       context.tmpCounters.update(nameBase, counter + 1)
     }
 
-    context.reservedNames.add(result)
-    result
+    val name = unusedName.get
+    context.reservedNames.add(name)
+    name
   }
 
   private def findEnclosingMethodContext(contextStack: List[Context]): MethodContext = {

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ContextStack.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ContextStack.scala
@@ -31,6 +31,8 @@ class ContextStack {
     val astParent: nodes.NewNode
     val order: AutoIncIndex
     val variables: mutable.Map[String, nodes.NewNode]
+    val reservedNames: mutable.Set[String]
+    val tmpCounters: mutable.Map[String, Int]
     var lambdaCounter: Int
     val methodCounter: mutable.Map[String, Int]
   }
@@ -43,6 +45,8 @@ class ContextStack {
     val methodBlockNode: Option[nodes.NewBlock] = None,
     val methodRefNode: Option[nodes.NewMethodRef] = None,
     val variables: mutable.Map[String, nodes.NewNode] = mutable.Map.empty,
+    val reservedNames: mutable.Set[String] = mutable.Set.empty,
+    val tmpCounters: mutable.Map[String, Int] = mutable.Map.empty,
     val globalVariables: mutable.Set[String] = mutable.Set.empty,
     val nonLocalVariables: mutable.Set[String] = mutable.Set.empty,
     var lambdaCounter: Int = 0,
@@ -54,6 +58,8 @@ class ContextStack {
     val astParent: nodes.NewNode,
     val order: AutoIncIndex,
     val variables: mutable.Map[String, nodes.NewNode] = mutable.Map.empty,
+    val reservedNames: mutable.Set[String] = mutable.Set.empty,
+    val tmpCounters: mutable.Map[String, Int] = mutable.Map.empty,
     var lambdaCounter: Int = 0,
     val methodCounter: mutable.Map[String, Int] = mutable.Map.empty
   ) extends Context {}
@@ -72,6 +78,8 @@ class ContextStack {
     val astParent: nodes.NewNode,
     val order: AutoIncIndex,
     val variables: mutable.Map[String, nodes.NewNode] = mutable.Map.empty,
+    val reservedNames: mutable.Set[String] = mutable.Set.empty,
+    val tmpCounters: mutable.Map[String, Int] = mutable.Map.empty,
     var lambdaCounter: Int = 0,
     val methodCounter: mutable.Map[String, Int] = mutable.Map.empty
   ) extends Context {}
@@ -101,7 +109,8 @@ class ContextStack {
     scopeName: Option[String],
     methodNode: nodes.NewMethod,
     methodBlockNode: nodes.NewBlock,
-    methodRefNode: Option[nodes.NewMethodRef]
+    methodRefNode: Option[nodes.NewMethodRef],
+    reservedNames: Iterable[String] = Nil
   ): Unit = {
     val isClassBodyMethod = stack.headOption.exists(_.isInstanceOf[ClassContext])
 
@@ -112,7 +121,8 @@ class ContextStack {
         new AutoIncIndex(1),
         isClassBodyMethod,
         Some(methodBlockNode),
-        methodRefNode
+        methodRefNode,
+        reservedNames = mutable.Set.from(reservedNames)
       )
     if (moduleMethodContext.isEmpty) {
       moduleMethodContext = Some(methodContext)
@@ -120,13 +130,23 @@ class ContextStack {
     push(methodContext)
   }
 
-  def pushClass(scopeName: Option[String], classNode: nodes.NewTypeDecl): Unit = {
-    push(new ClassContext(scopeName, classNode, new AutoIncIndex(1)))
+  def pushClass(
+    scopeName: Option[String],
+    classNode: nodes.NewTypeDecl,
+    reservedNames: Iterable[String] = Nil
+  ): Unit = {
+    push(new ClassContext(scopeName, classNode, new AutoIncIndex(1), reservedNames = mutable.Set.from(reservedNames)))
   }
 
-  def pushSpecialContext(): Unit = {
+  def pushSpecialContext(reservedNames: Iterable[String] = Nil): Unit = {
     val methodContext = findEnclosingMethodContext(stack)
-    push(new SpecialBlockContext(methodContext.astParent, methodContext.order))
+    push(
+      new SpecialBlockContext(
+        methodContext.astParent,
+        methodContext.order,
+        reservedNames = mutable.Set.from(reservedNames)
+      )
+    )
   }
 
   def pop(): Unit = {
@@ -144,6 +164,32 @@ class ContextStack {
   def getAndIncLambdaCounter(): Int = {
     val result = stack.head.lambdaCounter
     stack.head.lambdaCounter += 1
+    result
+  }
+
+  def getUnusedName(prefix: Option[String] = None): String = {
+    val context = stack.head
+    // Temporary stores in special contexts are materialized as locals in the
+    // enclosing method, so their names must be allocated from that method's
+    // shared counter and reservation set.
+    val enclosingMethodContext = context match {
+      case _: SpecialBlockContext => Some(findEnclosingMethodContext(stack))
+      case _                      => None
+    }
+    val allocationContext = enclosingMethodContext.getOrElse(context)
+    val nameBase          = prefix.map(prefix_value => s"${prefix_value}_tmp").getOrElse("tmp")
+    val isReserved = (name: String) =>
+      context.reservedNames.contains(name) || enclosingMethodContext.exists(_.reservedNames.contains(name))
+
+    var result: String = ""
+    while (result == "" || isReserved(result)) {
+      val counter = allocationContext.tmpCounters.getOrElse(nameBase, 0)
+      result = s"$nameBase$counter"
+      allocationContext.tmpCounters.update(nameBase, counter + 1)
+    }
+
+    context.reservedNames.add(result)
+    enclosingMethodContext.foreach(_.reservedNames.add(result))
     result
   }
 

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ContextStack.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ContextStack.scala
@@ -110,7 +110,7 @@ class ContextStack {
     methodNode: nodes.NewMethod,
     methodBlockNode: nodes.NewBlock,
     methodRefNode: Option[nodes.NewMethodRef],
-    reservedNames: Iterable[String] = Nil
+    reservedNames: Iterable[String]
   ): Unit = {
     val isClassBodyMethod = stack.headOption.exists(_.isInstanceOf[ClassContext])
 
@@ -130,21 +130,19 @@ class ContextStack {
     push(methodContext)
   }
 
-  def pushClass(
-    scopeName: Option[String],
-    classNode: nodes.NewTypeDecl,
-    reservedNames: Iterable[String] = Nil
-  ): Unit = {
+  def pushClass(scopeName: Option[String], classNode: nodes.NewTypeDecl, reservedNames: Iterable[String]): Unit = {
     push(new ClassContext(scopeName, classNode, new AutoIncIndex(1), reservedNames = mutable.Set.from(reservedNames)))
   }
 
-  def pushSpecialContext(reservedNames: Iterable[String] = Nil): Unit = {
+  def pushSpecialContext(reservedNames: Iterable[String]): Unit = {
     val methodContext = findEnclosingMethodContext(stack)
+    methodContext.reservedNames.addAll(reservedNames)
     push(
       new SpecialBlockContext(
         methodContext.astParent,
         methodContext.order,
-        reservedNames = mutable.Set.from(reservedNames)
+        reservedNames = methodContext.reservedNames,
+        tmpCounters = methodContext.tmpCounters
       )
     )
   }
@@ -168,28 +166,17 @@ class ContextStack {
   }
 
   def getUnusedName(prefix: Option[String] = None): String = {
-    val context = stack.head
-    // Temporary stores in special contexts are materialized as locals in the
-    // enclosing method, so their names must be allocated from that method's
-    // shared counter and reservation set.
-    val enclosingMethodContext = context match {
-      case _: SpecialBlockContext => Some(findEnclosingMethodContext(stack))
-      case _                      => None
-    }
-    val allocationContext = enclosingMethodContext.getOrElse(context)
-    val nameBase          = prefix.map(prefix_value => s"${prefix_value}_tmp").getOrElse("tmp")
-    val isReserved = (name: String) =>
-      context.reservedNames.contains(name) || enclosingMethodContext.exists(_.reservedNames.contains(name))
+    val context  = stack.head
+    val nameBase = prefix.map(prefixValue => s"${prefixValue}_tmp").getOrElse("tmp")
 
     var result: String = ""
-    while (result == "" || isReserved(result)) {
-      val counter = allocationContext.tmpCounters.getOrElse(nameBase, 0)
+    while (result == "" || context.reservedNames.contains(result)) {
+      val counter = context.tmpCounters.getOrElse(nameBase, 0)
       result = s"$nameBase$counter"
-      allocationContext.tmpCounters.update(nameBase, counter + 1)
+      context.tmpCounters.update(nameBase, counter + 1)
     }
 
     context.reservedNames.add(result)
-    enclosingMethodContext.foreach(_.reservedNames.add(result))
     result
   }
 

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
@@ -345,7 +345,7 @@ class PythonAstVisitor(
     isAsync: Boolean,
     lineAndColumn: LineAndColumn,
     additionalModifiers: List[String] = List.empty,
-    reservedNames: Iterable[String] = Nil
+    reservedNames: Iterable[String]
   ): (nodes.NewMethod, nodes.NewMethodRef) = {
     val suffix =
       contextStack.methodCounter.get(methodName) match {
@@ -398,7 +398,7 @@ class PythonAstVisitor(
     methodRefNode: Option[nodes.NewMethodRef],
     returnTypeHint: Option[String],
     lineAndColumn: LineAndColumn,
-    reservedNames: Iterable[String] = Nil
+    reservedNames: Iterable[String]
   ): nodes.NewMethod = {
     val methodNode = nodeBuilder.methodNode(name, fullName, relFileName, lineAndColumn)
     edgeBuilder.astEdge(methodNode, contextStack.astParent, contextStack.order.getAndInc)
@@ -688,7 +688,8 @@ class PythonAstVisitor(
       isAsync = false,
       methodRefNode = None,
       returnTypeHint = None,
-      lineAndColumn
+      lineAndColumn,
+      reservedNames = Nil
     )
   }
 
@@ -790,7 +791,8 @@ class PythonAstVisitor(
       isAsync = false,
       methodRefNode = None,
       returnTypeHint = Some(instanceTypeDeclFullName),
-      lineAndColumn
+      lineAndColumn,
+      reservedNames = Nil
     )
   }
 
@@ -851,7 +853,8 @@ class PythonAstVisitor(
       isAsync = false,
       methodRefNode = None,
       returnTypeHint = None,
-      lineAndColumn
+      lineAndColumn,
+      reservedNames = Nil
     )
   }
 

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
@@ -45,6 +45,7 @@ class PythonAstVisitor(
   protected val contextStack = new ContextStack()
 
   private var memOpMap: AstNodeToMemoryOperationMap = scala.compiletime.uninitialized
+  private var scopeNames: ScopeNameCollection       = scala.compiletime.uninitialized
 
   private val members = mutable.Map.empty[NewTypeDecl, List[String]]
 
@@ -81,6 +82,7 @@ class PythonAstVisitor(
     val memOpCalculator = new MemoryOperationCalculator()
     module.accept(memOpCalculator)
     memOpMap = memOpCalculator.astNodeToMemOp
+    scopeNames = memOpCalculator.scopeNames
 
     val contentOption = if (enableFileContent) Some(nodeToCode.content) else None
     val fileNode      = nodeBuilder.fileNode(relFileName, contentOption)
@@ -116,7 +118,8 @@ class PythonAstVisitor(
         isAsync = false,
         methodRefNode = None,
         returnTypeHint = None,
-        LineAndColumn(line, column, endLine, endColumn, offset, endOffset)
+        LineAndColumn(line, column, endLine, endColumn, offset, endOffset),
+        reservedNames = scopeNames.namesInScope(module)
       )
 
     createIdentifierLinks()
@@ -274,7 +277,8 @@ class PythonAstVisitor(
       () => body.map(convert),
       returns,
       isAsync,
-      lineAndColOf(functionDef)
+      lineAndColOf(functionDef),
+      reservedNames = scopeNames.namesInScope(functionDef)
     )
     functionDefToMethod.put(functionDef, methodNode)
 
@@ -340,7 +344,8 @@ class PythonAstVisitor(
     returns: Option[ast.iexpr],
     isAsync: Boolean,
     lineAndColumn: LineAndColumn,
-    additionalModifiers: List[String] = List.empty
+    additionalModifiers: List[String] = List.empty,
+    reservedNames: Iterable[String] = Nil
   ): (nodes.NewMethod, nodes.NewMethodRef) = {
     val suffix =
       contextStack.methodCounter.get(methodName) match {
@@ -366,7 +371,8 @@ class PythonAstVisitor(
         isAsync = true,
         Some(methodRefNode),
         returnTypeHint = None,
-        lineAndColumn
+        lineAndColumn,
+        reservedNames
       )
 
     contextStack.methodCounter.updateWith(methodName) {
@@ -391,7 +397,8 @@ class PythonAstVisitor(
     isAsync: Boolean,
     methodRefNode: Option[nodes.NewMethodRef],
     returnTypeHint: Option[String],
-    lineAndColumn: LineAndColumn
+    lineAndColumn: LineAndColumn,
+    reservedNames: Iterable[String] = Nil
   ): nodes.NewMethod = {
     val methodNode = nodeBuilder.methodNode(name, fullName, relFileName, lineAndColumn)
     edgeBuilder.astEdge(methodNode, contextStack.astParent, contextStack.order.getAndInc)
@@ -399,7 +406,7 @@ class PythonAstVisitor(
     val blockNode = nodeBuilder.blockNode("", lineAndColumn)
     edgeBuilder.astEdge(blockNode, methodNode, 1)
 
-    contextStack.pushMethod(scopeName, methodNode, blockNode, methodRefNode)
+    contextStack.pushMethod(scopeName, methodNode, blockNode, methodRefNode, reservedNames)
 
     var order = 0
     for (modifier <- modifiers) {
@@ -497,7 +504,7 @@ class PythonAstVisitor(
     edgeBuilder.astEdge(instanceTypeDecl, contextStack.astParent, contextStack.order.getAndInc)
 
     // Create <body> function which contains the code defining the class
-    contextStack.pushClass(Some(classDef.name), instanceTypeDecl)
+    contextStack.pushClass(Some(classDef.name), instanceTypeDecl, scopeNames.namesInScope(classDef))
     val classBodyFunctionName = "<body>"
     val (_, methodRefNode) = createMethodAndMethodRef(
       classBodyFunctionName,
@@ -510,12 +517,13 @@ class PythonAstVisitor(
       bodyProvider = () => classDef.body.map(convert),
       None,
       isAsync = false,
-      lineAndColOf(classDef)
+      lineAndColOf(classDef),
+      reservedNames = scopeNames.namesInScope(classDef)
     )
 
     contextStack.pop()
 
-    contextStack.pushClass(Some(classDef.name), metaTypeDeclNode)
+    contextStack.pushClass(Some(classDef.name), metaTypeDeclNode, scopeNames.namesInScope(classDef))
 
     // Create meta class call handling method and bind it to meta class type.
     val functions = classDef.body.collect { case func: ast.FunctionDef => func }
@@ -1511,7 +1519,8 @@ class PythonAstVisitor(
       returns = None,
       isAsync = false,
       lineAndColOf(lambda),
-      ModifierTypes.LAMBDA :: Nil
+      ModifierTypes.LAMBDA :: Nil,
+      reservedNames = scopeNames.namesInScope(lambda)
     )
     methodRefNode
   }
@@ -1598,7 +1607,7 @@ class PythonAstVisitor(
     */
   // TODO test
   def convert(listComp: ast.ListComp): NewNode = {
-    contextStack.pushSpecialContext()
+    contextStack.pushSpecialContext(scopeNames.namesInScope(listComp))
     val tmpVariableName = getUnusedName()
 
     // Create tmp = list()
@@ -1635,7 +1644,7 @@ class PythonAstVisitor(
     */
   // TODO test
   def convert(setComp: ast.SetComp): NewNode = {
-    contextStack.pushSpecialContext()
+    contextStack.pushSpecialContext(scopeNames.namesInScope(setComp))
     val tmpVariableName = getUnusedName()
 
     val setOperatorCall =
@@ -1671,7 +1680,7 @@ class PythonAstVisitor(
     */
   // TODO test
   def convert(dictComp: ast.DictComp): NewNode = {
-    contextStack.pushSpecialContext()
+    contextStack.pushSpecialContext(scopeNames.namesInScope(dictComp))
     val tmpVariableName = getUnusedName()
 
     val dictOperatorCall =
@@ -1709,7 +1718,7 @@ class PythonAstVisitor(
     */
   // TODO test
   def convert(generatorExp: ast.GeneratorExp): NewNode = {
-    contextStack.pushSpecialContext()
+    contextStack.pushSpecialContext(scopeNames.namesInScope(generatorExp))
     val tmpVariableName = getUnusedName()
 
     // Create tmp = list()
@@ -2110,7 +2119,7 @@ class PythonAstVisitor(
   // is right and that we convert the exception handler body.
   // TODO tests
   def convert(exceptHandler: ast.ExceptHandler): NewNode = {
-    contextStack.pushSpecialContext()
+    contextStack.pushSpecialContext(scopeNames.namesInScope(exceptHandler))
     val specialTargetLocals = mutable.ArrayBuffer.empty[nodes.NewLocal]
     if (exceptHandler.name.isDefined) {
       val localNode = nodeBuilder.localNode(exceptHandler.name.get, None)

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitorHelpers.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitorHelpers.scala
@@ -33,17 +33,8 @@ trait PythonAstVisitorHelpers(implicit withSchemaValidation: ValidationMode) { t
     )
   }
 
-  private var tmpCounter = 0
-
   protected def getUnusedName(prefix: String = null): String = {
-    // TODO check that result name does not collide with existing variables.
-    val result = if (prefix != null) {
-      s"${prefix}_tmp$tmpCounter"
-    } else {
-      s"tmp$tmpCounter"
-    }
-    tmpCounter += 1
-    result
+    contextStack.getUnusedName(Option(prefix))
   }
 
   protected def createTry(

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/memop/MemoryOperationCalculator.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/memop/MemoryOperationCalculator.scala
@@ -27,6 +27,7 @@ class MemoryOperationCalculator extends AstVisitor[Unit] {
   private val stack  = mutable.Stack.empty[MemoryOperation]
   val astNodeToMemOp = new AstNodeToMemoryOperationMap()
   val names          = mutable.Set.empty[String]
+  val scopeNames     = new ScopeNameCollection()
 
   private def accept(astNode: ast.iast): Unit = {
     astNode.accept(this)
@@ -44,41 +45,74 @@ class MemoryOperationCalculator extends AstVisitor[Unit] {
     stack.pop()
   }
 
+  private def pushScope(scope: ast.iast): Unit = {
+    scopeNames.pushScope(scope)
+  }
+
+  private def popScope(): Unit = {
+    scopeNames.popScope()
+  }
+
+  private def addName(name: String): Unit = {
+    scopeNames.addName(name)
+  }
+
   override def visit(astNode: ast.iast): Unit = ???
 
   override def visit(mod: ast.imod): Unit = ???
 
   override def visit(module: ast.Module): Unit = {
+    pushScope(module)
     accept(module.stmts)
+    popScope()
   }
 
   override def visit(stmt: ast.istmt): Unit = ???
 
   override def visit(functionDef: ast.FunctionDef): Unit = {
+    addName(functionDef.name)
     push(Load)
     accept(functionDef.decorator_list)
     accept(functionDef.args)
     accept(functionDef.returns)
     pop()
+    pushScope(functionDef)
+    functionDef.args.posonlyargs.foreach(arg => addName(arg.arg))
+    functionDef.args.args.foreach(arg => addName(arg.arg))
+    functionDef.args.vararg.foreach(arg => addName(arg.arg))
+    functionDef.args.kwonlyargs.foreach(arg => addName(arg.arg))
+    functionDef.args.kw_arg.foreach(arg => addName(arg.arg))
     accept(functionDef.body)
+    popScope()
   }
 
   override def visit(functionDef: ast.AsyncFunctionDef): Unit = {
+    addName(functionDef.name)
     push(Load)
     accept(functionDef.decorator_list)
     accept(functionDef.args)
     accept(functionDef.returns)
     pop()
+    pushScope(functionDef)
+    functionDef.args.posonlyargs.foreach(arg => addName(arg.arg))
+    functionDef.args.args.foreach(arg => addName(arg.arg))
+    functionDef.args.vararg.foreach(arg => addName(arg.arg))
+    functionDef.args.kwonlyargs.foreach(arg => addName(arg.arg))
+    functionDef.args.kw_arg.foreach(arg => addName(arg.arg))
     accept(functionDef.body)
+    popScope()
   }
 
   override def visit(classDef: ast.ClassDef): Unit = {
+    addName(classDef.name)
     push(Load)
     accept(classDef.decorator_list)
     accept(classDef.bases)
     accept(classDef.keywords)
     pop()
+    pushScope(classDef)
     accept(classDef.body)
+    popScope()
   }
 
   override def visit(ret: ast.Return): Unit = {
@@ -199,13 +233,13 @@ class MemoryOperationCalculator extends AstVisitor[Unit] {
     pop()
   }
 
-  override def visit(importStmt: ast.Import): Unit = {}
+  override def visit(importStmt: ast.Import): Unit = accept(importStmt.names)
 
-  override def visit(importFrom: ast.ImportFrom): Unit = {}
+  override def visit(importFrom: ast.ImportFrom): Unit = accept(importFrom.names)
 
-  override def visit(global: ast.Global): Unit = {}
+  override def visit(global: ast.Global): Unit = global.names.foreach(addName)
 
-  override def visit(nonlocal: ast.Nonlocal): Unit = {}
+  override def visit(nonlocal: ast.Nonlocal): Unit = nonlocal.names.foreach(addName)
 
   override def visit(expr: ast.Expr): Unit = {
     push(Load)
@@ -255,7 +289,14 @@ class MemoryOperationCalculator extends AstVisitor[Unit] {
     push(Load)
     accept(lambda.args)
     pop()
+    pushScope(lambda)
+    lambda.args.posonlyargs.foreach(arg => addName(arg.arg))
+    lambda.args.args.foreach(arg => addName(arg.arg))
+    lambda.args.vararg.foreach(arg => addName(arg.arg))
+    lambda.args.kwonlyargs.foreach(arg => addName(arg.arg))
+    lambda.args.kw_arg.foreach(arg => addName(arg.arg))
     accept(lambda.body)
+    popScope()
   }
 
   override def visit(ifExp: ast.IfExp): Unit = {
@@ -274,24 +315,32 @@ class MemoryOperationCalculator extends AstVisitor[Unit] {
   }
 
   override def visit(listComp: ast.ListComp): Unit = {
+    pushScope(listComp)
     accept(listComp.elt)
     accept(listComp.generators)
+    popScope()
   }
 
   override def visit(setComp: ast.SetComp): Unit = {
+    pushScope(setComp)
     accept(setComp.elt)
     accept(setComp.generators)
+    popScope()
   }
 
   override def visit(dictComp: ast.DictComp): Unit = {
+    pushScope(dictComp)
     accept(dictComp.key)
     accept(dictComp.value)
     accept(dictComp.generators)
+    popScope()
   }
 
   override def visit(generatorExp: ast.GeneratorExp): Unit = {
+    pushScope(generatorExp)
     accept(generatorExp.elt)
     accept(generatorExp.generators)
+    popScope()
   }
 
   override def visit(await: ast.Await): Unit = {
@@ -353,6 +402,7 @@ class MemoryOperationCalculator extends AstVisitor[Unit] {
   override def visit(name: ast.Name): Unit = {
     astNodeToMemOp.put(name, stack.head)
     names.add(name.id)
+    addName(name.id)
   }
 
   override def visit(list: ast.List): Unit = {
@@ -453,10 +503,13 @@ class MemoryOperationCalculator extends AstVisitor[Unit] {
   }
 
   override def visit(exceptHandler: ast.ExceptHandler): Unit = {
+    pushScope(exceptHandler)
+    exceptHandler.name.foreach(addName)
     push(Load)
     accept(exceptHandler.typ)
     pop()
     accept(exceptHandler.body)
+    popScope()
   }
 
   override def visit(arguments: ast.Arguments): Unit = {
@@ -496,7 +549,9 @@ class MemoryOperationCalculator extends AstVisitor[Unit] {
     accept(keyword.value)
   }
 
-  override def visit(alias: ast.Alias): Unit = {}
+  override def visit(alias: ast.Alias): Unit = {
+    addName(alias.asName.getOrElse(alias.name).split('.').head)
+  }
 
   override def visit(withItem: ast.Withitem): Unit = {
     push(Load)
@@ -526,6 +581,7 @@ class MemoryOperationCalculator extends AstVisitor[Unit] {
   override def visit(matchMapping: MatchMapping): Unit = {
     accept(matchMapping.keys)
     accept(matchMapping.patterns)
+    matchMapping.rest.foreach(addName)
   }
 
   override def visit(matchClass: MatchClass): Unit = {
@@ -534,10 +590,11 @@ class MemoryOperationCalculator extends AstVisitor[Unit] {
     accept(matchClass.kwd_patterns)
   }
 
-  override def visit(matchStar: MatchStar): Unit = {}
+  override def visit(matchStar: MatchStar): Unit = matchStar.name.foreach(addName)
 
   override def visit(matchAs: MatchAs): Unit = {
     accept(matchAs.pattern)
+    matchAs.name.foreach(addName)
   }
 
   override def visit(matchOr: MatchOr): Unit = {

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/memop/MemoryOperationCalculator.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/memop/MemoryOperationCalculator.scala
@@ -24,10 +24,11 @@ import MemoryOperation.{Del, Load, Store}
 import scala.collection.mutable
 
 class MemoryOperationCalculator extends AstVisitor[Unit] {
-  private val stack  = mutable.Stack.empty[MemoryOperation]
-  val astNodeToMemOp = new AstNodeToMemoryOperationMap()
-  val names          = mutable.Set.empty[String]
-  val scopeNames     = new ScopeNameCollection()
+  private val stack             = mutable.Stack.empty[MemoryOperation]
+  val astNodeToMemOp            = new AstNodeToMemoryOperationMap()
+  val names                     = mutable.Set.empty[String]
+  val scopeNames                = new ScopeNameCollection()
+  private var argumentNameScope = Option.empty[ast.iast]
 
   private def accept(astNode: ast.iast): Unit = {
     astNode.accept(this)
@@ -57,6 +58,23 @@ class MemoryOperationCalculator extends AstVisitor[Unit] {
     scopeNames.addName(name)
   }
 
+  private def addArgumentName(name: String): Unit = {
+    argumentNameScope match {
+      case Some(scope) => scopeNames.addName(scope, name)
+      case None        => addName(name)
+    }
+  }
+
+  private def acceptArgumentsInScope(arguments: ast.Arguments, scope: ast.iast): Unit = {
+    val previousArgumentNameScope = argumentNameScope
+    argumentNameScope = Some(scope)
+    try {
+      accept(arguments)
+    } finally {
+      argumentNameScope = previousArgumentNameScope
+    }
+  }
+
   override def visit(astNode: ast.iast): Unit = ???
 
   override def visit(mod: ast.imod): Unit = ???
@@ -73,15 +91,10 @@ class MemoryOperationCalculator extends AstVisitor[Unit] {
     addName(functionDef.name)
     push(Load)
     accept(functionDef.decorator_list)
-    accept(functionDef.args)
+    acceptArgumentsInScope(functionDef.args, functionDef)
     accept(functionDef.returns)
     pop()
     pushScope(functionDef)
-    functionDef.args.posonlyargs.foreach(arg => addName(arg.arg))
-    functionDef.args.args.foreach(arg => addName(arg.arg))
-    functionDef.args.vararg.foreach(arg => addName(arg.arg))
-    functionDef.args.kwonlyargs.foreach(arg => addName(arg.arg))
-    functionDef.args.kw_arg.foreach(arg => addName(arg.arg))
     accept(functionDef.body)
     popScope()
   }
@@ -90,15 +103,10 @@ class MemoryOperationCalculator extends AstVisitor[Unit] {
     addName(functionDef.name)
     push(Load)
     accept(functionDef.decorator_list)
-    accept(functionDef.args)
+    acceptArgumentsInScope(functionDef.args, functionDef)
     accept(functionDef.returns)
     pop()
     pushScope(functionDef)
-    functionDef.args.posonlyargs.foreach(arg => addName(arg.arg))
-    functionDef.args.args.foreach(arg => addName(arg.arg))
-    functionDef.args.vararg.foreach(arg => addName(arg.arg))
-    functionDef.args.kwonlyargs.foreach(arg => addName(arg.arg))
-    functionDef.args.kw_arg.foreach(arg => addName(arg.arg))
     accept(functionDef.body)
     popScope()
   }
@@ -287,14 +295,9 @@ class MemoryOperationCalculator extends AstVisitor[Unit] {
 
   override def visit(lambda: ast.Lambda): Unit = {
     push(Load)
-    accept(lambda.args)
+    acceptArgumentsInScope(lambda.args, lambda)
     pop()
     pushScope(lambda)
-    lambda.args.posonlyargs.foreach(arg => addName(arg.arg))
-    lambda.args.args.foreach(arg => addName(arg.arg))
-    lambda.args.vararg.foreach(arg => addName(arg.arg))
-    lambda.args.kwonlyargs.foreach(arg => addName(arg.arg))
-    lambda.args.kw_arg.foreach(arg => addName(arg.arg))
     accept(lambda.body)
     popScope()
   }
@@ -513,6 +516,11 @@ class MemoryOperationCalculator extends AstVisitor[Unit] {
   }
 
   override def visit(arguments: ast.Arguments): Unit = {
+    arguments.posonlyargs.foreach(arg => addArgumentName(arg.arg))
+    arguments.args.foreach(arg => addArgumentName(arg.arg))
+    arguments.vararg.foreach(arg => addArgumentName(arg.arg))
+    arguments.kwonlyargs.foreach(arg => addArgumentName(arg.arg))
+    arguments.kw_arg.foreach(arg => addArgumentName(arg.arg))
     accept(arguments.posonlyargs)
     accept(arguments.args)
     accept(arguments.vararg)

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/memop/ScopeNameCollection.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/memop/ScopeNameCollection.scala
@@ -1,0 +1,28 @@
+package io.joern.pysrc2cpg.memop
+
+import io.joern.pythonparser.ast
+
+import scala.collection.mutable
+
+/** Source identifier names grouped by the lexical AST scope that contains them. */
+class ScopeNameCollection {
+  private val namesByScope = new java.util.IdentityHashMap[ast.iast, mutable.Set[String]]()
+  private val scopeStack   = mutable.Stack.empty[ast.iast]
+
+  private[memop] def pushScope(scope: ast.iast): Unit = {
+    scopeStack.push(scope)
+    namesByScope.put(scope, mutable.Set.empty)
+  }
+
+  private[memop] def popScope(): Unit = {
+    scopeStack.pop()
+  }
+
+  private[memop] def addName(name: String): Unit = {
+    namesByScope.get(scopeStack.head).add(name)
+  }
+
+  def namesInScope(scope: ast.iast): collection.Set[String] = {
+    Option(namesByScope.get(scope)).map(_.toSet).getOrElse(Set.empty)
+  }
+}

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/memop/ScopeNameCollection.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/memop/ScopeNameCollection.scala
@@ -11,7 +11,9 @@ class ScopeNameCollection {
 
   private[memop] def pushScope(scope: ast.iast): Unit = {
     scopeStack.push(scope)
-    namesByScope.put(scope, mutable.Set.empty)
+    if (!namesByScope.containsKey(scope)) {
+      namesByScope.put(scope, mutable.Set.empty)
+    }
   }
 
   private[memop] def popScope(): Unit = {
@@ -20,6 +22,13 @@ class ScopeNameCollection {
 
   private[memop] def addName(name: String): Unit = {
     namesByScope.get(scopeStack.head).add(name)
+  }
+
+  private[memop] def addName(scope: ast.iast, name: String): Unit = {
+    if (!namesByScope.containsKey(scope)) {
+      namesByScope.put(scope, mutable.Set.empty)
+    }
+    namesByScope.get(scope).add(name)
   }
 
   def namesInScope(scope: ast.iast): collection.Set[String] = {

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/TemporaryVariableNameTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/TemporaryVariableNameTests.scala
@@ -1,0 +1,74 @@
+package io.joern.pysrc2cpg.cpg
+
+import io.joern.pysrc2cpg.testfixtures.PySrc2CpgFixture
+import io.shiftleft.semanticcpg.language.*
+
+class TemporaryVariableNameTests extends PySrc2CpgFixture {
+  "lowering temporary variables" should {
+    "avoid source names that occur later in the same scope" in {
+      val cpg = code("tmp0, value = source")
+
+      cpg.call.code("tmp1 = source").size shouldBe 1
+      cpg.method.name("<module>").local.name("tmp0").size shouldBe 1
+      cpg.method.name("<module>").local.name("tmp1").size shouldBe 1
+    }
+
+    "avoid parameter names" in {
+      val cpg = code("""def f(tmp0):
+          |    left, right = source
+          |""".stripMargin)
+
+      cpg.call.code("tmp1 = source").size shouldBe 1
+      cpg.method.name("f").local.name("tmp1").size shouldBe 1
+    }
+
+    "avoid import aliases for prefixed temporaries" in {
+      val cpg = code("""import manager as manager_tmp0
+          |with context():
+          |    pass
+          |""".stripMargin)
+
+      cpg.identifier.name("manager_tmp1").size should be > 0
+      cpg.identifier.name("enter_tmp0").size should be > 0
+    }
+
+    "avoid names in comprehension contexts" in {
+      val cpg = code("""result = [tmp0 for tmp0 in values]
+          |""".stripMargin)
+
+      cpg.call.code("tmp1 = \\[\\]").size shouldBe 1
+    }
+
+    "avoid names in exception-handler contexts" in {
+      val cpg = code("""try:
+          |    pass
+          |except Exception as tmp0:
+          |    left, right = source
+          |""".stripMargin)
+
+      cpg.call.code("tmp1 = source").size shouldBe 1
+    }
+
+    "start counters independently in sibling functions" in {
+      val cpg = code("""def first():
+          |    a, b = one
+          |def second():
+          |    c, d = two
+          |""".stripMargin)
+
+      cpg.method.name("first").ast.isCall.code("tmp0 = one").size shouldBe 1
+      cpg.method.name("second").ast.isCall.code("tmp0 = two").size shouldBe 1
+    }
+
+    "keep temporary names unique across sibling comprehensions" in {
+      val cpg = code("""first = [x for x in one]
+          |second = [y for y in two]
+          |""".stripMargin)
+
+      cpg.call.code("tmp0 = \\[\\]").size shouldBe 1
+      cpg.call.code("tmp2 = \\[\\]").size shouldBe 1
+      cpg.method.name("<module>").local.name("tmp0").size shouldBe 1
+      cpg.method.name("<module>").local.name("tmp2").size shouldBe 1
+    }
+  }
+}

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/TemporaryVariableNameTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/TemporaryVariableNameTests.scala
@@ -22,6 +22,20 @@ class TemporaryVariableNameTests extends PySrc2CpgFixture {
       cpg.method.name("f").local.name("tmp1").size shouldBe 1
     }
 
+    "avoid names captured from enclosing scopes" in {
+      val cpg = code("""def foo():
+          |    tmp0 = 1
+          |    def bar():
+          |        left, right = source
+          |        print(tmp0)
+          |    bar()
+          |foo()
+          |""".stripMargin)
+
+      cpg.method.name("bar").ast.isCall.code("tmp1 = source").size shouldBe 1
+      cpg.method.name("bar").local.name("tmp1").size shouldBe 1
+    }
+
     "avoid import aliases for prefixed temporaries" in {
       val cpg = code("""import manager as manager_tmp0
           |with context():


### PR DESCRIPTION
https://harness.atlassian.net/browse/QT-887

Temp variables can no longer collide with a source variable name
Temp variable names are scoped by scope, no longer per-file.