### PR TITLE
[rust2cpg] lower qualified calls.

### DIFF
--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustFullNames.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustFullNames.scala
@@ -53,14 +53,16 @@ trait RustFullNames { this: AstCreator =>
 
   protected def methodFullNameForCallExpr(
     callExpr: RustNodeSyntax.CallExpr,
-    nameRefs: Seq[RustNodeSyntax.NameRef]
+    nameRefs: Seq[RustNodeSyntax.NameRef],
+    name: String
   ): String = {
     callExpr.methodFullName.getOrElse {
       // TODO: take into account `use` (imports). We are incorrectly assuming here that an
       //  unresolved call e.g. `a::b::c()` has fullName `a::b::c`.
-      nameRefs match {
-        case name :: Nil => combineRustFullName(Defines.UnresolvedNamespace, code(name))
-        case names       => names.map(code).mkString(PathSep)
+      if (nameRefs.size > 1) {
+        nameRefs.map(code).reduce(combineRustFullName)
+      } else {
+        combineRustFullName(Defines.UnresolvedNamespace, name)
       }
     }
   }

--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
@@ -413,16 +413,28 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
   // CallExpr =
   //  Attr* Expr ArgList
   private def visitCallExpr(callExpr: CallExpr): Ast = {
-    viewExprAsPathExpr(callExpr.expr) match {
-      case Some(nameRefs) =>
-        val name           = code(nameRefs.last)
-        val methodFullName = methodFullNameForCallExpr(callExpr, nameRefs)
-        val typeFullName   = typeFullNameForExpr(callExpr)
-        val dispatch       = DispatchTypes.STATIC_DISPATCH
+    callExpr.expr match {
+      case pathExpr: PathExpr => lowerPathExprCall(callExpr, pathExpr)
+      case _                  => notHandledYet(callExpr)
+    }
+  }
+
+  private def lowerPathExprCall(callExpr: CallExpr, pathExpr: PathExpr): Ast = {
+    pathExpr.path.pathSegment.nameRef match {
+      case Some(nameRef) =>
+        val name = code(nameRef)
+        val methodFullName =
+          methodFullNameForCallExpr(callExpr, viewPathAsSequenceOfNameRefs(pathExpr.path).getOrElse(Nil), name)
+        val typeFullName    = typeFullNameForExpr(callExpr)
+        val argExprs        = callExpr.argList.expr
+        val hasSelfReceiver = callExpr.hasSelfReceiver.isDefined && argExprs.nonEmpty
+        val dispatch =
+          if (hasSelfReceiver && isTraitObject(typeFullNameForExpr(argExprs.head))) DispatchTypes.DYNAMIC_DISPATCH
+          else DispatchTypes.STATIC_DISPATCH
         val call =
           callNode(callExpr, code(callExpr), name, methodFullName, dispatch, None, Some(typeFullName))
-        val args = callExpr.argList.expr.map(visitExpr)
-        if (callExpr.hasSelfReceiver.isDefined && args.nonEmpty) {
+        val args = argExprs.map(visitExpr)
+        if (hasSelfReceiver) {
           callAst(call, args.tail, base = Some(args.head))
         } else {
           callAst(call, args)

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/CallTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/CallTests.scala
@@ -217,6 +217,88 @@ class CallTests extends Rust2CpgSuite(noSysRoot = true) {
     }
   }
 
+  "a `<S as Tr>::m` call" should {
+    val cpg = code("""
+        |trait Tr { fn m(&self) -> i32; }
+        |struct S;
+        |impl Tr for S { fn m(&self) -> i32 { 0 } }
+        |fn f(s: S) { <S as Tr>::m(&s); }
+        |""".stripMargin)
+
+    "resolve to the impl method" in {
+      inside(cpg.call.codeExact("<S as Tr>::m(&s)").l) { case call :: Nil =>
+        call.name shouldBe "m"
+        call.methodFullName shouldBe "<rust2cpgtest::S as rust2cpgtest::Tr>::m"
+        call.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+        inside(call.receiver.l) { case (recv: Call) :: Nil =>
+          recv.code shouldBe "&*&s"
+          recv.typeFullName shouldBe "&rust2cpgtest::S"
+          recv.argumentIndex shouldBe 0
+        }
+      }
+    }
+  }
+
+  "a `Tr::m` call" should {
+    val cpg = code("""
+        |trait Tr { fn m(&self) -> i32; }
+        |struct S;
+        |impl Tr for S { fn m(&self) -> i32 { 0 } }
+        |fn f(s: S) { Tr::m(&s); }
+        |""".stripMargin)
+
+    "resolve to the impl method" in {
+      inside(cpg.call.codeExact("Tr::m(&s)").l) { case call :: Nil =>
+        call.name shouldBe "m"
+        call.methodFullName shouldBe "<rust2cpgtest::S as rust2cpgtest::Tr>::m"
+        call.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+        inside(call.receiver.l) { case (recv: Call) :: Nil =>
+          recv.code shouldBe "&*&s"
+          recv.typeFullName shouldBe "&rust2cpgtest::S"
+          recv.argumentIndex shouldBe 0
+        }
+      }
+    }
+  }
+
+  "an unresolved `<S as Clone>::clone` call" should {
+    val cpg = code("""
+        |struct S;
+        |fn f(s: S) { <S as Clone>::clone(&s); }
+        |""".stripMargin)
+
+    "have an unresolved methodFullName" in {
+      inside(cpg.call.codeExact("<S as Clone>::clone(&s)").l) { case call :: Nil =>
+        call.name shouldBe "clone"
+        call.methodFullName shouldBe s"${Defines.UnresolvedNamespace}::clone"
+        call.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+      }
+    }
+  }
+
+  "a `Tr::m` call of a `&dyn Trait`" should {
+    val cpg = code("""
+        |trait Tr { fn m(&self) -> i32; }
+        |struct S;
+        |impl Tr for S { fn m(&self) -> i32 { 0 } }
+        |fn f(g: &dyn Tr) { Tr::m(g); }
+        |""".stripMargin)
+
+    "resolve to the trait method" in {
+      inside(cpg.call.codeExact("Tr::m(g)").l) { case call :: Nil =>
+        call.name shouldBe "m"
+        call.methodFullName shouldBe "rust2cpgtest::Tr::m"
+        call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
+        inside(call.receiver.l) { case (recv: Call) :: Nil =>
+          recv.code shouldBe "&*g"
+          // TODO(rust_ast_gen): in dyn T, T isn't fully-qualified
+          pendingUntilFixed(recv.typeFullName shouldBe "&dyn rust2cpgtest::Tr")
+          recv.argumentIndex shouldBe 0
+        }
+      }
+    }
+  }
+
   "an inherent method called through receiver and fully-qualified syntax" should {
     val cpg = code("""
         |struct Circle {


### PR DESCRIPTION
Previously, only single-identifier calls were being lowered. Now, we handle qualified calls (PathExprs) as well.