### PR TITLE
[rust2cpg] lower simple `for x in y`.

### DIFF
--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
@@ -677,9 +677,103 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
   //  Attr* Label? 'for' Pat 'in' iterable:Expr
   //  loop_body:BlockExpr
   private def visitForExpr(forExpr: ForExpr): Ast = {
-    // TODO
-    notHandledYet(forExpr)
-    visitBlockExpr(forExpr.blockExpr)
+    // TODO: only handling `for x in expr` with `x` an identifier.
+    forExpr.pat match {
+      case identPat: IdentPat =>
+        identPat.name.identToken match {
+          case Some(identToken) => lowerForExprWithIdentPattern(forExpr, identPat)
+          case None =>
+            notHandledYet(forExpr)
+            visitBlockExpr(forExpr.blockExpr)
+        }
+      case _ =>
+        notHandledYet(forExpr)
+        visitBlockExpr(forExpr.blockExpr)
+    }
+  }
+
+  // Lowering `for x in y` as follows:
+  // BLOCK {
+  //   LOCAL tmp
+  //   tmp = y.into_iter()
+  //   WHILE (UNKNOWN) {
+  //     LOCAL x
+  //     x = tmp.next()
+  //     body
+  //   }
+  // }
+  // NB: the condition is currently UNKNOWN. A more faithful lowering would be:
+  // WHILE (TRUE) {
+  //  match tmp.next() {
+  //    Some(x) => body
+  //    None    => break
+  //  }
+  // But we currently don't lower `match` expressions.
+  // TODO: revisit once match expressions are handled.
+  private def lowerForExprWithIdentPattern(forExpr: ForExpr, identPat: IdentPat): Ast = {
+    val iterable = forExpr.expr
+    val tmpName  = "tmp"
+    val tmpLocal = localNode(iterable, tmpName, tmpName, Defines.Any)
+
+    // tmp = y.into_iter()
+    val intoIterAssignAst = {
+      val intoIterName = "into_iter"
+      val receiverAst  = visitExpr(iterable)
+      val intoIterCode = s"${receiverAst.rootCodeOrEmpty}.$intoIterName()"
+      val intoIterCall = callNode(
+        node = iterable,
+        code = intoIterCode,
+        name = intoIterName,
+        methodFullName = combineRustFullName(Defines.UnresolvedNamespace, intoIterName),
+        dispatchType = DispatchTypes.STATIC_DISPATCH,
+        signature = None,
+        // TODO(rust_ast_gen): include what would be the type for this into_iter() call.
+        typeFullName = Some(Defines.Any)
+      )
+      val tmpIdent    = identifierNode(iterable, tmpName, tmpName, Defines.Any)
+      val tmpIdentAst = Ast(tmpIdent).withRefEdge(tmpIdent, tmpLocal) // TODO: remove once ref linker is in.
+      callAst(
+        assignmentNode(iterable, s"$tmpName = $intoIterCode"),
+        Seq(tmpIdentAst, callAst(intoIterCall, Seq.empty, base = Some(receiverAst)))
+      )
+    }
+
+    // LOCAL x; x = tmp.next()
+    val lhsName      = code(identPat)
+    val typeFullName = typeFullNameForIdentPat(identPat)
+    val local        = localNode(identPat, lhsName, lhsName, typeFullName)
+    val nextAssignAst = {
+      val nextName = "next"
+      val nextCode = s"$tmpName.$nextName()"
+      val ident    = identifierNode(identPat, lhsName, lhsName, typeFullName)
+      val lhsAst   = Ast(ident).withRefEdge(ident, local) // TODO: remove once ref linker is in.
+      val nextTypeFullName = typeFullName match {
+        case Defines.Any => Defines.Any
+        case other       => s"core::option::Option<$other>"
+      }
+      val nextCall = callNode(
+        node = identPat,
+        code = nextCode,
+        name = nextName,
+        methodFullName = combineRustFullName(Defines.UnresolvedNamespace, nextName),
+        dispatchType = DispatchTypes.STATIC_DISPATCH,
+        signature = None,
+        typeFullName = Some(nextTypeFullName)
+      )
+      val tmpIdent    = identifierNode(identPat, tmpName, tmpName, Defines.Any)
+      val tmpIdentAst = Ast(tmpIdent).withRefEdge(tmpIdent, tmpLocal) // TODO: remove once ref linker is in.
+      callAst(
+        assignmentNode(identPat, s"$lhsName = $nextCode"),
+        Seq(lhsAst, callAst(nextCall, Seq.empty, base = Some(tmpIdentAst)))
+      )
+    }
+
+    val stmts        = visitStmtList(forExpr.blockExpr.stmtList)
+    val bodyAst      = Ast(blockNode(forExpr.blockExpr)).withChildren(Seq(Ast(local), nextAssignAst) ++ stmts)
+    val conditionAst = Ast(unknownNode(forExpr, code(forExpr)))
+    val whileLoopAst = whileAst(forExpr, Some(conditionAst), Seq(bodyAst))
+
+    Ast(blockNode(forExpr)).withChildren(Seq(Ast(tmpLocal), intoIterAssignAst, whileLoopAst))
   }
 
   // ContinueExpr =

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/ForTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/ForTests.scala
@@ -1,0 +1,140 @@
+package io.joern.rust2cpg.passes.ast
+
+import io.joern.rust2cpg.testfixtures.Rust2CpgSuite
+import io.joern.x2cpg.Defines
+import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes}
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.*
+
+class ForTests extends Rust2CpgSuite(noSysRoot = true) {
+
+  "a for loop" should {
+    val cpg = code("""
+        |fn main(xs: Vec<i32>) {
+        | for x in xs {
+        |  foo(x);
+        | };
+        |}
+        |""".stripMargin)
+
+    "lower into a block with a local, the into_iter assignment and a WHILE" in {
+      inside(cpg.method.name("main").block.astChildren.isBlock.astChildren.l) {
+        case (tmp: Local) :: (intoIterAssign: Call) :: (loop: ControlStructure) :: Nil =>
+          tmp.name shouldBe "tmp"
+          intoIterAssign.code shouldBe "tmp = xs.into_iter()"
+          loop.controlStructureType shouldBe ControlStructureTypes.WHILE
+      }
+    }
+
+    "lower the iterable as an into_iter assignment" in {
+      inside(cpg.assignment.codeExact("tmp = xs.into_iter()").argument.sortBy(_.argumentIndex).l) {
+        case (lhs: Identifier) :: (rhs: Call) :: Nil =>
+          lhs.name shouldBe "tmp"
+          lhs.typeFullName shouldBe Defines.Any
+          rhs.name shouldBe "into_iter"
+          rhs.code shouldBe "xs.into_iter()"
+          rhs.methodFullName shouldBe s"${Defines.UnresolvedNamespace}::into_iter"
+          rhs.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+          rhs.typeFullName shouldBe Defines.Any
+
+          inside(rhs.argument(0)) { case xs: Identifier =>
+            xs.name shouldBe "xs"
+            xs.typeFullName shouldBe Defines.Any
+          }
+      }
+    }
+
+    "create a local for the loop variable" in {
+      inside(cpg.whileBlock.astChildren.isBlock.astChildren.isLocal.l) { case local :: Nil =>
+        local.name shouldBe "x"
+        local.typeFullName shouldBe Defines.Any
+      }
+    }
+
+    "lower the loop variable as a next assignment" in {
+      inside(cpg.assignment.codeExact("x = tmp.next()").argument.sortBy(_.argumentIndex).l) {
+        case (lhs: Identifier) :: (rhs: Call) :: Nil =>
+          lhs.name shouldBe "x"
+          lhs.typeFullName shouldBe Defines.Any
+          rhs.name shouldBe "next"
+          rhs.methodFullName shouldBe s"${Defines.UnresolvedNamespace}::next"
+          rhs.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+          rhs.typeFullName shouldBe Defines.Any
+
+          inside(rhs.argument(0)) { case tmp: Identifier =>
+            tmp.name shouldBe "tmp"
+            tmp.typeFullName shouldBe Defines.Any
+          }
+      }
+    }
+  }
+}
+
+class ForTestsWithSysroot extends Rust2CpgSuite(noSysRoot = false) {
+
+  "a for loop over a vector" should {
+    val cpg = code("""
+        |fn main() {
+        | let xs = vec![1, 2, 3];
+        | for x in xs {
+        |  foo(x);
+        | };
+        |}
+        |""".stripMargin)
+
+    "lower into a block with a local, the into_iter assignment and a WHILE" in {
+      inside(cpg.method.name("main").block.astChildren.isBlock.astChildren.l) {
+        case (tmp: Local) :: (intoIterAssign: Call) :: (loop: ControlStructure) :: Nil =>
+          tmp.name shouldBe "tmp"
+          intoIterAssign.code shouldBe "tmp = xs.into_iter()"
+          loop.controlStructureType shouldBe ControlStructureTypes.WHILE
+      }
+    }
+
+    "lower the iterable as an into_iter assignment" in {
+      inside(cpg.assignment.codeExact("tmp = xs.into_iter()").argument.sortBy(_.argumentIndex).l) {
+        case (lhs: Identifier) :: (rhs: Call) :: Nil =>
+          lhs.name shouldBe "tmp"
+          rhs.name shouldBe "into_iter"
+          rhs.methodFullName shouldBe s"${Defines.UnresolvedNamespace}::into_iter"
+          rhs.typeFullName shouldBe Defines.Any
+
+          inside(rhs.argument(0)) { case xs: Identifier =>
+            xs.name shouldBe "xs"
+            xs.typeFullName shouldBe "alloc::vec::Vec<i32, alloc::alloc::Global>"
+          }
+      }
+    }
+
+    "create a local for the loop variable" in {
+      inside(cpg.whileBlock.astChildren.isBlock.astChildren.isLocal.l) { case local :: Nil =>
+        local.name shouldBe "x"
+        local.typeFullName shouldBe "i32"
+      }
+    }
+
+    "lower the loop variable as a next assignment" in {
+      inside(cpg.assignment.codeExact("x = tmp.next()").argument.sortBy(_.argumentIndex).l) {
+        case (lhs: Identifier) :: (rhs: Call) :: Nil =>
+          lhs.name shouldBe "x"
+          lhs.typeFullName shouldBe "i32"
+          rhs.name shouldBe "next"
+          // TODO(rust_ast_gen): export this `next`'s methodFullName.
+          rhs.methodFullName shouldBe s"${Defines.UnresolvedNamespace}::next"
+          rhs.typeFullName shouldBe "core::option::Option<i32>"
+
+          inside(rhs.argument(0)) { case tmp: Identifier =>
+            tmp.name shouldBe "tmp"
+            tmp.typeFullName shouldBe Defines.Any
+          }
+      }
+    }
+
+    "have x as argument to the foo call" in {
+      inside(cpg.call.nameExact("foo").argument.l) { case (ident: Identifier) :: Nil =>
+        ident.name shouldBe "x"
+        ident.typeFullName shouldBe "i32"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Simple, meaning when `x` is an identifier pattern.

Lowered as:
```
BLOCK {
  LOCAL tmp
  tmp = y.into_iter();
  WHILE (UNKNOWN) {
   LOCAL x
   x = tmp.next()
   body
  }
}
```

The correct way would be something like:
```
...
WHILE (TRUE) {
  match tmp.next() {
   Some(x) => body
   None => break
  }
}
```

But we haven't yet tackled `match` statements nor pattern matching.