### PR TITLE
[pysrc2cpg] Correctly handle delete on list

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
@@ -2041,10 +2041,6 @@ class PythonAstVisitor(
   }
 
   def convert(list: ast.List): nodes.NewNode = {
-    // Must be a List as part of a Load memory operation because a List literal
-    // is not permitted as argument to a Del and List as part of a Store does not
-    // reach here.
-    assert(memOpMap.get(list).get == Load)
     val listElementNodes = list.elts.map(convert)
     val code             = listElementNodes.map(codeOf).mkString("[", ", ", "]")
 

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/DeleteCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/DeleteCpgTests.scala
@@ -52,4 +52,15 @@ class DeleteCpgTests extends PySrc2CpgFixture with Matchers {
     }
   }
 
+  "delete of list should be represented correctly" in {
+    val cpg      = code("""del [x, y]""".stripMargin)
+    val callNode = cpg.call.methodFullNameExact("<operator>.delete").head
+    callNode.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+    callNode.code shouldBe "del [x, y]"
+    callNode.lineNumber shouldBe Some(1)
+
+    val listArgument = callNode.argument(1)
+    listArgument.code shouldBe "[x, y]"
+  }
+
 }


### PR DESCRIPTION
My assumption that delete on a list is invalid python was wrong.
E.g. `del [a, b]` is perferctly valid and is equivalent to `del a`, `del
b`.

Fix for https://harness.atlassian.net/browse/QT-1147