### PR TITLE
[pysrc2cpg] mangle duplicate class and function names

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ClassDefDuplicateCalculator.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ClassDefDuplicateCalculator.scala
@@ -1,0 +1,106 @@
+package io.joern.pysrc2cpg
+
+import io.joern.pythonparser.ast
+
+import scala.collection.mutable
+
+/** Traverses a module and, per Python scope (module / function / class body), records the source-order index of every
+  * ClassDef whose simple name is duplicated within that scope. The LAST occurrence per name gets no entry (keeps the
+  * plain full name); earlier occurrences get 0, 1, 2, ...
+  *
+  * The traversal walks statement containers only (module/function/class bodies and nested control-flow statements whose
+  * bodies live in the same Python scope). Function / class bodies open a new scope; other statement bodies (if, try,
+  * for, while, with, match) do not.
+  *
+  * ==Downstream effect==
+  * The suffix is also propagated to `contextStack` when entering the class body, so members (methods, nested classes)
+  * of a mangled class receive fullNames prefixed with the mangled class name. Example:
+  * {{{
+  *   class A:
+  *     def m(self): ...     # fullName: Test.py:<module>.A<duplicate>0.m
+  *   class A:
+  *     def m(self): ...     # fullName: Test.py:<module>.A.m
+  * }}}
+  * Consumers querying by class simple name via `typeDecl.name("A").method` still find both, but queries pinned on full
+  * name must account for the `<duplicate>N` marker.
+  *
+  * ==Why the last occurrence stays unmangled==
+  * At runtime Python binds the class name to the most recent `class` statement, so callers that reference the name
+  * (e.g. `A()`) resolve to the last definition. Keeping that definition's fullName plain (unsuffixed) means: (1)
+  * existing queries against the CPG that assume one class per name still land on the runtime-effective definition, and
+  * (2) the earlier, shadowed definitions get disambiguated with `<duplicate>0`, `<duplicate>1`, ... in source order so
+  * they remain addressable for taint tracking and static queries.
+  */
+class ClassDefDuplicateCalculator {
+  private val classDefToDuplicateIndex: mutable.Map[ast.ClassDef, Int] = mutable.Map.empty
+
+  private val scopeStack =
+    mutable.Stack[mutable.LinkedHashMap[String, mutable.ArrayBuffer[ast.ClassDef]]]()
+
+  def calculate(module: ast.Module): Map[ast.ClassDef, Int] = {
+    pushScope()
+    module.stmts.foreach(visitStmt)
+    popScopeAndAssignIndices()
+    classDefToDuplicateIndex.toMap
+  }
+
+  private def pushScope(): Unit =
+    scopeStack.push(mutable.LinkedHashMap.empty)
+
+  private def popScopeAndAssignIndices(): Unit = {
+    val scope = scopeStack.pop()
+    scope.values.foreach { defs =>
+      if (defs.length > 1) {
+        defs.zipWithIndex.init.foreach { case (cd, idx) =>
+          classDefToDuplicateIndex(cd) = idx
+        }
+      }
+    }
+  }
+
+  private def recordClassDef(cd: ast.ClassDef): Unit = {
+    scopeStack.top.getOrElseUpdate(cd.name, mutable.ArrayBuffer.empty) += cd
+  }
+
+  private def visitStmts(stmts: Iterable[ast.istmt]): Unit =
+    stmts.foreach(visitStmt)
+
+  private def visitScopeBody(body: Iterable[ast.istmt]): Unit = {
+    pushScope()
+    visitStmts(body)
+    popScopeAndAssignIndices()
+  }
+
+  private def visitLoop(body: Iterable[ast.istmt], orelse: Iterable[ast.istmt]): Unit = {
+    visitStmts(body)
+    visitStmts(orelse)
+  }
+
+  private def visitStmt(stmt: ast.istmt): Unit = stmt match {
+    case cd: ast.ClassDef =>
+      recordClassDef(cd)
+      pushScope()
+      visitStmts(cd.body)
+      popScopeAndAssignIndices()
+    case fd: ast.FunctionDef      => visitScopeBody(fd.body)
+    case fd: ast.AsyncFunctionDef => visitScopeBody(fd.body)
+    case ifStmt: ast.If =>
+      visitStmts(ifStmt.body)
+      visitStmts(ifStmt.orelse)
+    case forStmt: ast.For      => visitLoop(forStmt.body, forStmt.orelse)
+    case forStmt: ast.AsyncFor => visitLoop(forStmt.body, forStmt.orelse)
+    case whileStmt: ast.While =>
+      visitStmts(whileStmt.body)
+      visitStmts(whileStmt.orelse)
+    case withStmt: ast.With      => visitStmts(withStmt.body)
+    case withStmt: ast.AsyncWith => visitStmts(withStmt.body)
+    case tryStmt: ast.Try =>
+      visitStmts(tryStmt.body)
+      tryStmt.handlers.foreach(h => visitStmts(h.body))
+      visitStmts(tryStmt.orelse)
+      visitStmts(tryStmt.finalbody)
+    case matchStmt: ast.Match =>
+      matchStmt.cases.foreach(mc => visitStmts(mc.body))
+    case _ =>
+  }
+}

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ClassDefDuplicateCalculator.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ClassDefDuplicateCalculator.scala
@@ -8,11 +8,6 @@ import scala.collection.mutable
   * ClassDef whose simple name is duplicated within that scope. The LAST occurrence per name gets no entry (keeps the
   * plain full name); earlier occurrences get 0, 1, 2, ...
   *
-  * The traversal walks statement containers only (module/function/class bodies and nested control-flow statements whose
-  * bodies live in the same Python scope). Function / class bodies open a new scope; other statement bodies (if, try,
-  * for, while, with, match) do not.
-  *
-  * ==Downstream effect==
   * The suffix is also propagated to `contextStack` when entering the class body, so members (methods, nested classes)
   * of a mangled class receive fullNames prefixed with the mangled class name. Example:
   * {{{
@@ -24,7 +19,6 @@ import scala.collection.mutable
   * Consumers querying by class simple name via `typeDecl.name("A").method` still find both, but queries pinned on full
   * name must account for the `<duplicate>N` marker.
   *
-  * ==Why the last occurrence stays unmangled==
   * At runtime Python binds the class name to the most recent `class` statement, so callers that reference the name
   * (e.g. `A()`) resolve to the last definition. Keeping that definition's fullName plain (unsuffixed) means: (1)
   * existing queries against the CPG that assume one class per name still land on the runtime-effective definition, and
@@ -32,7 +26,7 @@ import scala.collection.mutable
   * they remain addressable for taint tracking and static queries.
   */
 class ClassDefDuplicateCalculator {
-  private val classDefToDuplicateIndex: mutable.Map[ast.ClassDef, Int] = mutable.Map.empty
+  private val classDefToDuplicateIndex = mutable.Map[ast.ClassDef, Int]()
 
   private val scopeStack =
     mutable.Stack[mutable.LinkedHashMap[String, mutable.ArrayBuffer[ast.ClassDef]]]()
@@ -96,7 +90,7 @@ class ClassDefDuplicateCalculator {
     case withStmt: ast.AsyncWith => visitStmts(withStmt.body)
     case tryStmt: ast.Try =>
       visitStmts(tryStmt.body)
-      tryStmt.handlers.foreach(h => visitStmts(h.body))
+      tryStmt.handlers.foreach(handler => visitStmts(handler.body))
       visitStmts(tryStmt.orelse)
       visitStmts(tryStmt.finalbody)
     case matchStmt: ast.Match =>

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ContextStack.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ContextStack.scala
@@ -34,7 +34,6 @@ class ContextStack {
     val reservedNames: mutable.Set[String]
     val tmpCounters: mutable.Map[String, Int]
     var lambdaCounter: Int
-    val methodCounter: mutable.Map[String, Int]
   }
 
   private class MethodContext(
@@ -49,8 +48,7 @@ class ContextStack {
     val tmpCounters: mutable.Map[String, Int] = mutable.Map.empty,
     val globalVariables: mutable.Set[String] = mutable.Set.empty,
     val nonLocalVariables: mutable.Set[String] = mutable.Set.empty,
-    var lambdaCounter: Int = 0,
-    val methodCounter: mutable.Map[String, Int] = mutable.Map.empty
+    var lambdaCounter: Int = 0
   ) extends Context {}
 
   private class ClassContext(
@@ -60,8 +58,7 @@ class ContextStack {
     val variables: mutable.Map[String, nodes.NewNode] = mutable.Map.empty,
     val reservedNames: mutable.Set[String] = mutable.Set.empty,
     val tmpCounters: mutable.Map[String, Int] = mutable.Map.empty,
-    var lambdaCounter: Int = 0,
-    val methodCounter: mutable.Map[String, Int] = mutable.Map.empty
+    var lambdaCounter: Int = 0
   ) extends Context {}
 
   // Used to represent comprehension variable and exception
@@ -80,8 +77,7 @@ class ContextStack {
     val variables: mutable.Map[String, nodes.NewNode] = mutable.Map.empty,
     val reservedNames: mutable.Set[String] = mutable.Set.empty,
     val tmpCounters: mutable.Map[String, Int] = mutable.Map.empty,
-    var lambdaCounter: Int = 0,
-    val methodCounter: mutable.Map[String, Int] = mutable.Map.empty
+    var lambdaCounter: Int = 0
   ) extends Context {}
 
   private case class VariableReference(
@@ -470,10 +466,6 @@ class ContextStack {
       case methodContext: MethodContext if methodContext.isClassBodyMethod => true
       case _                                                               => false
     })
-  }
-
-  def methodCounter: mutable.Map[String, Int] = {
-    stack.head.methodCounter
   }
 
 }

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
@@ -47,7 +47,7 @@ class PythonAstVisitor(
   private var memOpMap: AstNodeToMemoryOperationMap = scala.compiletime.uninitialized
   private var scopeNames: ScopeNameCollection       = scala.compiletime.uninitialized
 
-  private val classDefToDuplicateIndex = mutable.Map.empty[ast.ClassDef, Int]
+  private val defToDuplicateIndex = mutable.Map.empty[ClassOrFunctionDef, Int]
 
   private val members = mutable.Map.empty[NewTypeDecl, List[String]]
 
@@ -86,7 +86,7 @@ class PythonAstVisitor(
     memOpMap = memOpCalculator.astNodeToMemOp
     scopeNames = memOpCalculator.scopeNames
 
-    classDefToDuplicateIndex ++= new ClassDefDuplicateCalculator().calculate(module)
+    defToDuplicateIndex ++= new RedefinitionCalculator().calculate(module)
 
     val contentOption = if (enableFileContent) Some(nodeToCode.content) else None
     val fileNode      = nodeBuilder.fileNode(relFileName, contentOption)
@@ -2190,13 +2190,13 @@ class PythonAstVisitor(
     if (contextQualName != "") relFileName + ":" + contextQualName + "." + name else relFileName + ":" + name
   }
 
-  // See ClassDefDuplicateCalculator for why only the last occurrence stays unmangled.
+  // See RedefinitionCalculator for why only the last occurrence stays unmangled.
   private def classFullNameWithDuplicateSuffix(classDef: ast.ClassDef, simpleName: String): String = {
     calculateFullNameFromContext(simpleName) + duplicateSuffixFor(classDef)
   }
 
   private def duplicateSuffixFor(classDef: ast.ClassDef): String = {
-    classDefToDuplicateIndex.get(classDef).map(idx => s"$duplicateSuffix$idx").getOrElse("")
+    defToDuplicateIndex.get(classDef).map(idx => s"$duplicateSuffix$idx").getOrElse("")
   }
 
   override protected def line(node: iast): Option[Int]         = None

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
@@ -1,6 +1,6 @@
 package io.joern.pysrc2cpg
 
-import PythonAstVisitor.{duplicateSuffix, keywordDictArgName, logger, metaClassSuffix, noLineAndColumn}
+import PythonAstVisitor.{redefinedSuffix, keywordDictArgName, logger, metaClassSuffix, noLineAndColumn}
 import io.joern.pysrc2cpg.memop.*
 import io.joern.pysrc2cpg.memop.MemoryOperation.{Del, Load, Store}
 import io.joern.x2cpg.frontendspecific.pysrc2cpg.Constants.builtinPrefix
@@ -36,8 +36,6 @@ class PythonAstVisitor(
     extends AstCreatorBase[ast.iast, PythonAstVisitor](relFileName)
     with PythonAstVisitorHelpers {
 
-  private val redefintionSuffix = "$redefinition"
-
   private val diffGraph     = Cpg.newDiffGraphBuilder
   protected val nodeBuilder = new NodeBuilder(diffGraph)
   protected val edgeBuilder = new EdgeBuilder(diffGraph)
@@ -47,7 +45,7 @@ class PythonAstVisitor(
   private var memOpMap: AstNodeToMemoryOperationMap = scala.compiletime.uninitialized
   private var scopeNames: ScopeNameCollection       = scala.compiletime.uninitialized
 
-  private val defToDuplicateIndex = mutable.Map.empty[ClassOrFunctionDef, Int]
+  private val defToRedefinedIndex = mutable.Map.empty[ClassOrFunctionDef, Int]
 
   private val members = mutable.Map.empty[NewTypeDecl, List[String]]
 
@@ -86,7 +84,7 @@ class PythonAstVisitor(
     memOpMap = memOpCalculator.astNodeToMemOp
     scopeNames = memOpCalculator.scopeNames
 
-    defToDuplicateIndex ++= new RedefinitionCalculator().calculate(module)
+    defToRedefinedIndex ++= new RedefinitionCalculator().calculate(module)
 
     val contentOption = if (enableFileContent) Some(nodeToCode.content) else None
     val fileNode      = nodeBuilder.fileNode(relFileName, contentOption)
@@ -270,19 +268,21 @@ class PythonAstVisitor(
     body: ast.CollType[istmt],
     returns: Option[iexpr],
     isAsync: Boolean,
-    functionDef: istmt
+    functionDef: ClassOrFunctionDef
   ): NewNode = {
     val methodIdentifierNode =
       createIdentifierNode(name, Store, lineAndColOf(functionDef))
+    val suffix = redefinedSuffixFor(functionDef)
     val (methodNode, methodRefNode) = createMethodAndMethodRef(
       name,
-      Some(name),
+      Some(name + suffix),
       createParameterProcessingFunction(args, isStaticMethod(decoratorList)),
       () => body.map(convert),
       returns,
       isAsync,
       lineAndColOf(functionDef),
-      reservedNames = scopeNames.namesInScope(functionDef)
+      reservedNames = scopeNames.namesInScope(functionDef),
+      redefinedSuffix = suffix
     )
     functionDefToMethod.put(functionDef, methodNode)
 
@@ -349,16 +349,10 @@ class PythonAstVisitor(
     isAsync: Boolean,
     lineAndColumn: LineAndColumn,
     additionalModifiers: List[String] = List.empty,
-    reservedNames: Iterable[String]
+    reservedNames: Iterable[String],
+    redefinedSuffix: String = ""
   ): (nodes.NewMethod, nodes.NewMethodRef) = {
-    val suffix =
-      contextStack.methodCounter.get(methodName) match {
-        case Some(counter) =>
-          redefintionSuffix + counter.toString
-        case None =>
-          ""
-      }
-    val methodFullName = calculateFullNameFromContext(methodName) + suffix
+    val methodFullName = calculateFullNameFromContext(methodName) + redefinedSuffix
 
     val methodRefNode =
       nodeBuilder.methodRefNode("def " + methodName + "(...)", methodFullName, lineAndColumn)
@@ -378,11 +372,6 @@ class PythonAstVisitor(
         lineAndColumn,
         reservedNames
       )
-
-    contextStack.methodCounter.updateWith(methodName) {
-      case None          => Some(1)
-      case Some(counter) => Some(counter + 1)
-    }
 
     (methodNode, methodRefNode)
   }
@@ -462,7 +451,7 @@ class PythonAstVisitor(
   def convert(classDef: ast.ClassDef): NewNode = {
     // Create type for the meta class object
     val metaTypeDeclName     = classDef.name + metaClassSuffix
-    val metaTypeDeclFullName = classFullNameWithDuplicateSuffix(classDef, metaTypeDeclName)
+    val metaTypeDeclFullName = classFullNameWithRedefinedSuffix(classDef, metaTypeDeclName)
 
     val metaTypeNode = nodeBuilder.typeNode(metaTypeDeclName, metaTypeDeclFullName)
     val metaTypeDeclNode =
@@ -477,7 +466,7 @@ class PythonAstVisitor(
 
     // Create type for class instances
     val instanceTypeDeclName     = classDef.name
-    val instanceTypeDeclFullName = classFullNameWithDuplicateSuffix(classDef, instanceTypeDeclName)
+    val instanceTypeDeclFullName = classFullNameWithRedefinedSuffix(classDef, instanceTypeDeclName)
 
     // TODO for now we just take the code of the base expression and pretend they are full names, converting special
     //  nodes as we go.
@@ -508,7 +497,7 @@ class PythonAstVisitor(
     edgeBuilder.astEdge(instanceTypeDecl, contextStack.astParent, contextStack.order.getAndInc)
 
     // Create <body> function which contains the code defining the class
-    val className = classDef.name + duplicateSuffixFor(classDef)
+    val className = classDef.name + redefinedSuffixFor(classDef)
     contextStack.pushClass(Some(className), instanceTypeDecl, scopeNames.namesInScope(classDef))
     val classBodyFunctionName = "<body>"
     val (_, methodRefNode) = createMethodAndMethodRef(
@@ -2191,12 +2180,12 @@ class PythonAstVisitor(
   }
 
   // See RedefinitionCalculator for why only the last occurrence stays unmangled.
-  private def classFullNameWithDuplicateSuffix(classDef: ast.ClassDef, simpleName: String): String = {
-    calculateFullNameFromContext(simpleName) + duplicateSuffixFor(classDef)
+  private def classFullNameWithRedefinedSuffix(classDef: ast.ClassDef, simpleName: String): String = {
+    calculateFullNameFromContext(simpleName) + redefinedSuffixFor(classDef)
   }
 
-  private def duplicateSuffixFor(classDef: ast.ClassDef): String = {
-    defToDuplicateIndex.get(classDef).map(idx => s"$duplicateSuffix$idx").getOrElse("")
+  private def redefinedSuffixFor(definition: ClassOrFunctionDef): String = {
+    defToRedefinedIndex.get(definition).map(idx => s"$redefinedSuffix$idx").getOrElse("")
   }
 
   override protected def line(node: iast): Option[Int]         = None
@@ -2212,7 +2201,7 @@ object PythonAstVisitor {
   val typingPrefix       = "typing."
   val metaClassSuffix    = "<meta>"
   val keywordDictArgName = "<keyword_dict>"
-  val duplicateSuffix    = "<duplicate>"
+  val redefinedSuffix    = "<redefined>"
 
   val noLineAndColumn = LineAndColumn(-1, -1, -1, -1, -1, -1)
 

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
@@ -462,7 +462,7 @@ class PythonAstVisitor(
   def convert(classDef: ast.ClassDef): NewNode = {
     // Create type for the meta class object
     val metaTypeDeclName     = classDef.name + metaClassSuffix
-    val metaTypeDeclFullName = calculateClassFullName(classDef, metaTypeDeclName)
+    val metaTypeDeclFullName = classFullNameWithDuplicateSuffix(classDef, metaTypeDeclName)
 
     val metaTypeNode = nodeBuilder.typeNode(metaTypeDeclName, metaTypeDeclFullName)
     val metaTypeDeclNode =
@@ -477,7 +477,7 @@ class PythonAstVisitor(
 
     // Create type for class instances
     val instanceTypeDeclName     = classDef.name
-    val instanceTypeDeclFullName = calculateClassFullName(classDef, instanceTypeDeclName)
+    val instanceTypeDeclFullName = classFullNameWithDuplicateSuffix(classDef, instanceTypeDeclName)
 
     // TODO for now we just take the code of the base expression and pretend they are full names, converting special
     //  nodes as we go.
@@ -2191,12 +2191,13 @@ class PythonAstVisitor(
   }
 
   // See ClassDefDuplicateCalculator for why only the last occurrence stays unmangled.
-  private def calculateClassFullName(classDef: ast.ClassDef, simpleName: String): String = {
+  private def classFullNameWithDuplicateSuffix(classDef: ast.ClassDef, simpleName: String): String = {
     calculateFullNameFromContext(simpleName) + duplicateSuffixFor(classDef)
   }
 
-  private def duplicateSuffixFor(classDef: ast.ClassDef): String =
-    classDefToDuplicateIndex.get(classDef).fold("")(i => s"$duplicateSuffix$i")
+  private def duplicateSuffixFor(classDef: ast.ClassDef): String = {
+    classDefToDuplicateIndex.get(classDef).map(idx => s"$duplicateSuffix$idx").getOrElse("")
+  }
 
   override protected def line(node: iast): Option[Int]         = None
   override protected def column(node: iast): Option[Int]       = None

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
@@ -1,6 +1,6 @@
 package io.joern.pysrc2cpg
 
-import PythonAstVisitor.{keywordDictArgName, logger, metaClassSuffix, noLineAndColumn}
+import PythonAstVisitor.{duplicateSuffix, keywordDictArgName, logger, metaClassSuffix, noLineAndColumn}
 import io.joern.pysrc2cpg.memop.*
 import io.joern.pysrc2cpg.memop.MemoryOperation.{Del, Load, Store}
 import io.joern.x2cpg.frontendspecific.pysrc2cpg.Constants.builtinPrefix
@@ -47,6 +47,8 @@ class PythonAstVisitor(
   private var memOpMap: AstNodeToMemoryOperationMap = scala.compiletime.uninitialized
   private var scopeNames: ScopeNameCollection       = scala.compiletime.uninitialized
 
+  private val classDefToDuplicateIndex = mutable.Map.empty[ast.ClassDef, Int]
+
   private val members = mutable.Map.empty[NewTypeDecl, List[String]]
 
   // As key only ast.FunctionDef and ast.AsyncFunctionDef are used but there
@@ -83,6 +85,8 @@ class PythonAstVisitor(
     module.accept(memOpCalculator)
     memOpMap = memOpCalculator.astNodeToMemOp
     scopeNames = memOpCalculator.scopeNames
+
+    classDefToDuplicateIndex ++= new ClassDefDuplicateCalculator().calculate(module)
 
     val contentOption = if (enableFileContent) Some(nodeToCode.content) else None
     val fileNode      = nodeBuilder.fileNode(relFileName, contentOption)
@@ -458,7 +462,7 @@ class PythonAstVisitor(
   def convert(classDef: ast.ClassDef): NewNode = {
     // Create type for the meta class object
     val metaTypeDeclName     = classDef.name + metaClassSuffix
-    val metaTypeDeclFullName = calculateFullNameFromContext(metaTypeDeclName)
+    val metaTypeDeclFullName = calculateClassFullName(classDef, metaTypeDeclName)
 
     val metaTypeNode = nodeBuilder.typeNode(metaTypeDeclName, metaTypeDeclFullName)
     val metaTypeDeclNode =
@@ -473,7 +477,7 @@ class PythonAstVisitor(
 
     // Create type for class instances
     val instanceTypeDeclName     = classDef.name
-    val instanceTypeDeclFullName = calculateFullNameFromContext(instanceTypeDeclName)
+    val instanceTypeDeclFullName = calculateClassFullName(classDef, instanceTypeDeclName)
 
     // TODO for now we just take the code of the base expression and pretend they are full names, converting special
     //  nodes as we go.
@@ -504,7 +508,8 @@ class PythonAstVisitor(
     edgeBuilder.astEdge(instanceTypeDecl, contextStack.astParent, contextStack.order.getAndInc)
 
     // Create <body> function which contains the code defining the class
-    contextStack.pushClass(Some(classDef.name), instanceTypeDecl, scopeNames.namesInScope(classDef))
+    val className = classDef.name + duplicateSuffixFor(classDef)
+    contextStack.pushClass(Some(className), instanceTypeDecl, scopeNames.namesInScope(classDef))
     val classBodyFunctionName = "<body>"
     val (_, methodRefNode) = createMethodAndMethodRef(
       classBodyFunctionName,
@@ -523,7 +528,7 @@ class PythonAstVisitor(
 
     contextStack.pop()
 
-    contextStack.pushClass(Some(classDef.name), metaTypeDeclNode, scopeNames.namesInScope(classDef))
+    contextStack.pushClass(Some(className), metaTypeDeclNode, scopeNames.namesInScope(classDef))
 
     // Create meta class call handling method and bind it to meta class type.
     val functions = classDef.body.collect { case func: ast.FunctionDef => func }
@@ -2185,6 +2190,14 @@ class PythonAstVisitor(
     if (contextQualName != "") relFileName + ":" + contextQualName + "." + name else relFileName + ":" + name
   }
 
+  // See ClassDefDuplicateCalculator for why only the last occurrence stays unmangled.
+  private def calculateClassFullName(classDef: ast.ClassDef, simpleName: String): String = {
+    calculateFullNameFromContext(simpleName) + duplicateSuffixFor(classDef)
+  }
+
+  private def duplicateSuffixFor(classDef: ast.ClassDef): String =
+    classDefToDuplicateIndex.get(classDef).fold("")(i => s"$duplicateSuffix$i")
+
   override protected def line(node: iast): Option[Int]         = None
   override protected def column(node: iast): Option[Int]       = None
   override protected def lineEnd(node: iast): Option[Int]      = None
@@ -2198,6 +2211,7 @@ object PythonAstVisitor {
   val typingPrefix       = "typing."
   val metaClassSuffix    = "<meta>"
   val keywordDictArgName = "<keyword_dict>"
+  val duplicateSuffix    = "<duplicate>"
 
   val noLineAndColumn = LineAndColumn(-1, -1, -1, -1, -1, -1)
 

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
@@ -1,11 +1,11 @@
 package io.joern.pysrc2cpg
 
-import PythonAstVisitor.{redefinedSuffix, keywordDictArgName, logger, metaClassSuffix, noLineAndColumn}
+import PythonAstVisitor.{keywordDictArgName, logger, metaClassSuffix, noLineAndColumn, redefinedSuffix}
 import io.joern.pysrc2cpg.memop.*
 import io.joern.pysrc2cpg.memop.MemoryOperation.{Del, Load, Store}
 import io.joern.x2cpg.frontendspecific.pysrc2cpg.Constants.builtinPrefix
 import io.joern.pythonparser.{AstPrinter, ast}
-import io.joern.pythonparser.ast.{Arguments, MatchAs, iast, iexpr, istmt}
+import io.joern.pythonparser.ast.{Arguments, AsyncFunctionDef, FunctionDef, MatchAs, iast, iexpr, istmt}
 import io.joern.x2cpg.frontendspecific.pysrc2cpg.Constants
 import io.joern.x2cpg.{AstCreatorBase, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.*
@@ -268,7 +268,7 @@ class PythonAstVisitor(
     body: ast.CollType[istmt],
     returns: Option[iexpr],
     isAsync: Boolean,
-    functionDef: ClassOrFunctionDef
+    functionDef: FunctionDef | AsyncFunctionDef
   ): NewNode = {
     val methodIdentifierNode =
       createIdentifierNode(name, Store, lineAndColOf(functionDef))

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/RedefinitionCalculator.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/RedefinitionCalculator.scala
@@ -4,6 +4,8 @@ import io.joern.pythonparser.ast
 
 import scala.collection.mutable
 
+type ClassOrFunctionDef = ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef
+
 /** Traverses a module and, per Python scope (module / function / class body), records the source-order index of every
   * ClassDef whose simple name is duplicated within that scope. The LAST occurrence per name gets no entry (keeps the
   * plain full name); earlier occurrences get 0, 1, 2, ...
@@ -25,17 +27,17 @@ import scala.collection.mutable
   * (2) the earlier, shadowed definitions get disambiguated with `<duplicate>0`, `<duplicate>1`, ... in source order so
   * they remain addressable for taint tracking and static queries.
   */
-class ClassDefDuplicateCalculator {
-  private val classDefToDuplicateIndex = mutable.Map[ast.ClassDef, Int]()
+class RedefinitionCalculator {
+  private val defToDuplicateIndex = mutable.Map[ClassOrFunctionDef, Int]()
 
   private val scopeStack =
-    mutable.Stack[mutable.LinkedHashMap[String, mutable.ArrayBuffer[ast.ClassDef]]]()
+    mutable.Stack[mutable.LinkedHashMap[String, mutable.ArrayBuffer[ClassOrFunctionDef]]]()
 
-  def calculate(module: ast.Module): Map[ast.ClassDef, Int] = {
+  def calculate(module: ast.Module): Map[ClassOrFunctionDef, Int] = {
     pushScope()
     module.stmts.foreach(visitStmt)
     popScopeAndAssignIndices()
-    classDefToDuplicateIndex.toMap
+    defToDuplicateIndex.toMap
   }
 
   private def pushScope(): Unit =
@@ -43,17 +45,20 @@ class ClassDefDuplicateCalculator {
 
   private def popScopeAndAssignIndices(): Unit = {
     val scope = scopeStack.pop()
-    scope.values.foreach { defs =>
-      if (defs.length > 1) {
-        defs.zipWithIndex.init.foreach { case (cd, idx) =>
-          classDefToDuplicateIndex(cd) = idx
+    scope.values.foreach { mixedDefs =>
+      if (mixedDefs.length > 1) {
+        mixedDefs.partition(_.isInstanceOf[ast.ClassDef]).toList.foreach { defs =>
+          defs.zipWithIndex.init.foreach { case (cd, idx) =>
+            defToDuplicateIndex(cd) = idx
+          }
         }
       }
     }
   }
 
-  private def recordClassDef(cd: ast.ClassDef): Unit = {
-    scopeStack.top.getOrElseUpdate(cd.name, mutable.ArrayBuffer.empty) += cd
+  private def recordDef(definition: ClassOrFunctionDef): Unit = {
+
+    scopeStack.top.getOrElseUpdate(definition.name, mutable.ArrayBuffer.empty) += definition
   }
 
   private def visitStmts(stmts: Iterable[ast.istmt]): Unit =
@@ -72,12 +77,16 @@ class ClassDefDuplicateCalculator {
 
   private def visitStmt(stmt: ast.istmt): Unit = stmt match {
     case cd: ast.ClassDef =>
-      recordClassDef(cd)
+      recordDef(cd)
       pushScope()
       visitStmts(cd.body)
       popScopeAndAssignIndices()
-    case fd: ast.FunctionDef      => visitScopeBody(fd.body)
-    case fd: ast.AsyncFunctionDef => visitScopeBody(fd.body)
+    case fd: ast.FunctionDef      => 
+      recordDef(fd)
+      visitScopeBody(fd.body)
+    case fd: ast.AsyncFunctionDef =>
+      recordDef(fd)
+      visitScopeBody(fd.body)
     case ifStmt: ast.If =>
       visitStmts(ifStmt.body)
       visitStmts(ifStmt.orelse)

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/RedefinitionCalculator.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/RedefinitionCalculator.scala
@@ -7,28 +7,29 @@ import scala.collection.mutable
 type ClassOrFunctionDef = ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef
 
 /** Traverses a module and, per Python scope (module / function / class body), records the source-order index of every
-  * ClassDef whose simple name is duplicated within that scope. The LAST occurrence per name gets no entry (keeps the
-  * plain full name); earlier occurrences get 0, 1, 2, ...
+  * ClassDef, FunctionDef or AsyncFunctionDef whose simple name is redefined within that scope. Classes and functions
+  * are bucketed separately: a `def A` and a `class A` in the same scope do not shadow each other in the map. The LAST
+  * occurrence per (kind, name) gets no entry (keeps the plain full name); earlier occurrences get 0, 1, 2, ...
   *
   * The suffix is also propagated to `contextStack` when entering the class body, so members (methods, nested classes)
   * of a mangled class receive fullNames prefixed with the mangled class name. Example:
   * {{{
   *   class A:
-  *     def m(self): ...     # fullName: Test.py:<module>.A<duplicate>0.m
+  *     def m(self): ...     # fullName: Test.py:<module>.A<redefined>0.m
   *   class A:
   *     def m(self): ...     # fullName: Test.py:<module>.A.m
   * }}}
   * Consumers querying by class simple name via `typeDecl.name("A").method` still find both, but queries pinned on full
-  * name must account for the `<duplicate>N` marker.
+  * name must account for the `<redefined>N` marker.
   *
   * At runtime Python binds the class name to the most recent `class` statement, so callers that reference the name
   * (e.g. `A()`) resolve to the last definition. Keeping that definition's fullName plain (unsuffixed) means: (1)
   * existing queries against the CPG that assume one class per name still land on the runtime-effective definition, and
-  * (2) the earlier, shadowed definitions get disambiguated with `<duplicate>0`, `<duplicate>1`, ... in source order so
+  * (2) the earlier, shadowed definitions get disambiguated with `<redefined>0`, `<redefined>1`, ... in source order so
   * they remain addressable for taint tracking and static queries.
   */
 class RedefinitionCalculator {
-  private val defToDuplicateIndex = mutable.Map[ClassOrFunctionDef, Int]()
+  private val defToRedefinedIndex = mutable.Map[ClassOrFunctionDef, Int]()
 
   private val scopeStack =
     mutable.Stack[mutable.LinkedHashMap[String, mutable.ArrayBuffer[ClassOrFunctionDef]]]()
@@ -37,7 +38,7 @@ class RedefinitionCalculator {
     pushScope()
     module.stmts.foreach(visitStmt)
     popScopeAndAssignIndices()
-    defToDuplicateIndex.toMap
+    defToRedefinedIndex.toMap
   }
 
   private def pushScope(): Unit =
@@ -46,10 +47,11 @@ class RedefinitionCalculator {
   private def popScopeAndAssignIndices(): Unit = {
     val scope = scopeStack.pop()
     scope.values.foreach { mixedDefs =>
-      if (mixedDefs.length > 1) {
-        mixedDefs.partition(_.isInstanceOf[ast.ClassDef]).toList.foreach { defs =>
+      val (classes, functions) = mixedDefs.partition(_.isInstanceOf[ast.ClassDef])
+      List(classes, functions).foreach { defs =>
+        if (defs.length > 1) {
           defs.zipWithIndex.init.foreach { case (cd, idx) =>
-            defToDuplicateIndex(cd) = idx
+            defToRedefinedIndex(cd) = idx
           }
         }
       }
@@ -57,8 +59,12 @@ class RedefinitionCalculator {
   }
 
   private def recordDef(definition: ClassOrFunctionDef): Unit = {
-
-    scopeStack.top.getOrElseUpdate(definition.name, mutable.ArrayBuffer.empty) += definition
+    val name = definition match {
+      case cd: ast.ClassDef         => cd.name
+      case fd: ast.FunctionDef      => fd.name
+      case fd: ast.AsyncFunctionDef => fd.name
+    }
+    scopeStack.top.getOrElseUpdate(name, mutable.ArrayBuffer.empty) += definition
   }
 
   private def visitStmts(stmts: Iterable[ast.istmt]): Unit =

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/RedefinitionCalculator.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/RedefinitionCalculator.scala
@@ -87,7 +87,7 @@ class RedefinitionCalculator {
       pushScope()
       visitStmts(cd.body)
       popScopeAndAssignIndices()
-    case fd: ast.FunctionDef      => 
+    case fd: ast.FunctionDef =>
       recordDef(fd)
       visitScopeBody(fd.body)
     case fd: ast.AsyncFunctionDef =>

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/ClassRedefinitionCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/ClassRedefinitionCpgTests.scala
@@ -19,11 +19,11 @@ class ClassRedefinitionCpgTests extends PySrc2CpgFixture(withOssDataflow = false
 
     "produce two distinct instance TypeDecl full names" in {
       val fullNames = cpg.typeDecl.name("A").fullName.toSet
-      fullNames shouldBe Set("Test0.py:<module>.A<duplicate>0", "Test0.py:<module>.A")
+      fullNames shouldBe Set("Test0.py:<module>.A<redefined>0", "Test0.py:<module>.A")
 
       inside(
         cpg.typeDecl
-          .fullNameExact("Test0.py:<module>.A<duplicate>0")
+          .fullNameExact("Test0.py:<module>.A<redefined>0")
           .ast
           .isCall(".*print.*")
           .argument
@@ -41,7 +41,7 @@ class ClassRedefinitionCpgTests extends PySrc2CpgFixture(withOssDataflow = false
 
     "produce two distinct meta TypeDecl full names" in {
       val fullNames = cpg.typeDecl.name("A<meta>").fullName.toSet
-      fullNames shouldBe Set("Test0.py:<module>.A<meta><duplicate>0", "Test0.py:<module>.A<meta>")
+      fullNames shouldBe Set("Test0.py:<module>.A<meta><redefined>0", "Test0.py:<module>.A<meta>")
     }
   }
 
@@ -54,8 +54,8 @@ class ClassRedefinitionCpgTests extends PySrc2CpgFixture(withOssDataflow = false
     "produce three distinct instance TypeDecl full names" in {
       val fullNames = cpg.typeDecl.name("A").fullName.toSet
       fullNames shouldBe Set(
-        "Test0.py:<module>.A<duplicate>0",
-        "Test0.py:<module>.A<duplicate>1",
+        "Test0.py:<module>.A<redefined>0",
+        "Test0.py:<module>.A<redefined>1",
         "Test0.py:<module>.A"
       )
     }
@@ -70,7 +70,7 @@ class ClassRedefinitionCpgTests extends PySrc2CpgFixture(withOssDataflow = false
 
     "produce two distinct instance TypeDecl full names" in {
       val fullNames = cpg.typeDecl.name("A").fullName.toSet
-      fullNames shouldBe Set("Test0.py:<module>.A<duplicate>0", "Test0.py:<module>.A")
+      fullNames shouldBe Set("Test0.py:<module>.A<redefined>0", "Test0.py:<module>.A")
     }
   }
 
@@ -94,7 +94,7 @@ class ClassRedefinitionCpgTests extends PySrc2CpgFixture(withOssDataflow = false
 
     "mangle the earlier definition and keep the last one unmangled" in {
       val fullNames = cpg.typeDecl.name("A").fullName.toSet
-      fullNames shouldBe Set("Test0.py:<module>.f.A<duplicate>0", "Test0.py:<module>.f.A")
+      fullNames shouldBe Set("Test0.py:<module>.f.A<redefined>0", "Test0.py:<module>.f.A")
     }
   }
 
@@ -106,7 +106,7 @@ class ClassRedefinitionCpgTests extends PySrc2CpgFixture(withOssDataflow = false
 
     "mangle the earlier Inner and keep the last Inner unmangled" in {
       typeDeclFullNames(cpg, "Inner") shouldBe Set(
-        "Test0.py:<module>.Outer.Inner<duplicate>0",
+        "Test0.py:<module>.Outer.Inner<redefined>0",
         "Test0.py:<module>.Outer.Inner"
       )
       typeDeclFullNames(cpg, "Outer") shouldBe Set("Test0.py:<module>.Outer")
@@ -124,8 +124,8 @@ class ClassRedefinitionCpgTests extends PySrc2CpgFixture(withOssDataflow = false
 
     "produce three distinct instance TypeDecl full names" in {
       typeDeclFullNames(cpg, "A") shouldBe Set(
-        "Test0.py:<module>.A<duplicate>0",
-        "Test0.py:<module>.A<duplicate>1",
+        "Test0.py:<module>.A<redefined>0",
+        "Test0.py:<module>.A<redefined>1",
         "Test0.py:<module>.A"
       )
     }
@@ -140,7 +140,7 @@ class ClassRedefinitionCpgTests extends PySrc2CpgFixture(withOssDataflow = false
         |""".stripMargin)
 
     "produce two distinct instance TypeDecl full names" in {
-      typeDeclFullNames(cpg, "A") shouldBe Set("Test0.py:<module>.A<duplicate>0", "Test0.py:<module>.A")
+      typeDeclFullNames(cpg, "A") shouldBe Set("Test0.py:<module>.A<redefined>0", "Test0.py:<module>.A")
     }
   }
 
@@ -151,7 +151,7 @@ class ClassRedefinitionCpgTests extends PySrc2CpgFixture(withOssDataflow = false
         |""".stripMargin)
 
     "mangle the earlier definition and keep the last one unmangled" in {
-      typeDeclFullNames(cpg, "A") shouldBe Set("Test0.py:<module>.f.A<duplicate>0", "Test0.py:<module>.f.A")
+      typeDeclFullNames(cpg, "A") shouldBe Set("Test0.py:<module>.f.A<redefined>0", "Test0.py:<module>.f.A")
     }
   }
 
@@ -162,7 +162,7 @@ class ClassRedefinitionCpgTests extends PySrc2CpgFixture(withOssDataflow = false
         |""".stripMargin)
 
     "produce two distinct instance TypeDecl full names since the while body shares module scope" in {
-      typeDeclFullNames(cpg, "A") shouldBe Set("Test0.py:<module>.A<duplicate>0", "Test0.py:<module>.A")
+      typeDeclFullNames(cpg, "A") shouldBe Set("Test0.py:<module>.A<redefined>0", "Test0.py:<module>.A")
     }
   }
 }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/ClassRedefinitionCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/ClassRedefinitionCpgTests.scala
@@ -1,0 +1,168 @@
+package io.joern.pysrc2cpg.cpg
+
+import io.joern.pysrc2cpg.testfixtures.PySrc2CpgFixture
+import io.shiftleft.codepropertygraph.generated.Cpg
+import io.shiftleft.semanticcpg.language.*
+
+class ClassRedefinitionCpgTests extends PySrc2CpgFixture(withOssDataflow = false) {
+  private def typeDeclFullNames(cpg: Cpg, name: String): Set[String] =
+    cpg.typeDecl.name(name).fullName.toSet
+
+  "two top-level classes with the same name" should {
+    val cpg = code("""class A:
+        |  def m(self):
+        |      print("zeroth")
+        |class A:
+        |  def m(self):
+        |      print("first")
+        |""".stripMargin)
+
+    "produce two distinct instance TypeDecl full names" in {
+      val fullNames = cpg.typeDecl.name("A").fullName.toSet
+      fullNames shouldBe Set("Test0.py:<module>.A<duplicate>0", "Test0.py:<module>.A")
+
+      inside(
+        cpg.typeDecl
+          .fullNameExact("Test0.py:<module>.A<duplicate>0")
+          .ast
+          .isCall(".*print.*")
+          .argument
+          .argumentIndex(1)
+          .l
+      ) { case List(firstAArg) =>
+        firstAArg.code shouldBe "\"zeroth\""
+      }
+
+      inside(cpg.typeDecl.fullNameExact("Test0.py:<module>.A").ast.isCall(".*print.*").argument.argumentIndex(1).l) {
+        case List(secondAArg) =>
+          secondAArg.code shouldBe "\"first\""
+      }
+    }
+
+    "produce two distinct meta TypeDecl full names" in {
+      val fullNames = cpg.typeDecl.name("A<meta>").fullName.toSet
+      fullNames shouldBe Set("Test0.py:<module>.A<meta><duplicate>0", "Test0.py:<module>.A<meta>")
+    }
+  }
+
+  "three top-level classes with the same name" should {
+    val cpg = code("""class A: print("zeroth")
+        |class A: print("first")
+        |class A: print("second")
+        |""".stripMargin)
+
+    "produce three distinct instance TypeDecl full names" in {
+      val fullNames = cpg.typeDecl.name("A").fullName.toSet
+      fullNames shouldBe Set(
+        "Test0.py:<module>.A<duplicate>0",
+        "Test0.py:<module>.A<duplicate>1",
+        "Test0.py:<module>.A"
+      )
+    }
+  }
+
+  "same-name class in different branches of if/else" should {
+    val cpg = code("""if cond:
+        |  class A: pass
+        |else:
+        |  class A: pass
+        |""".stripMargin)
+
+    "produce two distinct instance TypeDecl full names" in {
+      val fullNames = cpg.typeDecl.name("A").fullName.toSet
+      fullNames shouldBe Set("Test0.py:<module>.A<duplicate>0", "Test0.py:<module>.A")
+    }
+  }
+
+  "class inside a function does not collide with same-name class at module level" should {
+    val cpg = code("""class A: pass
+        |def f():
+        |  class A: pass
+        |""".stripMargin)
+
+    "produce plain full names for both" in {
+      val fullNames = cpg.typeDecl.name("A").fullName.toSet
+      fullNames shouldBe Set("Test0.py:<module>.A", "Test0.py:<module>.f.A")
+    }
+  }
+
+  "two same-name classes inside the same function scope" should {
+    val cpg = code("""def f():
+        |  class A: pass
+        |  class A: pass
+        |""".stripMargin)
+
+    "mangle the earlier definition and keep the last one unmangled" in {
+      val fullNames = cpg.typeDecl.name("A").fullName.toSet
+      fullNames shouldBe Set("Test0.py:<module>.f.A<duplicate>0", "Test0.py:<module>.f.A")
+    }
+  }
+
+  "two same-name nested classes inside the same enclosing class" should {
+    val cpg = code("""class Outer:
+        |  class Inner: pass
+        |  class Inner: pass
+        |""".stripMargin)
+
+    "mangle the earlier Inner and keep the last Inner unmangled" in {
+      typeDeclFullNames(cpg, "Inner") shouldBe Set(
+        "Test0.py:<module>.Outer.Inner<duplicate>0",
+        "Test0.py:<module>.Outer.Inner"
+      )
+      typeDeclFullNames(cpg, "Outer") shouldBe Set("Test0.py:<module>.Outer")
+    }
+  }
+
+  "same-name classes across try/except/finally bodies" should {
+    val cpg = code("""try:
+        |  class A: pass
+        |except Exception:
+        |  class A: pass
+        |finally:
+        |  class A: pass
+        |""".stripMargin)
+
+    "produce three distinct instance TypeDecl full names" in {
+      typeDeclFullNames(cpg, "A") shouldBe Set(
+        "Test0.py:<module>.A<duplicate>0",
+        "Test0.py:<module>.A<duplicate>1",
+        "Test0.py:<module>.A"
+      )
+    }
+  }
+
+  "same-name classes inside different match cases" should {
+    val cpg = code("""match x:
+        |  case 1:
+        |    class A: pass
+        |  case _:
+        |    class A: pass
+        |""".stripMargin)
+
+    "produce two distinct instance TypeDecl full names" in {
+      typeDeclFullNames(cpg, "A") shouldBe Set("Test0.py:<module>.A<duplicate>0", "Test0.py:<module>.A")
+    }
+  }
+
+  "two same-name classes inside the same async function scope" should {
+    val cpg = code("""async def f():
+        |  class A: pass
+        |  class A: pass
+        |""".stripMargin)
+
+    "mangle the earlier definition and keep the last one unmangled" in {
+      typeDeclFullNames(cpg, "A") shouldBe Set("Test0.py:<module>.f.A<duplicate>0", "Test0.py:<module>.f.A")
+    }
+  }
+
+  "same-name class inside a while body and at module level" should {
+    val cpg = code("""while cond:
+        |  class A: pass
+        |class A: pass
+        |""".stripMargin)
+
+    "produce two distinct instance TypeDecl full names since the while body shares module scope" in {
+      typeDeclFullNames(cpg, "A") shouldBe Set("Test0.py:<module>.A<duplicate>0", "Test0.py:<module>.A")
+    }
+  }
+}

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/FunctionRedefinitionCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/FunctionRedefinitionCpgTests.scala
@@ -74,10 +74,7 @@ class FunctionRedefinitionCpgTests extends PySrc2CpgFixture(withOssDataflow = fa
         |""".stripMargin)
 
     "mangle the earlier definition and keep the last one unmangled" in {
-      methodFullNames(cpg, "f") shouldBe Set(
-        "Test0.py:<module>.outer.f<redefined>0",
-        "Test0.py:<module>.outer.f"
-      )
+      methodFullNames(cpg, "f") shouldBe Set("Test0.py:<module>.outer.f<redefined>0", "Test0.py:<module>.outer.f")
     }
   }
 
@@ -88,10 +85,7 @@ class FunctionRedefinitionCpgTests extends PySrc2CpgFixture(withOssDataflow = fa
         |""".stripMargin)
 
     "mangle the earlier definition and keep the last one unmangled" in {
-      methodFullNames(cpg, "m") shouldBe Set(
-        "Test0.py:<module>.Foo.m<redefined>0",
-        "Test0.py:<module>.Foo.m"
-      )
+      methodFullNames(cpg, "m") shouldBe Set("Test0.py:<module>.Foo.m<redefined>0", "Test0.py:<module>.Foo.m")
     }
 
     "bind the last definition on the instance TypeDecl" in {
@@ -142,10 +136,7 @@ class FunctionRedefinitionCpgTests extends PySrc2CpgFixture(withOssDataflow = fa
         |""".stripMargin)
 
     "mangle the earlier definition and keep the last one unmangled" in {
-      methodFullNames(cpg, "f") shouldBe Set(
-        "Test0.py:<module>.outer.f<redefined>0",
-        "Test0.py:<module>.outer.f"
-      )
+      methodFullNames(cpg, "f") shouldBe Set("Test0.py:<module>.outer.f<redefined>0", "Test0.py:<module>.outer.f")
     }
   }
 

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/FunctionRedefinitionCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/FunctionRedefinitionCpgTests.scala
@@ -1,0 +1,225 @@
+package io.joern.pysrc2cpg.cpg
+
+import io.joern.pysrc2cpg.testfixtures.PySrc2CpgFixture
+import io.shiftleft.codepropertygraph.generated.Cpg
+import io.shiftleft.semanticcpg.language.*
+
+class FunctionRedefinitionCpgTests extends PySrc2CpgFixture(withOssDataflow = false) {
+  private def methodFullNames(cpg: Cpg, name: String): Set[String] =
+    cpg.method.name(name).fullName.toSet
+
+  "two top-level functions with the same name" should {
+    val cpg = code("""def f():
+        |  return "zeroth"
+        |def f():
+        |  return "first"
+        |""".stripMargin)
+
+    "produce two distinct method full names" in {
+      methodFullNames(cpg, "f") shouldBe Set("Test0.py:<module>.f<redefined>0", "Test0.py:<module>.f")
+    }
+
+    "route each body to its own method" in {
+      inside(cpg.method.fullNameExact("Test0.py:<module>.f<redefined>0").ast.isLiteral.code.l) { case List(code) =>
+        code shouldBe "\"zeroth\""
+      }
+      inside(cpg.method.fullNameExact("Test0.py:<module>.f").ast.isLiteral.code.l) { case List(code) =>
+        code shouldBe "\"first\""
+      }
+    }
+  }
+
+  "three top-level functions with the same name" should {
+    val cpg = code("""def f(): pass
+        |def f(): pass
+        |def f(): pass
+        |""".stripMargin)
+
+    "produce three distinct method full names" in {
+      methodFullNames(cpg, "f") shouldBe Set(
+        "Test0.py:<module>.f<redefined>0",
+        "Test0.py:<module>.f<redefined>1",
+        "Test0.py:<module>.f"
+      )
+    }
+  }
+
+  "same-name function in different branches of if/else" should {
+    val cpg = code("""if cond:
+        |  def f(): pass
+        |else:
+        |  def f(): pass
+        |""".stripMargin)
+
+    "produce two distinct method full names since branches share module scope" in {
+      methodFullNames(cpg, "f") shouldBe Set("Test0.py:<module>.f<redefined>0", "Test0.py:<module>.f")
+    }
+  }
+
+  "function inside another function does not collide with same-name function at module level" should {
+    val cpg = code("""def f(): pass
+        |def outer():
+        |  def f(): pass
+        |""".stripMargin)
+
+    "produce plain full names for both" in {
+      methodFullNames(cpg, "f") shouldBe Set("Test0.py:<module>.f", "Test0.py:<module>.outer.f")
+    }
+  }
+
+  "two same-name functions inside the same enclosing function scope" should {
+    val cpg = code("""def outer():
+        |  def f(): pass
+        |  def f(): pass
+        |""".stripMargin)
+
+    "mangle the earlier definition and keep the last one unmangled" in {
+      methodFullNames(cpg, "f") shouldBe Set(
+        "Test0.py:<module>.outer.f<redefined>0",
+        "Test0.py:<module>.outer.f"
+      )
+    }
+  }
+
+  "two same-name methods inside the same class scope" should {
+    val cpg = code("""class Foo:
+        |  def m(self): pass
+        |  def m(self): pass
+        |""".stripMargin)
+
+    "mangle the earlier definition and keep the last one unmangled" in {
+      methodFullNames(cpg, "m") shouldBe Set(
+        "Test0.py:<module>.Foo.m<redefined>0",
+        "Test0.py:<module>.Foo.m"
+      )
+    }
+
+    "bind the last definition on the instance TypeDecl" in {
+      cpg.typeDecl
+        .fullNameExact("Test0.py:<module>.Foo")
+        .member
+        .name("m")
+        .dynamicTypeHintFullName
+        .l shouldBe List("Test0.py:<module>.Foo.m")
+    }
+  }
+
+  "same-name functions across try/except/finally bodies" should {
+    val cpg = code("""try:
+        |  def f(): pass
+        |except Exception:
+        |  def f(): pass
+        |finally:
+        |  def f(): pass
+        |""".stripMargin)
+
+    "produce three distinct method full names" in {
+      methodFullNames(cpg, "f") shouldBe Set(
+        "Test0.py:<module>.f<redefined>0",
+        "Test0.py:<module>.f<redefined>1",
+        "Test0.py:<module>.f"
+      )
+    }
+  }
+
+  "same-name functions inside different match cases" should {
+    val cpg = code("""match x:
+        |  case 1:
+        |    def f(): pass
+        |  case _:
+        |    def f(): pass
+        |""".stripMargin)
+
+    "produce two distinct method full names" in {
+      methodFullNames(cpg, "f") shouldBe Set("Test0.py:<module>.f<redefined>0", "Test0.py:<module>.f")
+    }
+  }
+
+  "two same-name async functions inside the same enclosing function scope" should {
+    val cpg = code("""def outer():
+        |  async def f(): pass
+        |  async def f(): pass
+        |""".stripMargin)
+
+    "mangle the earlier definition and keep the last one unmangled" in {
+      methodFullNames(cpg, "f") shouldBe Set(
+        "Test0.py:<module>.outer.f<redefined>0",
+        "Test0.py:<module>.outer.f"
+      )
+    }
+  }
+
+  "same-name function inside a while body and at module level" should {
+    val cpg = code("""while cond:
+        |  def f(): pass
+        |def f(): pass
+        |""".stripMargin)
+
+    "produce two distinct method full names since the while body shares module scope" in {
+      methodFullNames(cpg, "f") shouldBe Set("Test0.py:<module>.f<redefined>0", "Test0.py:<module>.f")
+    }
+  }
+
+  "calls interleaved between two same-name top-level function definitions" should {
+    val cpg = code("""def f():
+        |    print("first f")
+        |
+        |f()
+        |
+        |def f():
+        |    print("second f")
+        |
+        |f()
+        |""".stripMargin)
+
+    "produce two method nodes with distinct full names, each with its own body" in {
+      methodFullNames(cpg, "f") shouldBe Set("Test0.py:<module>.f<redefined>0", "Test0.py:<module>.f")
+
+      inside(cpg.method.fullNameExact("Test0.py:<module>.f<redefined>0").ast.isLiteral.code.l) { case List(code) =>
+        code shouldBe "\"first f\""
+      }
+      inside(cpg.method.fullNameExact("Test0.py:<module>.f").ast.isLiteral.code.l) { case List(code) =>
+        code shouldBe "\"second f\""
+      }
+    }
+
+    "produce two call sites to f" in {
+      cpg.call.name("f").size shouldBe 2
+    }
+  }
+
+  "same-name nested function inside two same-name outer functions" should {
+    val cpg = code("""def outer():
+        |  def inner(): return "first"
+        |def outer():
+        |  def inner(): return "second"
+        |""".stripMargin)
+
+    "produce distinct full names for each inner because outer's mangled suffix propagates" in {
+      methodFullNames(cpg, "inner") shouldBe Set(
+        "Test0.py:<module>.outer<redefined>0.inner",
+        "Test0.py:<module>.outer.inner"
+      )
+    }
+
+    "route each inner body to its own method" in {
+      inside(cpg.method.fullNameExact("Test0.py:<module>.outer<redefined>0.inner").ast.isLiteral.code.l) {
+        case List(code) => code shouldBe "\"first\""
+      }
+      inside(cpg.method.fullNameExact("Test0.py:<module>.outer.inner").ast.isLiteral.code.l) { case List(code) =>
+        code shouldBe "\"second\""
+      }
+    }
+  }
+
+  "same-name function and class in the same scope" should {
+    val cpg = code("""def A(): pass
+        |class A: pass
+        |""".stripMargin)
+
+    "not mangle either since they occupy separate def buckets" in {
+      methodFullNames(cpg, "A") shouldBe Set("Test0.py:<module>.A")
+      cpg.typeDecl.name("A").fullName.toSet shouldBe Set("Test0.py:<module>.A")
+    }
+  }
+}

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/MethodCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/MethodCpgTests.scala
@@ -40,13 +40,13 @@ class MethodCpgTests extends PySrc2CpgFixture with Matchers {
     )
 
     cpg.method.name("method").map(m => (m.name, m.fullName)).l should contain theSameElementsAs (List(
-      ("method", s"$path:<module>.Foo.method"),
-      ("method", s"$path:<module>.Foo.method$$redefinition1"),
-      ("method", s"$path:<module>.Foo.method$$redefinition2")
+      ("method", s"$path:<module>.Foo.method<redefined>0"),
+      ("method", s"$path:<module>.Foo.method<redefined>1"),
+      ("method", s"$path:<module>.Foo.method")
     ))
 
     cpg.typeDecl.name("Foo").member.name("method").dynamicTypeHintFullName.l should contain theSameElementsAs (
-      List(s"$path:<module>.Foo.method$$redefinition2")
+      List(s"$path:<module>.Foo.method")
     )
 
     cpg.typeDecl.name("Foo<meta>").member.name("method").dynamicTypeHintFullName.l should contain theSameElementsAs (


### PR DESCRIPTION
This PR introduces the ClassDefDuplicateCalculator to pysrc2cpg which is used to calculate duplicate indices for conflicting class definitions, keeping the last definition unsuffixed since it's the one most likely to be used the most. 

I don't know if `<duplicate>N` is a good choice of suffix since it may be used with a different meaning in other frontends, so I'm open to suggestions for a better one!

sptests and integration tests are fine: https://buildbot.global.sltr.io/#/builders/82/builds/774