### PR TITLE
[c2cpg] Emit empty block for null-statement bodies in control structures

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForStatementsCreator.scala
@@ -233,11 +233,19 @@ trait AstForStatementsCreator { this: AstCreator =>
     Ast(labelNode) +: nestedStmts
   }
 
+  // For control structures like `while (cond);` or `for (...);`, CDT parses the body as IASTNullStatement.
+  // nullSafeAst returns Seq.empty for null statements, which would leave required body edges missing.
+  // This helper emits an empty block instead so validators find a proper body node.
+  private def nullSafeBodyAst(body: IASTStatement): Seq[Ast] = body match {
+    case _: IASTNullStatement => Seq(blockAst(blockNode(body), List.empty))
+    case _                    => nullSafeAst(body)
+  }
+
   private def astForDoStatement(doStmt: IASTDoStatement): Ast = {
     val doNode = doWhileAstInit(doStmt)
     scope.pushNewBlockScope(doNode)
     val conditionAst = wrapInNullComparison(doStmt.getCondition, astForConditionExpression(doStmt.getCondition))
-    val bodyAst      = nullSafeAst(doStmt.getBody)
+    val bodyAst      = nullSafeBodyAst(doStmt.getBody)
     scope.popScope()
     doWhileAstFinish(doNode, Some(conditionAst), bodyAst)
   }
@@ -331,7 +339,7 @@ trait AstForStatementsCreator { this: AstCreator =>
     val compareAst =
       wrapInNullComparison(forStmt.getConditionExpression, astForConditionExpression(forStmt.getConditionExpression))
     val updateAst = nullSafeAst(forStmt.getIterationExpression)
-    val bodyAsts  = nullSafeAst(forStmt.getBody)
+    val bodyAsts  = nullSafeBodyAst(forStmt.getBody)
     scope.popScope()
 
     forAstFinish(forNode, localAsts, initAsts, Seq(compareAst), Seq(updateAst), bodyAsts)
@@ -505,7 +513,7 @@ trait AstForStatementsCreator { this: AstCreator =>
   private def astForWhile(whileStmt: IASTWhileStatement): Ast = {
     val code       = s"while (${nullSafeCode(whileStmt.getCondition)})"
     val compareAst = wrapInNullComparison(whileStmt.getCondition, astForConditionExpression(whileStmt.getCondition))
-    val bodyAst    = nullSafeAst(whileStmt.getBody)
+    val bodyAst    = nullSafeBodyAst(whileStmt.getBody)
     whileAst(whileStmt, Some(compareAst), bodyAst, Some(code))
   }
 

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/ControlStructureTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/passes/ast/ControlStructureTests.scala
@@ -379,4 +379,50 @@ class ControlStructureTests extends C2CpgSuite(FileDefaults.CppExt) {
     }
   }
 
+  "control structures with semicolon body (empty body via null statement)" should {
+    val cpg = code(
+      """
+        |void checkSemicolon(int a, int b) {
+        |  if (a == b); {
+        |    something();
+        |  }
+        |  for (int i = 0; i < 10; i++); {
+        |    something();
+        |  }
+        |  while (a < b); {
+        |    something();
+        |  }
+        |}
+        |""".stripMargin,
+      fileName = "test.c"
+    )
+
+    "emit an empty block as true body for `if (cond);`" in {
+      inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.IF).l) {
+        case List(ifNode: ControlStructure) =>
+          inside(ifNode.trueBodyOut.l) { case List(emptyBlock: Block) =>
+            emptyBlock.astChildren.l shouldBe List.empty
+          }
+      }
+    }
+
+    "emit an empty block as for-body for `for (...);`" in {
+      inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.FOR).l) {
+        case List(forNode: ControlStructure) =>
+          inside(forNode.forBodyOut.l) { case List(emptyBlock: Block) =>
+            emptyBlock.astChildren.l shouldBe List.empty
+          }
+      }
+    }
+
+    "emit an empty block as true body for `while (cond);`" in {
+      inside(cpg.controlStructure.controlStructureType(ControlStructureTypes.WHILE).l) {
+        case List(whileNode: ControlStructure) =>
+          inside(whileNode.trueBodyOut.l) { case List(emptyBlock: Block) =>
+            emptyBlock.astChildren.l shouldBe List.empty
+          }
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
`if (cond);`, `for (...);`, and `while (cond);` have an IASTNullStatement as body. Previously nullSafeAst returned Seq.empty for these, leaving required TRUE_BODY/FOR_BODY/DO_BODY edges absent and failing V3 validation.

Enables V3 validation on the CS side of things.