### PR TITLE
[CI] Set Swift 6.3 on macos-latest CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -66,7 +66,23 @@ jobs:
         with:
           cache: false
           go-version: 1.25
+      - name: Set up Swift (macos-latest)
+        if: matrix.os == 'macos-latest'
+        uses: SwiftyLab/setup-swift@latest
+        # macos-latest runner switched to Xcode 26.4.1 as the new default
+        # Some swiftsrc2cpg tests use `import Foundation` which can not be
+        # compiled with an incompatible toolchain/SDK combination.
+        #
+        # error: failed to build module 'Darwin'; this SDK is not supported by the compiler
+        # (the SDK is built with 'Apple Swift version 6.3.2 (swiftlang-6.3.2.1.2 clang-2100.0.123.2)',
+        # while this compiler is 'Apple Swift version 6.1.3 (swift-6.1.3-RELEASE)').
+        # Please select a toolchain which matches the SDK.
+        #
+        # See: https://github.com/actions/runner-images/issues/14167
+        with:
+          swift-version: "6.3"
       - name: Set up Swift
+        if: matrix.os != 'macos-latest'
         uses: SwiftyLab/setup-swift@latest
         with:
           swift-version: "6.1"


### PR DESCRIPTION
Add a conditional Swift setup in the PR workflow to use swift-version 6.3 on macos-latest (SwiftyLab/setup-swift@latest). This addresses an SDK/toolchain mismatch introduced when the macos-latest runner moved to Xcode 26.4.1, which caused errors building Foundation/Darwin with an older compiler. The existing Swift setup remains for other runners (swift-version 6.1) and now runs only when matrix.os != 'macos-latest'. See linked runner-images issue for details.

Alternative to: https://github.com/joernio/joern/pull/6048