### PR TITLE
[javasrc2cpg] Always log delombok output to avoid silently swallowing errors

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Delombok.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Delombok.scala
@@ -85,7 +85,7 @@ object Delombok {
     Try(childPath.createWithParentsIfNotExists(asDirectory = true)).flatMap { packageOutputDir =>
       ExternalCommand
         .run(delombokToTempDirCommand(inputDir, packageOutputDir, analysisJavaHome))
-        .logIfFailed()
+        .logAlways()
         .toTry
         .map(_ => delombokTempDir.absolutePathAsString)
     }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/ExternalCommandResult.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/ExternalCommandResult.scala
@@ -30,6 +30,22 @@ case class ExternalCommandResult(
     this
   }
 
+  /** Same as [[logIfFailed]] for non-zero exits, but also logs the command's output at debug level when it succeeded.
+    * Useful for tools that exit 0 even when they did nothing useful (e.g. delombok writing files back unchanged).
+    */
+  def logAlways(): this.type = {
+    if (exitCode != 0) {
+      logIfFailed()
+    } else {
+      logger.debug(s"""Process exited with code 0.
+           |${additionalContext.getOrElse("")}
+           |Input: $input
+           |Output: ${stdOutAndError.mkString("\n")}
+           |""".stripMargin)
+    }
+    this
+  }
+
   /** convenience method: verify that the result is a success, throws an exception otherwise */
   def verifySuccess(): this.type = {
     toTry.get


### PR DESCRIPTION
When using javasrc2cpg to scan projects using lombok, we first run delombok to create new source files with the lombok annotations replaced with the actual generated code and then perform the analysis on the delomboked code instead. 

If delombok fails on part of the project for some reason, but succeeds for any sources at all, it just writes the unmodified source file to the destination instead and still returns with exit code 0, so we didn't log the failures, making any issues very difficult to debug. Delombok's output is not very noisy, however, so this PR just adds logging for the delombok output regardless of whether the command succeeded or not. Running this locally on a test project gave the output:

```
[DEBUG] Process exited with code 0.

  Input: cmd: <java_home>/bin/java -cp @<tmp>/classpath9251013804628349684 lombok.launch.Main delombok <test_repos>/lombok-large-test/src/main/java -d 
  <tmp>/delombok5726283001475370302/src/main/java, workingDir: <joern_repo>/., extraEnv: Map()
  Output: WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
  WARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit
  WARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit
  WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
  <test_repos>/lombok-large-test/src/main/java/com/example/bulk/Entity35.java:7: error: ';' expected
      private String name
                         ^
  <test_repos>/lombok-large-test/src/main/java/com/example/bulk/Entity35.java:11: error: ';' expected
          return name + "=" + value
                                   ^
  <test_repos>/lombok-large-test/src/main/java/com/example/bulk/Entity35.java:14: error: class, interface, enum, or record expected
  }}
   ^
  <test_repos>/lombok-large-test/src/main/java/com/example/bulk/Entity161.java:7: error: ';' expected
```