### PR TITLE
[kotlin2cpg] Enable V3 validation

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
@@ -92,9 +92,8 @@ class AstCreator(
   def createAst(): DiffGraphBuilder = {
     val fileNode = NewFile().name(filename).order(0)
     fileContent.foreach(fileNode.content(_))
-    val ast = astForTranslationUnit(javaParserAst)
+    val ast = Ast(fileNode).withChild(astForTranslationUnit(javaParserAst))
     storeInDiffGraph(ast)
-    diffGraph.addNode(fileNode)
     diffGraph
   }
 

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForStatementsCreator.scala
@@ -352,7 +352,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
       .map { text => s"${Constants.WhenKeyword}($text)" }
       .getOrElse(Constants.WhenKeyword)
     val switchNode = controlStructureNode(expr, ControlStructureTypes.SWITCH, shortenCode(codeForSwitch))
-    val ast        = Ast(withArgumentIndex(switchNode, argIdx)).withChildren(List(astForSubject, astForBlock))
+    val ast        = Ast(withArgumentIndex(switchNode, argIdx)).withChildren(List(finalAstForSubject, astForBlock))
     // TODO: rewrite this as well
     finalAstForSubject.root match {
       case Some(root) => ast.withConditionEdge(switchNode, root)

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForStatementsCreator.scala
@@ -324,19 +324,19 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
   }
 
   private def astForWhenAsStatement(expr: KtWhenExpression, argIdx: Option[Int]): Ast = {
-    val (astForSubject, finalAstForSubject) = Option(expr.getSubjectExpression) match {
+    val astForSubject = Option(expr.getSubjectExpression) match {
       case Some(subjectExpression) =>
-        val astForSubject = astsForExpression(subjectExpression, Some(1)).headOption.getOrElse(Ast())
-        val finalAstForSubject = expr.getSubjectExpression match {
+        val astForSubjectExpression = astsForExpression(subjectExpression, Some(1)).headOption.getOrElse(Ast())
+        expr.getSubjectExpression match {
           case p: KtProperty =>
             val block = blockNode(p, "", "").argumentIndex(1)
-            blockAst(block, List(astForSubject))
-          case _ => astForSubject
+            blockAst(block, List(astForSubjectExpression))
+          case _ =>
+            astForSubjectExpression
         }
-        (astForSubject, finalAstForSubject)
       case _ =>
         logger.warn(s"Subject Expression empty in this file `$relativizedPath`.")
-        (Ast(), Ast())
+        Ast()
     }
 
     val astsForEntries =
@@ -344,17 +344,16 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
         astsForWhenEntry(e, idx)
       }.flatten
 
-    val switchBlockNode =
-      blockNode(expr, expr.getEntries.asScala.map(_.getText).mkString("\n"), TypeConstants.Any)
-    val astForBlock = blockAst(switchBlockNode, astsForEntries.toList)
+    val switchBlockNode = blockNode(expr, expr.getEntries.asScala.map(_.getText).mkString("\n"), TypeConstants.Any)
+    val astForBlock     = blockAst(switchBlockNode, astsForEntries.toList)
     val codeForSwitch = Option(expr.getSubjectExpression)
       .map(_.getText)
       .map { text => s"${Constants.WhenKeyword}($text)" }
       .getOrElse(Constants.WhenKeyword)
     val switchNode = controlStructureNode(expr, ControlStructureTypes.SWITCH, shortenCode(codeForSwitch))
-    val ast        = Ast(withArgumentIndex(switchNode, argIdx)).withChildren(List(finalAstForSubject, astForBlock))
+    val ast        = Ast(withArgumentIndex(switchNode, argIdx)).withChildren(List(astForSubject, astForBlock))
     // TODO: rewrite this as well
-    finalAstForSubject.root match {
+    astForSubject.root match {
       case Some(root) => ast.withConditionEdge(switchNode, root)
       case None       => ast
     }

--- a/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/testfixtures/KotlinCodeToCpgFixture.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/test/scala/io/joern/kotlin2cpg/testfixtures/KotlinCodeToCpgFixture.scala
@@ -41,7 +41,7 @@ trait KotlinFrontend extends LanguageFrontend {
     }
 
     val tmp = new Kotlin2Cpg().createCpg(config.withInputPath(sourceCodeFile.getAbsolutePath)).get
-    new PostFrontendValidator(tmp, ValidationLevel.V1).run()
+    new PostFrontendValidator(tmp, ValidationLevel.V3).run()
     tmp
   }
 }


### PR DESCRIPTION
Bumps the kotlin2cpg test `PostFrontendValidator` from `V1` to `V3`, which makes `DANGLING_AST_NODE` (a node with no AST parent) fatal. This surfaced two genuine AST-malformation bugs that V1 had been hiding.

### Fixes

- **Dangling `BLOCK`** — In `astForWhenAsStatement`, a `when (val x = …)` subject is wrapped in a `BLOCK` (`finalAstForSubject`), but the switch's AST children used the unwrapped `astForSubject`; the block was only referenced by the CONDITION edge and had no AST parent. Now attaches `finalAstForSubject` as the child (identical to `astForSubject` for non-property subjects).

- **Dangling `NAMESPACE_BLOCK`** — `javasrc2cpg`'s `AstCreator.createAst` created the `FILE` node and namespace-block AST as disconnected subgraphs. Standalone javasrc2cpg validates at V0 so never caught it, but kotlin2cpg reuses that pass for Java interop at V3. Now roots the translation unit under the file node (`Ast(fileNode).withChild(...)`).

_Note:_ the second fix touches shared `javasrc2cpg` code. The correct place, since it was emitting a malformed AST.

CS integration tests and sptests for both frontends are green.