### PR TITLE
[x2cpg] Add version probe context and adjust AstGen runners

### DIFF
--- a/joern-cli/frontends/abap2cpg/src/main/scala/io/joern/abap2cpg/parser/AbapAstGenRunner.scala
+++ b/joern-cli/frontends/abap2cpg/src/main/scala/io/joern/abap2cpg/parser/AbapAstGenRunner.scala
@@ -22,7 +22,7 @@ class AbapAstGenRunner(config: Config) extends AstGenRunner(AbapAstGenRunner.ast
   // abapgen-linux, abapgen-linux-arm, abapgen-macos, abapgen-macos-arm, abapgen-win.exe
 
   // abapgen has no --version flag, so always use the bundled binary
-  override def hasCompatibleAstGenVersion(compatibleVersion: String): Boolean = false
+  override def hasCompatibleAstGenVersion(compatibleVersion: String, path: Option[String]): Boolean = false
 
   override def skippedFiles(in: Path, astGenOut: List[String]): List[String] = {
     astGenOut.collect {

--- a/joern-cli/frontends/rust2cpg/src/test/resources/log4j2-test.xml
+++ b/joern-cli/frontends/rust2cpg/src/test/resources/log4j2-test.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+    <Appenders>
+        <Console name="STDOUT" target="SYSTEM_OUT">
+            <PatternLayout pattern="[%-5p] %m%n" />
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="WARN">
+            <AppenderRef ref="STDOUT"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/astgen/AstGenRunner.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/astgen/AstGenRunner.scala
@@ -2,14 +2,13 @@ package io.joern.x2cpg.astgen
 
 import com.typesafe.config.ConfigFactory
 import io.joern.x2cpg.astgen.AstGenRunner.AstGenProgramMetaData
-import io.joern.x2cpg.utils.{Environment, JoernRunfilesLocator}
 import io.joern.x2cpg.utils.Environment.{ArchitectureType, OperatingSystemType}
+import io.joern.x2cpg.utils.{Environment, JoernRunfilesLocator}
 import io.joern.x2cpg.{SourceFiles, X2CpgConfig}
 import io.shiftleft.semanticcpg.utils.ExternalCommand
 import org.slf4j.LoggerFactory
 import versionsort.VersionHelper
 
-import java.io.FileNotFoundException
 import java.net.URL
 import java.nio.file.{Files, Path, Paths}
 import scala.util.{Failure, Success, Try}
@@ -251,19 +250,20 @@ abstract class AstGenRunner(metaData: AstGenProgramMetaData, config: X2CpgConfig
   }
 
   def executableDir: String =
-    ExternalCommand
-      .executableDir(Paths.get(metaData.packagePath.toURI))
-      .resolve("astgen")
-      .toString
-
-  def hasCompatibleAstGenVersion(compatibleVersion: String): Boolean =
-    hasCompatibleAstGenVersion(compatibleVersion, None)
+    ExternalCommand.executableDir(Paths.get(metaData.packagePath.toURI)).resolve("astgen").toString
 
   def hasCompatibleAstGenVersion(compatibleVersion: String, path: Option[String]): Boolean = {
     val command      = path.getOrElse(metaData.name)
     val workingDir   = path.flatMap(binPath => Option(Paths.get(binPath).getParent))
     val debugMsgPath = path.getOrElse("PATH")
-    ExternalCommand.run(Seq(command, metaData.versionFlag), workingDir).successOption match {
+    ExternalCommand
+      .run(
+        Seq(command, metaData.versionFlag),
+        workingDir,
+        additionalContext =
+          s"version probe for ${metaData.name} at '$debugMsgPath' - failure is expected if binary is not available there"
+      )
+      .successOption match {
       case Some(_) if metaData.skipVersionComparison =>
         logger.debug(s"Using ${metaData.name} from '$debugMsgPath'")
         true

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/ExternalCommand.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/ExternalCommand.scala
@@ -50,7 +50,8 @@ object ExternalCommand {
       case NonFatal(exception) =>
         val stdOut = IOUtils.readLinesInFile(stdOutFile.toPath)
         val stdErr = stdErrFile.map(f => IOUtils.readLinesInFile(f.toPath)).getOrElse(Seq.empty) :+ exception.getMessage
-        logger.debug(s"command did not finish successfully. Input was: $input")
+        val contextSuffix = additionalContextMaybe.map(ctx => s" ($ctx)").getOrElse("")
+        logger.debug(s"command did not finish successfully. Input was: $input$contextSuffix")
         ExternalCommandResult(1, stdOut, stdErr, input, additionalContextMaybe)
     } finally {
       stdOutFile.delete()


### PR DESCRIPTION
Propagate an additional message into `ExternalCommand.run` to improve logging for failing `*-astgen` version invocations and include that context in debug logs. Update x2cpg `AstGenRunner` to call `ExternalCommand.run` with the `additionalContext` parameter.

Also:
- Adjust `AbapAstGenRunner` to match the actual `hasCompatibleAstGenVersion` signature (the other one was never actually used and is now removed).
- Add a `log4j2-test.xml` for rust2cpg tests
- Minor cleanup of imports