### PR TITLE
[jssrc2cpg] JVM/Scala performance & memory fixes

### DIFF
--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreator.scala
@@ -55,7 +55,7 @@ class AstCreator(val config: Config, val usedTypes: mutable.HashSet[String], val
   // ujson.Value whose hashCode/equals are structural, so hashing a key would recurse over the entire function subtree.
   protected val functionNodeToNameAndFullName = mutable.HashMap.empty[String, (String, String)]
   protected val usedVariableNames             = mutable.HashMap.empty[String, Int]
-  protected val seenAliasTypes                = mutable.HashSet.empty[NewTypeDecl]
+  protected val seenAliasTypes                = mutable.HashMap.empty[String, NewTypeDecl]
   protected val functionFullNames             = mutable.HashSet.empty[String]
 
   // we track line and column numbers manually because astgen / @babel-parser sometimes

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreator.scala
@@ -46,12 +46,14 @@ class AstCreator(val config: Config, val usedTypes: mutable.HashSet[String], val
   // TypeDecls with their bindings (with their refs) for lambdas and methods are not put in the AST
   // where the respective nodes are defined. Instead, we put them under the parent TYPE_DECL in which they are defined.
   // To achieve this we need this extra stack.
-  protected val methodAstParentStack          = new Stack[NewNode]()
-  protected val typeRefIdStack                = new Stack[NewTypeRef]
-  protected val dynamicInstanceTypeStack      = new Stack[String]
-  protected val localAstParentStack           = new Stack[NewBlock]()
-  protected val rootTypeDecl                  = new Stack[NewTypeDecl]()
-  protected val functionNodeToNameAndFullName = mutable.HashMap.empty[BabelNodeInfo, (String, String)]
+  protected val methodAstParentStack     = new Stack[NewNode]()
+  protected val typeRefIdStack           = new Stack[NewTypeRef]
+  protected val dynamicInstanceTypeStack = new Stack[String]
+  protected val localAstParentStack      = new Stack[NewBlock]()
+  protected val rootTypeDecl             = new Stack[NewTypeDecl]()
+  // Keyed by the function node's source range (start:end) rather than the BabelNodeInfo itself: the latter holds a
+  // ujson.Value whose hashCode/equals are structural, so hashing a key would recurse over the entire function subtree.
+  protected val functionNodeToNameAndFullName = mutable.HashMap.empty[String, (String, String)]
   protected val usedVariableNames             = mutable.HashMap.empty[String, Int]
   protected val seenAliasTypes                = mutable.HashSet.empty[NewTypeDecl]
   protected val functionFullNames             = mutable.HashSet.empty[String]

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreator.scala
@@ -256,6 +256,6 @@ class AstCreator(val config: Config, val usedTypes: mutable.HashSet[String], val
     for {
       startOffset <- start(node)
       endOffset   <- end(node)
-    } yield (math.max(startOffset, 0), math.min(endOffset, parserResult.fileContent.length))
+    } yield clampOffsets(startOffset, endOffset)
   }
 }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreator.scala
@@ -51,8 +51,8 @@ class AstCreator(val config: Config, val usedTypes: mutable.HashSet[String], val
   protected val dynamicInstanceTypeStack = new Stack[String]
   protected val localAstParentStack      = new Stack[NewBlock]()
   protected val rootTypeDecl             = new Stack[NewTypeDecl]()
-  // Keyed by the function node's source range (start:end) rather than the BabelNodeInfo itself: the latter holds a
-  // ujson.Value whose hashCode/equals are structural, so hashing a key would recurse over the entire function subtree.
+  // Keyed by the function node's source range (start:end): a BabelNodeInfo key would hash its ujson.Value structurally,
+  // recursing over the entire function subtree on every lookup.
   protected val functionNodeToNameAndFullName = mutable.HashMap.empty[String, (String, String)]
   protected val usedVariableNames             = mutable.HashMap.empty[String, Int]
   protected val seenAliasTypes                = mutable.HashMap.empty[String, NewTypeDecl]

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreator.scala
@@ -228,7 +228,8 @@ class AstCreator(val config: Config, val usedTypes: mutable.HashSet[String], val
     }
   }
 
-  protected def astForNodes(jsons: List[Value]): List[Ast] = jsons.map(astForNodeWithFunctionReference)
+  protected def astForNodes(jsons: collection.Seq[Value]): List[Ast] =
+    jsons.iterator.map(astForNodeWithFunctionReference).toList
 
   protected def astForNodeWithFunctionReference(json: Value): Ast = {
     val nodeInfo = createBabelNodeInfo(json)

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreatorHelper.scala
@@ -18,9 +18,8 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
   protected def nodeTypeOf(json: Value): BabelNode = fromString(json("type").str)
 
   protected def createBabelNodeInfo(json: Value): BabelNodeInfo = {
-    // Resolve start/end offsets and their line numbers once, then derive columns and code from them. Going through the
-    // individual code/line/column/lineEnd/columnEnd accessors would recompute start/end and the line binary search
-    // several times per node, and createBabelNodeInfo runs for every AST node.
+    // Resolve start/end offsets and their line numbers once, then derive columns and code from them. This runs for
+    // every AST node, so we avoid recomputing the offsets and the line binary search per accessor.
     val startOffset   = start(json)
     val endOffset     = end(json)
     val lineOfStart   = startOffset.map(getLineOfSource)

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreatorHelper.scala
@@ -1,12 +1,12 @@
 package io.joern.jssrc2cpg.astcreation
 
 import io.joern.jssrc2cpg.parser.BabelAst.*
-import io.joern.jssrc2cpg.parser.{BabelAst, BabelNodeInfo}
-import io.joern.x2cpg.{Ast, ValidationMode}
+import io.joern.jssrc2cpg.parser.BabelNodeInfo
 import io.joern.x2cpg.frontendspecific.jssrc2cpg.Defines
 import io.joern.x2cpg.utils.IntervalKeyPool
-import io.shiftleft.codepropertygraph.generated.{EdgeTypes, PropertyDefaults, PropertyNames}
+import io.joern.x2cpg.{Ast, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.codepropertygraph.generated.{EdgeTypes, PropertyDefaults, PropertyNames}
 import ujson.Value
 
 import scala.collection.mutable
@@ -18,14 +18,35 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
   protected def nodeTypeOf(json: Value): BabelNode = fromString(json("type").str)
 
   protected def createBabelNodeInfo(json: Value): BabelNodeInfo = {
-    val c     = code(json)
-    val ln    = line(json)
-    val cn    = column(json)
-    val lnEnd = lineEnd(json)
-    val cnEnd = columnEnd(json)
-    val node  = nodeTypeOf(json)
-    BabelNodeInfo(node, json, c, ln, cn, lnEnd, cnEnd)
+    // Resolve start/end offsets and their line numbers once, then derive columns and code from them. Going through the
+    // individual code/line/column/lineEnd/columnEnd accessors would recompute start/end and the line binary search
+    // several times per node, and createBabelNodeInfo runs for every AST node.
+    val startOffset   = start(json)
+    val endOffset     = end(json)
+    val lineOfStart   = startOffset.map(getLineOfSource)
+    val lineOfEnd     = endOffset.map(getLineOfSource)
+    val columnOfStart = columnFor(startOffset, lineOfStart)
+    val columnOfEnd   = columnFor(endOffset, lineOfEnd)
+    val nodeCode      = codeForOffsets(startOffset, endOffset)
+    val node          = nodeTypeOf(json)
+    BabelNodeInfo(node, json, nodeCode, lineOfStart, columnOfStart, lineOfEnd, columnOfEnd)
   }
+
+  private def columnFor(offset: Option[Int], lineOfOffset: Option[Int]): Option[Int] =
+    offset.zip(lineOfOffset).map { case (position, line) => position - lineStartPositions(line - 1) }
+
+  /** Clamps a raw start/end offset pair to the bounds of the file content. */
+  protected def clampOffsets(startOffset: Int, endOffset: Int): (Int, Int) =
+    (math.max(startOffset, 0), math.min(endOffset, parserResult.fileContent.length))
+
+  private def codeForOffsets(startOffset: Option[Int], endOffset: Option[Int]): String =
+    startOffset
+      .zip(endOffset)
+      .map { case (startPosition, endPosition) =>
+        val (clampedStart, clampedEnd) = clampOffsets(startPosition, endPosition)
+        shortenCode(parserResult.fileContent.substring(clampedStart, clampedEnd).trim)
+      }
+      .getOrElse(PropertyDefaults.Code)
 
   protected def line(node: Value): Option[Int] = start(node).map(getLineOfSource)
 
@@ -283,14 +304,7 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
     }
   }
 
-  protected def code(node: Value): String = {
-    nodeOffsets(node) match {
-      case Some((startOffset, endOffset)) =>
-        shortenCode(parserResult.fileContent.substring(startOffset, endOffset).trim)
-      case _ =>
-        PropertyDefaults.Code
-    }
-  }
+  protected def code(node: Value): String = codeForOffsets(start(node), end(node))
 
   protected def hasKey(node: Value, key: String): Boolean =
     node.objOpt.exists(_.contains(key))

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstCreatorHelper.scala
@@ -39,6 +39,12 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
     } yield s"$nodeStart:$nodeEnd"
   }
 
+  /** A cheap, stable key identifying a function node within a file, used to memoize its (name, fullName). We rely on
+    * the node's source range, falling back to its rendered JSON when offsets are unavailable.
+    */
+  protected def functionNodeKey(node: BabelNodeInfo): String =
+    range(node.json).getOrElse(node.json.render())
+
   // Binary search: find first line whose end-position >= position
   private def getLineOfSource(position: Int): Int = {
     var lo = 0
@@ -175,7 +181,8 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
     // functionNode.getName is not necessarily unique and thus the full name calculated based on the scope
     // is not necessarily unique. Specifically we have this problem with lambda functions which are defined
     // in the same scope.
-    functionNodeToNameAndFullName.get(func) match {
+    val funcKey = functionNodeKey(func)
+    functionNodeToNameAndFullName.get(funcKey) match {
       case Some(nameAndFullName) => nameAndFullName
       case None =>
         val intendedName   = calcMethodName(func)
@@ -194,7 +201,7 @@ trait AstCreatorHelper(implicit withSchemaValidation: ValidationMode) { this: As
           }
         }
         functionFullNames.add(fullName)
-        functionNodeToNameAndFullName(func) = (name, fullName)
+        functionNodeToNameAndFullName(funcKey) = (name, fullName)
         (name, fullName)
     }
   }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForDeclarationsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForDeclarationsCreator.scala
@@ -343,8 +343,7 @@ trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) {
       diffGraph.addEdge(importNode, _dependencyNode, EdgeTypes.IMPORTS)
       assignment
     } else {
-      val specs = impDecl.json("specifiers").arr
-      val requireCalls = specs.map { importSpecifier =>
+      val requireCalls = specifiers.map { importSpecifier =>
         val isImportN = createBabelNodeInfo(importSpecifier).node match {
           case ImportSpecifier => true
           case _               => false
@@ -352,7 +351,7 @@ trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) {
         val name             = importSpecifier("local")("name").str
         val (alias, reqName) = reqNameFromImportSpecifier(importSpecifier, name)
         val assignment       = astForRequireCallFromImport(reqName, alias, source, isImportN = isImportN, impDecl)
-        val importedName     = importSpecifier("local")("name").str
+        val importedName     = name
         val call             = assignment.nodes.collectFirst { case x: NewCall if x.name == "require" => x }
         val importNode       = createImportNodeAndAttachToCall(impDecl, s"$source:$reqName", importedName, call)
         val _dependencyNode  = dependencyNode(importedName, source, ImportKeyword)

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -20,7 +20,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
       case _                => callee.code
     }
     val callNode = staticCallNode(callExpr.code, callName, fullName, callee.lineNumber, callee.columnNumber)
-    val argAsts  = astForNodes(callExpr.json("arguments").arr.toList)
+    val argAsts  = astForNodes(callExpr.json("arguments").arr)
     callAst(callNode, argAsts)
   }
 
@@ -31,7 +31,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     callExpressionInfo: CallExpressionInfo,
     maybeCallee: Option[BabelNodeInfo] = None
   ): Ast = {
-    val args      = astForNodes(callExpr.json("arguments").arr.toList)
+    val args      = astForNodes(callExpr.json("arguments").arr)
     val callNode_ = callNode(callExpr, callExpr.code, callExpressionInfo.callName, DispatchTypes.DYNAMIC_DISPATCH)
     // If the callee is a function itself, e.g. closure, then resolve this locally, if possible.
     // Reuse the already-built callee when the caller has one to avoid rebuilding it from JSON.
@@ -505,7 +505,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
     scope.popScope()
     localAstParentStack.pop()
 
-    val childrenAsts = (propertiesAsts :+ Ast(tmpNode)).toList
+    val childrenAsts = (propertiesAsts.iterator ++ Iterator.single(Ast(tmpNode))).toList
     blockAst(blockNode_, childrenAsts)
   }
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -26,13 +26,17 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
 
   private case class CallExpressionInfo(receiverAst: Ast, baseNode: NewIdentifier, callName: String)
 
-  private def handleCallNodeArgs(callExpr: BabelNodeInfo, callExpressionInfo: CallExpressionInfo): Ast = {
+  private def handleCallNodeArgs(
+    callExpr: BabelNodeInfo,
+    callExpressionInfo: CallExpressionInfo,
+    maybeCallee: Option[BabelNodeInfo] = None
+  ): Ast = {
     val args      = astForNodes(callExpr.json("arguments").arr.toList)
     val callNode_ = callNode(callExpr, callExpr.code, callExpressionInfo.callName, DispatchTypes.DYNAMIC_DISPATCH)
-    // If the callee is a function itself, e.g. closure, then resolve this locally, if possible
-    callExpr.json.obj
-      .get("callee")
-      .map(createBabelNodeInfo)
+    // If the callee is a function itself, e.g. closure, then resolve this locally, if possible.
+    // Reuse the already-built callee when the caller has one to avoid rebuilding it from JSON.
+    maybeCallee
+      .orElse(callExpr.json.obj.get("callee").map(createBabelNodeInfo))
       .flatMap {
         case callee if callee.node.isInstanceOf[FunctionLike] =>
           functionNodeToNameAndFullName.get(functionNodeKey(callee))
@@ -95,7 +99,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
       createBuiltinStaticCall(callExpr, callee, calleeCode)
     } else {
       val callExpressionInfo = callExpressionInfoForCallLikeExpr(callee)
-      handleCallNodeArgs(callExpr, callExpressionInfo)
+      handleCallNodeArgs(callExpr, callExpressionInfo, Option(callee))
     }
   }
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -34,8 +34,9 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
       .get("callee")
       .map(createBabelNodeInfo)
       .flatMap {
-        case callee if callee.node.isInstanceOf[FunctionLike] => functionNodeToNameAndFullName.get(callee)
-        case _                                                => None
+        case callee if callee.node.isInstanceOf[FunctionLike] =>
+          functionNodeToNameAndFullName.get(functionNodeKey(callee))
+        case _ => None
       }
       .foreach { case (name, fullName) => callNode_.name(name).methodFullName(fullName) }
     callAst(
@@ -409,8 +410,9 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
       .get("callee")
       .map(createBabelNodeInfo)
       .flatMap {
-        case callee if callee.node.isInstanceOf[FunctionLike] => functionNodeToNameAndFullName.get(callee)
-        case _                                                => None
+        case callee if callee.node.isInstanceOf[FunctionLike] =>
+          functionNodeToNameAndFullName.get(functionNodeKey(callee))
+        case _ => None
       }
       .foreach { case (name, fullName) => callNode_.name(name).methodFullName(fullName) }
     callAst(

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -112,7 +112,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
             EvaluationStrategies.BY_VALUE,
             typeFullName
           ).possibleTypes(possibleTypes)
-          additionalBlockStatements.addAll(nodeInfo.json("elements").arr.map {
+          additionalBlockStatements.addAll(nodeInfo.json("elements").arr.iterator.map {
             case element if !element.isNull =>
               val elementNodeInfo = createBabelNodeInfo(element)
               elementNodeInfo.node match {
@@ -180,7 +180,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
           ).possibleTypes(possibleTypes)
           scope.addVariable(paramName, param, typeFullName, VariableScopeManager.ScopeType.MethodScope)
 
-          additionalBlockStatements.addAll(nodeInfo.json("properties").arr.map { element =>
+          additionalBlockStatements.addAll(nodeInfo.json("properties").arr.iterator.map { element =>
             val elementNodeInfo = createBabelNodeInfo(element)
             elementNodeInfo.node match {
               case ObjectProperty =>

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForPrimitivesCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForPrimitivesCreator.scala
@@ -72,21 +72,22 @@ trait AstForPrimitivesCreator(implicit withSchemaValidation: ValidationMode) { t
     Ast(literalNode(booleanLiteral, booleanLiteral.code, Option(Defines.Boolean)))
 
   protected def astForTemplateLiteral(templateLiteral: BabelNodeInfo): Ast = {
-    val expressions = templateLiteral.json("expressions").arr
-    val quasis      = templateLiteral.json("quasis").arr.filterNot(_("tail").bool)
-    val quasisTail  = templateLiteral.json("quasis").arr.filter(_("tail").bool).head
+    val expressions           = templateLiteral.json("expressions").arr
+    val (quasisTails, quasis) = templateLiteral.json("quasis").arr.partition(_("tail").bool)
+    val quasisTail            = quasisTails.head
 
     if (expressions.isEmpty && quasis.isEmpty) {
       astForTemplateElement(createBabelNodeInfo(quasisTail))
     } else {
-      val callName = Operators.formatString
-      val argsCodes = expressions.zip(quasis).flatMap { case (expression, quasi) =>
+      val callName        = Operators.formatString
+      val expressionQuasi = expressions.zip(quasis)
+      val argsCodes = expressionQuasi.flatMap { case (expression, quasi) =>
         List(s"\"${quasi("value")("raw").str}\"", code(expression))
       }
       val callCode = s"$callName${(argsCodes :+ s"\"${quasisTail("value")("raw").str}\"").mkString("(", ", ", ")")}"
       val templateCall =
         callNode(templateLiteral, callCode, callName, DispatchTypes.STATIC_DISPATCH)
-      val argumentAsts = expressions.zip(quasis).flatMap { case (expression, quasi) =>
+      val argumentAsts = expressionQuasi.flatMap { case (expression, quasi) =>
         List(astForNodeWithFunctionReference(quasi), astForNodeWithFunctionReference(expression))
       }
       val argAsts = (argumentAsts :+ astForNodeWithFunctionReference(quasisTail)).toSeq

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -183,7 +183,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
   private def astsForSwitchCase(switchCase: BabelNodeInfo): List[Ast] = {
     val labelAst       = Ast(jumpTargetNode(switchCase))
     val testAsts       = safeObj(switchCase.json, "test").map(t => astForNodeWithFunctionReference(Obj(t))).toList
-    val consequentAsts = astForNodes(switchCase.json("consequent").arr.toList)
+    val consequentAsts = astForNodes(switchCase.json("consequent").arr)
     labelAst +: (testAsts ++ consequentAsts)
   }
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -36,7 +36,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
     }
 
   protected def createBlockStatementAsts(json: Value): List[Ast] = {
-    val blockStmts = sortBlockStatements(json.arr.toList.map(createBabelNodeInfo))
+    val blockStmts = sortBlockStatements(json.arr.iterator.map(createBabelNodeInfo).toList)
     blockStmts.map(stmt => astForNodeWithFunctionReferenceAndCall(stmt.json))
   }
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTemplateDomCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTemplateDomCreator.scala
@@ -10,7 +10,7 @@ trait AstForTemplateDomCreator(implicit withSchemaValidation: ValidationMode) { 
   protected def astForJsxElement(jsxElem: BabelNodeInfo): Ast = {
     val domNode      = templateDomNode(jsxElem.node.toString, jsxElem.code, jsxElem.lineNumber, jsxElem.columnNumber)
     val openingAst   = astForNodeWithFunctionReference(jsxElem.json("openingElement"))
-    val childrenAsts = astForNodes(jsxElem.json("children").arr.toList)
+    val childrenAsts = astForNodes(jsxElem.json("children").arr)
     val closingAst = safeObj(jsxElem.json, "closingElement")
       .map(e => astForNodeWithFunctionReference(Obj(e)))
       .getOrElse(Ast())
@@ -21,7 +21,7 @@ trait AstForTemplateDomCreator(implicit withSchemaValidation: ValidationMode) { 
   protected def astForJsxFragment(jsxFragment: BabelNodeInfo): Ast = {
     val name         = jsxFragment.node.toString
     val domNode      = templateDomNode(name, jsxFragment.code, jsxFragment.lineNumber, jsxFragment.columnNumber)
-    val childrenAsts = astForNodes(jsxFragment.json("children").arr.toList)
+    val childrenAsts = astForNodes(jsxFragment.json("children").arr)
     Ast(domNode).withChildren(childrenAsts)
   }
 
@@ -32,7 +32,7 @@ trait AstForTemplateDomCreator(implicit withSchemaValidation: ValidationMode) { 
     // We look at the previous character there and re-add the colon if needed.
     val colon = start(jsxAttr.json)
       .collect {
-        case position if position > 0 && parserResult.fileContent.substring(position - 1, position) == ":" => ":"
+        case position if position > 0 && parserResult.fileContent.charAt(position - 1) == ':' => ":"
       }
       .getOrElse("")
     val domNode =
@@ -55,7 +55,7 @@ trait AstForTemplateDomCreator(implicit withSchemaValidation: ValidationMode) { 
       jsxOpeningElem.lineNumber,
       jsxOpeningElem.columnNumber
     )
-    val childrenAsts = astForNodes(jsxOpeningElem.json("attributes").arr.toList)
+    val childrenAsts = astForNodes(jsxOpeningElem.json("attributes").arr)
     Ast(domNode).withChildren(childrenAsts)
   }
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
@@ -76,8 +76,8 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
     case _                               => safeStr(json, "kind").contains("constructor")
   }
 
-  /** The members of a class, decomposed once so callers can derive the member sequence (with or without the
-    * constructor) and reuse the located constructor without re-walking the class body.
+  /** The decomposed body of a class: its parameter properties, all declared members, the members declared dynamically
+    * in the constructor body, and the constructor itself (if present).
     */
   private case class ClassMembers(
     parameterProperties: Seq[Value],
@@ -483,6 +483,7 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
 
     scope.pushNewMethodScope(typeFullName, typeName, typeDeclNode_, None)
 
+    // Decompose the class body once and reuse it for both the member sequence and the located constructor below.
     val decomposedMembers = decomposeClassMembers(clazz)
     val allClassMembers   = decomposedMembers.members(withConstructor = false).toList
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
@@ -40,9 +40,9 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
 
     val aliasTypeDeclNode =
       typeDeclNode(alias, aliasName, aliasFullName, parserResult.filename, alias.code, astParentType, astParentFullName)
-    seenAliasTypes.add(aliasTypeDeclNode)
+    seenAliasTypes.update(aliasTypeDeclNode.name, aliasTypeDeclNode)
 
-    if (!Defines.JsTypes.contains(name) && !seenAliasTypes.exists(_.name == name)) {
+    if (!Defines.JsTypes.contains(name) && !seenAliasTypes.contains(name)) {
       val (typeName, typeFullName) = calcTypeNameAndFullName(alias, Option(name))
       registerType(typeFullName)
 
@@ -58,7 +58,7 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
       )
       diffGraph.addEdge(methodAstParentStack.head, typeDeclNode_, EdgeTypes.AST)
     } else {
-      seenAliasTypes.find(t => t.name == name).foreach(_.aliasTypeFullName(aliasFullName))
+      seenAliasTypes.get(name).foreach(_.aliasTypeFullName(aliasFullName))
     }
 
     // adding all class methods / functions and uninitialized, non-static members
@@ -280,7 +280,7 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
       astParentType,
       astParentFullName
     )
-    seenAliasTypes.add(typeDeclNode_)
+    seenAliasTypes.update(typeDeclNode_.name, typeDeclNode_)
 
     addModifier(typeDeclNode_, tsEnum.json)
 
@@ -445,7 +445,7 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
       astParentFullName,
       inherits = superClass ++ implements ++ mixins
     )
-    seenAliasTypes.add(typeDeclNode_)
+    seenAliasTypes.update(typeDeclNode_.name, typeDeclNode_)
 
     addModifier(typeDeclNode_, clazz.json)
     astsForDecorators(clazz).foreach { decoratorAst =>
@@ -1013,7 +1013,7 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
       astParentFullName,
       inherits = extendz
     )
-    seenAliasTypes.add(typeDeclNode_)
+    seenAliasTypes.update(typeDeclNode_.name, typeDeclNode_)
 
     addModifier(typeDeclNode_, tsInterface.json)
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForTypesCreator.scala
@@ -76,19 +76,35 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
     case _                               => safeStr(json, "kind").contains("constructor")
   }
 
-  private def classMembers(clazz: BabelNodeInfo, withConstructor: Boolean = true): Seq[Value] = {
+  /** The members of a class, decomposed once so callers can derive the member sequence (with or without the
+    * constructor) and reuse the located constructor without re-walking the class body.
+    */
+  private case class ClassMembers(
+    parameterProperties: Seq[Value],
+    allMembers: Seq[Value],
+    dynamicallyDeclaredMembers: Seq[Value],
+    constructor: Option[Value]
+  ) {
+    def members(withConstructor: Boolean): Seq[Value] =
+      if (withConstructor) {
+        parameterProperties ++ allMembers ++ dynamicallyDeclaredMembers
+      } else {
+        parameterProperties ++ allMembers.diff(constructor.toSeq) ++ dynamicallyDeclaredMembers
+      }
+  }
+
+  private def decomposeClassMembers(clazz: BabelNodeInfo): ClassMembers = {
     val allMembers            = clazz.json.obj.get("body").flatMap(_.obj.get("body")).flatMap(_.arrOpt).toSeq.flatten
     val constructor           = allMembers.find(isConstructor)
     val constructorBody       = constructor.flatMap(c => c.obj.get("body").flatMap(_.obj.get("body")).flatMap(_.arrOpt))
     val constructorParameters = constructor.flatMap(c => c.obj.get("params").flatMap(_.arrOpt))
     val dynamicallyDeclaredMembers = constructorBody.toSeq.flatten.filter(isInitializedMember)
     val parameterProperties        = constructorParameters.toSeq.flatten.filter(isParameterProperty)
-    if (withConstructor) {
-      parameterProperties ++ allMembers ++ dynamicallyDeclaredMembers
-    } else {
-      parameterProperties ++ allMembers.diff(constructor.toSeq) ++ dynamicallyDeclaredMembers
-    }
+    ClassMembers(parameterProperties, allMembers, dynamicallyDeclaredMembers, constructor)
   }
+
+  private def classMembers(clazz: BabelNodeInfo, withConstructor: Boolean = true): Seq[Value] =
+    decomposeClassMembers(clazz).members(withConstructor)
 
   private def classMembersForTypeAlias(alias: BabelNodeInfo): Seq[Value] =
     alias.json.obj.get("members").flatMap(_.arrOpt).toSeq.flatten
@@ -138,8 +154,12 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
     def empty: ConstructorContent = ConstructorContent(None, List.empty, None)
   }
 
-  private def createClassConstructor(classExpr: BabelNodeInfo, constructorContent: ConstructorContent): MethodAst =
-    findClassConstructor(classExpr) match {
+  private def createClassConstructor(
+    classExpr: BabelNodeInfo,
+    classConstructorNode: Option[Value],
+    constructorContent: ConstructorContent
+  ): MethodAst =
+    classConstructorNode match {
       case Some(classConstructor) if hasKey(classConstructor, "body") =>
         val result =
           createMethodAstAndNode(createBabelNodeInfo(classConstructor), false, false, constructorContent)
@@ -463,14 +483,19 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
 
     scope.pushNewMethodScope(typeFullName, typeName, typeDeclNode_, None)
 
-    val allClassMembers = classMembers(clazz, withConstructor = false).toList
+    val decomposedMembers = decomposeClassMembers(clazz)
+    val allClassMembers   = decomposedMembers.members(withConstructor = false).toList
 
     // adding all other members and retrieving their initialization calls
     val memberInitCalls =
       allClassMembers.filter(m => !isStaticMember(m) && (isInitializedMember(m) || isParameterProperty(m)))
 
     val constructor =
-      createClassConstructor(clazz, ConstructorContent(Some(clazz), memberInitCalls, Some(typeDeclNode_)))
+      createClassConstructor(
+        clazz,
+        decomposedMembers.constructor,
+        ConstructorContent(Some(clazz), memberInitCalls, Some(typeDeclNode_))
+      )
     val constructorNode = constructor.methodNode
 
     // adding all class methods / functions and uninitialized, non-static members
@@ -523,9 +548,11 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
         clazz.columnNumber
       )
 
+      val membersWithConstructor = decomposedMembers.members(withConstructor = true)
       val classDecorationAst     = createClassDecorationAst(clazz, classIdNode)
-      val propertyDecorationAsts = createPropertyDecorationAsts(clazz, classIdNode)
-      val methodDecorationAsts   = createMethodDecorationAsts(clazz, classIdNode)
+      val propertyDecorationAsts =
+        createPropertyDecorationAsts(membersWithConstructor, classNodeInfo = clazz, classIdNode)
+      val methodDecorationAsts = createMethodDecorationAsts(membersWithConstructor, classNodeInfo = clazz, classIdNode)
       if (classDecorationAst.root.isDefined || propertyDecorationAsts.nonEmpty || methodDecorationAsts.nonEmpty) {
         val blockNode_ = blockNode(clazz)
         val childrenAsts =
@@ -742,8 +769,12 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
     )
   }
 
-  private def createPropertyDecorationAsts(classNodeInfo: BabelNodeInfo, classIdNode: NewIdentifier): Seq[Ast] = {
-    val tsProperties = classMembers(classNodeInfo).flatMap { member =>
+  private def createPropertyDecorationAsts(
+    members: Seq[Value],
+    classNodeInfo: BabelNodeInfo,
+    classIdNode: NewIdentifier
+  ): Seq[Ast] = {
+    val tsProperties = members.flatMap { member =>
       val memberNodeInfo = createBabelNodeInfo(member)
       if (
         memberNodeInfo.node == ClassProperty ||
@@ -798,8 +829,12 @@ trait AstForTypesCreator(implicit withSchemaValidation: ValidationMode) { this: 
     }
   }
 
-  private def createMethodDecorationAsts(classNodeInfo: BabelNodeInfo, classIdNode: NewIdentifier): Seq[Ast] = {
-    val tsMethods = classMembers(classNodeInfo).flatMap { member =>
+  private def createMethodDecorationAsts(
+    members: Seq[Value],
+    classNodeInfo: BabelNodeInfo,
+    classIdNode: NewIdentifier
+  ): Seq[Ast] = {
+    val tsMethods = members.flatMap { member =>
       val memberNodeInfo = createBabelNodeInfo(member)
       if (memberNodeInfo.node == ClassMethod) {
         Some(memberNodeInfo)

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/TypeHelper.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/TypeHelper.scala
@@ -8,9 +8,10 @@ import java.util.regex.Pattern
 
 trait TypeHelper { this: AstCreator =>
 
-  private val TypeAnnotationKey = "typeAnnotation"
-  private val ReturnTypeKey     = "returnType"
-  private val ImportMatcher     = Pattern.compile("(typeof )?import\\([\"'](.*)[\"']\\)")
+  private val TypeAnnotationKey   = "typeAnnotation"
+  private val ReturnTypeKey       = "returnType"
+  private val ImportMatcher       = Pattern.compile("(typeof )?import\\([\"'](.*)[\"']\\)")
+  private val ArrayReplacePattern = Pattern.compile(":[^,.]+\\[]")
 
   private val TypeReplacements = Map(
     " any"       -> s" ${Defines.Any}",
@@ -126,7 +127,7 @@ trait TypeHelper { this: AstCreator =>
     val tpeWithArrayReplacements = if (tpeWithTypeReplacements.endsWith("[]")) {
       Defines.Array
     } else {
-      tpeWithTypeReplacements.replaceAll(":[^,.]+\\[]", s": ${Defines.Array}")
+      ArrayReplacePattern.matcher(tpeWithTypeReplacements).replaceAll(s": ${Defines.Array}")
     }
     if (!tpeWithArrayReplacements.contains("{") && !tpe.contains("(")) {
       registerType(tpeWithArrayReplacements)

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/TypeHelper.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/TypeHelper.scala
@@ -97,33 +97,36 @@ trait TypeHelper { this: AstCreator =>
 
   private def typeFromTypeMap(node: BabelNodeInfo): String =
     range(node.json).flatMap(parserResult.typeMap.get) match {
-      case Some(value) if value == "any"                         => Defines.Any
-      case Some(value) if value == "boolean"                     => Defines.Boolean
-      case Some(value) if value == "null"                        => Defines.Null
-      case Some(value) if isStringType(value)                    => Defines.String
-      case Some(value) if isNumberType(value)                    => Defines.Number
-      case Some(value) if ImportMatcher.matcher(value).matches() => importToModule(value)
-      case Some(value)                                           => value
-      case None                                                  => Defines.Any
+      case Some(value) if value == "any"      => Defines.Any
+      case Some(value) if value == "boolean"  => Defines.Boolean
+      case Some(value) if value == "null"     => Defines.Null
+      case Some(value) if isStringType(value) => Defines.String
+      case Some(value) if isNumberType(value) => Defines.Number
+      case Some(value) =>
+        val matcher = ImportMatcher.matcher(value)
+        if (matcher.matches()) importToModule(value, matcher) else value
+      case None => Defines.Any
     }
 
-  private def importToModule(value: String): String = {
-    val matcher = ImportMatcher.matcher(value)
+  private def importToModule(value: String, matcher: java.util.regex.Matcher): String =
     this.rootTypeDecl.headOption match {
       case Some(typeDecl)            => typeDecl.fullName
       case None if matcher.matches() => matcher.group(2).stripSuffix(".js").concat(s".js:${Defines.Program}")
       case None                      => value
     }
-  }
 
   protected def typeFor(node: BabelNodeInfo): String = {
     val tpe = Seq(TypeAnnotationKey, ReturnTypeKey).find(hasKey(node.json, _)) match {
       case Some(key) => typeForTypeAnnotation(createBabelNodeInfo(node.json(key)))
       case None      => typeFromTypeMap(node)
     }
-    val tpeWithTypeReplacements = TypeReplacements.foldLeft(tpe) { case (typeStr, (m, r)) =>
-      if (typeStr.contains(m)) typeStr.replace(m, r) else typeStr
-    }
+    // Every replacement key contains a space or a '{'; if the type has neither, none of them can match, so we can skip
+    // the twelve String.contains scans entirely.
+    val tpeWithTypeReplacements = if (tpe.indexOf(' ') >= 0 || tpe.indexOf('{') >= 0) {
+      TypeReplacements.foldLeft(tpe) { case (typeStr, (searchStr, replacement)) =>
+        if (typeStr.contains(searchStr)) typeStr.replace(searchStr, replacement) else typeStr
+      }
+    } else tpe
     val tpeWithArrayReplacements = if (tpeWithTypeReplacements.endsWith("[]")) {
       Defines.Array
     } else {

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/TypeHelper.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/TypeHelper.scala
@@ -11,7 +11,7 @@ trait TypeHelper { this: AstCreator =>
   private val TypeAnnotationKey   = "typeAnnotation"
   private val ReturnTypeKey       = "returnType"
   private val ImportMatcher       = Pattern.compile("(typeof )?import\\([\"'](.*)[\"']\\)")
-  private val ArrayReplacePattern = Pattern.compile(":[^,.]+\\[]")
+  private val ArrayReplacePattern = ":[^,.]+\\[]".r
 
   private val TypeReplacements = Map(
     " any"       -> s" ${Defines.Any}",
@@ -130,7 +130,7 @@ trait TypeHelper { this: AstCreator =>
     val tpeWithArrayReplacements = if (tpeWithTypeReplacements.endsWith("[]")) {
       Defines.Array
     } else {
-      ArrayReplacePattern.matcher(tpeWithTypeReplacements).replaceAll(s": ${Defines.Array}")
+      ArrayReplacePattern.replaceAllIn(tpeWithTypeReplacements, s": ${Defines.Array}")
     }
     if (!tpeWithArrayReplacements.contains("{") && !tpe.contains("(")) {
       registerType(tpeWithArrayReplacements)

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/parser/BabelJsonParser.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/parser/BabelJsonParser.scala
@@ -18,8 +18,14 @@ object BabelJsonParser {
     fileLoc: Int
   ) extends BaseParserResult
 
+  /** Strips the last file extension, i.e. everything after and including the final '.'. */
+  def stripExtension(path: String): String = {
+    val dotIndex = path.lastIndexOf('.')
+    if (dotIndex >= 0) path.substring(0, dotIndex) else path
+  }
+
   private def loadTypeMap(file: Path): Try[Map[String, String]] = Try {
-    val typeMapPathString = file.toString.replaceAll("\\.[^.]*$", "") + ".typemap"
+    val typeMapPathString = stripExtension(file.toString) + ".typemap"
     val typeMapPath       = Paths.get(typeMapPathString)
     if (typeMapPath.toFile.exists()) {
       val typeMapJsonContent = IOUtils.readEntireFile(typeMapPath)

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/AstCreationPass.scala
@@ -70,7 +70,7 @@ class AstCreationPass(cpg: Cpg, astGenRunnerResult: AstGenRunnerResult, config: 
               (true, parseResult.filename)
           }
         case Failure(exception) =>
-          val pathOfFailedFile = jsonFilename.replaceAll("\\.[^.]*$", "")
+          val pathOfFailedFile = BabelJsonParser.stripExtension(jsonFilename)
           logger.warn(s"Failed to read json parse result for: '$pathOfFailedFile'", exception)
           (false, pathOfFailedFile)
       }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/PrivateKeyFilePass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/PrivateKeyFilePass.scala
@@ -20,8 +20,8 @@ class PrivateKeyFilePass(cpg: Cpg, config: Config, report: Report = new Report()
     Seq("Content omitted for security reasons.")
 
   override def generateParts(): Array[Path] =
-    configFiles(config, selectedExtensions).toArray.filter(p =>
-      IOUtils.readLinesInFile(p).exists(PrivateKeyRegex.matches)
-    )
+    configFiles(config, selectedExtensions)
+      .filter(filePath => IOUtils.readLinesInFile(filePath).exists(PrivateKeyRegex.matches))
+      .toArray
 
 }

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/preprocessing/EjsPreprocessor.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/preprocessing/EjsPreprocessor.scala
@@ -23,7 +23,7 @@ class EjsPreprocessor {
       val matches     = TagGroupsRegex.findAllIn(scriptBlock).matchData.toList
       matches.foreach {
         case mat if mat.group(1) == "<%" && mat.group(3) == "-%>" =>
-          scriptBlock = scriptBlock.replace(mat.toString(), " " * mat.toString().replaceAll("\\S", " ").length)
+          scriptBlock = scriptBlock.replace(mat.toString(), " " * mat.toString().length)
         case _ =>
       }
       OpeningTagReplacements.foreach { case (search, replacement) =>
@@ -56,15 +56,19 @@ class EjsPreprocessor {
         val start = ma.start + ma.group(1).length
         val end   = ma.end - ma.group(3).length
         Option((start, end))
-    }
+    }.toArray
 
-    codeAsCharArray.zipWithIndex.foreach {
-      case (currChar, _) if currChar == '\n' || currChar == '\r' =>
-        preprocessedCode.append(currChar)
-      case (currChar, index) if positions.exists { case (start, end) => index >= start && index < end } =>
-        preprocessedCode.append(currChar)
-      case _ =>
-        preprocessedCode.append(" ")
+    // Keep characters inside a tag body (or newlines); blank everything else out. `positions` are sorted and
+    // non-overlapping, so a single advancing pointer replaces the previous per-character linear scan.
+    var positionIndex = 0
+    var index         = 0
+    while (index < codeAsCharArray.length) {
+      val currChar = codeAsCharArray(index)
+      while (positionIndex < positions.length && index >= positions(positionIndex)._2) positionIndex += 1
+      val insideTagBody = positionIndex < positions.length && index >= positions(positionIndex)._1
+      if (currChar == '\n' || currChar == '\r' || insideTagBody) preprocessedCode.append(currChar)
+      else preprocessedCode.append(' ')
+      index += 1
     }
 
     matches.foreach {

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/preprocessing/EjsPreprocessor.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/preprocessing/EjsPreprocessor.scala
@@ -59,7 +59,7 @@ class EjsPreprocessor {
     }.toArray
 
     // Keep characters inside a tag body (or newlines); blank everything else out. `positions` are sorted and
-    // non-overlapping, so a single advancing pointer replaces the previous per-character linear scan.
+    // non-overlapping, so a single advancing pointer suffices to track which tag body the current index falls in.
     var positionIndex = 0
     var index         = 0
     while (index < codeAsCharArray.length) {

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/utils/AstGenRunner.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/utils/AstGenRunner.scala
@@ -127,15 +127,19 @@ class AstGenRunner(config: Config) extends io.joern.x2cpg.astgen.AstGenRunner(As
 
   override protected def fileFilter(file: String, out: Path): Boolean = {
     Try {
-      file.stripSuffix(".json").replace(out.toString, config.inputPath) match {
+      val filePath = file.stripSuffix(".json").replace(out.toString, config.inputPath)
+      // The minified and transpiled checks both need the file's lines; read them at most once per invocation and only
+      // when a check actually forces this lazy val (i.e. for existing .js files).
+      lazy val fileLines = IOUtils.readLinesInFile(Paths.get(filePath))
+      filePath match {
         // We are not interested in JS / TS type definition files at this stage.
         // TODO: maybe we can enable that later on and use the type definitions there
         //  for enhancing the CPG with additional type information for functions
-        case filePath if TypeDefinitionFileExtensions.exists(filePath.endsWith)    => false
-        case filePath if isIgnoredByUserConfig(filePath)                           => false
-        case filePath if isIgnoredByDefault(filePath)                              => false
-        case filePath if isTranspiledFile(filePath) && !hasEjsSourceFile(filePath) => false
-        case _                                                                     => true
+        case _ if TypeDefinitionFileExtensions.exists(filePath.endsWith)               => false
+        case _ if isIgnoredByUserConfig(filePath)                                      => false
+        case _ if isIgnoredByDefault(filePath, fileLines)                              => false
+        case _ if isTranspiledFile(filePath, fileLines) && !hasEjsSourceFile(filePath) => false
+        case _                                                                         => true
       }
     } match {
       case Success(result) => result
@@ -145,10 +149,10 @@ class AstGenRunner(config: Config) extends io.joern.x2cpg.astgen.AstGenRunner(As
     }
   }
 
-  private def isMinifiedFile(filePath: String): Boolean = filePath match {
+  private def isMinifiedFile(filePath: String, fileLines: => Seq[String]): Boolean = filePath match {
     case p if MinifiedPathRegex.matches(p) => true
     case p if Files.exists(Paths.get(p)) && p.endsWith(".js") =>
-      val lines             = IOUtils.readLinesInFile(Paths.get(filePath))
+      val lines             = fileLines
       val linesOfCode       = lines.size
       val longestLineLength = if (lines.isEmpty) 0 else lines.map(_.length).max
       if (longestLineLength >= LineLengthThreshold && linesOfCode <= 50) {
@@ -158,10 +162,10 @@ class AstGenRunner(config: Config) extends io.joern.x2cpg.astgen.AstGenRunner(As
     case _ => false
   }
 
-  private def isIgnoredByDefault(filePath: String): Boolean = {
+  private def isIgnoredByDefault(filePath: String, fileLines: => Seq[String]): Boolean = {
     lazy val isIgnored     = IgnoredFilesRegex.exists(_.matches(filePath))
     lazy val isIgnoredTest = IgnoredTestsRegex.exists(_.matches(filePath))
-    lazy val isMinified    = isMinifiedFile(filePath)
+    lazy val isMinified    = isMinifiedFile(filePath, fileLines)
     if (isIgnored || isIgnoredTest || isMinified) {
       logger.debug(s"'$filePath' ignored by default")
       true
@@ -170,14 +174,14 @@ class AstGenRunner(config: Config) extends io.joern.x2cpg.astgen.AstGenRunner(As
     }
   }
 
-  private def isTranspiledFile(filePath: String): Boolean = {
+  private def isTranspiledFile(filePath: String, fileLines: => Seq[String]): Boolean = {
     val file = Paths.get(filePath)
     // We ignore files iff:
     // - they are *.js files and
     // - they contain a //sourceMappingURL comment or have an associated source map file and
     // - a file with the same name is located directly next to them
     lazy val isJsFile            = Files.exists(file) && file.extension().contains(".js")
-    lazy val hasSourceMapComment = IOUtils.readLinesInFile(file).exists(_.contains("//sourceMappingURL"))
+    lazy val hasSourceMapComment = fileLines.exists(_.contains("//sourceMappingURL"))
     lazy val hasSourceMapFile    = Files.exists(Paths.get(s"$filePath.map"))
     lazy val hasSourceMap        = hasSourceMapComment || hasSourceMapFile
     lazy val hasFileWithSameName =
@@ -222,7 +226,7 @@ class AstGenRunner(config: Config) extends io.joern.x2cpg.astgen.AstGenRunner(As
     val tmpJsFiles = ejsFiles.flatMap { ejsFilePath =>
       val ejsFile             = Paths.get(ejsFilePath)
       val maybeTranspiledFile = Paths.get(s"${ejsFilePath.stripSuffix(".ejs")}.js")
-      if (!isTranspiledFile(maybeTranspiledFile.toString)) {
+      if (!isTranspiledFile(maybeTranspiledFile.toString, IOUtils.readLinesInFile(maybeTranspiledFile))) {
         val sourceFileContent = IOUtils.readEntireFile(ejsFile)
         val preprocessContent = new EjsPreprocessor().preprocess(sourceFileContent)
         (out / in.relativize(ejsFile).toString).getParent

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/utils/AstGenRunner.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/utils/AstGenRunner.scala
@@ -150,8 +150,8 @@ class AstGenRunner(config: Config) extends io.joern.x2cpg.astgen.AstGenRunner(As
   }
 
   private def isMinifiedFile(filePath: String, fileLines: => Seq[String]): Boolean = filePath match {
-    case p if MinifiedPathRegex.matches(p) => true
-    case p if Files.exists(Paths.get(p)) && p.endsWith(".js") =>
+    case _ if MinifiedPathRegex.matches(filePath) => true
+    case _ if Files.exists(Paths.get(filePath)) && filePath.endsWith(".js") =>
       val lines             = fileLines
       val linesOfCode       = lines.size
       val longestLineLength = if (lines.isEmpty) 0 else lines.map(_.length).max

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/utils/PackageJsonParser.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/utils/PackageJsonParser.scala
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory
 import upickle.default.read
 
 import java.nio.file.{Path, Paths}
+import scala.collection.mutable
 import scala.collection.concurrent.TrieMap
 import scala.jdk.CollectionConverters.*
 import scala.util.{Failure, Success, Try}
@@ -44,19 +45,19 @@ object PackageJsonParser {
           val content     = IOUtils.readEntireFile(lockDepsPath)
           val packageJson = read[ujson.Obj](content)
 
-          var depToVersion = Map.empty[String, String]
+          val depToVersion = mutable.LinkedHashMap.empty[String, String]
           val dependencyIt = packageJson.value.get("dependencies").map(_.obj).getOrElse(Map.empty[String, ujson.Value])
           dependencyIt.foreach {
             case (depName, value @ ujson.Str(version)) =>
-              depToVersion = depToVersion.updated(depName, version)
+              depToVersion.update(depName, version)
             case (depName, value @ ujson.Obj(obj)) =>
               obj.get("version").foreach { version =>
-                depToVersion = depToVersion.updated(depName, version.str)
+                depToVersion.update(depName, version.str)
               }
             case (depName, value) =>
               logger.warn(s"Unexpected version structure for dependency $depName: ${value.getClass}")
           }
-          depToVersion
+          depToVersion.toMap
         }.toOption
 
         // lazy val because we only evaluate this in case no package lock file is available.
@@ -64,15 +65,15 @@ object PackageJsonParser {
           val content     = IOUtils.readEntireFile(depsPath)
           val packageJson = read[ujson.Obj](content)
 
-          var depToVersion = Map.empty[String, String]
+          val depToVersion = mutable.LinkedHashMap.empty[String, String]
           ProjectDependencies
             .foreach { dependency =>
               val dependencyIt = packageJson.value.get(dependency).map(_.obj).getOrElse(Map.empty[String, ujson.Value])
               dependencyIt.foreach { case (key, value) =>
-                depToVersion = depToVersion.updated(key, value.str)
+                depToVersion.update(key, value.str)
               }
             }
-          depToVersion
+          depToVersion.toMap
         }.toOption
 
         if (lockDeps.isDefined && lockDeps.get.nonEmpty) {

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/jssrc2cpg/Defines.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/jssrc2cpg/Defines.scala
@@ -36,8 +36,8 @@ object Defines {
   // first two bytes of an EJS output tag in the original source
   val EjsOutputTagPrefix: String = "<%"
 
-  val JsTypes: List[String] =
-    List(
+  val JsTypes: Set[String] =
+    Set(
       Any,
       Array,
       Number,


### PR DESCRIPTION
Targeted, behavior-preserving performance work, from an Opus 4.8 review of `jssrc2cpg/src/main`. Fixes hot-path allocation, redundant regex compilation, and a couple of O(n²)/O(n) lookups on the per-node and per-file paths. No functional changes.

Findings from the LLM were manually reviewed.

### High impact
- **Memoize array-replacement regex in `typeFor`** — hoist `Pattern.compile` out
  of the per-type hot path.
- **Key function-name memoization by source range** — `functionNodeToNameAndFullName`
  was keyed by `BabelNodeInfo`, whose `ujson.Value` hashes structurally over the
  whole function subtree; now keyed by `start:end`.
- **Compute node offsets once in `createBabelNodeInfo`** — resolve `start`/`end`
  and the line binary-search a single time per node instead of 3–4×.

### Medium
- **`JsTypes` List → Set** (`x2cpg`) — O(1) `isBuiltinType`.
- **Index `seenAliasTypes` by name** — `HashSet` linear scan → `HashMap`, removing
  the O(n²) over alias-heavy files.
- **Decompose class members once per class** — one walk feeds the constructor +
  both decoration helpers instead of ~4 re-walks.
- **Read each candidate file at most once during filtering** (`AstGenRunner`) —
  previously read twice (minified + transpiled checks).
- **Strip file extension without recompiling a pattern per parsed file**
  (`BabelJsonParser`/`AstCreationPass`).
- **Reuse already-built callee in `handleCallNodeArgs`** instead of rebuilding it.
- **Single-pass EJS scan** — replace the O(n·m) per-char `positions.exists` +
  `zipWithIndex` with an advancing pointer; drop a throwaway `\S`→space regex.
- **Build block-statement list once** in `createBlockStatementAsts`.

### Cleanups
- Avoid redundant ujson `ArrayBuffer`→`List` copies across AST creation
  (`astForNodes` takes `collection.Seq`, single template-literal `partition`/zip,
  JSX `charAt`, `addAll` via iterator).
- Reuse the import `Matcher` and short-circuit `TypeReplacements` in `typeFor`.
- Drop duplicate specifier lookups in `astForImportDeclaration`.
- Accumulate dependencies in place (`PackageJsonParser`) and filter `.key` files
  before copying (`PrivateKeyFilePass`).
  
Commits are small and focused on the individual findings and can be reviewed in isolation. CS integration and sptests are green.