### PR TITLE
[bazel] Optimize imports.

### DIFF
--- a/bazel/reexports/BUILD
+++ b/bazel/reexports/BUILD
@@ -7,6 +7,7 @@ scala_library(
         "@maven//:io_joern_flatgraph_core_3",
         "@maven//:io_joern_flatgraph_help_3",
         "@maven//:io_shiftleft_codepropertygraph_3",
+        "@maven//:io_shiftleft_codepropertygraph_protos_3",
     ],
     deps = [
     ],

--- a/joern-cli/frontends/c2cpg/BUILD
+++ b/joern-cli/frontends/c2cpg/BUILD
@@ -15,7 +15,6 @@ scala_library(
     deps = [
         "//bazel/reexports:io_shiftleft_codepropertygraph_with_deps",
         "//joern-cli/frontends/x2cpg",
-        "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:com_lihaoyi_ujson_3",
         "@maven//:io_joern_eclipse_cdt_core",
         "@maven//:org_apache_commons_commons_lang3",

--- a/joern-cli/frontends/javasrc2cpg/BUILD
+++ b/joern-cli/frontends/javasrc2cpg/BUILD
@@ -10,7 +10,6 @@ scala_library(
         "//bazel/reexports:io_shiftleft_codepropertygraph_with_deps",
         "//joern-cli/frontends/x2cpg",
         "@maven//:com_github_javaparser_javaparser_symbol_solver_core",
-        "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:net_lingala_zip4j_zip4j",
         "@maven//:org_gradle_gradle_tooling_api",
         "@maven//:org_ow2_asm_asm",

--- a/joern-cli/frontends/jssrc2cpg/BUILD
+++ b/joern-cli/frontends/jssrc2cpg/BUILD
@@ -32,7 +32,6 @@ scala_library(
         "//bazel/reexports:com_lihaoyi_upickle_with_deps",
         "//bazel/reexports:io_shiftleft_codepropertygraph_with_deps",
         "//joern-cli/frontends/x2cpg",
-        "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:org_apache_commons_commons_lang3",
     ],
 )

--- a/joern-cli/frontends/kotlin2cpg/BUILD
+++ b/joern-cli/frontends/kotlin2cpg/BUILD
@@ -11,7 +11,6 @@ scala_library(
         "//bazel/reexports:io_shiftleft_codepropertygraph_with_deps",
         "//joern-cli/frontends/javasrc2cpg",
         "//joern-cli/frontends/x2cpg",
-        "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:com_lihaoyi_requests_3",
         "@maven//:com_lihaoyi_ujson_3",
         "@maven//:com_squareup_tools_build_maven_archeologist",

--- a/joern-cli/frontends/php2cpg/BUILD
+++ b/joern-cli/frontends/php2cpg/BUILD
@@ -21,7 +21,6 @@ scala_library(
         "//joern-cli/frontends/x2cpg",
         "@maven//:com_github_albfernandez_juniversalchardet",
         "@maven//:com_github_sh4869_semver_parser_scala_3",
-        "@maven//:com_google_protobuf_protobuf_java",
     ],
 )
 

--- a/joern-cli/frontends/pysrc2cpg/BUILD
+++ b/joern-cli/frontends/pysrc2cpg/BUILD
@@ -36,7 +36,6 @@ scala_library(
     deps = [
         "//bazel/reexports:io_shiftleft_codepropertygraph_with_deps",
         "//joern-cli/frontends/x2cpg",
-        "@maven//:com_google_protobuf_protobuf_java",
     ],
 )
 

--- a/joern-cli/frontends/rubysrc2cpg/BUILD
+++ b/joern-cli/frontends/rubysrc2cpg/BUILD
@@ -15,7 +15,6 @@ scala_library(
         "//bazel/reexports:com_lihaoyi_upickle_with_deps",
         "//bazel/reexports:io_shiftleft_codepropertygraph_with_deps",
         "//joern-cli/frontends/x2cpg",
-        "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:org_apache_commons_commons_compress",
         "@maven//:org_jruby_jruby_complete",
     ],

--- a/joern-cli/frontends/rust2cpg/BUILD
+++ b/joern-cli/frontends/rust2cpg/BUILD
@@ -31,7 +31,6 @@ scala_library(
     deps = [
         "//bazel/reexports:io_shiftleft_codepropertygraph_with_deps",
         "//joern-cli/frontends/x2cpg",
-        "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:com_lihaoyi_ujson_3",
     ],
 )

--- a/joern-cli/frontends/swiftsrc2cpg/BUILD
+++ b/joern-cli/frontends/swiftsrc2cpg/BUILD
@@ -30,7 +30,6 @@ scala_library(
         "//bazel/reexports:io_shiftleft_codepropertygraph_with_deps",
         "//joern-cli/frontends/x2cpg",
         "@maven//:com_google_code_gson_gson",
-        "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:com_googlecode_plist_dd_plist",
         "@maven//:org_apache_commons_commons_lang3",
         "@maven//:org_scala_lang_modules_scala_parallel_collections_3",

--- a/joern-cli/frontends/x2cpg/BUILD
+++ b/joern-cli/frontends/x2cpg/BUILD
@@ -58,7 +58,6 @@ scala_test(
         ":x2cpg",
         "//bazel/reexports:io_shiftleft_codepropertygraph_with_deps",
         "//joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/testfixtures",
-        "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:org_apache_commons_commons_lang3",
     ],
 )

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/testfixtures/BUILD
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/testfixtures/BUILD
@@ -7,7 +7,6 @@ scala_library(
     deps = [
         "//bazel/reexports:io_shiftleft_codepropertygraph_with_deps",
         "//joern-cli/frontends/x2cpg",
-        "@maven//:com_google_protobuf_protobuf_java",
         "@rules_scala//testing/toolchain:scalatest_classpath",
     ],
 )

--- a/semanticcpg/BUILD
+++ b/semanticcpg/BUILD
@@ -6,7 +6,6 @@ scala_library(
     visibility = ["//visibility:public"],
     deps = [
         "//bazel/reexports:io_shiftleft_codepropertygraph_with_deps",
-        "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:com_michaelpollmeier_scala_repl_pp_3_3_6",
         "@maven//:org_apache_commons_commons_lang3",
         "@maven//:org_apache_commons_commons_text",


### PR DESCRIPTION
Avoid explicit import requirements for nested transitive dependency by
reexporting it alongside with codepropertygraph dependency which brings
it in.
