### PR TITLE
[pysrc2cpg] Include .jinja2 files as config nodes in the CPG

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ConfigFileCreationPass.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ConfigFileCreationPass.scala
@@ -15,6 +15,8 @@ class ConfigFileCreationPass(cpg: Cpg, requirementsTxt: String = "requirement.tx
     extensionFilter(".ini"),
     // YAML files
     extensionFilter(".yaml"),
+    // Jinja2 templates
+    extensionFilter(".jinja2"),
     // HTML files
     extensionFilter(".html"),
     // HTM files

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/ConfigPassTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/passes/ConfigPassTests.scala
@@ -29,6 +29,13 @@ class ConfigPassTests extends PySrc2CpgFixture(withOssDataflow = false) {
     config.content should include("verify_ssl = true")
   }
 
+  "`.jinja2` files should be included" in {
+    val cpg = code("{{ secret }}", "config.jinja2")
+
+    val config = cpg.configFile.name("config.jinja2").head
+    config.content shouldBe "{{ secret }}"
+  }
+
   "Pipfile.lock should be included" in {
     val cpg = code(
       """


### PR DESCRIPTION
Usually people use the regular extensions e.g. `.html` for jinja templates. But dvpwa (Damn Vulnerable Python Web Application) for example uses the `.jinja2` extension.