### PR TITLE
[x2cpg] Make --fetch-dependencies and --download-dependencies idempotent

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/Main.scala
@@ -116,7 +116,8 @@ private object Frontend {
             "projects: delombok resolves symbols against these jars, so without this flag delombok will fail on " +
             "any Lombok-annotated code that references third-party libraries."
         )
-        .action((_, conf) => conf.withFetchDependencies(true)),
+        .action((_, conf) => conf.withFetchDependencies(true))
+        .unbounded(),
       opt[String]("delombok-java-home")
         .text("Optional override to set java home used to run Delombok. Java 17 is recommended for the best results.")
         .action((path, c) => c.withDelombokJavaHome(path)),

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/X2Cpg.scala
@@ -111,6 +111,7 @@ object DependencyDownloadConfig {
       opt[Unit]("download-dependencies")
         .text("Download the dependencies of the target project and use their symbols to resolve types.")
         .action((_, c) => c.withDownloadDependencies(true))
+        .unbounded()
     )
   }
 }


### PR DESCRIPTION
Our javasrc2cpg e2e tests in stg have been failing due to https://github.com/ShiftLeftSecurity/codescience/pull/8996/changes which added an explict `--fetch-dependencies` flag to the test config. The issue is that `sl` already adds `--fetch-dependencies` by default, so this change led to the flag being added twice which broke the opt parser (since the flag is not unbounded). This PR fixes it so that `--fetch-dependencies` (and `--download-dependencies` which is vulnerable to the same bug) are unbounded and can therefore appear multiple times in the command without issues. IMO this is a much simpler fix than figuring out how to properly split configs between sptests and e2e and it could potentially help customers who read the documentation and decide to manually add the flag as well.