### PR TITLE
[kotlin2cpg] Avoid quadratic runtime in dirsForRoot

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/ContentSourcesPicker.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/ContentSourcesPicker.scala
@@ -20,24 +20,34 @@ object ContentSourcesPicker {
   //  `Seq("dir1/dir2/dir3")` and nothing else.
 
   def dirsForRoot(rootDir: String): Seq[String] = {
-    val dir        = Paths.get(rootDir)
-    val hasSubDirs = dir.listFiles().exists(Files.isDirectory(_))
-    if (!hasSubDirs) {
+    val dir = Paths.get(rootDir)
+    if (!dir.listFiles().exists(Files.isDirectory(_))) {
       return Seq(rootDir)
     }
-    dir
-      .walk()
-      .filterNot(_ == dir)
-      .filter(Files.isDirectory(_))
-      .flatMap { f =>
-        val hasKtsFile = f.walk().filterNot(_ == f).exists { f => f.hasExtension && f.toString.endsWith(".kts") }
-        val dirsPicked = f.listFiles().filter(Files.isDirectory(_)).filterNot { d =>
-          d.walk().filterNot(_ == d).filter(_.hasExtension).exists(_.toString.endsWith(".kts"))
-        }
-        if (hasKtsFile) Some(dirsPicked.map(_.toString))
-        else Some(Seq(f.toString))
-      }
-      .flatten
-      .toSeq
+
+    // Single traversal of the entire tree
+    val allPaths     = dir.walk().filterNot(_ == dir).toSeq
+    val allDirs      = allPaths.filter(Files.isDirectory(_))
+    val dirsByParent = allDirs.groupBy(_.getParent)
+
+    // For each .kts file, mark all ancestor dirs (within rootDir) as containing .kts
+    val ktsFiles = allPaths
+      .filter(p => p.hasExtension && p.toString.endsWith(".kts"))
+    val dirsWithKts: Set[java.nio.file.Path] = ktsFiles.flatMap { kts =>
+      val dirs =
+        Iterator
+          .iterate(kts.getParent)(_.getParent)
+          .takeWhile(p => p != null && p.startsWith(dir))
+          .toSeq
+
+      dirs
+    }.toSet
+
+    allDirs.flatMap { f =>
+      val subDirs    = dirsByParent.getOrElse(f, Seq.empty)
+      val dirsPicked = subDirs.filterNot(dirsWithKts.contains)
+      if (dirsWithKts.contains(f)) dirsPicked.map(_.toString)
+      else Seq(f.toString)
+    }
   }
 }

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/ContentSourcesPicker.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/ContentSourcesPicker.scala
@@ -32,22 +32,22 @@ object ContentSourcesPicker {
 
     // For each .kts file, mark all ancestor dirs (within rootDir) as containing .kts
     val ktsFiles = allPaths
-      .filter(p => p.hasExtension && p.toString.endsWith(".kts"))
+      .filter(path => path.hasExtension && path.toString.endsWith(".kts"))
     val dirsWithKts: Set[java.nio.file.Path] = ktsFiles.flatMap { kts =>
       val dirs =
         Iterator
           .iterate(kts.getParent)(_.getParent)
-          .takeWhile(p => p != null && p.startsWith(dir))
+          .takeWhile(parent => parent != null && parent.startsWith(dir))
           .toSeq
 
       dirs
     }.toSet
 
-    allDirs.flatMap { f =>
-      val subDirs    = dirsByParent.getOrElse(f, Seq.empty)
+    allDirs.flatMap { dir =>
+      val subDirs    = dirsByParent.getOrElse(dir, Seq.empty)
       val dirsPicked = subDirs.filterNot(dirsWithKts.contains)
-      if (dirsWithKts.contains(f)) dirsPicked.map(_.toString)
-      else Seq(f.toString)
+      if (dirsWithKts.contains(dir)) dirsPicked.map(_.toString)
+      else Seq(dir.toString)
     }
   }
 }


### PR DESCRIPTION
Change originally by @ml86 to avoid a quadratic time-complexity traversal of directories when finding source dirs for the kotlin compiler. This surfaced while debugging a very large customer project