### PR TITLE
[jssrc2cpg] Update javascript-astgen hashes

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -140,35 +140,35 @@ PHP_PARSER_VERSION = "4.15.10"
 http_file(
     name = "jssrc2cpg_astgen_macos_arm",
     executable = True,
-    sha256 = "530494524a94a2ef64ac2217290b8d1feaae59ec39be4433008b950a6f512a06",
+    sha256 = "dc47e619b3c4bea1f98de7b89a59a6351b83c75777f143055d1a6c38fe3bec5d",
     url = "https://github.com/joernio/astgen-monorepo/releases/download/javascript-astgen%2Fv{}/astgen-macos-arm".format(JSSRC2CPG_ASTGEN_VERSION),
 )
 
 http_file(
     name = "jssrc2cpg_astgen_macos_x86",
     executable = True,
-    sha256 = "ce07e0266938d17c559d48a1e70bd2f7b4b431d505571133db4a5566fd2c19d5",
+    sha256 = "2b4dac59661fc29bd659a0324f477042a1206e29d572b50212e0b0da22794aae",
     url = "https://github.com/joernio/astgen-monorepo/releases/download/javascript-astgen%2Fv{}/astgen-macos".format(JSSRC2CPG_ASTGEN_VERSION),
 )
 
 http_file(
     name = "jssrc2cpg_astgen_linux_arm",
     executable = True,
-    sha256 = "eaed227be1674c03418db3784e6da0d0c88bc8112a8835cc82260d62e20c986c",
+    sha256 = "551203388b237b1642cbb73619202363ca24cbb1ad6aba85f0a3740443718986",
     url = "https://github.com/joernio/astgen-monorepo/releases/download/javascript-astgen%2fv{}/astgen-linux-arm".format(JSSRC2CPG_ASTGEN_VERSION),
 )
 
 http_file(
     name = "jssrc2cpg_astgen_linux_x86",
     executable = True,
-    sha256 = "8c54c044d5e759cb49f4bf06e6c08721ba882ca4a3f1d4b479706f1aa3d1603b",
+    sha256 = "88b83632f6e8149d51b8d47503bda802c04501c099da98ce8ee3597fe1835f17",
     url = "https://github.com/joernio/astgen-monorepo/releases/download/javascript-astgen%2Fv{}/astgen-linux".format(JSSRC2CPG_ASTGEN_VERSION),
 )
 
 http_file(
     name = "jssrc2cpg_astgen_win_x86",
     executable = True,
-    sha256 = "ee4ddc128fe30749868e44e04c39bd50f72f8cc7a5a72d7d0cc4994a8c781840",
+    sha256 = "95f7b4f63d98170607a37d186ee11131d6456c41082feb9c68ac73c0affdae0d",
     url = "https://github.com/joernio/astgen-monorepo/releases/download/javascript-astgen%2Fv{}/astgen-win.exe".format(JSSRC2CPG_ASTGEN_VERSION),
 )
 


### PR DESCRIPTION
Otherwise bazel refuses to download (i.e., keep) them.