### PR TITLE
[php2cpg] More V3 validation fixes

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/Php2Cpg.scala
@@ -69,6 +69,7 @@ class Php2Cpg extends X2CpgFrontend {
               var buffer = Option.empty[Map[String, Seq[SymbolSummary]]]
               new SymbolSummaryPass(config, cpg, parser, summary => buffer = Option(summary)).createAndApply()
               new AstCreationPass(config, cpg, parser, buffer.getOrElse(Map.empty)).createAndApply()
+              new FullNameUniquenessPass(cpg).createAndApply()
               TypeNodePass.withTypesFromCpg(cpg).createAndApply()
             }
           case None =>

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreator.scala
@@ -3,7 +3,7 @@ package io.joern.php2cpg.astcreation
 import io.joern.php2cpg.astcreation.AstCreator.{NameConstants, TypeConstants}
 import io.joern.php2cpg.parser.Domain.*
 import io.joern.php2cpg.passes.SymbolSummaryPass.SymbolSummary
-import io.joern.php2cpg.utils.{NamespaceScope, Scope}
+import io.joern.php2cpg.utils.{BlockScope, NamespaceScope, Scope}
 import io.joern.x2cpg.Ast.storeInDiffGraph
 import io.joern.x2cpg.utils.AstPropertiesUtil.RootProperties
 import io.joern.x2cpg.{Ast, AstCreatorBase, Defines, ValidationMode}
@@ -161,10 +161,13 @@ class AstCreator(
       .fullName(fullName)
 
     scope.pushNewScope(NamespaceScope(namespaceBlock, namespaceBlock.fullName))
+    val block = blockNode(stmt)
+    scope.pushNewScope(BlockScope(block, ""))
     val bodyStmts = astsForClassLikeBody(stmt, stmt.stmts, createDefaultConstructor = false, None)
     scope.popScope()
+    scope.popScope()
 
-    Ast(namespaceBlock).withChildren(bodyStmts)
+    Ast(namespaceBlock).withChild(Ast(block).withChildren(bodyStmts))
   }
 
   private def astForHaltCompilerStmt(stmt: PhpHaltCompilerStmt): Ast = {

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreatorHelper.scala
@@ -150,22 +150,6 @@ trait AstCreatorHelper(disableFileContent: Boolean)(implicit withSchemaValidatio
     modifiers: List[String] = List.empty
   ): NewNode = {
     scope.lookupVariable(name) match {
-      case None =>
-        val localCode = if (name == NameConstants.Self) NameConstants.Self else s"$$$name"
-        val local     = localNode(expr, name, code.getOrElse(localCode), tfn.getOrElse(Defines.Any))
-
-        modifiers.foreach { modifier =>
-          val modNode = modifierNode(expr, modifier)
-          diffGraph.addEdge(local, modNode, EdgeTypes.AST)
-        }
-
-        scope.addToScope(name, local) match {
-          case BlockScope(block, _)                 => diffGraph.addEdge(block, local, EdgeTypes.AST)
-          case MethodScope(_, block, _, _, _, _, _) => diffGraph.addEdge(block, local, EdgeTypes.AST)
-          case _                                    => // do nothing
-        }
-
-        local
       case Some(local: NewLocal)
           if scope.isSurroundedByArrowClosure && local.closureBindingId.exists(_.contains("<lambda>")) =>
         local // the contains check ensures that we can capture global variables into an arrow closure
@@ -174,7 +158,26 @@ trait AstCreatorHelper(disableFileContent: Boolean)(implicit withSchemaValidatio
         createClosureBindingsForArrowClosure(expr, name)
       case Some(_: NewLocal) if scope.isSurroundedByArrowClosure =>
         createClosureBindingsForArrowClosure(expr, name)
-      case Some(local) => local
+      case _ =>
+        scope.lookupVariableInCurrentMethod(name) match {
+          case Some(existing) => existing
+          case None =>
+            val localCode = if (name == NameConstants.Self) NameConstants.Self else s"$$$name"
+            val local     = localNode(expr, name, code.getOrElse(localCode), tfn.getOrElse(Defines.Any))
+
+            modifiers.foreach { modifier =>
+              val modNode = modifierNode(expr, modifier)
+              diffGraph.addEdge(local, modNode, EdgeTypes.AST)
+            }
+
+            scope.addToScope(name, local) match {
+              case BlockScope(block, _)                 => diffGraph.addEdge(block, local, EdgeTypes.AST)
+              case MethodScope(_, block, _, _, _, _, _) => diffGraph.addEdge(block, local, EdgeTypes.AST)
+              case _                                    => // do nothing
+            }
+
+            local
+        }
     }
   }
 

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForFunctionsCreator.scala
@@ -57,7 +57,6 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
           logger.warn(s"Unable to find local variable for closure ref: ${local.name}")
       }
 
-      scope.addToScope(local.name, local)
       diffGraph.addNode(closureBindingNode)
       diffGraph.addEdge(methodRef, closureBindingNode, EdgeTypes.CAPTURE)
     }
@@ -120,15 +119,9 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
       getAstParentInfo
     }
     val isStatic = decl.modifiers.contains(ModifierTypes.STATIC)
-    val thisParam =
-      if (!isAnonymousMethod && decl.isClassMethod && !isStatic) Option(thisParamAstForMethod(decl)) else None
 
     val methodName = decl.name.name
     val fullName   = fullNameOverride.getOrElse(composeMethodFullName(methodName))
-
-    val parameters = thisParam.toList ++ decl.params.zipWithIndex.map { case (param, idx) =>
-      astForParam(param, idx + 1)
-    }
 
     val constructorModifier   = Option.when(isConstructor)(ModifierTypes.CONSTRUCTOR)
     val virtualModifier       = Option.unless(isStatic || isConstructor)(ModifierTypes.VIRTUAL)
@@ -141,9 +134,8 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
       case Nil  => ""
       case mods => s"${mods.mkString(" ")} "
     }
-    val methodCode =
-      s"${modifierString}function $methodName(${parameters.filterNot(_.rootName.contains(NameConstants.This)).map(_.rootCodeOrEmpty).mkString(",")})${usesCode
-          .getOrElse("")}"
+    val paramsCode = decl.params.map(param => s"${if (param.byRef) "&" else ""}$$${param.name}").mkString(",")
+    val methodCode = s"${modifierString}function $methodName($paramsCode)${usesCode.getOrElse("")}"
 
     val methodRef =
       if (methodName == NamespaceTraversal.globalNamespaceName) None
@@ -165,6 +157,20 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     scope.pushNewScope(
       MethodScope(method, methodBodyNode, method.fullName, decl.params.map(_.name), methodRef, isArrowClosure)
     )
+
+    val thisParam =
+      if (!isAnonymousMethod && decl.isClassMethod && !isStatic) Option(thisParamAstForMethod(decl)) else None
+    val parameters = thisParam.toList ++ decl.params.zipWithIndex.map { case (param, idx) =>
+      astForParam(param, idx + 1)
+    }
+    parameters.flatMap(_.root).foreach {
+      case param: NewMethodParameterIn => scope.addToScope(param.name, param)
+      case _                           =>
+    }
+    bodyPrefixAsts.flatMap(_.root).foreach {
+      case local: NewLocal => scope.addToScope(local.name, local)
+      case _               =>
+    }
     scope.useFunctionDecl(methodName, fullName)
 
     val returnType = decl.returnType.map(_.name).getOrElse(Defines.Any)
@@ -251,8 +257,6 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     ).dynamicTypeHintFullName(typeFullName :: Nil)
     // TODO Add dynamicTypeHintFullName to parameterInNode param list
 
-    scope.addToScope(NameConstants.This, thisNode)
-
     Ast(thisNode)
   }
 
@@ -280,11 +284,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
       attributeGroups = Nil
     )
 
-    val initAsts = scope.getFieldInits.map { fieldInit =>
-      astForMemberAssignment(fieldInit.originNode, fieldInit.memberNode, fieldInit.value, isField = true)
-    }
-
-    astForMethodDecl(defaultConstructorDecl, initAsts, isConstructor = true, fullNameOverride = fullNameOverride)
+    astForMethodDecl(defaultConstructorDecl, isConstructor = true, fullNameOverride = fullNameOverride)
   }
 
   protected def astForAttributeGroup(attrGrp: PhpAttributeGroup): Seq[Ast] = {
@@ -313,8 +313,6 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
     val code            = s"$byRefCodePrefix$$${param.name}"
     val paramNode = parameterInNode(param, param.name, code, index, param.isVariadic, evaluationStrategy, typeFullName)
     val attributeAsts = param.attributeGroups.flatMap(astForAttributeGroup)
-
-    scope.addToScope(param.name, paramNode)
 
     Ast(paramNode).withChildren(attributeAsts)
   }

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/Domain.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/Domain.scala
@@ -83,6 +83,7 @@ object Domain {
   // Used for creating the default constructor.
   val ConstructorMethodName = "__construct"
   val GlobalName            = "<global>"
+  val DuplicateSuffix       = "<duplicate>"
 
   final case class PhpAttributes(
     lineNumber: Option[Int],

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/FullNameUniquenessPass.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/FullNameUniquenessPass.scala
@@ -1,0 +1,103 @@
+package io.joern.php2cpg.passes
+
+import io.joern.php2cpg.parser.Domain
+import io.shiftleft.codepropertygraph.generated.nodes.{Method, NamespaceBlock, TypeDecl}
+import io.shiftleft.codepropertygraph.generated.{Cpg, PropertyNames}
+import io.shiftleft.passes.CpgPass
+import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
+import org.slf4j.LoggerFactory
+
+/** Ensures that method, type decl, and namespace block fullNames are unique across the CPG. In PHP code, the same
+  * top-level class or function name may be declared in multiple files (they are never loaded together at runtime, e.g.
+  * an admin and a frontend variant of a class). Joern folds every file into a single CPG, so these declarations collide
+  * on their fullName.
+  *
+  * The CPG specification requires unique fullNames for all kind of linking and querying operations.
+  *
+  * This unique fullName generation cannot be performed during the initial AST traversal because:
+  *   - The AST is built on a per-file basis where we don't have knowledge of methods defined in other files.
+  *   - Name uniqueness must be established across the entire codebase, not just within a single file.
+  *   - Using a global cache during parsing would slow down our parallel processing.
+  *
+  * Instead, this pass runs after all methods, type decls, and namespaces have been added to the CPG, identifies
+  * duplicates, and appends a unique suffix to ensure each one can be uniquely identified. Calls resolved (via the naive
+  * namespace-by-filename approach) to a renamed method in the same file are updated to reflect the new fullName.
+  */
+class FullNameUniquenessPass(cpg: Cpg) extends CpgPass(cpg) {
+
+  private type AffectedNodeType = Method | TypeDecl | NamespaceBlock
+  private val logger = LoggerFactory.getLogger(classOf[FullNameUniquenessPass])
+
+  override def run(dstGraph: DiffGraphBuilder): Unit = {
+    handleMethods(dstGraph)
+    handleTypeDecls(dstGraph)
+    handleNamespaceBlocks(dstGraph)
+  }
+
+  private def handleMethods(dstGraph: DiffGraphBuilder): Unit = {
+    val methodFullNameMap = generateStableFullNameMapping(cpg.method.nameNot(NamespaceTraversal.globalNamespaceName))
+    methodFullNameMap.foreach { case (fullName, methods) =>
+      logDuplicates(methods, fullName)
+      val sortedMethods = sortNodesByLocation(methods)
+      lazy val callsAffected =
+        cpg.call.methodFullNameExact(fullName).filterNot(_.file.exists(_.name == sortedMethods.head.filename)).l
+      sortedMethods.tail.zipWithIndex.foreach { case (method, index) =>
+        val suffix      = s"${Domain.DuplicateSuffix}$index"
+        val newFullName = s"$fullName$suffix"
+        dstGraph.setNodeProperty(method, PropertyNames.FullName, newFullName)
+        // Fix up calls resolved to this method within the same file via the naive namespace-by-filename approach.
+        val callCandidates = callsAffected.filter(_.file.exists(_.name == method.filename))
+        callCandidates.foreach { call =>
+          dstGraph.setNodeProperty(call, PropertyNames.MethodFullName, newFullName)
+        }
+      }
+    }
+  }
+
+  private def handleTypeDecls(dstGraph: DiffGraphBuilder): Unit = {
+    handleDuplicateFullNames(cpg.typeDecl.nameNot(NamespaceTraversal.globalNamespaceName), dstGraph)
+  }
+
+  private def handleNamespaceBlocks(dstGraph: DiffGraphBuilder): Unit = {
+    handleDuplicateFullNames(cpg.namespaceBlock.nameNot(NamespaceTraversal.globalNamespaceName), dstGraph)
+  }
+
+  private def handleDuplicateFullNames[T <: AffectedNodeType](nodes: Iterator[T], dstGraph: DiffGraphBuilder): Unit = {
+    val fullNameMap = generateStableFullNameMapping(nodes)
+    fullNameMap.foreach { case (fullName, nodesList) =>
+      logDuplicates(nodesList, fullName)
+      val sortedNodes = sortNodesByLocation(nodesList)
+      sortedNodes.tail.zipWithIndex.foreach { case (node, index) =>
+        val suffix      = s"${Domain.DuplicateSuffix}$index"
+        val newFullName = s"$fullName$suffix"
+        dstGraph.setNodeProperty(node, PropertyNames.FullName, newFullName)
+      }
+    }
+  }
+
+  private def generateStableFullNameMapping[T <: AffectedNodeType](nodes: Iterator[T]): Seq[(String, List[T])] = {
+    nodes
+      .groupBy(_.fullName)
+      .filter(_._2.size > 1)
+      .sortBy(_._1)
+  }
+
+  private def sortNodesByLocation[T <: AffectedNodeType](nodes: List[T]): List[T] = {
+    nodes.sortBy { node =>
+      val fileName = node.filename
+      val lineNr   = node.lineNumber.getOrElse(-1)
+      val columnNr = node.columnNumber.getOrElse(-1)
+      (fileName, lineNr, columnNr)
+    }
+  }
+
+  private def logDuplicates[T <: AffectedNodeType](nodes: List[T], fullName: String): Unit = {
+    if (logger.isDebugEnabled) {
+      val fromFiles = nodes.map(_.filename).mkString("[", ", ", "]")
+      val nodeLabel = nodes.headOption.map(_.label).getOrElse("")
+      logger.debug(s"Found ${nodes.size} duplicate $nodeLabel fullNames for '$fullName' in: $fromFiles")
+    }
+  }
+
+}

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/utils/Scope.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/utils/Scope.scala
@@ -164,6 +164,19 @@ class Scope(summary: Map[String, Seq[SymbolSummary]] = Map.empty)
   def isSurroundedByArrowClosure: Boolean =
     stack.map(_.scopeNode).collectFirst { case nm: MethodScope if nm.isArrowFunc => nm }.isDefined
 
+  /** Looks up a variable, but only within the current method boundary, i.e. the block scopes up to and including the
+    * nearest enclosing method scope.
+    */
+  def lookupVariableInCurrentMethod(identifier: String): Option[NewNode] = {
+    val (upToMethod, methodAndBelow) = stack.span {
+      case ScopeElement(_: MethodScope, _) => false
+      case _                               => true
+    }
+    (upToMethod ++ methodAndBelow.take(1)).collectFirst {
+      case scopeElement if scopeElement.variables.contains(identifier) => scopeElement.variables(identifier)
+    }
+  }
+
   def isTopLevel: Boolean =
     getEnclosingTypeDeclTypeName.forall(_ == NamespaceTraversal.globalNamespaceName)
 
@@ -254,14 +267,16 @@ class Scope(summary: Map[String, Seq[SymbolSummary]] = Map.empty)
   }
 
   def getScopedClosureName: String = {
-    stack.headOption match {
-      case Some(ScopeElement(ns: NamespaceScope, _)) => ns.getClosureMethodName
-      case Some(ScopeElement(ts: TypeScope, _))      => ts.getClosureMethodName
-      case Some(ScopeElement(ms: MethodScope, _))    => ms.getClosureMethodName
-      case _ =>
-        logger.warn("BUG: Attempting to get scopedClosureName, but no scope has been push. Defaulting to unscoped")
+    stack
+      .collectFirst {
+        case ScopeElement(ns: NamespaceScope, _) => ns.getClosureMethodName
+        case ScopeElement(ts: TypeScope, _)      => ts.getClosureMethodName
+        case ScopeElement(ms: MethodScope, _)    => ms.getClosureMethodName
+      }
+      .getOrElse {
+        logger.warn("Attempting to get scopedClosureName, but no scope has been pushed. Defaulting to unscoped.")
         NameConstants.Closure
-    }
+      }
   }
 
   private def addInitToScope(init: PhpInit, initList: List[mutable.ArrayBuffer[PhpInit]]): Unit = {

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/passes/FullNameUniquenessPassTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/passes/FullNameUniquenessPassTests.scala
@@ -1,0 +1,145 @@
+package io.joern.php2cpg.passes
+
+import io.joern.php2cpg.testfixtures.PhpCode2CpgFixture
+import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
+
+class FullNameUniquenessPassTests extends PhpCode2CpgFixture {
+
+  "the FullNameUniquenessPass" should {
+    "create unique type decl fullNames for a class declared in multiple files" in {
+      val cpg = code(
+        """<?php
+          |class Log {
+          |  public function __destruct() {}
+          |}
+          |""".stripMargin,
+        fileName = "utils.php"
+      ).moreCode(
+        """<?php
+          |class Log {
+          |  public function __destruct() {}
+          |}
+          |""".stripMargin,
+        fileName = "payload.php"
+      )
+
+      cpg.typeDecl.name("Log").fullName.sorted.l shouldBe List("Log", "Log<duplicate>0")
+      cpg.typeDecl.nameExact("Log").map(td => (td.fullName, td.filename)).sorted.l shouldBe List(
+        ("Log", "payload.php"),
+        ("Log<duplicate>0", "utils.php")
+      )
+    }
+
+    "create unique method fullNames for a class method declared in multiple files" in {
+      val cpg = code(
+        """<?php
+          |class Log {
+          |  public function __destruct() {}
+          |}
+          |""".stripMargin,
+        fileName = "payload.php"
+      ).moreCode(
+        """<?php
+          |class Log {
+          |  public function __destruct() {}
+          |}
+          |""".stripMargin,
+        fileName = "utils.php"
+      )
+
+      cpg.method.nameExact("__destruct").map(method => (method.fullName, method.filename)).sorted.l shouldBe List(
+        ("Log.__destruct", "payload.php"),
+        ("Log.__destruct<duplicate>0", "utils.php")
+      )
+    }
+
+    "keep the binding of a renamed class method pointing to the correct method" in {
+      val cpg = code(
+        """<?php
+          |class Log {
+          |  public function write() {}
+          |}
+          |""".stripMargin,
+        fileName = "a.php"
+      ).moreCode(
+        """<?php
+          |class Log {
+          |  public function write() {}
+          |}
+          |""".stripMargin,
+        fileName = "b.php"
+      )
+
+      cpg.typeDecl.fullNameExact("Log<duplicate>0").bindsOut.refOut.fullName.l shouldBe List("Log.write<duplicate>0")
+    }
+
+    "create unique fullNames for a top-level function declared in multiple files and fix same-file calls" in {
+      val cpg = code(
+        """<?php
+          |function generateToken() { return 1; }
+          |generateToken();
+          |""".stripMargin,
+        fileName = "a.php"
+      ).moreCode(
+        """<?php
+          |function generateToken() { return 2; }
+          |generateToken();
+          |""".stripMargin,
+        fileName = "b.php"
+      )
+
+      cpg.method.nameExact("generateToken").map(method => (method.fullName, method.filename)).sorted.l shouldBe List(
+        ("generateToken", "a.php"),
+        ("generateToken<duplicate>0", "b.php")
+      )
+
+      val callInB = cpg.call.name("generateToken").where(_.file.name("b.php")).loneElement
+      callInB.methodFullName shouldBe "generateToken<duplicate>0"
+
+      val callInA = cpg.call.name("generateToken").where(_.file.name("a.php")).loneElement
+      callInA.methodFullName shouldBe "generateToken"
+    }
+
+    "leave unique fullNames untouched" in {
+      val cpg = code(
+        """<?php
+          |class Foo {
+          |  public function bar() {}
+          |}
+          |""".stripMargin,
+        fileName = "a.php"
+      ).moreCode(
+        """<?php
+          |class Baz {
+          |  public function qux() {}
+          |}
+          |""".stripMargin,
+        fileName = "b.php"
+      )
+
+      cpg.method.fullName(".*<duplicate>.*") shouldBe empty
+      cpg.typeDecl.fullName(".*<duplicate>.*") shouldBe empty
+      cpg.typeDecl.nameExact("Foo").fullName.l shouldBe List("Foo")
+      cpg.typeDecl.nameExact("Baz").fullName.l shouldBe List("Baz")
+    }
+
+    "not rename the global namespace method" in {
+      val cpg = code(
+        """<?php
+          |echo 1;
+          |""".stripMargin,
+        fileName = "a.php"
+      ).moreCode(
+        """<?php
+          |echo 2;
+          |""".stripMargin,
+        fileName = "b.php"
+      )
+
+      cpg.method.nameExact(NamespaceTraversal.globalNamespaceName).fullName.l.foreach { fullName =>
+        fullName should not include "<duplicate>"
+      }
+    }
+  }
+}

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/ClosureTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/ClosureTests.scala
@@ -59,6 +59,21 @@ class ClosureTests extends PhpCode2CpgFixture {
     }
   }
 
+  "multiple top-level closures inside a named namespace" should {
+    val cpg = code(
+      """<?
+        |namespace X;
+        |$a = function () {};
+        |$b = function () {};
+        |""".stripMargin,
+      fileName = "foo.php"
+    )
+
+    "get unique, namespace-scoped fullNames" in {
+      cpg.method.name(".*<lambda>.*").fullName.sorted.l shouldBe List("foo.php:X.<lambda>0", "foo.php:X.<lambda>1")
+    }
+  }
+
   "long-form closures with uses " should {
     val cpg = code(
       """<?php
@@ -121,6 +136,39 @@ class ClosureTests extends PhpCode2CpgFixture {
         methodRef.code shouldBe expectedName
         methodRef.lineNumber shouldBe Some(3)
       }
+    }
+  }
+
+  "a variable captured by a use-closure and also referenced in the enclosing method" should {
+    val cpg = code(
+      """<?php
+        |class articles {
+        |  public function getArticles() {
+        |    $result = foo();
+        |    foreach ($result AS $res) {
+        |      $res->body = preg_replace_callback("/x/", function($match) use ($res) {
+        |        $res->video = $match[1];
+        |      }, $res->body);
+        |    }
+        |    return $result;
+        |  }
+        |}
+        |""".stripMargin,
+      fileName = "articles.php"
+    )
+
+    "create separate locals for the outer method and the closure" in {
+      val outerLocal = cpg.method.name("getArticles").local.nameExact("res").loneElement
+      outerLocal.closureBindingId shouldBe None
+
+      val closureLocal = cpg.method.name(".*<lambda>0").local.nameExact("res").loneElement
+      closureLocal.closureBindingId shouldBe Some("articles.getArticles.<lambda>0:res")
+    }
+
+    "not create a REF edge crossing the method boundary" in {
+      cpg.method.name("getArticles").ast.isIdentifier.nameExact("res")._localViaRefOut.method.name.toSet shouldBe Set(
+        "getArticles"
+      )
     }
   }
 

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/LocalTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/LocalTests.scala
@@ -74,4 +74,71 @@ class LocalTests extends PhpCode2CpgFixture {
       xLocal.lineNumber shouldBe Some(4)
     }
   }
+
+  "function-local variable scoping" should {
+    "not resolve a variable to a top-level local without the global keyword" in {
+      val cpg = code(
+        """<?php
+          |$aaa = 1;
+          |function foo() {
+          |  return $aaa;
+          |}
+          |""".stripMargin,
+        fileName = "main.php"
+      )
+
+      val fooLocal = cpg.method.name("foo").local.nameExact("aaa").loneElement
+      fooLocal.code shouldBe "$aaa"
+      cpg.method.name("foo").ast.isIdentifier.nameExact("aaa")._localViaRefOut.l shouldBe List(fooLocal)
+    }
+
+    "not resolve a variable to a parameter of a sibling method" in {
+      val cpg = code("""<?php
+          |class ClassLoader {
+          |  public function setPsr4($prefix) {
+          |    return $prefix;
+          |  }
+          |  public function findFile() {
+          |    return $prefix;
+          |  }
+          |}
+          |""".stripMargin)
+
+      cpg.method.name("setPsr4").parameter.nameExact("prefix").size shouldBe 1
+      val findFileLocal = cpg.method.name("findFile").local.nameExact("prefix").loneElement
+      findFileLocal.code shouldBe "$prefix"
+    }
+
+    "not capture an outer variable into a plain closure without a use clause" in {
+      val cpg = code(
+        """<?php
+          |$aaa = 1;
+          |$fn = function () {
+          |  return $aaa;
+          |};
+          |""".stripMargin,
+        fileName = "server.php"
+      )
+
+      val closure      = cpg.method.name(".*<lambda>0").loneElement
+      val closureLocal = closure.local.nameExact("aaa").loneElement
+      closureLocal.closureBindingId shouldBe None
+    }
+
+    "keep the tmp local for a parameter attribute array literal inside the method" in {
+      val cpg = code(
+        """<?php
+          |function f(
+          |  #[CompletionProvider(values: ['welcome', 'faq'])]
+          |  string $noteId
+          |): string {
+          |  return $noteId;
+          |}
+          |""".stripMargin,
+        fileName = "server.php"
+      )
+
+      cpg.local.method.name.toSet shouldBe Set("f")
+    }
+  }
 }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/MemberTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/MemberTests.scala
@@ -99,6 +99,24 @@ class MemberTests extends PhpCode2CpgFixture {
     }
   }
 
+  "array-literal field initializer without an explicit constructor" should {
+    val cpg = code("""<?php
+      |class Kernel {
+      |  protected $middleware = [ 1, 2, 3 ];
+      |}
+      |""".stripMargin)
+
+    "lower the initializer into the default constructor and keep the tmp local inside it" in {
+      inside(cpg.method.nameExact(Domain.ConstructorMethodName).l) { case List(initMethod) =>
+        initMethod.fullName shouldBe "Kernel.__construct"
+        inside(initMethod.local.name.l) { case List(tmpLocalName) =>
+          tmpLocalName shouldBe "Kernel.__construct@tmp-0"
+        }
+      }
+      cpg.local.name.l shouldBe List("Kernel.__construct@tmp-0")
+    }
+  }
+
   "class properties (fields) for classes with a constructor" should {
 
     val cpg = code("""<?php

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/NamespaceTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/NamespaceTests.scala
@@ -3,18 +3,32 @@ package io.joern.php2cpg.querying
 import io.joern.php2cpg.testfixtures.PhpCode2CpgFixture
 import io.joern.php2cpg.parser.Domain
 import io.shiftleft.semanticcpg.language.*
-import io.shiftleft.codepropertygraph.generated.nodes.Method
+import io.shiftleft.codepropertygraph.generated.nodes.{Block, Local, Method}
 
 class NamespaceTests extends PhpCode2CpgFixture {
-  "namespaces should be able to contain statements as top-level AST children" in {
+  "namespaces should be able to contain statements in a top-level block" in {
     val cpg = code("""<?php
         |namespace foo {
         |  echo 0;
         |}
         |""".stripMargin)
 
-    inside(cpg.namespaceBlock.name("foo").l) { case List(ns) =>
-      ns.astChildren.code.l shouldBe List("echo 0")
+    inside(cpg.namespaceBlock.name("foo").astChildren.l) { case List(block: Block) =>
+      block.astChildren.code.l shouldBe List("echo 0")
+    }
+  }
+
+  "locals declared by top-level statements in a namespace should be nested in the namespace block" in {
+    val cpg = code("""<?php
+        |namespace foo;
+        |$x = new Bar();
+        |""".stripMargin)
+
+    inside(cpg.namespaceBlock.name("foo").astChildren.l) { case List(block: Block) =>
+      inside(block.astChildren.isLocal.l) { case List(local: Local) =>
+        local.name shouldBe "x"
+        local.code shouldBe "$x"
+      }
     }
   }
 

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/TypeDeclTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/TypeDeclTests.scala
@@ -543,23 +543,23 @@ class TypeDeclTests extends PhpCode2CpgFixture {
     }
   }
 
-  "Members for anonymous class directly under class created" in {
+  "Anonymous class in field initializer lowered into the default constructor" in {
     val cpg = code("""<?php
       |class Foo {
       |  public $foo = new class(10) {
       |   private int $x;
       |  };
       |}""".stripMargin)
-    inside(cpg.typeDecl.name("Foo").member.l) { case _ :: fooAnonMem :: Nil =>
-      fooAnonMem.name shouldBe "Foo.anon-class-0"
-    }
+    cpg.typeDecl.name("Foo").member.name.l shouldBe List("foo")
+    cpg.typeDecl.fullNameExact("Foo.__construct.anon-class-0").nonEmpty shouldBe true
     inside(cpg.local.l) { case List(fooLocal) =>
-      fooLocal.name shouldBe "Foo@tmp-0"
+      fooLocal.name shouldBe "Foo.__construct@tmp-0"
+      fooLocal.method.name.l shouldBe List("__construct")
       fooLocal.astIn.isBlock.loneElement.astChildren.code.l shouldBe List(
-        "$Foo@tmp-0",
-        "$Foo@tmp-0 = Foo.anon-class-0.<alloc>()",
-        "new Foo.anon-class-0(10)",
-        "$Foo@tmp-0"
+        "$Foo.__construct@tmp-0",
+        "$Foo.__construct@tmp-0 = Foo.__construct.anon-class-0.<alloc>()",
+        "new Foo.__construct.anon-class-0(10)",
+        "$Foo.__construct@tmp-0"
       )
     }
   }


### PR DESCRIPTION
**1. Dangling Local under a named namespace (`AstCreator.astForNamespaceStmt`)** Top-level statements inside `namespace Foo; ...` were attached directly under the namespace block, but `handleVariableOccurrence` only wires locals to `BlockScope`/`MethodScope`. Iinsert an intermediate `Block` (and `BlockScope`) between the namespace block and its statements, giving locals a valid AST parent.

**2. Dangling Local from default-constructor field inits (`AstForFunctionsCreator.defaultConstructorAst`)** Array/new field initializers (`protected $x = [...]`) were evaluated before the constructor's `MethodScope` was pushed, so their tmp locals dangled. Removed the premature evaluation so `astForMethodDecl` builds them inside the method scope — matching the explicit-constructor path.

**3. `NONLOCAL_REF` — cross-method variable resolution (`Scope` + `AstCreatorHelper.handleVariableOccurrence`)** `lookupVariable` walked the whole scope stack, so a function/closure resolved a name to a Local/param in an enclosing method (the "global var without global keyword" case, sibling-method params, plain closures). Added `lookupVariableInCurrentMethod` (stops at the nearest method boundary). and use it for non-arrow-closure lookups — arrow/use captures still work. Also deferred parameter scope-registration and param-attribute AST creation (array literals) until after the MethodScope push.

**4. Closure-name collision regression (`Scope.getScopedClosureName`)** Fix 1's block-on-stack broke closure naming (only inspected `stack.headOption`). Changed to `collectFirst` over the stack, so multiple top-level closures in a namespace get unique names.

**5. Duplicate fullNames for symbols declared across multiple files (new `FullNameUniquenessPass`)** PHP allows the same top-level class or function name to be declared in multiple files (they are never loaded together at runtime, e.g., an admin and a frontend variant of a class). The dedup counter in `ScopeElement` is per-file, so these cross-file collisions survive as duplicate fullNames. Added a `FullNameUniquenessPass` (mirroring the c2cpg/swiftsrc2cpg passes; needs DRY-cleanup later), run after `AstCreationPass`, which appends a deterministic `<duplicate>N` suffix (ordered by file/line/column) to duplicate `Method`/`TypeDecl`/`NamespaceBlock` fullnames and fixes up same-file calls resolved to a renamed method.

**6. `NONLOCAL_REF` — use-closure local leaking into the enclosing scope (`AstForFunctionsCreator.astForClosureExpr`)** When a variable was captured by a `use ($var)` closure, `scope.addToScope(var, local)` inserted the closure's captured Local into the enclosing scope (the closure's own `MethodScope` is not pushed until `astForMethodDecl`). A later identifier for the same name in the outer method then resolved to the closure's Local, producing a `REF` edge across the method boundary. Removed that call — the captured Local is already registered into the closure's own method scope via `astForMethodDecl`'s `bodyPrefixAsts` handling — so outer identifiers now ref the outer Local.

Enables CS V3 validation for both integration and sptest.