### PR TITLE
[javasrc2cpg] Set up classpath and sourcepath for delombok

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
@@ -111,7 +111,11 @@ private object Frontend {
         .text(s"extra jars used only for type information (comma-separated list of paths)")
         .action((paths, c) => c.withInferenceJarPaths(c.inferenceJarPaths ++ paths)),
       opt[Unit]("fetch-dependencies")
-        .text("attempt to fetch dependencies jars for extra type information")
+        .text(
+          "attempt to fetch dependencies jars for extra type information. Recommended when scanning Lombok " +
+            "projects: delombok resolves symbols against these jars, so without this flag delombok will fail on " +
+            "any Lombok-annotated code that references third-party libraries."
+        )
         .action((_, c) => c.withFetchDependencies(true)),
       opt[String]("delombok-java-home")
         .text("Optional override to set java home used to run Delombok. Java 17 is recommended for the best results.")

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
@@ -116,7 +116,7 @@ private object Frontend {
             "projects: delombok resolves symbols against these jars, so without this flag delombok will fail on " +
             "any Lombok-annotated code that references third-party libraries."
         )
-        .action((_, conf) => conf.withFetchDependencies(true)),
+        .action((_, c) => c.withFetchDependencies(true)),
       opt[String]("delombok-java-home")
         .text("Optional override to set java home used to run Delombok. Java 17 is recommended for the best results.")
         .action((path, c) => c.withDelombokJavaHome(path)),

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
@@ -116,7 +116,7 @@ private object Frontend {
             "projects: delombok resolves symbols against these jars, so without this flag delombok will fail on " +
             "any Lombok-annotated code that references third-party libraries."
         )
-        .action((_, c) => c.withFetchDependencies(true)),
+        .action((_, conf) => conf.withFetchDependencies(true)),
       opt[String]("delombok-java-home")
         .text("Optional override to set java home used to run Delombok. Java 17 is recommended for the best results.")
         .action((path, c) => c.withDelombokJavaHome(path)),

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
@@ -86,7 +86,7 @@ class AstCreationPass(config: Config, cpg: Cpg, sourcesOverride: Option[List[Str
 
   private def initParserAndUtils(config: Config): (SourceParser, JavaSymbolSolver, SimpleCombinedTypeSolver) = {
     val dependencies                   = getDependencyList(config.inputPath)
-    val sourceParser                   = SourceParser(config, sourcesOverride)
+    val sourceParser                   = SourceParser(config, sourcesOverride, dependencies)
     val (symbolSolver, combinedSolver) = createSymbolSolver(config, dependencies, sourceParser)
     (sourceParser, symbolSolver, combinedSolver)
   }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Delombok.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Delombok.scala
@@ -5,6 +5,7 @@ import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.semanticcpg.utils.{ExternalCommand, FileUtil}
 import org.slf4j.LoggerFactory
 
+import java.io.File
 import java.nio.file.{Files, Path, Paths}
 import scala.util.Failure
 import scala.util.Success
@@ -57,7 +58,7 @@ object Delombok {
     val ownClasspath = System.getProperty("java.class.path")
     val fullClasspath =
       if (dependencies.isEmpty) ownClasspath
-      else (dependencies :+ ownClasspath).mkString(java.io.File.pathSeparator)
+      else (dependencies :+ ownClasspath).mkString(File.pathSeparator)
     val classPathArg = Try(FileUtil.newTemporaryFile("classpath")) match {
       case Success(file) =>
         FileUtil.deleteOnExit(file)
@@ -77,7 +78,7 @@ object Delombok {
       else
         Seq(
           "--sourcepath",
-          peerSourceRoots.map(_.toString).mkString(java.io.File.pathSeparator)
+          peerSourceRoots.map(_.toString).mkString(File.pathSeparator)
         )
     val command =
       Seq(
@@ -144,8 +145,9 @@ object Delombok {
     if (dependencies.isEmpty) {
       logger.warn(
         "Running delombok without any project dependencies on the classpath. Delombok may fail to resolve " +
-          "symbols from third-party libraries used in Lombok-annotated code. Re-run with --fetch-dependencies " +
-          "to make project dependencies available to delombok."
+          "symbols from third-party libraries used in Lombok-annotated code. If you did not pass " +
+          "--fetch-dependencies, re-run with it. If you did, dependency resolution may have failed silently — " +
+          "check earlier logs."
       )
     }
     Try(Files.createTempDirectory("delombok")) match {

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Delombok.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Delombok.scala
@@ -50,9 +50,22 @@ object Delombok {
   ) = {
     val javaPath     = analysisJavaHome.getOrElse(systemJavaPath)
     val ownClasspath = System.getProperty("java.class.path")
-    val fullClasspath =
-      if (dependencies.isEmpty) ownClasspath
-      else (dependencies :+ ownClasspath).mkString(File.pathSeparator)
+    val ownEntries   = ownClasspath.split(File.pathSeparator).toList
+    // Locate joern's bundled lombok jar by filename so we can force it to be resolved before any
+    // project-supplied lombok that might be incompatible with the analysis JDK.
+    val (lombokEntries, otherEntries) = ownEntries.partition { entry =>
+      val name = Paths.get(entry).getFileName.toString.toLowerCase
+      name.startsWith("lombok-") && name.endsWith(".jar")
+    }
+    if (lombokEntries.isEmpty) {
+      logger.warn(
+        "Could not locate joern's bundled lombok jar on the classpath. If a project dependency supplies a " +
+          "lombok version incompatible with the analysis JDK, delombok may fail."
+      )
+    }
+    // Prepend the bundled lombok so the classloader resolves it before any project-supplied lombok in
+    // `dependencies`. Order: bundled lombok, project dependencies, everything else from ownClasspath.
+    val fullClasspath = (lombokEntries ++ dependencies ++ otherEntries).mkString(File.pathSeparator)
     val classPathArg = Try(FileUtil.newTemporaryFile("classpath")) match {
       case Success(file) =>
         FileUtil.deleteOnExit(file)
@@ -67,10 +80,27 @@ object Delombok {
         )
         fullClasspath
     }
+    // `--sourcepath` can grow past Windows' command-length limit on large projects, so route it through
+    // a `@argfile` the same way we do for `-cp`. The java launcher expands `@file` before dispatching
+    // to `lombok.launch.Main`, so delombok itself sees an already-tokenised `--sourcepath <paths>`.
     val sourcepathArgs =
       if (peerSourceRoots.isEmpty) Nil
-      else
-        Seq("--sourcepath", peerSourceRoots.map(_.toString).mkString(File.pathSeparator))
+      else {
+        val fullSourcePath = peerSourceRoots.map(_.toString).mkString(File.pathSeparator)
+        Try(FileUtil.newTemporaryFile("sourcepath")) match {
+          case Success(file) =>
+            FileUtil.deleteOnExit(file)
+            Files.writeString(file, s"--sourcepath\n$fullSourcePath")
+            Seq(s"@${file.absolutePathAsString}")
+
+          case Failure(t) =>
+            logger.warn(
+              s"Failed to create sourcepath file for delombok execution. Results may be missing on Windows systems",
+              t
+            )
+            Seq("--sourcepath", fullSourcePath)
+        }
+      }
     val command =
       Seq(
         javaPath,

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Delombok.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Delombok.scala
@@ -22,6 +22,15 @@ object Delombok {
 
   case class DelombokRunResult(path: Path, isDelombokedPath: Boolean)
 
+  /** Per-invocation inputs for [[delombokPackageRoot]]. All absolute paths are already normalised. */
+  case class DelombokInvocation(
+    projectDir: Path,
+    relativePackageRoot: Path,
+    absRoot: Path,
+    absPeerRoots: Seq[Path],
+    fqnIndex: DelombokStderrFilter.FqnIndex
+  )
+
   private val logger = LoggerFactory.getLogger(this.getClass)
 
   private def systemJavaPath: String = {
@@ -41,7 +50,7 @@ object Delombok {
     inputPath: Path,
     outputDir: Path,
     analysisJavaHome: Option[String],
-    dependencies: Seq[String],
+    dependencies: List[String],
     peerSourceRoots: Seq[Path]
   ) = {
     val javaPath     = analysisJavaHome.getOrElse(systemJavaPath)
@@ -68,7 +77,7 @@ object Delombok {
       else
         Seq(
           "--sourcepath",
-          peerSourceRoots.map(_.toAbsolutePath.normalize().toString).mkString(java.io.File.pathSeparator)
+          peerSourceRoots.map(_.toString).mkString(java.io.File.pathSeparator)
         )
     val command =
       Seq(
@@ -84,27 +93,23 @@ object Delombok {
   }
 
   def delombokPackageRoot(
-    projectDir: Path,
-    relativePackageRoot: Path,
+    inv: DelombokInvocation,
     delombokTempDir: Path,
     analysisJavaHome: Option[String],
-    dependencies: Seq[String],
-    peerSourceRoots: Seq[Path],
-    currentRootAbsolute: Path,
-    fqnIndex: DelombokStderrFilter.FqnIndex
+    dependencies: List[String]
   ): Try[String] = {
-    val rootIsFile = Files.isRegularFile(projectDir.resolve(relativePackageRoot))
+    val rootIsFile = Files.isRegularFile(inv.projectDir.resolve(inv.relativePackageRoot))
     val relativeOutputPath =
-      if (rootIsFile) Option(relativePackageRoot.getParent).map(_.toString).getOrElse(".")
-      else relativePackageRoot.toString
-    val inputDir = projectDir.resolve(relativePackageRoot)
+      if (rootIsFile) Option(inv.relativePackageRoot.getParent).map(_.toString).getOrElse(".")
+      else inv.relativePackageRoot.toString
+    val inputDir = inv.projectDir.resolve(inv.relativePackageRoot)
 
     val childPath = (delombokTempDir / relativeOutputPath).toAbsolutePath.normalize()
 
     Try(childPath.createWithParentsIfNotExists(asDirectory = true)).flatMap { packageOutputDir =>
       val result =
         ExternalCommand.run(
-          delombokToTempDirCommand(inputDir, packageOutputDir, analysisJavaHome, dependencies, peerSourceRoots)
+          delombokToTempDirCommand(inputDir, packageOutputDir, analysisJavaHome, dependencies, inv.absPeerRoots)
         )
       if (!result.successful) {
         // Always log the stdout/stderr if delombok exited with a non-zero code
@@ -114,7 +119,7 @@ object Delombok {
         // positives for this invocation), then log the remainder as a WARN if non-empty. Fail-open:
         // if the filter itself throws, fall back to logging the original stderr.
         val filteredStdErr =
-          Try(DelombokStderrFilter.filter(currentRootAbsolute, peerSourceRoots, fqnIndex, result.stdErr)) match {
+          Try(DelombokStderrFilter.filter(inv.absPeerRoots.toSet, inv.fqnIndex, result.stdErr)) match {
             case Success(filtered) => filtered
             case Failure(err) =>
               logger.warn("DelombokStderrFilter threw; falling back to unfiltered stderr", err)
@@ -134,7 +139,7 @@ object Delombok {
     inputPath: Path,
     fileInfo: List[SourceParser.FileInfo],
     analysisJavaHome: Option[String],
-    dependencies: Seq[String]
+    dependencies: List[String]
   ): DelombokRunResult = {
     if (dependencies.isEmpty) {
       logger.warn(
@@ -150,21 +155,16 @@ object Delombok {
 
       case Success(tempDir) =>
         FileUtil.deleteOnExit(tempDir)
-        val packageRoots  = PackageRootFinder.packageRootsFromFiles(inputPath, fileInfo)
-        val absoluteRoots = packageRoots.map(inputPath.resolve)
-        val fqnIndex      = DelombokStderrFilter.FqnIndex.build(inputPath, fileInfo, packageRoots)
-        packageRoots.zip(absoluteRoots).par.foreach { case (relativeRoot, absoluteRoot) =>
-          val absoluteRootNormalised = absoluteRoot.toAbsolutePath.normalize()
-          val peerRoots              = absoluteRoots.filterNot(_ == absoluteRoot).map(_.toAbsolutePath.normalize())
+        val packageRoots = PackageRootFinder.packageRootsFromFiles(inputPath, fileInfo).distinct
+        val fqnIndex     = DelombokStderrFilter.FqnIndex.build(inputPath, fileInfo, packageRoots)
+        val absRoots     = fqnIndex.absoluteRoots
+        packageRoots.zip(absRoots).par.foreach { case (relativeRoot, absRoot) =>
+          val absPeerRoots = absRoots.filterNot(_ == absRoot)
           delombokPackageRoot(
-            inputPath,
-            relativeRoot,
+            DelombokInvocation(inputPath, relativeRoot, absRoot, absPeerRoots, fqnIndex),
             tempDir,
             analysisJavaHome,
-            dependencies,
-            peerRoots,
-            absoluteRootNormalised,
-            fqnIndex
+            dependencies
           )
         }
         DelombokRunResult(tempDir, true)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Delombok.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Delombok.scala
@@ -149,8 +149,7 @@ object Delombok {
         DelombokRunResult(inputPath, false)
 
       case Success(tempDir) =>
-        // FileUtil.deleteOnExit(tempDir)
-        println(s"delombok dir : $tempDir")
+        FileUtil.deleteOnExit(tempDir)
         val packageRoots  = PackageRootFinder.packageRootsFromFiles(inputPath, fileInfo)
         val absoluteRoots = packageRoots.map(inputPath.resolve)
         val fqnIndex      = DelombokStderrFilter.FqnIndex.build(inputPath, fileInfo, packageRoots)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Delombok.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Delombok.scala
@@ -48,7 +48,7 @@ object Delombok {
     val ownClasspath = System.getProperty("java.class.path")
     val fullClasspath =
       if (dependencies.isEmpty) ownClasspath
-      else (ownClasspath +: dependencies).mkString(java.io.File.pathSeparator)
+      else (dependencies :+ ownClasspath).mkString(java.io.File.pathSeparator)
     val classPathArg = Try(FileUtil.newTemporaryFile("classpath")) match {
       case Success(file) =>
         FileUtil.deleteOnExit(file)

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Delombok.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Delombok.scala
@@ -37,13 +37,23 @@ object Delombok {
       .getOrElse("java")
   }
 
-  private def delombokToTempDirCommand(inputPath: Path, outputDir: Path, analysisJavaHome: Option[String]) = {
-    val javaPath = analysisJavaHome.getOrElse(systemJavaPath)
+  private def delombokToTempDirCommand(
+    inputPath: Path,
+    outputDir: Path,
+    analysisJavaHome: Option[String],
+    dependencies: Seq[String],
+    peerSourceRoots: Seq[Path]
+  ) = {
+    val javaPath     = analysisJavaHome.getOrElse(systemJavaPath)
+    val ownClasspath = System.getProperty("java.class.path")
+    val fullClasspath =
+      if (dependencies.isEmpty) ownClasspath
+      else (ownClasspath +: dependencies).mkString(java.io.File.pathSeparator)
     val classPathArg = Try(FileUtil.newTemporaryFile("classpath")) match {
       case Success(file) =>
         FileUtil.deleteOnExit(file)
         // Write classpath to a file to work around Windows length limits.
-        Files.writeString(file, System.getProperty("java.class.path"))
+        Files.writeString(file, fullClasspath)
         s"@${file.absolutePathAsString}"
 
       case Failure(t) =>
@@ -51,8 +61,15 @@ object Delombok {
           s"Failed to create classpath file for delombok execution. Results may be missing on Windows systems",
           t
         )
-        System.getProperty("java.class.path")
+        fullClasspath
     }
+    val sourcepathArgs =
+      if (peerSourceRoots.isEmpty) Nil
+      else
+        Seq(
+          "--sourcepath",
+          peerSourceRoots.map(_.toAbsolutePath.normalize().toString).mkString(java.io.File.pathSeparator)
+        )
     val command =
       Seq(
         javaPath,
@@ -60,10 +77,8 @@ object Delombok {
         classPathArg,
         "lombok.launch.Main",
         "delombok",
-        inputPath.absolutePathAsString,
-        "-d",
-        outputDir.absolutePathAsString
-      )
+        inputPath.absolutePathAsString
+      ) ++ sourcepathArgs ++ Seq("-d", outputDir.absolutePathAsString)
     logger.debug(s"Executing delombok with command ${command.mkString(" ")}")
     command
   }
@@ -72,7 +87,9 @@ object Delombok {
     projectDir: Path,
     relativePackageRoot: Path,
     delombokTempDir: Path,
-    analysisJavaHome: Option[String]
+    analysisJavaHome: Option[String],
+    dependencies: Seq[String],
+    peerSourceRoots: Seq[Path]
   ): Try[String] = {
     val rootIsFile = Files.isRegularFile(projectDir.resolve(relativePackageRoot))
     val relativeOutputPath =
@@ -84,7 +101,7 @@ object Delombok {
 
     Try(childPath.createWithParentsIfNotExists(asDirectory = true)).flatMap { packageOutputDir =>
       ExternalCommand
-        .run(delombokToTempDirCommand(inputDir, packageOutputDir, analysisJavaHome))
+        .run(delombokToTempDirCommand(inputDir, packageOutputDir, analysisJavaHome, dependencies, peerSourceRoots))
         .logAlways()
         .toTry
         .map(_ => delombokTempDir.absolutePathAsString)
@@ -94,19 +111,30 @@ object Delombok {
   def run(
     inputPath: Path,
     fileInfo: List[SourceParser.FileInfo],
-    analysisJavaHome: Option[String]
+    analysisJavaHome: Option[String],
+    dependencies: Seq[String]
   ): DelombokRunResult = {
+    if (dependencies.isEmpty) {
+      logger.warn(
+        "Running delombok without any project dependencies on the classpath. Delombok may fail to resolve " +
+          "symbols from third-party libraries used in Lombok-annotated code. Re-run with --fetch-dependencies " +
+          "to make project dependencies available to delombok."
+      )
+    }
     Try(Files.createTempDirectory("delombok")) match {
       case Failure(_) =>
         logger.warn(s"Could not create temporary directory for delombok output. Scanning original sources instead")
         DelombokRunResult(inputPath, false)
 
       case Success(tempDir) =>
-        FileUtil.deleteOnExit(tempDir)
-        PackageRootFinder
-          .packageRootsFromFiles(inputPath, fileInfo)
-          .par
-          .foreach(delombokPackageRoot(inputPath, _, tempDir, analysisJavaHome))
+        // FileUtil.deleteOnExit(tempDir)
+        println(s"delombok dir : $tempDir")
+        val packageRoots  = PackageRootFinder.packageRootsFromFiles(inputPath, fileInfo)
+        val absoluteRoots = packageRoots.map(inputPath.resolve)
+        packageRoots.zip(absoluteRoots).par.foreach { case (relativeRoot, absoluteRoot) =>
+          val peerRoots = absoluteRoots.filterNot(_ == absoluteRoot)
+          delombokPackageRoot(inputPath, relativeRoot, tempDir, analysisJavaHome, dependencies, peerRoots)
+        }
         DelombokRunResult(tempDir, true)
     }
   }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Delombok.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Delombok.scala
@@ -24,13 +24,7 @@ object Delombok {
   case class DelombokRunResult(path: Path, isDelombokedPath: Boolean)
 
   /** Per-invocation inputs for [[delombokPackageRoot]]. All absolute paths are already normalised. */
-  case class DelombokInvocation(
-    projectDir: Path,
-    relativePackageRoot: Path,
-    absRoot: Path,
-    absPeerRoots: Seq[Path],
-    fqnIndex: DelombokStderrFilter.FqnIndex
-  )
+  case class DelombokInvocation(projectDir: Path, relativePackageRoot: Path, absRoot: Path, absPeerRoots: Seq[Path])
 
   private val logger = LoggerFactory.getLogger(this.getClass)
 
@@ -76,10 +70,7 @@ object Delombok {
     val sourcepathArgs =
       if (peerSourceRoots.isEmpty) Nil
       else
-        Seq(
-          "--sourcepath",
-          peerSourceRoots.map(_.toString).mkString(File.pathSeparator)
-        )
+        Seq("--sourcepath", peerSourceRoots.map(_.toString).mkString(File.pathSeparator))
     val command =
       Seq(
         javaPath,
@@ -87,47 +78,47 @@ object Delombok {
         classPathArg,
         "lombok.launch.Main",
         "delombok",
-        inputPath.absolutePathAsString
+        inputPath.absolutePathAsString,
+        "--verbose"
       ) ++ sourcepathArgs ++ Seq("-d", outputDir.absolutePathAsString)
     logger.debug(s"Executing delombok with command ${command.mkString(" ")}")
     command
   }
 
   def delombokPackageRoot(
-    inv: DelombokInvocation,
+    delombokInvocation: DelombokInvocation,
     delombokTempDir: Path,
     analysisJavaHome: Option[String],
     dependencies: List[String]
   ): Try[String] = {
-    val rootIsFile = Files.isRegularFile(inv.projectDir.resolve(inv.relativePackageRoot))
+    val rootIsFile = Files.isRegularFile(delombokInvocation.projectDir.resolve(delombokInvocation.relativePackageRoot))
     val relativeOutputPath =
-      if (rootIsFile) Option(inv.relativePackageRoot.getParent).map(_.toString).getOrElse(".")
-      else inv.relativePackageRoot.toString
-    val inputDir = inv.projectDir.resolve(inv.relativePackageRoot)
+      if (rootIsFile) Option(delombokInvocation.relativePackageRoot.getParent).map(_.toString).getOrElse(".")
+      else delombokInvocation.relativePackageRoot.toString
+    val inputDir = delombokInvocation.projectDir.resolve(delombokInvocation.relativePackageRoot)
 
     val childPath = (delombokTempDir / relativeOutputPath).toAbsolutePath.normalize()
 
     Try(childPath.createWithParentsIfNotExists(asDirectory = true)).flatMap { packageOutputDir =>
       val result =
         ExternalCommand.run(
-          delombokToTempDirCommand(inputDir, packageOutputDir, analysisJavaHome, dependencies, inv.absPeerRoots)
+          delombokToTempDirCommand(
+            inputDir,
+            packageOutputDir,
+            analysisJavaHome,
+            dependencies,
+            delombokInvocation.absPeerRoots
+          )
         )
       if (!result.successful) {
-        // Always log the stdout/stderr if delombok exited with a non-zero code
+        // Always log the unfiltered stdout/stderr if delombok exited with a non-zero code
         result.logIfFailed()
       } else {
-        // Exit 0: filter out `cannot find symbol` records that reference peer roots (false
-        // positives for this invocation), then log the remainder as a WARN if non-empty. Fail-open:
-        // if the filter itself throws, fall back to logging the original stderr.
-        val filteredStdErr =
-          Try(DelombokStderrFilter.filter(inv.absPeerRoots.toSet, inv.fqnIndex, result.stdErr)) match {
-            case Success(filtered) => filtered
-            case Failure(err) =>
-              logger.warn("DelombokStderrFilter threw; falling back to unfiltered stderr", err)
-              result.stdErr
-          }
+        // Exit 0: filter out error logs that reference peer roots (these will be logged anyways when the peer is
+        // delomboked), then log the remainder as a DEBUG if non-empty.
+        val filteredStdErr = DelombokStderrFilter.filter(delombokInvocation.absRoot, result.stdErr)
         if (filteredStdErr.nonEmpty) {
-          logger.warn(s"Delombok emitted diagnostics for $inputDir:\n${filteredStdErr.mkString("\n")}")
+          logger.debug(s"Delombok emitted diagnostics for $inputDir:\n${filteredStdErr.mkString("\n")}")
         }
       }
       // Call `toTry` on the original result so the failure message (used downstream) still
@@ -146,7 +137,7 @@ object Delombok {
       logger.warn(
         "Running delombok without any project dependencies on the classpath. Delombok may fail to resolve " +
           "symbols from third-party libraries used in Lombok-annotated code. If you did not pass " +
-          "--fetch-dependencies, re-run with it. If you did, dependency resolution may have failed silently — " +
+          "--fetch-dependencies, re-run with it. If you did, dependency resolution may have failed — " +
           "check earlier logs."
       )
     }
@@ -157,13 +148,13 @@ object Delombok {
 
       case Success(tempDir) =>
         FileUtil.deleteOnExit(tempDir)
-        val packageRoots = PackageRootFinder.packageRootsFromFiles(inputPath, fileInfo).distinct
-        val fqnIndex     = DelombokStderrFilter.FqnIndex.build(inputPath, fileInfo, packageRoots)
-        val absRoots     = fqnIndex.absoluteRoots
-        packageRoots.zip(absRoots).par.foreach { case (relativeRoot, absRoot) =>
-          val absPeerRoots = absRoots.filterNot(_ == absRoot)
+        val packageRoots         = PackageRootFinder.packageRootsFromFiles(inputPath, fileInfo).distinct
+        val absolutePackageRoots = packageRoots.map(_.toAbsolutePath)
+        packageRoots.par.foreach { case relativeRoot =>
+          val absoluteRoot      = relativeRoot.toAbsolutePath
+          val absolutePeerRoots = absolutePackageRoots.filterNot(_ == absoluteRoot)
           delombokPackageRoot(
-            DelombokInvocation(inputPath, relativeRoot, absRoot, absPeerRoots, fqnIndex),
+            DelombokInvocation(inputPath, relativeRoot, absoluteRoot, absolutePeerRoots),
             tempDir,
             analysisJavaHome,
             dependencies

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Delombok.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/Delombok.scala
@@ -89,7 +89,9 @@ object Delombok {
     delombokTempDir: Path,
     analysisJavaHome: Option[String],
     dependencies: Seq[String],
-    peerSourceRoots: Seq[Path]
+    peerSourceRoots: Seq[Path],
+    currentRootAbsolute: Path,
+    fqnIndex: DelombokStderrFilter.FqnIndex
   ): Try[String] = {
     val rootIsFile = Files.isRegularFile(projectDir.resolve(relativePackageRoot))
     val relativeOutputPath =
@@ -100,11 +102,31 @@ object Delombok {
     val childPath = (delombokTempDir / relativeOutputPath).toAbsolutePath.normalize()
 
     Try(childPath.createWithParentsIfNotExists(asDirectory = true)).flatMap { packageOutputDir =>
-      ExternalCommand
-        .run(delombokToTempDirCommand(inputDir, packageOutputDir, analysisJavaHome, dependencies, peerSourceRoots))
-        .logAlways()
-        .toTry
-        .map(_ => delombokTempDir.absolutePathAsString)
+      val result =
+        ExternalCommand.run(
+          delombokToTempDirCommand(inputDir, packageOutputDir, analysisJavaHome, dependencies, peerSourceRoots)
+        )
+      if (!result.successful) {
+        // Always log the stdout/stderr if delombok exited with a non-zero code
+        result.logIfFailed()
+      } else {
+        // Exit 0: filter out `cannot find symbol` records that reference peer roots (false
+        // positives for this invocation), then log the remainder as a WARN if non-empty. Fail-open:
+        // if the filter itself throws, fall back to logging the original stderr.
+        val filteredStdErr =
+          Try(DelombokStderrFilter.filter(currentRootAbsolute, peerSourceRoots, fqnIndex, result.stdErr)) match {
+            case Success(filtered) => filtered
+            case Failure(err) =>
+              logger.warn("DelombokStderrFilter threw; falling back to unfiltered stderr", err)
+              result.stdErr
+          }
+        if (filteredStdErr.nonEmpty) {
+          logger.warn(s"Delombok emitted diagnostics for $inputDir:\n${filteredStdErr.mkString("\n")}")
+        }
+      }
+      // Call `toTry` on the original result so the failure message (used downstream) still
+      // contains the full unfiltered stderr.
+      result.toTry.map(_ => delombokTempDir.absolutePathAsString)
     }
   }
 
@@ -131,9 +153,20 @@ object Delombok {
         println(s"delombok dir : $tempDir")
         val packageRoots  = PackageRootFinder.packageRootsFromFiles(inputPath, fileInfo)
         val absoluteRoots = packageRoots.map(inputPath.resolve)
+        val fqnIndex      = DelombokStderrFilter.FqnIndex.build(inputPath, fileInfo, packageRoots)
         packageRoots.zip(absoluteRoots).par.foreach { case (relativeRoot, absoluteRoot) =>
-          val peerRoots = absoluteRoots.filterNot(_ == absoluteRoot)
-          delombokPackageRoot(inputPath, relativeRoot, tempDir, analysisJavaHome, dependencies, peerRoots)
+          val absoluteRootNormalised = absoluteRoot.toAbsolutePath.normalize()
+          val peerRoots              = absoluteRoots.filterNot(_ == absoluteRoot).map(_.toAbsolutePath.normalize())
+          delombokPackageRoot(
+            inputPath,
+            relativeRoot,
+            tempDir,
+            analysisJavaHome,
+            dependencies,
+            peerRoots,
+            absoluteRootNormalised,
+            fqnIndex
+          )
         }
         DelombokRunResult(tempDir, true)
     }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/DelombokStderrFilter.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/DelombokStderrFilter.scala
@@ -1,0 +1,178 @@
+package io.joern.javasrc2cpg.util
+
+import org.slf4j.LoggerFactory
+
+import java.nio.file.Path
+import scala.util.matching.Regex
+
+/** Filters delombok stderr to drop noisy false-positive `cannot find symbol` diagnostics that reference peer package
+  * roots. Peer-root errors are false positives for a given delombok invocation because Lombok's AST-manipulation pass
+  * only runs on files given as inputs — peer sources reached via `--sourcepath` are compiled but not lomboked. Anything
+  * genuinely wrong in a peer root will surface when that peer is itself the input root in a different invocation.
+  *
+  * Fail-open: any stderr line that doesn't parse as a recognised diagnostic record is kept verbatim.
+  */
+object DelombokStderrFilter {
+
+  private val logger = LoggerFactory.getLogger(this.getClass)
+
+  /** Index that maps top-level Java FQNs (and inner-class prefixes) to the absolute package root they belong to, plus
+    * the ordered list of absolute roots so file paths can be mapped to a root.
+    *
+    * @param fqnToRoot
+    *   top-level class FQN (dotted) to absolute package root.
+    * @param absoluteRoots
+    *   absolute, normalised package roots in original ordering.
+    */
+  case class FqnIndex(fqnToRoot: Map[String, Path], absoluteRoots: Seq[Path]) {
+
+    /** Longest dotted-prefix match on the given FQN. So `com.example.UserRecord.InnerClass` matches an entry
+      * `com.example.UserRecord`. Returns `None` if no match.
+      */
+    def rootFor(fqn: String): Option[Path] = {
+      val prefixes = Iterator
+        .iterate(fqn.replace('$', '.')) { candidate =>
+          val dot = candidate.lastIndexOf('.')
+          if (dot < 0) "" else candidate.substring(0, dot)
+        }
+        .takeWhile(_.nonEmpty)
+      prefixes.flatMap(fqnToRoot.get).nextOption()
+    }
+
+    /** Which package root (if any) contains this absolute file path. Returns the longest matching root. */
+    def rootForFile(absPath: Path): Option[Path] = {
+      val normalised = absPath.toAbsolutePath.normalize()
+      absoluteRoots
+        .filter(root => normalised.startsWith(root))
+        .sortBy(-_.getNameCount)
+        .headOption
+    }
+  }
+
+  object FqnIndex {
+
+    /** Build an index from the SourceParser file infos and the discovered package roots.
+      *
+      *   - For each file, compute the top-level FQN as `packageName + "." + <file stem>`.
+      *   - Each file is assigned to the (unique) package root whose relative path is a prefix of the file's relative
+      *     path. The dot-root matches everything.
+      *   - Absolute-root list is `packageRoots.map(inputPath.resolve(_).toAbsolutePath.normalize)`.
+      */
+    def build(inputPath: Path, fileInfo: List[SourceParser.FileInfo], packageRoots: List[Path]): FqnIndex = {
+      val dotPath           = Path.of(".")
+      val absoluteInputPath = inputPath.toAbsolutePath.normalize()
+      val absoluteRoots     = packageRoots.map(root => absoluteInputPath.resolve(root.toString).normalize())
+
+      // For lookup: pair each relative root with its absolute root, sort by descending name count so that the
+      // most specific (longest) root wins.
+      val rootsByNameCount =
+        packageRoots.zip(absoluteRoots).sortBy { case (rel, _) => -rel.getNameCount }
+
+      val fqnToRoot: Map[String, Path] = fileInfo.iterator.flatMap { info =>
+        val stem = {
+          val fileName = info.relativePath.getFileName.toString
+          if (fileName.endsWith(".java")) fileName.dropRight(".java".length) else fileName
+        }
+        val fqn = info.packageName match {
+          case Some(pkg) if pkg.nonEmpty => s"$pkg.$stem"
+          case _                         => stem
+        }
+        val matchingRoot = rootsByNameCount.collectFirst {
+          case (rel, abs) if rel == dotPath                    => abs
+          case (rel, abs) if info.relativePath.startsWith(rel) => abs
+        }
+        matchingRoot.map(root => fqn -> root)
+      }.toMap
+
+      FqnIndex(fqnToRoot, absoluteRoots)
+    }
+  }
+
+  /** Regex for the header line of a `cannot find symbol` diagnostic record: `<absolute file path>:<line>: error:
+    * <msg>`. The path may contain colons on Windows drive letters, but on the platforms we run delombok on it starts
+    * with `/`.
+    */
+  private val HeaderRegex: Regex = raw"^(/[^:]+):(\d+):\s*error:\s*(.*)$$".r
+
+  /** `location:` line, class/interface/enum form. */
+  private val LocationClassRegex: Regex = raw"^\s*location:\s*(?:class|interface|enum)\s+([A-Za-z0-9_.$$]+)\s*$$".r
+
+  /** `location:` line, `variable NAME of type FQN` form. */
+  private val LocationVariableRegex: Regex =
+    raw"^\s*location:\s*variable\s+\S+\s+of\s+type\s+([A-Za-z0-9_.$$]+)\s*$$".r
+
+  /** `symbol:` line marker. */
+  private val SymbolRegex: Regex = raw"^\s*symbol:\s*.*$$".r
+
+  /** A parsed `cannot find symbol` record. */
+  private case class Record(lines: Seq[String], file: Path, locationFqn: Option[String])
+
+  /** Result of streaming stderr into records and unclassified passthrough lines, preserving their original order.
+    */
+  private sealed trait Element
+  private case class RecordElement(record: Record) extends Element
+  private case class PassthroughLine(line: String) extends Element
+
+  /** Filter the given stderr lines: drop `cannot find symbol` records that reference peer roots; keep everything else
+    * verbatim. Order is preserved.
+    */
+  def filter(currentRoot: Path, peerRoots: Seq[Path], index: FqnIndex, stderrLines: Seq[String]): Seq[String] = {
+    val normalisedPeerRoots = peerRoots.map(_.toAbsolutePath.normalize()).toSet
+    val elements            = splitIntoElements(stderrLines)
+
+    elements.flatMap {
+      case PassthroughLine(line) => Seq(line)
+      case RecordElement(record) =>
+        val fileRoot     = index.rootForFile(record.file)
+        val locationRoot = record.locationFqn.flatMap(index.rootFor)
+        val fileInPeer   = fileRoot.exists(normalisedPeerRoots.contains)
+        val locInPeer    = locationRoot.exists(normalisedPeerRoots.contains)
+        if (fileInPeer || locInPeer) Seq.empty
+        else record.lines
+    }
+  }
+
+  /** Stream-parse stderr lines into a mixed list of records (5-line `cannot find symbol` diagnostics) and passthrough
+    * lines (anything we didn't recognise).
+    */
+  private def splitIntoElements(lines: Seq[String]): Seq[Element] = {
+    val indexed = lines.toIndexedSeq
+    val out     = collection.mutable.ArrayBuffer.empty[Element]
+    var i       = 0
+    while (i < indexed.length) {
+      tryParseRecord(indexed, i) match {
+        case Some(record) =>
+          out += RecordElement(record)
+          i += record.lines.length
+        case None =>
+          out += PassthroughLine(indexed(i))
+          i += 1
+      }
+    }
+    out.toSeq
+  }
+
+  /** Try to parse the 5-line `cannot find symbol` diagnostic starting at `start`. Returns `None` if any of the required
+    * lines is missing or doesn't match the expected shape (header / symbol / location). Snippet and caret lines
+    * (indices +1 and +2) are consumed but not inspected.
+    */
+  private def tryParseRecord(lines: IndexedSeq[String], start: Int): Option[Record] = {
+    for {
+      header <- lines.lift(start).flatMap(HeaderRegex.findFirstMatchIn)
+      if header.group(3).contains("cannot find symbol")
+      _          <- lines.lift(start + 1) // snippet
+      _          <- lines.lift(start + 2) // caret
+      symbolLine <- lines.lift(start + 3)
+      if SymbolRegex.matches(symbolLine)
+      locationLine <- lines.lift(start + 4)
+      locationFqn <- LocationClassRegex
+        .findFirstMatchIn(locationLine)
+        .map(_.group(1))
+        .orElse(LocationVariableRegex.findFirstMatchIn(locationLine).map(_.group(1)))
+    } yield Record(
+      lines = lines.slice(start, start + 5),
+      file = Path.of(header.group(1)),
+      locationFqn = Some(locationFqn)
+    )
+  }
+}

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/DelombokStderrFilter.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/DelombokStderrFilter.scala
@@ -2,183 +2,62 @@ package io.joern.javasrc2cpg.util
 
 import java.nio.file.Path
 import scala.util.matching.Regex
+import scala.collection.mutable.ArrayBuffer
 
-/** Filters delombok stderr to drop noisy false-positive `cannot find symbol` diagnostics that reference peer package
-  * roots. Peer-root errors are false positives for a given delombok invocation because Lombok's AST-manipulation pass
-  * only runs on files given as inputs — peer sources reached via `--sourcepath` are compiled but not lomboked. Anything
-  * genuinely wrong in a peer root will surface when that peer is itself the input root in a different invocation.
-  *
-  * Fail-open: any stderr line that doesn't parse as a recognised diagnostic record is kept verbatim.
+private type RegexSplitResult = (regexMatch: Regex.Match, lineGroup: Seq[String])
+
+/** Delombok
   */
 object DelombokStderrFilter {
 
-  /** Index that maps top-level Java FQNs (and inner-class prefixes) to the absolute package roots they belong to, plus
-    * the ordered list of absolute roots so file paths can be mapped to a root.
-    *
-    * @param fqnToRoots
-    *   top-level class FQN (dotted) to the set of absolute package roots declaring that FQN. Multiple roots per FQN
-    *   are possible when peer source trees declare the same class name — callers must treat this as ambiguous.
-    * @param absoluteRoots
-    *   absolute, normalised package roots in original ordering.
-    */
-  case class FqnIndex(fqnToRoots: Map[String, Set[Path]], absoluteRoots: Seq[Path]) {
-    private val rootsByDepth: Seq[Path] = absoluteRoots.sortBy(-_.getNameCount)
+  private val ErrorHeaderRegex = raw"^((?:/|[A-Za-z]:[\\/])[^:]+):(\d+):\s*error:\s*(.*)$$".r
+  private val FileStatusRegex  = raw"^File: (.+) \[(delomboked|unchanged)]$$".r
 
-    /** Longest dotted-prefix match on the given FQN. So `com.example.UserRecord.InnerClass` matches an entry
-      * `com.example.UserRecord`. Returns the empty set if no match.
-      */
-    def rootsFor(fqn: String): Set[Path] = {
-      val prefixes = Iterator
-        .iterate(fqn.replace('$', '.')) { candidate =>
-          val dot = candidate.lastIndexOf('.')
-          if (dot < 0) "" else candidate.substring(0, dot)
+  def splitWhen(seq: Seq[String])(predicate: String => Boolean): Iterator[Array[String]] = {
+    val it = seq.iterator.buffered
+
+    new Iterator[Array[String]] {
+      def hasNext: Boolean = it.hasNext
+
+      def next(): Array[String] = {
+        if (!hasNext) throw new NoSuchElementException("next on empty iterator")
+
+        val buffer = ArrayBuffer[String]()
+
+        // Unconditionally take the first element to start the group
+        buffer += it.next()
+
+        // Keep taking elements until the NEXT element matches the predicate
+        while (it.hasNext && !predicate(it.head)) {
+          buffer += it.next()
         }
-        .takeWhile(_.nonEmpty)
-      prefixes.flatMap(fqnToRoots.get).nextOption().getOrElse(Set.empty)
-    }
 
-    /** Which package root (if any) contains this absolute file path. Returns the longest matching root. */
-    def rootForFile(absPath: Path): Option[Path] = {
-      val normalised = absPath.toAbsolutePath.normalize()
-      rootsByDepth.find(normalised.startsWith)
-    }
-  }
-
-  object FqnIndex {
-
-    /** Build an index from the SourceParser file infos and the discovered package roots.
-      *
-      *   - For each file, compute the top-level FQN as `packageName + "." + <file stem>`.
-      *   - Each file is assigned to the (unique) package root whose relative path is a prefix of the file's relative
-      *     path. The dot-root matches everything.
-      *   - Absolute-root list is `packageRoots.map(inputPath.resolve(_).toAbsolutePath.normalize)`.
-      */
-    def build(inputPath: Path, fileInfo: List[SourceParser.FileInfo], packageRoots: List[Path]): FqnIndex = {
-      val dotPath           = Path.of(".")
-      val absoluteInputPath = inputPath.toAbsolutePath.normalize()
-      val absoluteRoots     = packageRoots.map(root => absoluteInputPath.resolve(root.toString).normalize())
-
-      // For lookup: pair each relative root with its absolute root, sort by descending name count so that the
-      // most specific (longest) root wins.
-      val rootsByNameCount =
-        packageRoots.zip(absoluteRoots).sortBy { case (rel, _) => -rel.getNameCount }
-
-      val fqnToRoots: Map[String, Set[Path]] = fileInfo.iterator.flatMap { info =>
-        val stem = {
-          val fileName = info.relativePath.getFileName.toString
-          if (fileName.endsWith(".java")) fileName.dropRight(".java".length) else fileName
-        }
-        val fqn = info.packageName match {
-          case Some(pkg) if pkg.nonEmpty => s"$pkg.$stem"
-          case _                         => stem
-        }
-        val matchingRoot = rootsByNameCount.collectFirst {
-          case (rel, abs) if rel == dotPath                    => abs
-          case (rel, abs) if info.relativePath.startsWith(rel) => abs
-        }
-        matchingRoot.map(root => fqn -> root)
-      }.toList.groupMap(_._1)(_._2).view.mapValues(_.toSet).toMap
-
-      FqnIndex(fqnToRoots, absoluteRoots)
-    }
-  }
-
-  /** Regex for the header line of a `cannot find symbol` diagnostic record: `<absolute file path>:<line>: error:
-    * <msg>`. Matches POSIX absolute paths (`/…`) as well as Windows drive-letter paths (`C:\…` / `C:/…`).
-    */
-  private val HeaderRegex: Regex =
-    raw"^((?:/|[A-Za-z]:[\\/])[^:]+):(\d+):\s*error:\s*(.*)$$".r
-
-  /** `location:` line, class/interface/enum form. */
-  private val LocationClassRegex: Regex = raw"^\s*location:\s*(?:class|interface|enum)\s+([A-Za-z0-9_.$$]+)\s*$$".r
-
-  /** `location:` line, `variable NAME of type FQN` form. */
-  private val LocationVariableRegex: Regex =
-    raw"^\s*location:\s*variable\s+\S+\s+of\s+type\s+([A-Za-z0-9_.$$]+)\s*$$".r
-
-  /** `symbol:` line marker. */
-  private val SymbolRegex: Regex = raw"^\s*symbol:\s*.*$$".r
-
-  /** A parsed `cannot find symbol` record.
-    *
-    * @param locationFqn
-    *   dotted FQN as extracted from the `location:` line. `$` (from inner-class names in javac output) is preserved
-    *   as-is here; normalisation to dots happens at lookup time in [[FqnIndex.rootsFor]].
-    */
-  private case class Record(lines: Seq[String], file: Path, locationFqn: Option[String])
-
-  /** Result of streaming stderr into records and unclassified passthrough lines, preserving their original order.
-    */
-  private sealed trait Element
-  private case class RecordElement(record: Record) extends Element
-  private case class PassthroughLine(line: String) extends Element
-
-  /** Filter the given stderr lines: drop `cannot find symbol` records that reference peer roots; keep everything else
-    * verbatim. Order is preserved.
-    *
-    * @param peerRoots
-    *   absolute, normalised peer package roots (callers must pre-normalise; matched by exact equality).
-    */
-  def filter(peerRoots: Set[Path], index: FqnIndex, stderrLines: Seq[String]): Seq[String] = {
-    val elements = splitIntoElements(stderrLines)
-
-    elements.flatMap {
-      case PassthroughLine(line) => Seq(line)
-      case RecordElement(record) =>
-        val fileRoot      = index.rootForFile(record.file)
-        val locationRoots = record.locationFqn.map(index.rootsFor).getOrElse(Set.empty)
-        val fileInPeer    = fileRoot.exists(peerRoots.contains)
-        // Drop only when every possible originating root is a peer — if the FQN could also
-        // resolve to the current root, keep the record (fail-open, may log a false positive).
-        val locInPeer     = locationRoots.nonEmpty && locationRoots.forall(peerRoots.contains)
-        if (fileInPeer || locInPeer)
-          Seq.empty
-        else
-          record.lines
-    }
-  }
-
-  /** Stream-parse stderr lines into a mixed list of records (5-line `cannot find symbol` diagnostics) and passthrough
-    * lines (anything we didn't recognise).
-    */
-  private def splitIntoElements(lines: Seq[String]): Seq[Element] = {
-    val indexed = lines.toIndexedSeq
-    val out     = collection.mutable.ArrayBuffer.empty[Element]
-    var i       = 0
-    while (i < indexed.length) {
-      tryParseRecord(indexed, i) match {
-        case Some(record) =>
-          out += RecordElement(record)
-          i += record.lines.length
-        case None =>
-          out += PassthroughLine(indexed(i))
-          i += 1
+        buffer.toArray
       }
     }
-    out.toSeq
   }
 
-  /** Try to parse the 5-line `cannot find symbol` diagnostic starting at `start`. Returns `None` if any of the required
-    * lines is missing or doesn't match the expected shape (header / symbol / location). Snippet and caret lines
-    * (indices +1 and +2) are consumed but not inspected.
+  /** Filter the given stderr lines: drop records that are not contained within the current packageRoot; keep everything
+    * else verbatim. Order is preserved.
     */
-  private def tryParseRecord(lines: IndexedSeq[String], start: Int): Option[Record] = {
-    for {
-      header <- lines.lift(start).flatMap(HeaderRegex.findFirstMatchIn)
-      if header.group(3).contains("cannot find symbol")
-      _          <- lines.lift(start + 1) // snippet
-      _          <- lines.lift(start + 2) // caret
-      symbolLine <- lines.lift(start + 3)
-      if SymbolRegex.matches(symbolLine)
-      locationLine <- lines.lift(start + 4)
-      locationFqn <- LocationClassRegex
-        .findFirstMatchIn(locationLine)
-        .map(_.group(1))
-        .orElse(LocationVariableRegex.findFirstMatchIn(locationLine).map(_.group(1)))
-    } yield Record(
-      lines = lines.slice(start, start + 5),
-      file = Path.of(header.group(1)),
-      locationFqn = Some(locationFqn)
-    )
+  def filter(packageRoot: Path, stderrLines: Seq[String]): Seq[String] = {
+    splitWhen(stderrLines)(line => ErrorHeaderRegex.matches(line) || FileStatusRegex.matches(line)).flatMap {
+      lineGroup =>
+        ErrorHeaderRegex.findFirstMatchIn(lineGroup.head) match {
+          case None =>
+            // If the first line doesn't match the error header, add the line group to the output to avoid silently
+            // missing warnings at the start of the logs.
+            // Otherwise, if it is a file status line, output it as well
+            lineGroup
+
+          case Some(regexMatch) =>
+            val filePath = Path.of(regexMatch.group(1)).toAbsolutePath
+
+            if (filePath.startsWith(packageRoot)) {
+              lineGroup
+            } else
+              Nil
+        }
+    }.toSeq
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/DelombokStderrFilter.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/DelombokStderrFilter.scala
@@ -116,20 +116,22 @@ object DelombokStderrFilter {
 
   /** Filter the given stderr lines: drop `cannot find symbol` records that reference peer roots; keep everything else
     * verbatim. Order is preserved.
+    *
+    * @param peerRoots
+    *   absolute, normalised peer package roots (callers must pre-normalise; matched by exact equality).
     */
-  def filter(currentRoot: Path, peerRoots: Seq[Path], index: FqnIndex, stderrLines: Seq[String]): Seq[String] = {
-    val normalisedPeerRoots = peerRoots.map(_.toAbsolutePath.normalize()).toSet
-    val elements            = splitIntoElements(stderrLines)
+  def filter(peerRoots: Set[Path], index: FqnIndex, stderrLines: Seq[String]): Seq[String] = {
+    val elements = splitIntoElements(stderrLines)
 
     elements.flatMap {
       case PassthroughLine(line) => Seq(line)
       case RecordElement(record) =>
         val fileRoot      = index.rootForFile(record.file)
         val locationRoots = record.locationFqn.map(index.rootsFor).getOrElse(Set.empty)
-        val fileInPeer    = fileRoot.exists(normalisedPeerRoots.contains)
+        val fileInPeer    = fileRoot.exists(peerRoots.contains)
         // Drop only when every possible originating root is a peer — if the FQN could also
         // resolve to the current root, keep the record (fail-open, may log a false positive).
-        val locInPeer     = locationRoots.nonEmpty && locationRoots.forall(normalisedPeerRoots.contains)
+        val locInPeer     = locationRoots.nonEmpty && locationRoots.forall(peerRoots.contains)
         if (fileInPeer || locInPeer) Seq.empty
         else record.lines
     }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/DelombokStderrFilter.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/DelombokStderrFilter.scala
@@ -16,27 +16,28 @@ object DelombokStderrFilter {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
 
-  /** Index that maps top-level Java FQNs (and inner-class prefixes) to the absolute package root they belong to, plus
+  /** Index that maps top-level Java FQNs (and inner-class prefixes) to the absolute package roots they belong to, plus
     * the ordered list of absolute roots so file paths can be mapped to a root.
     *
-    * @param fqnToRoot
-    *   top-level class FQN (dotted) to absolute package root.
+    * @param fqnToRoots
+    *   top-level class FQN (dotted) to the set of absolute package roots declaring that FQN. Multiple roots per FQN
+    *   are possible when peer source trees declare the same class name — callers must treat this as ambiguous.
     * @param absoluteRoots
     *   absolute, normalised package roots in original ordering.
     */
-  case class FqnIndex(fqnToRoot: Map[String, Path], absoluteRoots: Seq[Path]) {
+  case class FqnIndex(fqnToRoots: Map[String, Set[Path]], absoluteRoots: Seq[Path]) {
 
     /** Longest dotted-prefix match on the given FQN. So `com.example.UserRecord.InnerClass` matches an entry
-      * `com.example.UserRecord`. Returns `None` if no match.
+      * `com.example.UserRecord`. Returns the empty set if no match.
       */
-    def rootFor(fqn: String): Option[Path] = {
+    def rootsFor(fqn: String): Set[Path] = {
       val prefixes = Iterator
         .iterate(fqn.replace('$', '.')) { candidate =>
           val dot = candidate.lastIndexOf('.')
           if (dot < 0) "" else candidate.substring(0, dot)
         }
         .takeWhile(_.nonEmpty)
-      prefixes.flatMap(fqnToRoot.get).nextOption()
+      prefixes.flatMap(fqnToRoots.get).nextOption().getOrElse(Set.empty)
     }
 
     /** Which package root (if any) contains this absolute file path. Returns the longest matching root. */
@@ -68,7 +69,7 @@ object DelombokStderrFilter {
       val rootsByNameCount =
         packageRoots.zip(absoluteRoots).sortBy { case (rel, _) => -rel.getNameCount }
 
-      val fqnToRoot: Map[String, Path] = fileInfo.iterator.flatMap { info =>
+      val fqnToRoots: Map[String, Set[Path]] = fileInfo.iterator.flatMap { info =>
         val stem = {
           val fileName = info.relativePath.getFileName.toString
           if (fileName.endsWith(".java")) fileName.dropRight(".java".length) else fileName
@@ -82,17 +83,17 @@ object DelombokStderrFilter {
           case (rel, abs) if info.relativePath.startsWith(rel) => abs
         }
         matchingRoot.map(root => fqn -> root)
-      }.toMap
+      }.toList.groupMap(_._1)(_._2).view.mapValues(_.toSet).toMap
 
-      FqnIndex(fqnToRoot, absoluteRoots)
+      FqnIndex(fqnToRoots, absoluteRoots)
     }
   }
 
   /** Regex for the header line of a `cannot find symbol` diagnostic record: `<absolute file path>:<line>: error:
-    * <msg>`. The path may contain colons on Windows drive letters, but on the platforms we run delombok on it starts
-    * with `/`.
+    * <msg>`. Matches POSIX absolute paths (`/…`) as well as Windows drive-letter paths (`C:\…` / `C:/…`).
     */
-  private val HeaderRegex: Regex = raw"^(/[^:]+):(\d+):\s*error:\s*(.*)$$".r
+  private val HeaderRegex: Regex =
+    raw"^((?:/|[A-Za-z]:[\\/])[^:]+):(\d+):\s*error:\s*(.*)$$".r
 
   /** `location:` line, class/interface/enum form. */
   private val LocationClassRegex: Regex = raw"^\s*location:\s*(?:class|interface|enum)\s+([A-Za-z0-9_.$$]+)\s*$$".r
@@ -123,10 +124,12 @@ object DelombokStderrFilter {
     elements.flatMap {
       case PassthroughLine(line) => Seq(line)
       case RecordElement(record) =>
-        val fileRoot     = index.rootForFile(record.file)
-        val locationRoot = record.locationFqn.flatMap(index.rootFor)
-        val fileInPeer   = fileRoot.exists(normalisedPeerRoots.contains)
-        val locInPeer    = locationRoot.exists(normalisedPeerRoots.contains)
+        val fileRoot      = index.rootForFile(record.file)
+        val locationRoots = record.locationFqn.map(index.rootsFor).getOrElse(Set.empty)
+        val fileInPeer    = fileRoot.exists(normalisedPeerRoots.contains)
+        // Drop only when every possible originating root is a peer — if the FQN could also
+        // resolve to the current root, keep the record (fail-open, may log a false positive).
+        val locInPeer     = locationRoots.nonEmpty && locationRoots.forall(normalisedPeerRoots.contains)
         if (fileInPeer || locInPeer) Seq.empty
         else record.lines
     }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/DelombokStderrFilter.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/DelombokStderrFilter.scala
@@ -1,7 +1,5 @@
 package io.joern.javasrc2cpg.util
 
-import org.slf4j.LoggerFactory
-
 import java.nio.file.Path
 import scala.util.matching.Regex
 
@@ -14,8 +12,6 @@ import scala.util.matching.Regex
   */
 object DelombokStderrFilter {
 
-  private val logger = LoggerFactory.getLogger(this.getClass)
-
   /** Index that maps top-level Java FQNs (and inner-class prefixes) to the absolute package roots they belong to, plus
     * the ordered list of absolute roots so file paths can be mapped to a root.
     *
@@ -26,6 +22,7 @@ object DelombokStderrFilter {
     *   absolute, normalised package roots in original ordering.
     */
   case class FqnIndex(fqnToRoots: Map[String, Set[Path]], absoluteRoots: Seq[Path]) {
+    private val rootsByDepth: Seq[Path] = absoluteRoots.sortBy(-_.getNameCount)
 
     /** Longest dotted-prefix match on the given FQN. So `com.example.UserRecord.InnerClass` matches an entry
       * `com.example.UserRecord`. Returns the empty set if no match.
@@ -43,10 +40,7 @@ object DelombokStderrFilter {
     /** Which package root (if any) contains this absolute file path. Returns the longest matching root. */
     def rootForFile(absPath: Path): Option[Path] = {
       val normalised = absPath.toAbsolutePath.normalize()
-      absoluteRoots
-        .filter(root => normalised.startsWith(root))
-        .sortBy(-_.getNameCount)
-        .headOption
+      rootsByDepth.find(normalised.startsWith)
     }
   }
 
@@ -105,7 +99,12 @@ object DelombokStderrFilter {
   /** `symbol:` line marker. */
   private val SymbolRegex: Regex = raw"^\s*symbol:\s*.*$$".r
 
-  /** A parsed `cannot find symbol` record. */
+  /** A parsed `cannot find symbol` record.
+    *
+    * @param locationFqn
+    *   dotted FQN as extracted from the `location:` line. `$` (from inner-class names in javac output) is preserved
+    *   as-is here; normalisation to dots happens at lookup time in [[FqnIndex.rootsFor]].
+    */
   private case class Record(lines: Seq[String], file: Path, locationFqn: Option[String])
 
   /** Result of streaming stderr into records and unclassified passthrough lines, preserving their original order.
@@ -132,8 +131,10 @@ object DelombokStderrFilter {
         // Drop only when every possible originating root is a peer — if the FQN could also
         // resolve to the current root, keep the record (fail-open, may log a false positive).
         val locInPeer     = locationRoots.nonEmpty && locationRoots.forall(peerRoots.contains)
-        if (fileInPeer || locInPeer) Seq.empty
-        else record.lines
+        if (fileInPeer || locInPeer)
+          Seq.empty
+        else
+          record.lines
     }
   }
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/SourceParser.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/SourceParser.scala
@@ -138,7 +138,7 @@ object SourceParser {
     checkExists(file)
   }
 
-  def apply(config: Config, filenamesOverride: Option[List[String]]): SourceParser = {
+  def apply(config: Config, filenamesOverride: Option[List[String]], dependencies: Seq[String] = Nil): SourceParser = {
     val inputPath = Path.of(config.inputPath)
 
     val fileInfo = filenamesOverride
@@ -156,7 +156,7 @@ object SourceParser {
     val usesLombok = fileInfo.exists(_.usesLombok)
 
     var dirToDelete: Option[Path] = None
-    lazy val delombokResult       = Delombok.run(inputPath, fileInfo, config.delombokJavaHome)
+    lazy val delombokResult       = Delombok.run(inputPath, fileInfo, config.delombokJavaHome, dependencies)
     lazy val delombokDir = {
       dirToDelete = Option.when(delombokResult.isDelombokedPath)(delombokResult.path)
       delombokResult.path

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/SourceParser.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/SourceParser.scala
@@ -138,7 +138,7 @@ object SourceParser {
     checkExists(file)
   }
 
-  def apply(config: Config, filenamesOverride: Option[List[String]], dependencies: Seq[String] = Nil): SourceParser = {
+  def apply(config: Config, filenamesOverride: Option[List[String]], dependencies: List[String] = Nil): SourceParser = {
     val inputPath = Path.of(config.inputPath)
 
     val fileInfo = filenamesOverride

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LombokTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/LombokTests.scala
@@ -188,6 +188,120 @@ class LombokTypesOnlyTests extends JavaSrcCode2CpgFixture {
   }
 }
 
+class SimpleDelombokProjectTests extends JavaSrcCode2CpgFixture {
+
+  "delombok on a maven project with multiple source roots" should {
+    val fileA =
+      """package com.example.a;
+        |
+        |import lombok.Data;
+        |
+        |@Data
+        |public class FileA {
+        |    private String name;
+        |}
+        |""".stripMargin
+
+    val fileB =
+      """package com.example.b;
+        |
+        |import com.example.a.FileA;
+        |import lombok.ToString;
+        |
+        |@ToString
+        |public class FileB {
+        |
+        |    private FileA fileA;
+        |
+        |    @ToString.Include(name = "aName")
+        |    String describeA() {
+        |        return fileA.getName();
+        |    }
+        |}
+        |""".stripMargin
+
+    val fileB2 =
+      """package com.example.b;
+        |
+        |import com.example.a.FileA;
+        |import lombok.ToString;
+        |
+        |@ToString
+        |public class FileB2 {
+        |
+        |    private FileA fileA;
+        |
+        |    @ToString.Include(name = "aName")
+        |    String describeA() {
+        |        return fileA.getName();
+        |    }
+        |}
+        |""".stripMargin
+
+    val fileC =
+      """package com.example.c;
+        |
+        |import com.example.a.FileA;
+        |import com.example.b.FileB;
+        |import lombok.ToString;
+        |
+        |@ToString
+        |public class FileC {
+        |
+        |    private FileA fileA;
+        |    private FileB fileB;
+        |
+        |    @ToString.Include(name = "combined")
+        |    String describeCombined() {
+        |        return fileA.getName() + " / " + fileB.toString();
+        |    }
+        |}
+        |""".stripMargin
+
+    val cpg = code(fileA, "src/main/java/com/example/a/FileA.java")
+      .moreCode(fileB, "src/main/java-b/com/example/b/FileB.java")
+      .moreCode(fileB2, "src/main/java-b/com/example/b/FileB2.java")
+      .moreCode(fileC, "src/main/java-c/com/example/c/FileC.java")
+      .withConfig(Config().withDelombokMode("default"))
+
+    "generate the @Data getters and setters on FileA" in {
+      cpg.method.fullName.toSet should contain allOf (
+        "com.example.a.FileA.getName:java.lang.String()",
+        "com.example.a.FileA.setName:void(java.lang.String)"
+      )
+    }
+
+    "generate the @ToString-produced toString on FileB, FileB2, and FileC" in {
+      val toStringOwners = cpg.method.name("toString").typeDecl.fullName.toSet
+      toStringOwners should contain allOf (
+        "com.example.b.FileB",
+        "com.example.b.FileB2",
+        "com.example.c.FileC"
+      )
+    }
+
+    "resolve the cross-source-root FileA#getName call from FileB#describeA" in {
+      val call = cpg.typeDecl.fullNameExact("com.example.b.FileB").method.name("describeA").call.name("getName").head
+      call.methodFullName shouldBe "com.example.a.FileA.getName:java.lang.String()"
+    }
+
+    "resolve the cross-source-root FileA and FileB references from FileC#describeCombined" in {
+      val method      = cpg.typeDecl.fullNameExact("com.example.c.FileC").method.name("describeCombined").head
+      val getNameCall = method.call.name("getName").head
+      getNameCall.methodFullName shouldBe "com.example.a.FileA.getName:java.lang.String()"
+
+      val toStringCall = method.call.name("toString").head
+      toStringCall.methodFullName shouldBe "com.example.b.FileB.toString:java.lang.String()"
+    }
+
+    "not expose delomboked temp paths on typeDecl filenames" in {
+      cpg.typeDecl.fullName("com.example\\..*").filename.foreach { filename =>
+        filename.contains("delombok") shouldBe false
+      }
+    }
+  }
+}
+
 class NoLombokTests extends JavaSrcCode2CpgFixture {
   "source with some lombok annotations should have correct type information" in {
     val cpg = code(

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/util/DelombokStderrFilterTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/util/DelombokStderrFilterTests.scala
@@ -1,0 +1,146 @@
+package io.joern.javasrc2cpg.util
+
+import io.joern.javasrc2cpg.util.DelombokStderrFilter.FqnIndex
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.nio.file.{Path, Paths}
+
+class DelombokStderrFilterTests extends AnyWordSpec with Matchers {
+
+  // Two synthetic absolute package roots that share an input path. The current root is `root-b`, the peer is
+  // `root-a`. `com.example.UserRecord` lives in `root-a` (as its source stem); `com.example.UserService` and
+  // `com.example.report.UserReport` live in `root-b`.
+  private val inputPath: Path     = Paths.get("/tmp/delombok-input").toAbsolutePath.normalize()
+  private val relativeRootA: Path = Path.of("src/main/java")
+  private val relativeRootB: Path = Path.of("src/main/java-report")
+  private val absoluteRootA: Path = inputPath.resolve(relativeRootA).toAbsolutePath.normalize()
+  private val absoluteRootB: Path = inputPath.resolve(relativeRootB).toAbsolutePath.normalize()
+
+  private val userRecordRelativePath: Path =
+    relativeRootA.resolve("com/example/UserRecord.java")
+  private val userServiceRelativePath: Path =
+    relativeRootA.resolve("com/example/UserService.java")
+  private val userReportRelativePath: Path =
+    relativeRootB.resolve("com/example/report/UserReport.java")
+
+  private val absUserRecord = absoluteRootA.resolve("com/example/UserRecord.java")
+  private val absUserReport = absoluteRootB.resolve("com/example/report/UserReport.java")
+
+  private val fileInfo: List[SourceParser.FileInfo] = List(
+    SourceParser.FileInfo(userRecordRelativePath, Some("com.example"), usesLombok = true),
+    SourceParser.FileInfo(userServiceRelativePath, Some("com.example"), usesLombok = true),
+    SourceParser.FileInfo(userReportRelativePath, Some("com.example.report"), usesLombok = true)
+  )
+
+  private val packageRoots = List(relativeRootA, relativeRootB)
+  private val index        = FqnIndex.build(inputPath, fileInfo, packageRoots)
+
+  "DelombokStderrFilter" should {
+
+    "drop all peer-root errors and preserve JVM warnings when current root is root-b" in {
+      // Six diagnostics from the reproducer: four in UserRecord.java (root-a), two in UserReport.java (root-b).
+      // When we're delomboking root-b, the peer is root-a — so all UserRecord errors (whose files live under
+      // root-a) are false positives and must be dropped. The UserReport errors reference
+      // `com.example.UserRecord.builder` / `com.example.UserRecord` (a peer-root FQN) and must also be dropped.
+      val stderr = Seq(
+        "WARNING: A restricted method in java.lang.System has been called",
+        "WARNING: java.lang.System::load has been called by com.zaxxer.nuprocess.internal.LibJava10",
+        s"$absUserRecord:19: error: cannot find symbol",
+        "        log.info(\"hello\");",
+        "        ^",
+        "  symbol:   variable log",
+        "  location: class com.example.UserRecord",
+        s"$absUserRecord:25: error: cannot find symbol",
+        "        return log;",
+        "               ^",
+        "  symbol:   variable log",
+        "  location: class com.example.UserRecord",
+        s"$absUserReport:19: error: cannot find symbol",
+        "        UserRecord u = UserRecord.builder().build();",
+        "                                 ^",
+        "  symbol:   method builder()",
+        "  location: class com.example.UserRecord",
+        s"$absUserReport:20: error: cannot find symbol",
+        "        String name = subject.getName();",
+        "                             ^",
+        "  symbol:   method getName()",
+        "  location: variable subject of type com.example.UserRecord",
+        s"$absUserRecord:30: error: cannot find symbol",
+        "        this.log.warn(\"boom\");",
+        "             ^",
+        "  symbol:   variable log",
+        "  location: class com.example.UserRecord",
+        s"$absUserRecord:35: error: cannot find symbol",
+        "        log.error(\"oops\");",
+        "        ^",
+        "  symbol:   variable log",
+        "  location: class com.example.UserRecord"
+      )
+
+      val filtered = DelombokStderrFilter.filter(absoluteRootB, Seq(absoluteRootA), index, stderr)
+
+      filtered shouldBe Seq(
+        "WARNING: A restricted method in java.lang.System has been called",
+        "WARNING: java.lang.System::load has been called by com.zaxxer.nuprocess.internal.LibJava10"
+      )
+    }
+
+    "keep non-peer errors" in {
+      // Same UserRecord errors, but now we're delomboking root-a itself — so UserRecord is NOT in a peer root
+      // and the errors must be kept. (This is a hypothetical, since delombok wouldn't emit these when
+      // UserRecord is the input, but we're testing the routing.)
+      val stderr = Seq(
+        s"$absUserRecord:19: error: cannot find symbol",
+        "        log.info(\"hello\");",
+        "        ^",
+        "  symbol:   variable log",
+        "  location: class com.example.UserRecord"
+      )
+
+      val filtered = DelombokStderrFilter.filter(absoluteRootA, Seq(absoluteRootB), index, stderr)
+
+      filtered shouldBe stderr
+    }
+
+    "pass through unclassified diagnostics" in {
+      val stderr = Seq(
+        s"$absUserReport:5: error: something new and unrecognised",
+        "  more context we don't parse",
+        "an entirely freeform line"
+      )
+
+      val filtered = DelombokStderrFilter.filter(absoluteRootB, Seq(absoluteRootA), index, stderr)
+
+      filtered shouldBe stderr
+    }
+
+    "drop records whose location is an inner class of a peer-root type" in {
+      val stderr = Seq(
+        s"$absUserReport:19: error: cannot find symbol",
+        "        UserRecord.Builder b = UserRecord.builder();",
+        "                  ^",
+        "  symbol:   class Builder",
+        "  location: class com.example.UserRecord.Builder"
+      )
+
+      val filtered = DelombokStderrFilter.filter(absoluteRootB, Seq(absoluteRootA), index, stderr)
+
+      filtered shouldBe empty
+    }
+
+    "drop records whose location is the `variable v of type C` form referencing a peer root type" in {
+      val stderr = Seq(
+        s"$absUserReport:20: error: cannot find symbol",
+        "        String name = subject.getName();",
+        "                             ^",
+        "  symbol:   method getName()",
+        "  location: variable subject of type com.example.UserRecord"
+      )
+
+      val filtered = DelombokStderrFilter.filter(absoluteRootB, Seq(absoluteRootA), index, stderr)
+
+      filtered shouldBe empty
+    }
+  }
+}

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/util/DelombokStderrFilterTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/util/DelombokStderrFilterTests.scala
@@ -1,6 +1,5 @@
 package io.joern.javasrc2cpg.util
 
-import io.joern.javasrc2cpg.util.DelombokStderrFilter.FqnIndex
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -9,81 +8,75 @@ import java.nio.file.{Path, Paths}
 
 class DelombokStderrFilterTests extends AnyWordSpec with Matchers {
 
-  // Two synthetic absolute package roots that share an input path. The current root is `root-b`, the peer is
-  // `root-a`. `com.example.UserRecord` lives in `root-a` (as its source stem); `com.example.UserService` and
-  // `com.example.report.UserReport` live in `root-b`.
   private val inputPath: Path     = Paths.get("/tmp/delombok-input").toAbsolutePath.normalize()
-  private val relativeRootA: Path = Path.of("src/main/java")
-  private val relativeRootB: Path = Path.of("src/main/java-report")
+  private val relativeRootA: Path = Path.of("src/main/root-a")
+  private val relativeRootB: Path = Path.of("src/main/root-b")
   private val absoluteRootA: Path = inputPath.resolve(relativeRootA).toAbsolutePath.normalize()
   private val absoluteRootB: Path = inputPath.resolve(relativeRootB).toAbsolutePath.normalize()
 
-  private val userRecordRelativePath: Path =
-    relativeRootA.resolve("com/example/UserRecord.java")
-  private val userServiceRelativePath: Path =
-    relativeRootA.resolve("com/example/UserService.java")
-  private val userReportRelativePath: Path =
-    relativeRootB.resolve("com/example/report/UserReport.java")
+  private val fileInRootA: Path =
+    absoluteRootA.resolve("com/example/FileA.java")
 
-  private val absUserRecord = absoluteRootA.resolve("com/example/UserRecord.java")
-  private val absUserReport = absoluteRootB.resolve("com/example/report/UserReport.java")
-
-  private val fileInfo: List[SourceParser.FileInfo] = List(
-    SourceParser.FileInfo(userRecordRelativePath, Some("com.example"), usesLombok = true),
-    SourceParser.FileInfo(userServiceRelativePath, Some("com.example"), usesLombok = true),
-    SourceParser.FileInfo(userReportRelativePath, Some("com.example.report"), usesLombok = true)
-  )
-
-  private val packageRoots = List(relativeRootA, relativeRootB)
-  private val index        = FqnIndex.build(inputPath, fileInfo, packageRoots)
+  private val fileInRootB: Path =
+    absoluteRootB.resolve("com/example/FileB.java")
 
   "DelombokStderrFilter" should {
 
     "drop all peer-root errors and preserve JVM warnings when current root is root-b" in {
-      // Six diagnostics from the reproducer: four in UserRecord.java (root-a), two in UserReport.java (root-b).
-      // When we're delomboking root-b, the peer is root-a — so all UserRecord errors (whose files live under
-      // root-a) are false positives and must be dropped. The UserReport errors reference
-      // `com.example.UserRecord.builder` / `com.example.UserRecord` (a peer-root FQN) and must also be dropped.
       val stderr = Seq(
         "WARNING: A restricted method in java.lang.System has been called",
         "WARNING: java.lang.System::load has been called by com.zaxxer.nuprocess.internal.LibJava10",
-        s"$absUserRecord:19: error: cannot find symbol",
+        s"$fileInRootB:19: error: cannot find symbol",
         "        log.info(\"hello\");",
         "        ^",
         "  symbol:   variable log",
         "  location: class com.example.UserRecord",
-        s"$absUserRecord:25: error: cannot find symbol",
+        s"$fileInRootB:25: error: cannot find symbol",
         "        return log;",
         "               ^",
         "  symbol:   variable log",
         "  location: class com.example.UserRecord",
-        s"$absUserReport:19: error: cannot find symbol",
+        s"$fileInRootB:19: error: cannot find symbol",
         "        UserRecord u = UserRecord.builder().build();",
         "                                 ^",
         "  symbol:   method builder()",
         "  location: class com.example.UserRecord",
-        s"$absUserReport:20: error: cannot find symbol",
+        s"$fileInRootB:20: error: cannot find symbol",
         "        String name = subject.getName();",
         "                             ^",
         "  symbol:   method getName()",
         "  location: variable subject of type com.example.UserRecord",
-        s"$absUserRecord:30: error: cannot find symbol",
+        s"$fileInRootB:30: error: cannot find symbol",
         "        this.log.warn(\"boom\");",
         "             ^",
         "  symbol:   variable log",
         "  location: class com.example.UserRecord",
-        s"$absUserRecord:35: error: cannot find symbol",
+        s"$fileInRootA:35: error: cannot find symbol",
         "        log.error(\"oops\");",
         "        ^",
         "  symbol:   variable log",
-        "  location: class com.example.UserRecord"
+        "  location: class com.example.UserRecord",
+        s"$fileInRootB:42: error: cannot find symbol",
+        "        this.log.warn(\"boom\");",
+        "             ^",
+        "  symbol:   variable log",
+        "  location: class com.example.UserRecord",
+        s"File: $fileInRootA [delomboked]",
+        s"File: $fileInRootB [unchanged]"
       )
 
-      val filtered = DelombokStderrFilter.filter(Set(absoluteRootA), index, stderr)
+      val filtered = DelombokStderrFilter.filter(absoluteRootA, stderr)
 
       filtered shouldBe Seq(
         "WARNING: A restricted method in java.lang.System has been called",
-        "WARNING: java.lang.System::load has been called by com.zaxxer.nuprocess.internal.LibJava10"
+        "WARNING: java.lang.System::load has been called by com.zaxxer.nuprocess.internal.LibJava10",
+        s"$fileInRootA:35: error: cannot find symbol",
+        "        log.error(\"oops\");",
+        "        ^",
+        "  symbol:   variable log",
+        "  location: class com.example.UserRecord",
+        s"File: $fileInRootA [delomboked]",
+        s"File: $fileInRootB [unchanged]"
       )
     }
 
@@ -92,79 +85,14 @@ class DelombokStderrFilterTests extends AnyWordSpec with Matchers {
       // and the errors must be kept. (This is a hypothetical, since delombok wouldn't emit these when
       // UserRecord is the input, but we're testing the routing.)
       val stderr = Seq(
-        s"$absUserRecord:19: error: cannot find symbol",
+        s"$fileInRootB:19: error: cannot find symbol",
         "        log.info(\"hello\");",
         "        ^",
         "  symbol:   variable log",
         "  location: class com.example.UserRecord"
       )
 
-      val filtered = DelombokStderrFilter.filter(Set(absoluteRootB), index, stderr)
-
-      filtered shouldBe stderr
-    }
-
-    "pass through unclassified diagnostics" in {
-      val stderr = Seq(
-        s"$absUserReport:5: error: something new and unrecognised",
-        "  more context we don't parse",
-        "an entirely freeform line"
-      )
-
-      val filtered = DelombokStderrFilter.filter(Set(absoluteRootA), index, stderr)
-
-      filtered shouldBe stderr
-    }
-
-    "drop records whose location is an inner class of a peer-root type" in {
-      val stderr = Seq(
-        s"$absUserReport:19: error: cannot find symbol",
-        "        UserRecord.Builder b = UserRecord.builder();",
-        "                  ^",
-        "  symbol:   class Builder",
-        "  location: class com.example.UserRecord.Builder"
-      )
-
-      val filtered = DelombokStderrFilter.filter(Set(absoluteRootA), index, stderr)
-
-      filtered shouldBe empty
-    }
-
-    "drop records whose location is the `variable v of type C` form referencing a peer root type" in {
-      val stderr = Seq(
-        s"$absUserReport:20: error: cannot find symbol",
-        "        String name = subject.getName();",
-        "                             ^",
-        "  symbol:   method getName()",
-        "  location: variable subject of type com.example.UserRecord"
-      )
-
-      val filtered = DelombokStderrFilter.filter(Set(absoluteRootA), index, stderr)
-
-      filtered shouldBe empty
-    }
-
-    "keep records when the location FQN is declared in both current and peer roots (fail-open)" in {
-      // Two file infos declaring the SAME FQN `com.example.Shared` from two different roots. When delomboking
-      // root-b, an error whose location is `com.example.Shared` could originate from either root — keep it.
-      val sharedRelativeA: Path = relativeRootA.resolve("com/example/Shared.java")
-      val sharedRelativeB: Path = relativeRootB.resolve("com/example/Shared.java")
-      val absSharedInB: Path    = absoluteRootB.resolve("com/example/Shared.java")
-      val collidingFileInfo = List(
-        SourceParser.FileInfo(sharedRelativeA, Some("com.example"), usesLombok = true),
-        SourceParser.FileInfo(sharedRelativeB, Some("com.example"), usesLombok = true)
-      )
-      val collidingIndex = FqnIndex.build(inputPath, collidingFileInfo, packageRoots)
-
-      val stderr = Seq(
-        s"$absSharedInB:19: error: cannot find symbol",
-        "        doSomething();",
-        "        ^",
-        "  symbol:   method doSomething()",
-        "  location: class com.example.Shared"
-      )
-
-      val filtered = DelombokStderrFilter.filter(Set(absoluteRootA), collidingIndex, stderr)
+      val filtered = DelombokStderrFilter.filter(absoluteRootB, stderr)
 
       filtered shouldBe stderr
     }
@@ -175,29 +103,23 @@ class DelombokStderrFilterTests extends AnyWordSpec with Matchers {
       assume(File.separatorChar == '\\')
       // Synthetic setup with drive-letter absolute roots. The filter should parse the header and route the
       // location FQN through the index to conclude the record is a peer-root false positive.
-      val winInput: Path        = Paths.get("C:\\repo\\proj").toAbsolutePath.normalize()
-      val winRelRootA: Path     = Path.of("src/main/java")
-      val winRelRootB: Path     = Path.of("src/main/java-report")
-      val winAbsRootA: Path     = winInput.resolve(winRelRootA).toAbsolutePath.normalize()
-      val winAbsRootB: Path     = winInput.resolve(winRelRootB).toAbsolutePath.normalize()
-      val winRecordRel: Path    = winRelRootA.resolve("com/example/UserRecord.java")
-      val winReportRel: Path    = winRelRootB.resolve("com/example/report/UserReport.java")
-      val winAbsReport: Path    = winAbsRootB.resolve("com/example/report/UserReport.java")
-      val winFileInfo = List(
-        SourceParser.FileInfo(winRecordRel, Some("com.example"), usesLombok = true),
-        SourceParser.FileInfo(winReportRel, Some("com.example.report"), usesLombok = true)
-      )
-      val winIndex = FqnIndex.build(winInput, winFileInfo, List(winRelRootA, winRelRootB))
+      val winInput: Path         = Paths.get("C:\\repo\\proj").toAbsolutePath.normalize()
+      val winRelativeRootA: Path = Path.of("src/main/java")
+      val winRelativeRootB: Path = Path.of("src/main/java-report")
+      val winAbsoluteRootA: Path = winInput.resolve(winRelativeRootA).toAbsolutePath.normalize()
+      val winAbsoluteRootB: Path = winInput.resolve(winRelativeRootB).toAbsolutePath.normalize()
+      val winFileInA: Path       = winAbsoluteRootA.resolve("com/example/a/FileA.java")
+      val winFileInB: Path       = winAbsoluteRootB.resolve("com/example/b/FileB.java")
 
       val stderr = Seq(
-        s"$winAbsReport:19: error: cannot find symbol",
+        s"$winFileInA:19: error: cannot find symbol",
         "        UserRecord u = UserRecord.builder().build();",
         "                                 ^",
         "  symbol:   method builder()",
         "  location: class com.example.UserRecord"
       )
 
-      val filtered = DelombokStderrFilter.filter(Set(winAbsRootA), winIndex, stderr)
+      val filtered = DelombokStderrFilter.filter(winAbsoluteRootB, stderr)
 
       filtered shouldBe empty
     }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/util/DelombokStderrFilterTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/util/DelombokStderrFilterTests.scala
@@ -4,6 +4,7 @@ import io.joern.javasrc2cpg.util.DelombokStderrFilter.FqnIndex
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
+import java.io.File
 import java.nio.file.{Path, Paths}
 
 class DelombokStderrFilterTests extends AnyWordSpec with Matchers {
@@ -139,6 +140,64 @@ class DelombokStderrFilterTests extends AnyWordSpec with Matchers {
       )
 
       val filtered = DelombokStderrFilter.filter(absoluteRootB, Seq(absoluteRootA), index, stderr)
+
+      filtered shouldBe empty
+    }
+
+    "keep records when the location FQN is declared in both current and peer roots (fail-open)" in {
+      // Two file infos declaring the SAME FQN `com.example.Shared` from two different roots. When delomboking
+      // root-b, an error whose location is `com.example.Shared` could originate from either root — keep it.
+      val sharedRelativeA: Path = relativeRootA.resolve("com/example/Shared.java")
+      val sharedRelativeB: Path = relativeRootB.resolve("com/example/Shared.java")
+      val absSharedInB: Path    = absoluteRootB.resolve("com/example/Shared.java")
+      val collidingFileInfo = List(
+        SourceParser.FileInfo(sharedRelativeA, Some("com.example"), usesLombok = true),
+        SourceParser.FileInfo(sharedRelativeB, Some("com.example"), usesLombok = true)
+      )
+      val collidingIndex = FqnIndex.build(inputPath, collidingFileInfo, packageRoots)
+
+      val stderr = Seq(
+        s"$absSharedInB:19: error: cannot find symbol",
+        "        doSomething();",
+        "        ^",
+        "  symbol:   method doSomething()",
+        "  location: class com.example.Shared"
+      )
+
+      val filtered = DelombokStderrFilter.filter(absoluteRootB, Seq(absoluteRootA), collidingIndex, stderr)
+
+      filtered shouldBe stderr
+    }
+
+    "parse Windows-style diagnostic headers and drop peer-root records" in {
+      // Path.of/Paths.get with a Windows drive-letter string only produces a proper absolute path on
+      // Windows; on POSIX it becomes a relative fragment. Skip on non-Windows platforms.
+      assume(File.separatorChar == '\\')
+      // Synthetic setup with drive-letter absolute roots. The filter should parse the header and route the
+      // location FQN through the index to conclude the record is a peer-root false positive.
+      val winInput: Path        = Paths.get("C:\\repo\\proj").toAbsolutePath.normalize()
+      val winRelRootA: Path     = Path.of("src/main/java")
+      val winRelRootB: Path     = Path.of("src/main/java-report")
+      val winAbsRootA: Path     = winInput.resolve(winRelRootA).toAbsolutePath.normalize()
+      val winAbsRootB: Path     = winInput.resolve(winRelRootB).toAbsolutePath.normalize()
+      val winRecordRel: Path    = winRelRootA.resolve("com/example/UserRecord.java")
+      val winReportRel: Path    = winRelRootB.resolve("com/example/report/UserReport.java")
+      val winAbsReport: Path    = winAbsRootB.resolve("com/example/report/UserReport.java")
+      val winFileInfo = List(
+        SourceParser.FileInfo(winRecordRel, Some("com.example"), usesLombok = true),
+        SourceParser.FileInfo(winReportRel, Some("com.example.report"), usesLombok = true)
+      )
+      val winIndex = FqnIndex.build(winInput, winFileInfo, List(winRelRootA, winRelRootB))
+
+      val stderr = Seq(
+        s"$winAbsReport:19: error: cannot find symbol",
+        "        UserRecord u = UserRecord.builder().build();",
+        "                                 ^",
+        "  symbol:   method builder()",
+        "  location: class com.example.UserRecord"
+      )
+
+      val filtered = DelombokStderrFilter.filter(winAbsRootB, Seq(winAbsRootA), winIndex, stderr)
 
       filtered shouldBe empty
     }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/util/DelombokStderrFilterTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/util/DelombokStderrFilterTests.scala
@@ -79,7 +79,7 @@ class DelombokStderrFilterTests extends AnyWordSpec with Matchers {
         "  location: class com.example.UserRecord"
       )
 
-      val filtered = DelombokStderrFilter.filter(absoluteRootB, Seq(absoluteRootA), index, stderr)
+      val filtered = DelombokStderrFilter.filter(Set(absoluteRootA), index, stderr)
 
       filtered shouldBe Seq(
         "WARNING: A restricted method in java.lang.System has been called",
@@ -99,7 +99,7 @@ class DelombokStderrFilterTests extends AnyWordSpec with Matchers {
         "  location: class com.example.UserRecord"
       )
 
-      val filtered = DelombokStderrFilter.filter(absoluteRootA, Seq(absoluteRootB), index, stderr)
+      val filtered = DelombokStderrFilter.filter(Set(absoluteRootB), index, stderr)
 
       filtered shouldBe stderr
     }
@@ -111,7 +111,7 @@ class DelombokStderrFilterTests extends AnyWordSpec with Matchers {
         "an entirely freeform line"
       )
 
-      val filtered = DelombokStderrFilter.filter(absoluteRootB, Seq(absoluteRootA), index, stderr)
+      val filtered = DelombokStderrFilter.filter(Set(absoluteRootA), index, stderr)
 
       filtered shouldBe stderr
     }
@@ -125,7 +125,7 @@ class DelombokStderrFilterTests extends AnyWordSpec with Matchers {
         "  location: class com.example.UserRecord.Builder"
       )
 
-      val filtered = DelombokStderrFilter.filter(absoluteRootB, Seq(absoluteRootA), index, stderr)
+      val filtered = DelombokStderrFilter.filter(Set(absoluteRootA), index, stderr)
 
       filtered shouldBe empty
     }
@@ -139,7 +139,7 @@ class DelombokStderrFilterTests extends AnyWordSpec with Matchers {
         "  location: variable subject of type com.example.UserRecord"
       )
 
-      val filtered = DelombokStderrFilter.filter(absoluteRootB, Seq(absoluteRootA), index, stderr)
+      val filtered = DelombokStderrFilter.filter(Set(absoluteRootA), index, stderr)
 
       filtered shouldBe empty
     }
@@ -164,7 +164,7 @@ class DelombokStderrFilterTests extends AnyWordSpec with Matchers {
         "  location: class com.example.Shared"
       )
 
-      val filtered = DelombokStderrFilter.filter(absoluteRootB, Seq(absoluteRootA), collidingIndex, stderr)
+      val filtered = DelombokStderrFilter.filter(Set(absoluteRootA), collidingIndex, stderr)
 
       filtered shouldBe stderr
     }
@@ -197,7 +197,7 @@ class DelombokStderrFilterTests extends AnyWordSpec with Matchers {
         "  location: class com.example.UserRecord"
       )
 
-      val filtered = DelombokStderrFilter.filter(winAbsRootB, Seq(winAbsRootA), winIndex, stderr)
+      val filtered = DelombokStderrFilter.filter(Set(winAbsRootA), winIndex, stderr)
 
       filtered shouldBe empty
     }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/ExternalCommandResult.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/ExternalCommandResult.scala
@@ -30,22 +30,6 @@ case class ExternalCommandResult(
     this
   }
 
-  /** Same as [[logIfFailed]] for non-zero exits, but also logs the command's output at debug level when it succeeded.
-    * Useful for tools that exit 0 even when they did nothing useful (e.g. delombok writing files back unchanged).
-    */
-  def logAlways(): this.type = {
-    if (exitCode != 0) {
-      logIfFailed()
-    } else {
-      logger.debug(s"""Process exited with code 0.
-           |${additionalContext.getOrElse("")}
-           |Input: $input
-           |Output: ${stdOutAndError.mkString("\n")}
-           |""".stripMargin)
-    }
-    this
-  }
-
   /** convenience method: verify that the result is a success, throws an exception otherwise */
   def verifySuccess(): this.type = {
     toTry.get


### PR DESCRIPTION
This PR sets up the classpath and sourcepath for delombok so that symbols can be resolved (which is required for some delombok annotations). A better solution would be to invoke maven or gradle directly to do this, but that would likely be a large change and could run into different issues with non-standard build configurations.

It also adds the DelombokStdErrFilter which is used to clean up output from Delombok so that errors are not logged multiple times if multiple source roots depend on a project with errors. The filter is fairly crude and should be considered best-effort since a proper filter would require accurately parsing (possibly multiple versions of) javac output. 