### PR TITLE
Fixed scaladoc warnings

### DIFF
--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/utils/ExternalCommand.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/utils/ExternalCommand.scala
@@ -80,7 +80,7 @@ object ExternalCommand {
     }
   }
 
-  /** Executes a command and returns the started [[Process]].
+  /** Executes a command and returns the started `java.lang.Process`.
     *
     * Callers are responsible for destroying the process when done (e.g. via `destroyForcibly().waitFor()`). The
     * process's stdout and stderr are merged into a single stream accessible via `process.getInputStream`.
@@ -90,7 +90,7 @@ object ExternalCommand {
     * @param workingDir
     *   The directory to execute the command in
     * @return
-    *   The started Process whose merged stdout/stderr can be read via `getInputStream`
+    *   the started `java.lang.Process` whose merged stdout/stderr can be read via `getInputStream`
     */
   def processFromCommand(command: Seq[String], workingDir: String): Process = {
     val builder = new ProcessBuilder(command*)

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/utils/GsonTypeInfoReader.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/utils/GsonTypeInfoReader.scala
@@ -183,13 +183,13 @@ object GsonTypeInfoReader {
     filename.contains("/.build/") || filename.contains("\\.build\\") || filename.contains("/Build/")
   }
 
-  /** Collects type information from Swift AST JSON, emitting each [[TypeInfo]] via the provided callback as it is
+  /** Collects type information from Swift AST JSON, emitting each `TypeInfo` via the provided callback as it is
     * discovered during streaming token-by-token parsing. No intermediate collection is built.
     *
     * @param reader
     *   The reader providing the JSON input
     * @param emit
-    *   Called once for each [[TypeInfo]] extracted from the JSON stream
+    *   Called once for each `TypeInfo` extracted from the JSON stream
     */
   def collectTypeInfo(reader: Reader, emit: TypeInfo => Unit): Unit = {
     val jsonReader   = new JsonReader(reader)

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstCreatorBase.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/AstCreatorBase.scala
@@ -11,7 +11,7 @@ import java.nio.file.Paths
 /** Abstract base for all language-specific CPG AST creators.
   *
   * Mixes in builder traits for annotations, calls, methods, and control structures. Each concrete frontend subclasses
-  * this and implements [[createAst]], populating [[diffGraph]] with the CPG nodes and edges derived from `filename`.
+  * this and implements `createAst`, populating `diffGraph` with the CPG nodes and edges derived from `filename`.
   *
   * @tparam Node
   *   the parser's AST node type
@@ -33,21 +33,20 @@ abstract class AstCreatorBase[Node, NodeProcessor](filename: String)(implicit va
 
   /** Entry point: build the CPG diffgraph for `filename`.
     *
-    * Implementations traverse the parsed AST, create CPG nodes and edges, and add them to [[diffGraph]].
+    * Implementations traverse the parsed AST, create CPG nodes and edges, and add them to `diffGraph`.
     *
     * @return
-    *   the populated [[DiffGraphBuilder]] ready to be applied to the CPG
+    *   the populated `DiffGraphBuilder` ready to be applied to the CPG
     */
   def createAst(): DiffGraphBuilder
 
   /** Creates a global namespace block for the source file being processed.
     *
-    * Uses [[io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal.globalNamespaceName]] as the name and
-    * derives the full name from `filename` via [[io.joern.x2cpg.passes.frontend.MetaDataPass]]. The block is placed at
-    * order 1 by convention.
+    * Uses `NamespaceTraversal.globalNamespaceName` as the name and derives the full name from `filename` via
+    * `MetaDataPass`. The block is placed at order 1 by convention.
     *
     * @return
-    *   a new [[NewNamespaceBlock]] representing the file's top-level scope
+    *   a new `NewNamespaceBlock` representing the file's top-level scope
     */
   def globalNamespaceBlock(): NewNamespaceBlock = {
     val name     = NamespaceTraversal.globalNamespaceName
@@ -59,7 +58,7 @@ abstract class AstCreatorBase[Node, NodeProcessor](filename: String)(implicit va
       .order(1)
   }
 
-  /** Wraps a sequence of ASTs in a [[NewBlock]] when there is more than one element.
+  /** Wraps a sequence of ASTs in a `NewBlock` when there is more than one element.
     *
     *   - Empty sequence → an empty block node.
     *   - Exactly one AST → returned as-is (no wrapper).
@@ -91,7 +90,7 @@ abstract class AstCreatorBase[Node, NodeProcessor](filename: String)(implicit va
 
   /** Assigns monotonically increasing `argumentIndex` values to a sequence of argument ASTs.
     *
-    * Only AST roots that implement [[ExpressionNew]] are updated; other roots are silently skipped. Indices start at
+    * Only AST roots that implement `ExpressionNew` are updated; other roots are silently skipped. Indices start at
     * `start` (default 1) and increment by 1 per argument.
     *
     * @param arguments

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/internal/ControlStructureAstBuilder.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/internal/ControlStructureAstBuilder.scala
@@ -189,9 +189,9 @@ private[x2cpg] trait ControlStructureAstBuilder[Node, NodeProcessor] {
   /** Creates an AST for a C-style `for` loop (`for (init; condition; update) body`).
     *
     * Multiple init, condition, or update expressions are each wrapped in a synthetic block. The resulting blocks and
-    * body are placed at explicit orders so that [[io.joern.x2cpg.passes.cfg.CfgCreator]] can reconstruct the correct
-    * CFG edges. Condition, init, update, and body roots receive the corresponding CFG-typed edges (`CONDITION`,
-    * `FOR_INIT`, `FOR_UPDATE`, `FOR_BODY`).
+    * body are placed at explicit orders so that [[io.joern.x2cpg.passes.controlflow.cfgcreation.CfgCreator]] can
+    * reconstruct the correct CFG edges. Condition, init, update, and body roots receive the corresponding CFG-typed
+    * edges (`CONDITION`, `FOR_INIT`, `FOR_UPDATE`, `FOR_BODY`).
     *
     * @param node
     *   the source AST node representing the `for` statement (used for position and code)
@@ -236,9 +236,9 @@ private[x2cpg] trait ControlStructureAstBuilder[Node, NodeProcessor] {
   /** Wires the children of a C-style `for` loop onto a `forNode` created by [[forAstInit]].
     *
     * Multiple init, condition, or update expressions are each wrapped in a synthetic block. The resulting blocks and
-    * body are placed at explicit orders so that [[io.joern.x2cpg.passes.cfg.CfgCreator]] can reconstruct the correct
-    * CFG edges. Condition, init, update, and body roots receive the corresponding CFG-typed edges (`CONDITION`,
-    * `FOR_INIT`, `FOR_UPDATE`, `FOR_BODY`).
+    * body are placed at explicit orders so that [[io.joern.x2cpg.passes.controlflow.cfgcreation.CfgCreator]] can
+    * reconstruct the correct CFG edges. Condition, init, update, and body roots receive the corresponding CFG-typed
+    * edges (`CONDITION`, `FOR_INIT`, `FOR_UPDATE`, `FOR_BODY`).
     *
     * @param forNode
     *   the `for` control-structure node created by [[forAstInit]]

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/internal/MethodAstBuilder.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/internal/MethodAstBuilder.scala
@@ -59,8 +59,8 @@ private[x2cpg] trait MethodAstBuilder[Node, NodeProcessor] {
 
   /** Creates an AST for a static initialiser method (e.g. a class-level `static { … }` block or module-level init).
     *
-    * The method is given the [[io.joern.x2cpg.Defines.StaticInitMethodName]] name and a `STATIC` modifier. Its body
-    * wraps `initAsts` in a block.
+    * The method is given the `Defines.StaticInitMethodName` name and a `STATIC` modifier. Its body wraps `initAsts` in
+    * a block.
     *
     * @param node
     *   the source AST node that triggered the static init (used for position)
@@ -69,11 +69,11 @@ private[x2cpg] trait MethodAstBuilder[Node, NodeProcessor] {
     * @param fullName
     *   fully-qualified name of the synthesised method
     * @param signature
-    *   optional method signature; defaults to [[io.shiftleft.codepropertygraph.generated.PropertyDefaults.Signature]]
+    *   optional method signature; defaults to `PropertyDefaults.Signature`
     * @param returnType
     *   fully-qualified return type name
     * @param fileName
-    *   optional source file name; defaults to [[io.shiftleft.codepropertygraph.generated.PropertyDefaults.Filename]]
+    *   optional source file name; defaults to `PropertyDefaults.Filename`
     */
   def staticInitMethodAst(
     node: Node,

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/validation/validation.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/validation/validation.scala
@@ -95,7 +95,7 @@ object PostFrontendValidator {
   * faster checking code, then enable in sptests and prod.
   *
   * NOTE: All validation checks with a level lower or equal to [[fatalValidationLevel]] will result in an exception. See
-  * [[ValidationLevel]] and [[ErrorType]] for the highest validation level.
+  * [[ValidationLevel]] and [[PostFrontendValidator.ErrorType]] for the highest validation level.
   */
 class PostFrontendValidator(cpg: Cpg, fatalValidationLevel: ValidationLevel) extends AbstractValidator(cpg) {
   import PostFrontendValidator.logger


### PR DESCRIPTION
We had many warnings like this during compilation:

```
  [warn] -- Warning: joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/internal/ControlStructureAstBuilder.scala:211:6
  [warn] 211 |  def forAst(
  [warn]     |      ^
  [warn]     |Couldn't resolve a member for the given link query: io.joern.x2cpg.passes.cfg.CfgCreator
```

scaladoc [[...]] links reference types that are imported via wildcard (import io.shiftleft.codepropertygraph.generated.*) but scaladoc can't resolve them without explicit imports or fully qualified names. Sometimes it failed to look up generated code or members in the current scope. Fixed them all.