### PR TITLE
[console] fix importCode.rust.fromString, add additional fromStringWithExtraDeps

### DIFF
--- a/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
@@ -72,7 +72,7 @@ class ImportCode[T <: Project](console: io.joern.console.Console[T])(implicit
   def llvm: Frontend            = new BinaryFrontend("llvm", Languages.LLVM, "LLVM Bitcode Frontend")
   def php: SourceBasedFrontend  = new SourceBasedFrontend("php", Languages.PHP, "PHP source frontend", "php")
   def ruby: SourceBasedFrontend = SourceBasedFrontend("ruby", Languages.RUBYSRC, "Ruby source frontend", "rb")
-  def rust: SourceBasedFrontend = new SourceBasedFrontend("rust", Languages.RUST, "Rust Source Frontend", "rs")
+  def rust: RustFrontend        = new RustFrontend()
   def abap: SourceBasedFrontend = new SourceBasedFrontend("abap", Languages.ABAP, "ABAP Source Frontend", "abap")
 
   private def allFrontends: List[Frontend] =
@@ -178,6 +178,36 @@ class ImportCode[T <: Project](console: io.joern.console.Console[T])(implicit
 
   class CFrontend(name: String, extension: String = "c")
       extends SourceBasedFrontend(name, Languages.NEWC, "Eclipse CDT Based Frontend for C/C++", extension)
+
+  class RustFrontend extends SourceBasedFrontend("rust", Languages.RUST, "Rust Source Frontend", "rs") {
+    override def fromString(str: String, args: List[String] = List()): Cpg = {
+      fromStringWithExtraDeps(str, Nil, args)
+    }
+
+    def fromStringWithExtraDeps(
+      str: String,
+      extraDeps: collection.Seq[String],
+      args: collection.Seq[String] = Nil
+    ): Cpg = {
+      FileUtil.usingTemporaryDirectory("console") { dir =>
+        Files.writeString(
+          dir / "Cargo.toml",
+          s"""[package]
+             |name = "importCode"
+             |version = "0.1.0"
+             |edition = "2021"
+             |
+             |
+             |[dependencies]
+             |${extraDeps.mkString("\n")}
+             |""".stripMargin
+        )
+        Files.createDirectory(dir / "src")
+        Files.writeString(dir / "src" / "lib.rs", str)
+        super.apply(dir.toString, args = args.toList)
+      }
+    }
+  }
 
   private def withCodeInTmpFile(str: String, filename: String)(f: Path => Cpg): Try[Cpg] = {
     FileUtil.usingTemporaryDirectory("console") { dir =>

--- a/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
@@ -209,11 +209,11 @@ class ImportCode[T <: Project](console: io.joern.console.Console[T])(implicit
     }
   }
 
-  private def withCodeInTmpFile(str: String, filename: String)(f: Path => Cpg): Try[Cpg] = {
+  private def withCodeInTmpFile(str: String, filename: String)(callback: Path => Cpg): Try[Cpg] = {
     FileUtil.usingTemporaryDirectory("console") { dir =>
       Try {
         Files.writeString((dir / filename), str)
-        f(dir)
+        callback(dir)
       }
     }
   }


### PR DESCRIPTION
Ensure we create a Cargo.toml, and ensure the code is stored in a `src/lib.rs` file. Without that, the CPGs are always be empty.

Also adds an additional method that allows adding extra entries in the dependencies section of `Cargo.toml` for easy testing of code that requires a library.