### PR TITLE
[jssrc2cpg] Preserve EJS output tags as fake calls for sink detection

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreatorHelper.scala
@@ -258,6 +258,24 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
     if (hasKey(classNode.json, "id") && !classNode.json("id").isNull) code(classNode.json("id"))
     else nextAnonClassName()
 
+  /** If `nodeInfo` is the callee of a fake EJS output call, its source bytes are exactly the EJS output-tag prefix
+    * `<%`; the character right after (the tag's third char) selects escaped (`=`) vs. unescaped (`-`) output. Returns
+    * the CPG call name to use, or None for every ordinary node. The `<%` guard is safe: a bare `<%` is never the full
+    * source text of a real JS/TS identifier.
+    */
+  protected def ejsOutputCallName(nodeInfo: BabelNodeInfo): Option[String] = {
+    val fileContent = parserResult.fileContent
+    end(nodeInfo.json) match {
+      case Some(endOffset) if nodeInfo.code == Defines.EjsOutputTagPrefix && endOffset < fileContent.length =>
+        fileContent.charAt(endOffset) match {
+          case '=' => Some(Defines.EscapedOutputName)
+          case '-' => Some(Defines.UnescapedOutputName)
+          case _   => None
+        }
+      case _ => None
+    }
+  }
+
   protected def code(node: Value): String = {
     nodeOffsets(node) match {
       case Some((startOffset, endOffset)) =>

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -82,7 +82,8 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
         val receiverAst = astForNodeWithFunctionReference(callLike.json)
         val thisNode    = identifierNode(callLike, "this").dynamicTypeHintFullName(typeHintForThisExpression())
         scope.addVariableReference(thisNode.name, thisNode, Defines.Any, EvaluationStrategies.BY_REFERENCE)
-        CallExpressionInfo(receiverAst, thisNode, callLike.code)
+        val callName = ejsOutputCallName(callLike).getOrElse(callLike.code)
+        CallExpressionInfo(receiverAst, thisNode, callName)
     }
   }
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForPrimitivesCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForPrimitivesCreator.scala
@@ -9,7 +9,7 @@ import io.shiftleft.codepropertygraph.generated.EvaluationStrategies
 trait AstForPrimitivesCreator(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
   protected def astForIdentifier(ident: BabelNodeInfo, maybePossibleType: Option[String] = None): Ast = {
-    val name      = ident.json("name").str
+    val name      = ejsOutputCallName(ident).getOrElse(ident.json("name").str)
     val identNode = identifierNode(ident, name)
     val possibleType = maybePossibleType match {
       case None              => typeFor(ident)

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/preprocessing/EjsPreprocessor.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/preprocessing/EjsPreprocessor.scala
@@ -13,6 +13,8 @@ class EjsPreprocessor {
   private val TagSpaces              = Tags.map(tag => tag -> (" " * tag.length)).toMap
   private val OpeningTagReplacements = OpeningTags.map(tag => ("'" + tag) -> ("\"" + " " * (tag.length - 1)))
   private val ClosingTagReplacements = ClosingTags.map(tag => (tag + "'") -> (" " * (tag.length - 1) + "\""))
+  private val OutputTags             = Set("<%=", "<%-")
+  private val FakeOutputCall         = "ap" // valid 2-char JS identifier; makes the parser emit a CallExpression
 
   private def stripScriptTag(code: String): String = {
     var x = code.replace("<script>", "<%      ").replace("</script>", "%>       ")
@@ -65,24 +67,26 @@ class EjsPreprocessor {
         preprocessedCode.append(" ")
     }
 
-    var codeWithoutSemicolon = preprocessedCode.toString()
-    val alreadyReplaced      = mutable.ArrayBuffer.empty[(Int, Int)]
     matches.foreach {
       case ma if ma.group(1) == CommentTag               => // ignore comments
       case ma if ma.group(2).trim.startsWith("include ") => // ignore including other ejs templates
+      case ma if OutputTags.contains(ma.group(1))        =>
+        // opening 3-char tag (<%= / <%-) -> `ap(`
+        preprocessedCode.setCharAt(ma.start, FakeOutputCall.charAt(0))
+        preprocessedCode.setCharAt(ma.start + 1, FakeOutputCall.charAt(1))
+        preprocessedCode.setCharAt(ma.start + 2, '(')
+        // close the call: `);` at the start of the closing tag; any extra closing chars stay whitespace
+        val closeStart = ma.end - ma.group(3).length
+        preprocessedCode.setCharAt(closeStart, ')')
+        preprocessedCode.setCharAt(closeStart + 1, ';')
       case ma if needsSemicolon(ma.group(2)) =>
-        val start = ma.start + ma.group(1).length
-        val end   = ma.end - ma.group(3).length
-        if (!alreadyReplaced.contains((start, end))) {
-          val replacementCode = s"${ma.group(2)};"
-          codeWithoutSemicolon =
-            s"${codeWithoutSemicolon.substring(0, start)}$replacementCode${codeWithoutSemicolon.substring(end + 1, codeWithoutSemicolon.length)}"
-          alreadyReplaced.append((start, end))
-        }
+        // scriptlet needing a statement terminator: overwrite the first closing-tag char with `;`
+        val closeStart = ma.end - ma.group(3).length
+        preprocessedCode.setCharAt(closeStart, ';')
       case _ => // others are fine already
     }
 
-    codeWithoutSemicolon
+    preprocessedCode.toString()
   }
 
 }

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/preprocessing/EjsPassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/preprocessing/EjsPassTests.scala
@@ -17,7 +17,7 @@ class EjsPassTests extends JsSrc2CpgSuite {
         "index.js.ejs"
       )
       cpg.file.name.l shouldBe List("index.js.ejs")
-      cpg.call.code.l.sorted shouldBe List("user.name")
+      cpg.call.name("escapeFn").argument(1).code.l shouldBe List("user.name")
     }
 
     "be ignored at folders excluded by default" in {
@@ -31,7 +31,7 @@ class EjsPassTests extends JsSrc2CpgSuite {
         .moreCode(codeString, "vendor/bar.js.ejs")
         .moreCode(codeString, "www/baz.js.ejs")
       cpg.file.name.l shouldBe List("index.js.ejs")
-      cpg.call.code.l.sorted shouldBe List("user.name")
+      cpg.call.name("escapeFn").argument(1).code.l shouldBe List("user.name")
     }
 
     "be handled correctly" in {
@@ -66,25 +66,21 @@ class EjsPassTests extends JsSrc2CpgSuite {
         "index.ejs"
       )
       cpg.file.name.l shouldBe List("index.ejs")
-      cpg.call.code.l.sorted shouldBe
-        List(
-          "console.log",
-          "console.log(user)",
-          "exampleWrite = 'some value'",
-          "foo.callUnescaped",
-          "foo.callUnescaped()",
-          "foo.callWithWhitespaces",
-          "foo.callWithWhitespaces()",
-          "friend.name",
-          "friend.name",
-          "friend.name === selected",
-          "friend.name === selected ? \"selected\" : \"\"",
-          "friends.forEach",
-          "friends.forEach(function(friend, index) { %>\n        <li class=\"<%= index === 0 ? \"first\" : \"\" %> <%= friend.name === selected ? \"selected\" : \"\" %>\"><%= friend.name %></li>\n    <% })",
-          "index === 0",
-          "index === 0 ? \"first\" : \"\"",
-          "user.name"
-        )
+      // unescaped output <%- %> -> __append wrapping the raw expression
+      cpg.call.name("__append").argument(1).code.l shouldBe List("foo.callUnescaped()")
+      // escaped output <%= %> -> escapeFn, one per output expression
+      cpg.call.name("escapeFn").argument(1).code.sorted.l shouldBe List(
+        "friend.name",
+        "friend.name === selected ? \"selected\" : \"\"",
+        "index === 0 ? \"first\" : \"\"",
+        "user.name"
+      )
+      // the throwaway `ap` identifier never surfaces as a call name OR an identifier;
+      // scriptlet/slurp blocks keep their real call names
+      val callNames = cpg.call.name.toSet
+      callNames should contain allOf ("callWithWhitespaces", "forEach", "log", "callUnescaped")
+      callNames should not contain "ap"
+      cpg.identifier.name.toSet should not contain "ap"
     }
 
     "invalid EJS file test" in {

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/preprocessing/EjsPreprocessorTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/preprocessing/EjsPreprocessorTests.scala
@@ -123,11 +123,11 @@ class EjsPreprocessorTests extends AnyWordSpec with Matchers {
         """
           |      
           |
-          |                user.name ;      
+          |            ap( user.name );     
           |
           |       foo.callWithWhitespaces() ;      
           |
-          |       foo.callUnescaped() ;      
+          |   ap( foo.callUnescaped() );     
           |
           |                           
           |   if (admin) {   
@@ -136,7 +136,7 @@ class EjsPreprocessorTests extends AnyWordSpec with Matchers {
           |
           |    
           |       friends.forEach(function(friend, index) {   
-          |                       index === 0 ? "first" : "" ;      friend.name === selected ? "selected" : "" ;       friend.name ;      
+          |                   ap( index === 0 ? "first" : "" ); ap( friend.name === selected ? "selected" : "" );  ap( friend.name );     
           |       });   
           |     
           |
@@ -148,6 +148,25 @@ class EjsPreprocessorTests extends AnyWordSpec with Matchers {
           |       
           |""".stripMargin
       new EjsPreprocessor().preprocess(code) shouldBe expectedCode
+    }
+
+    "wrap an escaped output tag in a fake call" in {
+      new EjsPreprocessor().preprocess("<%= user.name %>") shouldBe "ap( user.name );"
+    }
+
+    "wrap an unescaped output tag with trim-close in a fake call" in {
+      new EjsPreprocessor().preprocess("<%- foo.bar() -%>") shouldBe "ap( foo.bar() ); "
+    }
+
+    "wrap an output tag without surrounding spaces and keep length" in {
+      val input  = "<%=x%>"
+      val output = new EjsPreprocessor().preprocess(input)
+      output shouldBe "ap(x);"
+      output.length shouldBe input.length
+    }
+
+    "leave scriptlet control-flow tags unwrapped" in {
+      new EjsPreprocessor().preprocess("<% if (a) { %>") shouldBe "   if (a) {   "
     }
   }
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/jssrc2cpg/Defines.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/jssrc2cpg/Defines.scala
@@ -3,25 +3,28 @@ package io.joern.x2cpg.frontendspecific.jssrc2cpg
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 
 object Defines {
-  val Any: String               = "ANY"
-  val Array: String             = "__ecma.Array"
-  val Number: String            = "__ecma.Number"
-  val String: String            = "__ecma.String"
-  val Boolean: String           = "__ecma.Boolean"
-  val Null: String              = "__ecma.Null"
-  val Math: String              = "__ecma.Math"
-  val Symbol: String            = "__ecma.Symbol"
-  val Console: String           = "__whatwg.console"
-  val Object: String            = "__ecma.Object"
-  val BigInt: String            = "__ecma.BigInt"
-  val Unknown: String           = Any
-  val Void: String              = Any
-  val Never: String             = Any
-  val Undefined: String         = Any
-  val NodeModulesFolder: String = "node_modules"
-  val Program: String           = ":program"
-  val GlobalNamespace: String   = NamespaceTraversal.globalNamespaceName
-  val OperatorsNew: String      = "<operator>.new" // TODO: place "<operator>.new" into the schema
+  val Any: String                 = "ANY"
+  val Array: String               = "__ecma.Array"
+  val Number: String              = "__ecma.Number"
+  val String: String              = "__ecma.String"
+  val Boolean: String             = "__ecma.Boolean"
+  val Null: String                = "__ecma.Null"
+  val Math: String                = "__ecma.Math"
+  val Symbol: String              = "__ecma.Symbol"
+  val Console: String             = "__whatwg.console"
+  val Object: String              = "__ecma.Object"
+  val BigInt: String              = "__ecma.BigInt"
+  val Unknown: String             = Any
+  val Void: String                = Any
+  val Never: String               = Any
+  val Undefined: String           = Any
+  val NodeModulesFolder: String   = "node_modules"
+  val Program: String             = ":program"
+  val GlobalNamespace: String     = NamespaceTraversal.globalNamespaceName
+  val OperatorsNew: String        = "<operator>.new" // TODO: place "<operator>.new" into the schema
+  val EscapedOutputName: String   = "escapeFn"       // EJS <%= %> escaped output, modeled as a call for sink detection
+  val UnescapedOutputName: String = "__append"       // EJS <%- %> unescaped (raw) output, modeled as a call
+  val EjsOutputTagPrefix: String  = "<%"             // first two bytes of an EJS output tag in the original source
 
   val JsTypes: List[String] =
     List(

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/jssrc2cpg/Defines.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/jssrc2cpg/Defines.scala
@@ -3,28 +3,38 @@ package io.joern.x2cpg.frontendspecific.jssrc2cpg
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 
 object Defines {
-  val Any: String                 = "ANY"
-  val Array: String               = "__ecma.Array"
-  val Number: String              = "__ecma.Number"
-  val String: String              = "__ecma.String"
-  val Boolean: String             = "__ecma.Boolean"
-  val Null: String                = "__ecma.Null"
-  val Math: String                = "__ecma.Math"
-  val Symbol: String              = "__ecma.Symbol"
-  val Console: String             = "__whatwg.console"
-  val Object: String              = "__ecma.Object"
-  val BigInt: String              = "__ecma.BigInt"
-  val Unknown: String             = Any
-  val Void: String                = Any
-  val Never: String               = Any
-  val Undefined: String           = Any
-  val NodeModulesFolder: String   = "node_modules"
-  val Program: String             = ":program"
-  val GlobalNamespace: String     = NamespaceTraversal.globalNamespaceName
-  val OperatorsNew: String        = "<operator>.new" // TODO: place "<operator>.new" into the schema
-  val EscapedOutputName: String   = "escapeFn"       // EJS <%= %> escaped output, modeled as a call for sink detection
-  val UnescapedOutputName: String = "__append"       // EJS <%- %> unescaped (raw) output, modeled as a call
-  val EjsOutputTagPrefix: String  = "<%"             // first two bytes of an EJS output tag in the original source
+  val Any: String               = "ANY"
+  val Array: String             = "__ecma.Array"
+  val Number: String            = "__ecma.Number"
+  val String: String            = "__ecma.String"
+  val Boolean: String           = "__ecma.Boolean"
+  val Null: String              = "__ecma.Null"
+  val Math: String              = "__ecma.Math"
+  val Symbol: String            = "__ecma.Symbol"
+  val Console: String           = "__whatwg.console"
+  val Object: String            = "__ecma.Object"
+  val BigInt: String            = "__ecma.BigInt"
+  val Unknown: String           = Any
+  val Void: String              = Any
+  val Never: String             = Any
+  val Undefined: String         = Any
+  val NodeModulesFolder: String = "node_modules"
+  val Program: String           = ":program"
+  val GlobalNamespace: String   = NamespaceTraversal.globalNamespaceName
+  val OperatorsNew: String      = "<operator>.new" // TODO: place "<operator>.new" into the schema
+
+  // EJS <%= %> escaped output, modeled as a call for sink detection.
+  // Same as the actual EJS compiler output:
+  // https://github.com/mde/ejs/blob/2c41365ca042a70978e5795adc05fbb8b35fb013/lib/esm/ejs.js#L878
+  val EscapedOutputName: String = "escapeFn"
+
+  // EJS <%- %> unescaped (raw) output, modeled as a call for sink detection.
+  // Same as the actual EJS compiler output:
+  // https://github.com/mde/ejs/blob/2c41365ca042a70978e5795adc05fbb8b35fb013/lib/esm/ejs.js#L586
+  val UnescapedOutputName: String = "__append"
+
+  // first two bytes of an EJS output tag in the original source
+  val EjsOutputTagPrefix: String = "<%"
 
   val JsTypes: List[String] =
     List(


### PR DESCRIPTION
### Problem
EJS output tags were replaced with equal-length whitespace during preprocessing, so the output expression survived in the CPG but was **not wrapped in any call**. Template output could not be matched as an XSS/output sink.

### Change
Output tags now surface as named calls, preserving exact source offsets:

| Tag | Meaning | CPG call name |
|-----|---------|---------------|
| `<%= X %>` | escaped output | `escapeFn` |
| `<%- X %>` | unescaped output (raw HTML) | `__append` |

Names mirror EJS's own transpilation, so unescaped output (`__append`) can be flagged as a sink while escaped output (`escapeFn`) is treated as sanitized.

### How
- `EjsPreprocessor` rewrites each output tag into a **same-length** fake call `ap( X );` in the generated `.js` (the `ap` identifier is throwaway — it only makes the parser emit a `CallExpression`).
- The real name is resolved by a one-character lookahead (`=` vs `-`) in a shared `ejsOutputCallName` helper, wired into **both** the identifier and call-name sites so neither the call name nor any identifier leaks `ap` into the CPG.
- Scriptlet (`<%`, `<%_`), comment (`<%#`), `include` tags, and output tags inside `<script>` blocks are unchanged.