### PR TITLE
[c2cpg] JVM/Scala performance & memory fixes 

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/Main.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/Main.scala
@@ -1,9 +1,7 @@
 package io.joern.c2cpg
 
 import io.joern.c2cpg.Frontend.*
-import io.joern.x2cpg.utils.server.FrontendHTTPServer
 import io.joern.x2cpg.{SourceFiles, X2CpgConfig, X2CpgMain}
-import org.slf4j.LoggerFactory
 import scopt.OParser
 
 final case class Config(

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreator.scala
@@ -110,10 +110,7 @@ class AstCreator(
   }
 
   private def nodeOffsets(node: IASTNode): Option[(Int, Int)] = {
-    for {
-      startOffset <- nullSafeFileLocation(node).map(l => l.getNodeOffset)
-      endOffset   <- nullSafeFileLocation(node).map(l => l.getNodeOffset + l.getNodeLength)
-    } yield (startOffset, endOffset)
+    nullSafeFileLocation(node).map(loc => (loc.getNodeOffset, loc.getNodeOffset + loc.getNodeLength))
   }
 
   protected def columnEnd(node: IASTNode): Option[Int] = {

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
@@ -232,7 +232,14 @@ trait AstCreatorHelper { this: AstCreator =>
   }
 
   private def genFileOffsetTable(): Array[Int] = {
-    cdtAst.getRawSignature.toCharArray.zipWithIndex.collect { case ('\n', idx) => idx + 1 }
+    val chars   = cdtAst.getRawSignature.toCharArray
+    val buf     = new scala.collection.mutable.ArrayBuffer[Int](256)
+    var charIdx = 0
+    while (charIdx < chars.length) {
+      if (chars(charIdx) == '\n') buf += charIdx + 1
+      charIdx += 1
+    }
+    buf.toArray
   }
 
   private def notHandledText(node: IASTNode): String = {

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
@@ -39,8 +39,9 @@ trait AstCreatorHelper { this: AstCreator =>
     val bse = base.getOrElse(Ast())
     var ast = Ast(callNode).withChild(bse)
 
+    val receiverRoot = receiver.flatMap(_.root)
     if (receiver.isDefined && receiver != base) {
-      receiver.get.root.get.asInstanceOf[ExpressionNew].argumentIndex = -1
+      receiverRoot.get.asInstanceOf[ExpressionNew].argumentIndex = -1
       ast = ast.withChild(receiver.get)
     }
 
@@ -49,8 +50,8 @@ trait AstCreatorHelper { this: AstCreator =>
       .withArgEdges(callNode, baseRoot)
       .withArgEdges(callNode, arguments.flatMap(_.root))
 
-    if (receiver.isDefined) {
-      ast = ast.withReceiverEdge(callNode, receiver.get.root.get)
+    receiverRoot.foreach { root =>
+      ast = ast.withReceiverEdge(callNode, root)
     }
     ast
   }
@@ -177,7 +178,7 @@ trait AstCreatorHelper { this: AstCreator =>
   }
 
   protected def astsForDependenciesAndImports(iASTTranslationUnit: IASTTranslationUnit): Seq[Ast] = {
-    val allIncludes = iASTTranslationUnit.getIncludeDirectives.toList.filterNot(isIncludedNode)
+    val allIncludes = iASTTranslationUnit.getIncludeDirectives.iterator.filterNot(isIncludedNode).toSeq
     allIncludes.map { include =>
       val name       = include.getName.toString
       val dependency = dependencyNode(name, name, "include")
@@ -190,7 +191,7 @@ trait AstCreatorHelper { this: AstCreator =>
 
   protected def astsForComments(iASTTranslationUnit: IASTTranslationUnit): Seq[Ast] = {
     if (config.includeComments)
-      iASTTranslationUnit.getComments.toList.filterNot(isIncludedNode).map(comment => astForComment(comment))
+      iASTTranslationUnit.getComments.iterator.filterNot(isIncludedNode).map(comment => astForComment(comment)).toSeq
     else Seq.empty
   }
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
@@ -1,23 +1,27 @@
 package io.joern.c2cpg.astcreation
 
-import io.joern.c2cpg.passes.{AstCreationPass, FunctionDeclNodePass}
+import io.joern.c2cpg.passes.FunctionDeclNodePass
 import io.joern.x2cpg.AstNodeBuilder.dependencyNode
-import io.joern.x2cpg.{Ast, AstNodeBuilder, SourceFiles}
+import io.joern.x2cpg.Ast
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
-import io.shiftleft.codepropertygraph.generated.nodes.{ExpressionNew, NewCall, NewNode}
+import io.shiftleft.codepropertygraph.generated.nodes.{ExpressionNew, NewCall}
 import org.eclipse.cdt.core.dom.ast.*
 import org.eclipse.cdt.core.dom.ast.c.{ICASTArrayDesignator, ICASTDesignatedInitializer, ICASTFieldDesignator}
 import org.eclipse.cdt.core.dom.ast.cpp.*
 import org.eclipse.cdt.internal.core.dom.parser.c.CASTArrayRangeDesignator
 import org.eclipse.cdt.internal.core.dom.parser.cpp.{CPPASTArrayRangeDesignator, ICPPEvaluation}
 
+import java.nio.file.{Path, Paths}
 import scala.collection.mutable
 import scala.util.{Success, Try}
 
 trait AstCreatorHelper { this: AstCreator =>
 
+  private val resolvedInputPath: Path = Paths.get(config.inputPath).toAbsolutePath.normalize()
+
   private val scopeLocalUniqueNames: mutable.Map[String, Int] = mutable.HashMap.empty
   private val file2OffsetTable: Array[Int]                    = genFileOffsetTable()
+  private val relativePathCache: mutable.Map[String, String]  = mutable.HashMap.empty
 
   // We use our own call ast creation function since the version in x2cpg treats
   // base as receiver if no receiver is given which does not fit the needs of this
@@ -198,11 +202,22 @@ trait AstCreatorHelper { this: AstCreator =>
   protected def isIncludedNode(node: IASTNode): Boolean = fileName(node) != filename
 
   protected def fileName(node: IASTNode): String = {
-    val path = Try(node.getContainingFilename) match {
+    val rawPath = Try(node.getContainingFilename) match {
       case Success(value) if value.nonEmpty => value
       case _                                => filename
     }
-    SourceFiles.toRelativePath(path, config.inputPath)
+    relativePathCache.getOrElseUpdate(
+      rawPath, {
+        val absPath = Paths.get(rawPath).normalize()
+        if (absPath.equals(resolvedInputPath)) {
+          absPath.getFileName.toString
+        } else if (absPath.startsWith(resolvedInputPath)) {
+          resolvedInputPath.relativize(absPath).toString
+        } else {
+          rawPath
+        }
+      }
+    )
   }
 
   protected def astForNode(node: IASTNode): Ast = {

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForExpressionsCreator.scala
@@ -1,18 +1,9 @@
 package io.joern.c2cpg.astcreation
 
 import io.joern.x2cpg.{Ast, Defines as X2CpgDefines}
-import io.joern.x2cpg.datastructures.Stack.*
-import io.joern.x2cpg.datastructures.VariableScopeManager
 import io.shiftleft.codepropertygraph.generated.nodes.ExpressionNew
-import io.shiftleft.codepropertygraph.generated.{
-  ControlStructureTypes,
-  DispatchTypes,
-  EdgeTypes,
-  EvaluationStrategies,
-  Operators
-}
+import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, EvaluationStrategies, Operators}
 import org.apache.commons.lang3.StringUtils
-import org.eclipse.cdt.core.dom.ast
 import org.eclipse.cdt.core.dom.ast.*
 import org.eclipse.cdt.core.dom.ast.c.ICArrayType
 import org.eclipse.cdt.core.dom.ast.cpp.*
@@ -23,13 +14,13 @@ import org.eclipse.cdt.internal.core.dom.parser.c.{
   CFunctionType,
   CPointerType
 }
+import org.eclipse.cdt.internal.core.dom.parser.cpp.semantics.EvalFunctionCall
 import org.eclipse.cdt.internal.core.dom.parser.cpp.{
   CPPASTFoldExpression,
   CPPASTIdExpression,
   CPPASTQualifiedName,
   CPPClosureType
 }
-import org.eclipse.cdt.internal.core.dom.parser.cpp.semantics.EvalFunctionCall
 
 import scala.annotation.tailrec
 import scala.util.Try

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForFunctionsCreator.scala
@@ -518,15 +518,15 @@ trait AstForFunctionsCreator { this: AstCreator =>
           case _ => // do nothing
         }
       case other =>
-        val validCaptures = other.filter(_.getIdentifier != null)
+        val validCaptures  = other.filter(_.getIdentifier != null)
+        val capturesByName = validCaptures.map(capture => code(capture.getIdentifier) -> capture).toMap
         bodyAst.nodes.foreach {
-          case i: NewIdentifier if !scope.variableIsInMethodScope(i.name) =>
-            val maybeInCaptures = validCaptures.find(c => code(c.getIdentifier) == i.name)
-            val strategy = maybeInCaptures match {
-              case Some(c) if c.isByReference => EvaluationStrategies.BY_REFERENCE
-              case _                          => strategyMapping
+          case identifier: NewIdentifier if !scope.variableIsInMethodScope(identifier.name) =>
+            val strategy = capturesByName.get(identifier.name) match {
+              case Some(capture) if capture.isByReference => EvaluationStrategies.BY_REFERENCE
+              case _                                      => strategyMapping
             }
-            scope.updateVariableReference(i, strategy)
+            scope.updateVariableReference(identifier, strategy)
           case _ => // do nothing
         }
     }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForFunctionsCreator.scala
@@ -21,16 +21,20 @@ trait AstForFunctionsCreator { this: AstCreator =>
 
   import FullNameProvider.*
 
-  final protected def parameters(functionNode: IASTNode): Seq[IASTNode] = functionNode match {
-    case arr: IASTArrayDeclarator       => parameters(arr.getNestedDeclarator)
-    case decl: CPPASTFunctionDeclarator => decl.getParameters.toIndexedSeq ++ parameters(decl.getNestedDeclarator)
-    case decl: CASTFunctionDeclarator   => decl.getParameters.toIndexedSeq ++ parameters(decl.getNestedDeclarator)
-    case defn: IASTFunctionDefinition   => parameters(defn.getDeclarator)
-    case lambdaExpression: ICPPASTLambdaExpression => parameters(lambdaExpression.getDeclarator)
-    case knr: ICASTKnRFunctionDeclarator           => knr.getParameterDeclarations.toIndexedSeq
-    case _: IASTDeclarator                         => Seq.empty
-    case other if other != null                    => notHandledYet(other); Seq.empty
-    case null                                      => Seq.empty
+  final protected def parameters(functionNode: IASTNode): Seq[IASTNode] = {
+    @scala.annotation.tailrec
+    def collect(node: IASTNode, acc: Vector[IASTNode]): Vector[IASTNode] = node match {
+      case arr: IASTArrayDeclarator        => collect(arr.getNestedDeclarator, acc)
+      case decl: CPPASTFunctionDeclarator  => collect(decl.getNestedDeclarator, acc ++ decl.getParameters.toIndexedSeq)
+      case decl: CASTFunctionDeclarator    => collect(decl.getNestedDeclarator, acc ++ decl.getParameters.toIndexedSeq)
+      case defn: IASTFunctionDefinition    => collect(defn.getDeclarator, acc)
+      case lambda: ICPPASTLambdaExpression => collect(lambda.getDeclarator, acc)
+      case knr: ICASTKnRFunctionDeclarator => acc ++ knr.getParameterDeclarations.toIndexedSeq
+      case _: IASTDeclarator               => acc
+      case other if other != null          => notHandledYet(other); acc
+      case null                            => acc
+    }
+    collect(functionNode, Vector.empty)
   }
 
   @tailrec

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForFunctionsCreator.scala
@@ -420,7 +420,7 @@ trait AstForFunctionsCreator { this: AstCreator =>
     parameter match {
       case p: CPPASTParameterDeclaration =>
         val paramName       = shortName(p.getDeclarator)
-        val parentSignature = Try(parameter.getParent.getRawSignature.replaceAll(" ", "")).toOption
+        val parentSignature = Try(parameter.getParent.getRawSignature.replace(" ", "")).toOption
         parentSignature.exists(_.contains(s"$paramName,...")) || parentSignature.exists(_.contains(s"$paramName..."))
       case _ => false
     }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForPrimitivesCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForPrimitivesCreator.scala
@@ -243,15 +243,15 @@ trait AstForPrimitivesCreator { this: AstCreator =>
         def fieldAccesses(names: List[IASTNode]): Ast = names match {
           case Nil         => Ast()
           case head :: Nil => astForNode(head)
-          case _ =>
-            val init       = names.init
-            val last       = names.last
-            val codeString = names.map(code).mkString("::")
-            val callNode_  = callNode(names.head, codeString, op, op, dispatchType, None, Some(Defines.Any))
-            val arg1       = fieldAccesses(init)
-            val lastCode   = code(last)
-            val arg2       = Ast(fieldIdentifierNode(last, lastCode, lastCode))
-            callAst(callNode_, List(arg1, arg2))
+          case head :: tail =>
+            val (resultAst, _) = tail.foldLeft((astForNode(head), code(head))) { case ((accAst, accCode), nameNode) =>
+              val nameCode  = code(nameNode)
+              val newCode   = s"$accCode::$nameCode"
+              val callNode_ = callNode(names.head, newCode, op, op, dispatchType, None, Some(Defines.Any))
+              val arg2      = Ast(fieldIdentifierNode(nameNode, nameCode, nameCode))
+              (callAst(callNode_, List(accAst, arg2)), newCode)
+            }
+            resultAst
         }
         val qualifier = fieldAccesses(qualId.getQualifier.toIndexedSeq.toList)
         val owner = if (qualifier != Ast()) { qualifier }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForStatementsCreator.scala
@@ -145,11 +145,12 @@ trait AstForStatementsCreator { this: AstCreator =>
   }
 
   private def astsForIASTSimpleDeclaration(simpleDecl: IASTSimpleDeclaration): Seq[Ast] = {
-    val declAsts = simpleDecl.getDeclarators.zipWithIndex.map {
+    val declarators = simpleDecl.getDeclarators
+    val declAsts = declarators.zipWithIndex.map {
       case (d: IASTFunctionDeclarator, _) => astForFunctionDeclarator(d)
       case (d, i)                         => astForDeclarator(simpleDecl, d, i)
     }
-    val arrayModCallsAsts = simpleDecl.getDeclarators
+    val arrayModCallsAsts = declarators
       .collect { case d: IASTArrayDeclarator if hasValidArrayModifier(d) => d }
       .map { d =>
         val name          = Operators.alloc
@@ -172,7 +173,7 @@ trait AstForStatementsCreator { this: AstCreator =>
         val left = astForNode(d.getName)
         callAst(assignmentCallNode, List(left, allocCallAst))
       }
-    val initCallsAsts = simpleDecl.getDeclarators.map {
+    val initCallsAsts = declarators.map {
       case d: ICPPASTDeclarator if d.getInitializer == null && isCPPClassLike(simpleDecl) => astForConstructorCall(d)
       case d if d.getInitializer != null => astForInitializer(d, d.getInitializer)
       case _                             => Ast()

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForTypesCreator.scala
@@ -264,20 +264,21 @@ trait AstForTypesCreator { this: AstCreator =>
       case declStmt: CPPASTSimpleDeclaration if isUnsupportedCoroutineKeyword(declStmt) =>
         Seq(astForUnsupportedCoroutineNode(declStmt))
       case declaration: IASTSimpleDeclaration =>
+        val declarators = declaration.getDeclarators
         declaration.getDeclSpecifier match {
           case spec: IASTCompositeTypeSpecifier =>
-            astsForCompositeType(spec, declaration.getDeclarators.toList)
+            astsForCompositeType(spec, declarators.toList)
           case spec: IASTEnumerationSpecifier =>
-            astsForEnum(spec, declaration.getDeclarators.toList)
+            astsForEnum(spec, declarators.toList)
           case spec: IASTElaboratedTypeSpecifier =>
-            astsForElaboratedType(spec, declaration.getDeclarators.toList)
-          case spec: IASTNamedTypeSpecifier if declaration.getDeclarators.isEmpty =>
+            astsForElaboratedType(spec, declarators.toList)
+          case spec: IASTNamedTypeSpecifier if declarators.isEmpty =>
             val filename  = fileName(spec)
             val name      = shortName(spec)
             val fullName_ = fullName(spec)
             Seq(Ast(typeDeclNode(spec, name, registerType(fullName_), filename, code(spec), alias = Option(name))))
-          case _ if declaration.getDeclarators.nonEmpty =>
-            declaration.getDeclarators.toIndexedSeq.zipWithIndex.map {
+          case _ if declarators.nonEmpty =>
+            declarators.toIndexedSeq.zipWithIndex.map {
               case (d: IASTFunctionDeclarator, _) =>
                 astForFunctionDeclarator(d)
               case (d: IASTSimpleDeclaration, _) if d.getInitializer != null =>
@@ -287,9 +288,9 @@ trait AstForTypesCreator { this: AstCreator =>
             }
           case _ if code(declaration) == ";" =>
             Seq.empty // dangling decls from unresolved macros; we ignore them
-          case _ if declaration.getDeclarators.isEmpty && declaration.getParent.isInstanceOf[IASTTranslationUnit] =>
+          case _ if declarators.isEmpty && declaration.getParent.isInstanceOf[IASTTranslationUnit] =>
             Seq.empty // dangling decls from unresolved macros; we ignore them
-          case _ if declaration.getDeclarators.isEmpty => Seq(astForNode(declaration))
+          case _ if declarators.isEmpty => Seq(astForNode(declaration))
         }
       case alias: CPPASTAliasDeclaration                         => Seq(astForAliasDeclaration(alias))
       case functionDefinition: IASTFunctionDefinition            => Seq(astForFunctionDefinition(functionDefinition))
@@ -578,8 +579,9 @@ trait AstForTypesCreator { this: AstCreator =>
     typeRefNodeMaybe.foreach(typeRefIdStack.push)
     scope.pushNewMethodScope(typeDecl.fullName, typeDecl.name, typeDecl, None)
 
-    val memberNodesWithInitializer = typeSpecifier.getEnumerators.toList.filter(_.getValue != null)
-    val memberAsts                 = typeSpecifier.getEnumerators.toList.map(memberAstForEnumerator)
+    val enumerators                = typeSpecifier.getEnumerators.toList
+    val memberNodesWithInitializer = enumerators.filter(_.getValue != null)
+    val memberAsts                 = enumerators.map(memberAstForEnumerator)
 
     typeRefNodeMaybe.foreach(_ => typeRefIdStack.pop())
     methodAstParentStack.pop()

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/FullNameProvider.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/FullNameProvider.scala
@@ -88,9 +88,11 @@ trait FullNameProvider { this: AstCreator =>
 
   protected def replaceQualifiedNameSeparator(name: String): String = {
     if (name.isEmpty || name == Defines.Any || name == Defines.Void) return name
-    val normalizedName = StringUtils.normalizeSpace(name)
-    normalizedName.replace(Defines.QualifiedNameSeparator, ".").stripPrefix(".")
+    StringUtils.normalizeSpace(name).replace(Defines.QualifiedNameSeparator, ".").stripPrefix(".")
   }
+
+  protected def applyQualifiedNameSeparator(normalizedName: String): String =
+    normalizedName.replace(Defines.QualifiedNameSeparator, ".").stripPrefix(".")
 
   protected def methodFullNameInfo(methodLike: MethodLike): MethodFullNameInfo = {
     val name_             = shortName(methodLike)

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/FullNameProvider.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/FullNameProvider.scala
@@ -17,7 +17,7 @@ object FullNameProvider {
 
   type MethodLike = IASTFunctionDeclarator | IASTFunctionDefinition | ICPPASTLambdaExpression
 
-  private val TagsToKeepInFullName = List(
+  private val TagsToKeepInFullName = Set(
     "<anonymous>",
     "<const>",
     "<duplicate>",
@@ -313,9 +313,9 @@ trait FullNameProvider { this: AstCreator =>
           case Some(evalBinding: EvalBinding) =>
             evalBinding.getBinding match {
               case f: CPPFunction if f.getDeclarations != null =>
-                Option(f.getDeclarations.headOption.map(n => s"${fullName(n)}").getOrElse(f.getName))
+                Option(f.getDeclarations.headOption.map(n => fullName(n)).getOrElse(f.getName))
               case f: CPPFunction if f.getDefinition != null =>
-                Option(s"${fullName(f.getDefinition)}")
+                Option(fullName(f.getDefinition))
               case other =>
                 Option(other.getName)
             }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/FullNameProvider.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/FullNameProvider.scala
@@ -313,7 +313,7 @@ trait FullNameProvider { this: AstCreator =>
           case Some(evalBinding: EvalBinding) =>
             evalBinding.getBinding match {
               case f: CPPFunction if f.getDeclarations != null =>
-                Option(f.getDeclarations.headOption.map(n => fullName(n)).getOrElse(f.getName))
+                Option(f.getDeclarations.headOption.map(decl => fullName(decl)).getOrElse(f.getName))
               case f: CPPFunction if f.getDefinition != null =>
                 Option(fullName(f.getDefinition))
               case other =>

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroArgumentExtractor.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroArgumentExtractor.scala
@@ -71,13 +71,14 @@ class C2CpgMacroExpansionTracker(stepToTrack: Int) extends MacroExpansionTracker
   }
 
   private def tokenListToString(tokenList: TokenList): String = {
+    val sb          = new java.lang.StringBuilder
     var tok: IToken = tokenList.first()
-    var arg         = ""
     while (tok != null) {
-      arg += s"${tok.toString} "
+      sb.append(tok.toString).append(' ')
       tok = tok.getNext
     }
-    arg.trim
+    if (sb.length > 0) sb.setLength(sb.length - 1)
+    sb.toString
   }
 
 }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroHandler.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroHandler.scala
@@ -173,10 +173,10 @@ trait MacroHandler { this: AstCreator =>
     val codeIndex: Map[String, ExpressionNew] = ast.nodes.collect {
       case x: ExpressionNew if !x.isInstanceOf[NewFieldIdentifier] => x.code.replace(" ", "") -> x
     }.toMap
-    arguments.zipWithIndex.map { case (arg, i) =>
+    arguments.zipWithIndex.map { case (arg, argIndex) =>
       val normalizedCode = arg.replace(" ", "")
       if (normalizedCode.isEmpty) None
-      else codeIndex.get(normalizedCode).map(x => ast.subTreeCopy(x.asInstanceOf[AstNodeNew], i + 1))
+      else codeIndex.get(normalizedCode).map(node => ast.subTreeCopy(node.asInstanceOf[AstNodeNew], argIndex + 1))
     }
   }
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroHandler.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroHandler.scala
@@ -170,20 +170,13 @@ trait MacroHandler { this: AstCreator =>
   }
 
   private def argumentTrees(arguments: List[String], ast: Ast): List[Option[Ast]] = {
+    val codeIndex: Map[String, ExpressionNew] = ast.nodes.collect {
+      case x: ExpressionNew if !x.isInstanceOf[NewFieldIdentifier] => x.code.replace(" ", "") -> x
+    }.toMap
     arguments.zipWithIndex.map { case (arg, i) =>
-      val rootNode = argForCode(arg, ast)
-      rootNode.map(x => ast.subTreeCopy(x.asInstanceOf[AstNodeNew], i + 1))
-    }
-  }
-
-  private def argForCode(code: String, ast: Ast): Option[NewNode] = {
-    val normalizedCode = code.replace(" ", "")
-    if (normalizedCode == "") {
-      None
-    } else {
-      ast.nodes.collectFirst {
-        case x: ExpressionNew if !x.isInstanceOf[NewFieldIdentifier] && x.code == normalizedCode => x
-      }
+      val normalizedCode = arg.replace(" ", "")
+      if (normalizedCode.isEmpty) None
+      else codeIndex.get(normalizedCode).map(x => ast.subTreeCopy(x.asInstanceOf[AstNodeNew], i + 1))
     }
   }
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroHandler.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroHandler.scala
@@ -184,7 +184,7 @@ trait MacroHandler { this: AstCreator =>
 
   private def expandedFromMacro(node: IASTNode): Option[IASTMacroExpansionLocation] = {
     val rawLocations = node.getNodeLocations
-    if (rawLocations == null || rawLocations.length == 0) return None
+    if (rawLocations == null || rawLocations.isEmpty) return None
     val locations = rawLocations.toList
     val locationsSorted = node match {
       // For binary expressions the expansion locations may occur in any order.

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroHandler.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroHandler.scala
@@ -81,7 +81,7 @@ trait MacroHandler { this: AstCreator =>
   /** Determine whether `node` is expanded from the macro expansion at `loc`.
     */
   private def isExpandedFrom(node: IASTNode, loc: IASTMacroExpansionLocation): Boolean = {
-    expandedFromMacro(node).map(_.getExpansion.getMacroDefinition).contains(loc.getExpansion.getMacroDefinition)
+    expandedFromMacro(node).exists(_.getExpansion.getMacroDefinition == loc.getExpansion.getMacroDefinition)
   }
 
   /** Create an AST that represents a macro expansion as a call. The AST is rooted in a CALL node and contains subtrees
@@ -190,7 +190,9 @@ trait MacroHandler { this: AstCreator =>
   private def isExpandedFromMacro(node: IASTNode): Boolean = expandedFromMacro(node).nonEmpty
 
   private def expandedFromMacro(node: IASTNode): Option[IASTMacroExpansionLocation] = {
-    val locations = node.getNodeLocations.toList
+    val rawLocations = node.getNodeLocations
+    if (rawLocations == null || rawLocations.length == 0) return None
+    val locations = rawLocations.toList
     val locationsSorted = node match {
       // For binary expressions the expansion locations may occur in any order.
       // We manually sort them here to ignore this.

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/TypeNameProvider.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/TypeNameProvider.scala
@@ -411,11 +411,12 @@ trait TypeNameProvider { this: AstCreator =>
   @nowarn
   private def typeForIASTArrayDeclarator(a: IASTArrayDeclarator): String = {
     import org.eclipse.cdt.core.dom.ast.ASTSignatureUtil.getNodeSignature
-    if (safeGetNodeType(a).startsWith("? ")) {
+    val nodeType = safeGetNodeType(a)
+    if (nodeType.startsWith("? ")) {
       val tpe = getNodeSignature(a).replace("[]", "").strip()
-      val arr = safeGetNodeType(a).replace("? ", "")
+      val arr = nodeType.replace("? ", "")
       s"$tpe$arr"
-    } else if (safeGetNodeType(a).contains("} ") || safeGetNodeType(a).contains(" [")) {
+    } else if (nodeType.contains("} ") || nodeType.contains(" [")) {
       val tpe = getNodeSignature(a).replace("[]", "").strip()
       val arr = a.getArrayModifiers.map {
         case m if m.getConstantExpression != null => s"[${nodeSignature(m.getConstantExpression)}]"
@@ -428,7 +429,7 @@ trait TypeNameProvider { this: AstCreator =>
       }.mkString
       s"$tpe$arr"
     } else {
-      safeGetNodeType(a)
+      nodeType
     }
   }
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/TypeNameProvider.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/TypeNameProvider.scala
@@ -108,16 +108,16 @@ trait TypeNameProvider { this: AstCreator =>
         }
     stripTemplateTags(replaceWhitespaceAfterKeyword(tpe)) match {
       // Empty or problematic types
-      case ""                                                                      => Defines.Any
-      case t if t.contains("?")                                                    => Defines.Any
-      case t if t.contains("#")                                                    => Defines.Any
-      case t if t.contains("::{") || t.contains("}::")                             => Defines.Any
-      case t if (t.contains("{") || t.contains("}")) && !isThisLambdaCapture(t)    => Defines.Any
-      case t if t.contains("org.eclipse.cdt.internal.core.dom.parser.ProblemType") => Defines.Any
+      case ""                                                                           => Defines.Any
+      case tpe if tpe.contains("?")                                                     => Defines.Any
+      case tpe if tpe.contains("#")                                                     => Defines.Any
+      case tpe if tpe.contains("::{") || tpe.contains("}::")                            => Defines.Any
+      case tpe if (tpe.contains("{") || tpe.contains("}")) && !isThisLambdaCapture(tpe) => Defines.Any
+      case tpe if tpe.contains("org.eclipse.cdt.internal.core.dom.parser.ProblemType")  => Defines.Any
       // Special patterns with specific handling
-      case t if t.startsWith("[") && t.endsWith("]")       => Defines.Array
-      case t if isThisLambdaCapture(t) || t.contains("->") => Defines.Function
-      case t if t.contains("( ") => applyQualifiedNameSeparator(t.substring(0, t.indexOf("( ")))
+      case tpe if tpe.startsWith("[") && tpe.endsWith("]")       => Defines.Array
+      case tpe if isThisLambdaCapture(tpe) || tpe.contains("->") => Defines.Function
+      case tpe if tpe.contains("( ") => applyQualifiedNameSeparator(tpe.substring(0, tpe.indexOf("( ")))
       // Default case
       case typeStr => applyQualifiedNameSeparator(typeStr)
     }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/TypeNameProvider.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/TypeNameProvider.scala
@@ -60,10 +60,10 @@ trait TypeNameProvider { this: AstCreator =>
         val parentDecl = s.getParent.asInstanceOf[IASTFunctionDefinition].getDeclarator
         ASTStringUtil.getReturnTypeString(s, parentDecl)
       case s: IASTSimpleDeclaration if s.getParent.isInstanceOf[ICASTKnRFunctionDeclarator] =>
-        val decl = s.getDeclarators.toList(index)
+        val decl = s.getDeclarators.apply(index)
         pointersAsString(s.getDeclSpecifier, decl)
       case s: IASTSimpleDeclSpecifier if s.getParent.isInstanceOf[IASTSimpleDeclaration] =>
-        val parentDecl = s.getParent.asInstanceOf[IASTSimpleDeclaration].getDeclarators.toList(index)
+        val parentDecl = s.getParent.asInstanceOf[IASTSimpleDeclaration].getDeclarators.apply(index)
         pointersAsString(s, parentDecl)
       case s: IASTSimpleDeclSpecifier =>
         ASTStringUtil.getReturnTypeString(s, null)
@@ -71,23 +71,23 @@ trait TypeNameProvider { this: AstCreator =>
         val parentDecl = s.getParent.asInstanceOf[IASTParameterDeclaration].getDeclarator
         pointersAsString(s, parentDecl)
       case s: IASTNamedTypeSpecifier if s.getParent.isInstanceOf[IASTSimpleDeclaration] =>
-        val parentDecl = s.getParent.asInstanceOf[IASTSimpleDeclaration].getDeclarators.toList(index)
+        val parentDecl = s.getParent.asInstanceOf[IASTSimpleDeclaration].getDeclarators.apply(index)
         pointersAsString(s, parentDecl)
       case s: IASTNamedTypeSpecifier =>
         ASTStringUtil.getSimpleName(s.getName)
       case s: IASTCompositeTypeSpecifier if s.getParent.isInstanceOf[IASTSimpleDeclaration] =>
-        val parentDecl = s.getParent.asInstanceOf[IASTSimpleDeclaration].getDeclarators.toList(index)
+        val parentDecl = s.getParent.asInstanceOf[IASTSimpleDeclaration].getDeclarators.apply(index)
         pointersAsString(s, parentDecl)
       case s: IASTCompositeTypeSpecifier => ASTStringUtil.getSimpleName(s.getName)
       case s: IASTEnumerationSpecifier if s.getParent.isInstanceOf[IASTSimpleDeclaration] =>
-        val parentDecl = s.getParent.asInstanceOf[IASTSimpleDeclaration].getDeclarators.toList(index)
+        val parentDecl = s.getParent.asInstanceOf[IASTSimpleDeclaration].getDeclarators.apply(index)
         pointersAsString(s, parentDecl)
       case s: IASTEnumerationSpecifier => ASTStringUtil.getSimpleName(s.getName)
       case s: IASTElaboratedTypeSpecifier if s.getParent.isInstanceOf[IASTParameterDeclaration] =>
         val parentDecl = s.getParent.asInstanceOf[IASTParameterDeclaration].getDeclarator
         pointersAsString(s, parentDecl)
       case s: IASTElaboratedTypeSpecifier if s.getParent.isInstanceOf[IASTSimpleDeclaration] =>
-        val parentDecl = s.getParent.asInstanceOf[IASTSimpleDeclaration].getDeclarators.toList(index)
+        val parentDecl = s.getParent.asInstanceOf[IASTSimpleDeclaration].getDeclarators.apply(index)
         pointersAsString(s, parentDecl)
       case s: IASTElaboratedTypeSpecifier => ASTStringUtil.getSignatureString(s, null)
       // TODO: handle other types of IASTDeclSpecifier

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/TypeNameProvider.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/TypeNameProvider.scala
@@ -42,14 +42,14 @@ trait TypeNameProvider { this: AstCreator =>
     )
 
   private val ReservedKeywordsAtTypesPatterns: List[(String, String)] =
-    ReservedKeywordsAtTypes.map(k => (s"$k ", s" $k "))
+    ReservedKeywordsAtTypes.map(keyword => (s"$keyword ", s" $keyword "))
 
   private val ReservedKeywordsAtTypesSet: Set[String] = ReservedKeywordsAtTypes.toSet
 
   private val KeywordsAtTypesToKeep: List[String] = List("unsigned", "volatile")
 
   private val KeywordsAtTypesToKeepPatterns: List[(String, String)] =
-    KeywordsAtTypesToKeep.map(k => (s"$k ", s" $k "))
+    KeywordsAtTypesToKeep.map(keyword => (s"$keyword ", s" $keyword "))
 
   protected def typeForDeclSpecifier(spec: IASTNode, index: Int = 0): String = {
     val tpeString = spec match {

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/TypeNameProvider.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/TypeNameProvider.scala
@@ -364,7 +364,7 @@ trait TypeNameProvider { this: AstCreator =>
     }
     val pointers = parentDecl.getPointerOperators
     val arr = parentDecl match {
-      case p: IASTArrayDeclarator => p.getArrayModifiers.toList.map(_.getRawSignature).mkString
+      case p: IASTArrayDeclarator => p.getArrayModifiers.iterator.map(_.getRawSignature).mkString
       case _                      => ""
     }
     if (pointers.isEmpty) {

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/TypeNameProvider.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/TypeNameProvider.scala
@@ -117,9 +117,9 @@ trait TypeNameProvider { this: AstCreator =>
       // Special patterns with specific handling
       case t if t.startsWith("[") && t.endsWith("]")       => Defines.Array
       case t if isThisLambdaCapture(t) || t.contains("->") => Defines.Function
-      case t if t.contains("( ") => replaceQualifiedNameSeparator(t.substring(0, t.indexOf("( ")))
+      case t if t.contains("( ") => applyQualifiedNameSeparator(t.substring(0, t.indexOf("( ")))
       // Default case
-      case typeStr => replaceQualifiedNameSeparator(typeStr)
+      case typeStr => applyQualifiedNameSeparator(typeStr)
     }
   }
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/TypeNameProvider.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/TypeNameProvider.scala
@@ -101,10 +101,11 @@ trait TypeNameProvider { this: AstCreator =>
     val normalizedTpe = StringUtils.normalizeSpace(rawType.stripSuffix(" ()"))
     val tpe =
       if (!ReservedKeywordsAtTypesSet.exists(normalizedTpe.contains)) normalizedTpe
-      else ReservedKeywordsAtTypesPatterns.foldLeft(normalizedTpe) { case (cur, (prefix, infix)) =>
-        if (cur.startsWith(prefix) || cur.contains(infix)) cur.replace(infix, " ").stripPrefix(prefix)
-        else cur
-      }
+      else
+        ReservedKeywordsAtTypesPatterns.foldLeft(normalizedTpe) { case (cur, (prefix, infix)) =>
+          if (cur.startsWith(prefix) || cur.contains(infix)) cur.replace(infix, " ").stripPrefix(prefix)
+          else cur
+        }
     stripTemplateTags(replaceWhitespaceAfterKeyword(tpe)) match {
       // Empty or problematic types
       case ""                                                                      => Defines.Any
@@ -329,7 +330,9 @@ trait TypeNameProvider { this: AstCreator =>
   }
 
   private def replaceWhitespaceAfterKeyword(tpe: String): String = {
-    if (KeywordsAtTypesToKeepPatterns.exists { case (prefix, infix) => tpe.startsWith(prefix) || tpe.contains(infix) }) {
+    if (
+      KeywordsAtTypesToKeepPatterns.exists { case (prefix, infix) => tpe.startsWith(prefix) || tpe.contains(infix) }
+    ) {
       KeywordsAtTypesToKeepPatterns.foldLeft(tpe) { case (cur, (prefix, infix)) =>
         if (cur.startsWith(prefix)) {
           prefix + replaceWhitespaceAfterKeyword(cur.substring(prefix.length))

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/TypeNameProvider.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/TypeNameProvider.scala
@@ -41,7 +41,15 @@ trait TypeNameProvider { this: AstCreator =>
       "virtual"
     )
 
+  private val ReservedKeywordsAtTypesPatterns: List[(String, String)] =
+    ReservedKeywordsAtTypes.map(k => (s"$k ", s" $k "))
+
+  private val ReservedKeywordsAtTypesSet: Set[String] = ReservedKeywordsAtTypes.toSet
+
   private val KeywordsAtTypesToKeep: List[String] = List("unsigned", "volatile")
+
+  private val KeywordsAtTypesToKeepPatterns: List[(String, String)] =
+    KeywordsAtTypesToKeep.map(k => (s"$k ", s" $k "))
 
   protected def typeForDeclSpecifier(spec: IASTNode, index: Int = 0): String = {
     val tpeString = spec match {
@@ -91,11 +99,12 @@ trait TypeNameProvider { this: AstCreator =>
   protected def cleanType(rawType: String): String = {
     if (rawType == Defines.Any) return rawType
     val normalizedTpe = StringUtils.normalizeSpace(rawType.stripSuffix(" ()"))
-    val tpe = ReservedKeywordsAtTypes.foldLeft(normalizedTpe) { (cur, repl) =>
-      if (cur.startsWith(s"$repl ") || cur.contains(s" $repl ")) {
-        cur.replace(s" $repl ", " ").stripPrefix(s"$repl ")
-      } else cur
-    }
+    val tpe =
+      if (!ReservedKeywordsAtTypesSet.exists(normalizedTpe.contains)) normalizedTpe
+      else ReservedKeywordsAtTypesPatterns.foldLeft(normalizedTpe) { case (cur, (prefix, infix)) =>
+        if (cur.startsWith(prefix) || cur.contains(infix)) cur.replace(infix, " ").stripPrefix(prefix)
+        else cur
+      }
     stripTemplateTags(replaceWhitespaceAfterKeyword(tpe)) match {
       // Empty or problematic types
       case ""                                                                      => Defines.Any
@@ -320,16 +329,15 @@ trait TypeNameProvider { this: AstCreator =>
   }
 
   private def replaceWhitespaceAfterKeyword(tpe: String): String = {
-    if (KeywordsAtTypesToKeep.exists(k => tpe.startsWith(s"$k ") || tpe.contains(s" $k "))) {
-      KeywordsAtTypesToKeep.foldLeft(tpe) { (cur, repl) =>
-        val prefixStartsWith = s"$repl "
-        val prefixContains   = s" $repl "
-        if (cur.startsWith(prefixStartsWith)) {
-          prefixStartsWith + replaceWhitespaceAfterKeyword(cur.substring(prefixStartsWith.length))
-        } else if (cur.contains(prefixContains)) {
-          val front = tpe.substring(0, tpe.indexOf(prefixContains))
-          val back  = tpe.substring(tpe.indexOf(prefixContains) + prefixContains.length)
-          s"${replaceWhitespaceAfterKeyword(front)}$prefixContains${replaceWhitespaceAfterKeyword(back)}"
+    if (KeywordsAtTypesToKeepPatterns.exists { case (prefix, infix) => tpe.startsWith(prefix) || tpe.contains(infix) }) {
+      KeywordsAtTypesToKeepPatterns.foldLeft(tpe) { case (cur, (prefix, infix)) =>
+        if (cur.startsWith(prefix)) {
+          prefix + replaceWhitespaceAfterKeyword(cur.substring(prefix.length))
+        } else if (cur.contains(infix)) {
+          val idx   = cur.indexOf(infix)
+          val front = cur.substring(0, idx)
+          val back  = cur.substring(idx + infix.length)
+          s"${replaceWhitespaceAfterKeyword(front)}$infix${replaceWhitespaceAfterKeyword(back)}"
         } else {
           cur
         }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/TypeNameProvider.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/TypeNameProvider.scala
@@ -60,10 +60,10 @@ trait TypeNameProvider { this: AstCreator =>
         val parentDecl = s.getParent.asInstanceOf[IASTFunctionDefinition].getDeclarator
         ASTStringUtil.getReturnTypeString(s, parentDecl)
       case s: IASTSimpleDeclaration if s.getParent.isInstanceOf[ICASTKnRFunctionDeclarator] =>
-        val decl = s.getDeclarators.apply(index)
+        val decl = s.getDeclarators()(index)
         pointersAsString(s.getDeclSpecifier, decl)
       case s: IASTSimpleDeclSpecifier if s.getParent.isInstanceOf[IASTSimpleDeclaration] =>
-        val parentDecl = s.getParent.asInstanceOf[IASTSimpleDeclaration].getDeclarators.apply(index)
+        val parentDecl = s.getParent.asInstanceOf[IASTSimpleDeclaration].getDeclarators()(index)
         pointersAsString(s, parentDecl)
       case s: IASTSimpleDeclSpecifier =>
         ASTStringUtil.getReturnTypeString(s, null)
@@ -71,23 +71,23 @@ trait TypeNameProvider { this: AstCreator =>
         val parentDecl = s.getParent.asInstanceOf[IASTParameterDeclaration].getDeclarator
         pointersAsString(s, parentDecl)
       case s: IASTNamedTypeSpecifier if s.getParent.isInstanceOf[IASTSimpleDeclaration] =>
-        val parentDecl = s.getParent.asInstanceOf[IASTSimpleDeclaration].getDeclarators.apply(index)
+        val parentDecl = s.getParent.asInstanceOf[IASTSimpleDeclaration].getDeclarators()(index)
         pointersAsString(s, parentDecl)
       case s: IASTNamedTypeSpecifier =>
         ASTStringUtil.getSimpleName(s.getName)
       case s: IASTCompositeTypeSpecifier if s.getParent.isInstanceOf[IASTSimpleDeclaration] =>
-        val parentDecl = s.getParent.asInstanceOf[IASTSimpleDeclaration].getDeclarators.apply(index)
+        val parentDecl = s.getParent.asInstanceOf[IASTSimpleDeclaration].getDeclarators()(index)
         pointersAsString(s, parentDecl)
       case s: IASTCompositeTypeSpecifier => ASTStringUtil.getSimpleName(s.getName)
       case s: IASTEnumerationSpecifier if s.getParent.isInstanceOf[IASTSimpleDeclaration] =>
-        val parentDecl = s.getParent.asInstanceOf[IASTSimpleDeclaration].getDeclarators.apply(index)
+        val parentDecl = s.getParent.asInstanceOf[IASTSimpleDeclaration].getDeclarators()(index)
         pointersAsString(s, parentDecl)
       case s: IASTEnumerationSpecifier => ASTStringUtil.getSimpleName(s.getName)
       case s: IASTElaboratedTypeSpecifier if s.getParent.isInstanceOf[IASTParameterDeclaration] =>
         val parentDecl = s.getParent.asInstanceOf[IASTParameterDeclaration].getDeclarator
         pointersAsString(s, parentDecl)
       case s: IASTElaboratedTypeSpecifier if s.getParent.isInstanceOf[IASTSimpleDeclaration] =>
-        val parentDecl = s.getParent.asInstanceOf[IASTSimpleDeclaration].getDeclarators.apply(index)
+        val parentDecl = s.getParent.asInstanceOf[IASTSimpleDeclaration].getDeclarators()(index)
         pointersAsString(s, parentDecl)
       case s: IASTElaboratedTypeSpecifier => ASTStringUtil.getSignatureString(s, null)
       // TODO: handle other types of IASTDeclSpecifier

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CdtParser.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CdtParser.scala
@@ -15,6 +15,7 @@ import org.eclipse.cdt.core.parser.{DefaultLogService, FileContent, ScannerInfo}
 import org.slf4j.LoggerFactory
 
 import java.nio.file.{Files, Path, Paths}
+import java.util.concurrent.ConcurrentHashMap
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
 import scala.util.control.NonFatal
@@ -94,8 +95,12 @@ object CdtParser {
 
 }
 
-class CdtParser(config: Config, headerFileFinder: HeaderFileFinder, compilationDatabase: Option[CompilationDatabase])
-    extends ParseProblemsLogger
+class CdtParser(
+  config: Config,
+  headerFileFinder: HeaderFileFinder,
+  compilationDatabase: Option[CompilationDatabase],
+  headerContentCache: ConcurrentHashMap[String, Array[Char]] = new ConcurrentHashMap()
+) extends ParseProblemsLogger
     with PreprocessorStatementsLogger {
 
   import io.joern.c2cpg.parser.CdtParser.*
@@ -160,9 +165,10 @@ class CdtParser(config: Config, headerFileFinder: HeaderFileFinder, compilationD
     fileContent: FileContent,
     accumulator: AstCreationPass.Accumulator
   ): ParseResult = {
-    val relativeFilePath    = SourceFiles.toRelativePath(file.toString, config.inputPath)
-    val fileContentProvider = new CustomFileContentProvider(headerFileFinder, file.toString, accumulator)
-    val scannerInfo         = createScannerInfo(file)
+    val relativeFilePath = SourceFiles.toRelativePath(file.toString, config.inputPath)
+    val fileContentProvider =
+      new CustomFileContentProvider(headerFileFinder, file.toString, accumulator, headerContentCache)
+    val scannerInfo = createScannerInfo(file)
     safeParseInternal(fileContent, scannerInfo, fileContentProvider, lang, relativeFilePath)
   }
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CdtParser.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CdtParser.scala
@@ -108,13 +108,17 @@ class CdtParser(
   private val parserConfig = ParserConfig.fromConfig(config, compilationDatabase)
   private val log          = new DefaultLogService
 
-  private var opts: Int =
-    ILanguage.OPTION_NO_IMAGE_LOCATIONS | // performance optimization, allows the parser not to create image-locations
-      ILanguage.OPTION_SKIP_TRIVIAL_EXPRESSIONS_IN_AGGREGATE_INITIALIZERS // performance optimization, skips trivial expressions in aggregate initializers
-  // instructs the parser to skip function and method bodies
-  if (config.skipFunctionBodies) opts |= ILanguage.OPTION_SKIP_FUNCTION_BODIES
-  // enables parsing of code behind disabled preprocessor defines
-  if (config.compilationDatabaseFilename.isEmpty && config.defines.isEmpty) opts |= ILanguage.OPTION_PARSE_INACTIVE_CODE
+  private val opts: Int = {
+    var flags =
+      ILanguage.OPTION_NO_IMAGE_LOCATIONS | // performance optimization, allows the parser not to create image-locations
+        ILanguage.OPTION_SKIP_TRIVIAL_EXPRESSIONS_IN_AGGREGATE_INITIALIZERS // performance optimization, skips trivial expressions in aggregate initializers
+    // instructs the parser to skip function and method bodies
+    if (config.skipFunctionBodies) flags |= ILanguage.OPTION_SKIP_FUNCTION_BODIES
+    // enables parsing of code behind disabled preprocessor defines
+    if (config.compilationDatabaseFilename.isEmpty && config.defines.isEmpty)
+      flags |= ILanguage.OPTION_PARSE_INACTIVE_CODE
+    flags
+  }
 
   def preprocessorStatements(
     file: Path,

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CdtParser.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CdtParser.scala
@@ -1,10 +1,9 @@
 package io.joern.c2cpg.parser
 
 import io.joern.c2cpg.Config
-import io.joern.c2cpg.passes.AstCreationPass
 import io.joern.c2cpg.parser.JSONCompilationDatabaseParser.CompilationDatabase
+import io.joern.c2cpg.passes.AstCreationPass
 import io.joern.x2cpg.SourceFiles
-import io.shiftleft.semanticcpg.utils.FileUtil
 import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.utils.IOUtils
 import org.eclipse.cdt.core.dom.ast.gnu.c.GCCLanguage

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CdtParser.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CdtParser.scala
@@ -14,7 +14,6 @@ import org.eclipse.cdt.core.parser.{DefaultLogService, FileContent, ScannerInfo}
 import org.slf4j.LoggerFactory
 
 import java.nio.file.{Files, Path, Paths}
-import java.util.concurrent.ConcurrentHashMap
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
 import scala.util.control.NonFatal
@@ -94,12 +93,8 @@ object CdtParser {
 
 }
 
-class CdtParser(
-  config: Config,
-  headerFileFinder: HeaderFileFinder,
-  compilationDatabase: Option[CompilationDatabase],
-  headerContentCache: ConcurrentHashMap[String, Array[Char]] = new ConcurrentHashMap()
-) extends ParseProblemsLogger
+class CdtParser(config: Config, headerFileFinder: HeaderFileFinder, compilationDatabase: Option[CompilationDatabase])
+    extends ParseProblemsLogger
     with PreprocessorStatementsLogger {
 
   import io.joern.c2cpg.parser.CdtParser.*
@@ -168,10 +163,9 @@ class CdtParser(
     fileContent: FileContent,
     accumulator: AstCreationPass.Accumulator
   ): ParseResult = {
-    val relativeFilePath = SourceFiles.toRelativePath(file.toString, config.inputPath)
-    val fileContentProvider =
-      new CustomFileContentProvider(headerFileFinder, file.toString, accumulator, headerContentCache)
-    val scannerInfo = createScannerInfo(file)
+    val relativeFilePath    = SourceFiles.toRelativePath(file.toString, config.inputPath)
+    val fileContentProvider = new CustomFileContentProvider(headerFileFinder, file.toString, accumulator)
+    val scannerInfo         = createScannerInfo(file)
     safeParseInternal(fileContent, scannerInfo, fileContentProvider, lang, relativeFilePath)
   }
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CustomFileContentProvider.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CustomFileContentProvider.scala
@@ -10,11 +10,13 @@ import org.eclipse.cdt.internal.core.parser.scanner.InternalFileContent
 import org.eclipse.cdt.internal.core.parser.scanner.InternalFileContentProvider
 
 import java.nio.file.Paths
+import java.util.concurrent.ConcurrentHashMap
 
 class CustomFileContentProvider(
   headerFileFinder: HeaderFileFinder,
   sourceFile: String,
-  accumulator: AstCreationPass.Accumulator
+  accumulator: AstCreationPass.Accumulator,
+  contentCache: ConcurrentHashMap[String, Array[Char]] = new ConcurrentHashMap()
 ) extends InternalFileContentProvider {
 
   override def getContentForInclusion(path: String, macroDictionary: IMacroDictionary): InternalFileContent = {
@@ -30,7 +32,11 @@ class CustomFileContentProvider(
     else { Option(path) }
     maybeFullPath.map { foundPath =>
       updateHeaderFileParserLanguage(foundPath)
-      val content = IOUtils.readLinesInFile(Paths.get(foundPath)).mkString("\n").toArray
+      val content =
+        contentCache.computeIfAbsent(
+          foundPath,
+          filePath => IOUtils.readLinesInFile(Paths.get(filePath)).mkString("\n").toArray
+        )
       FileContent.create(path, false, content).asInstanceOf[InternalFileContent]
     }.orNull
   }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CustomFileContentProvider.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/CustomFileContentProvider.scala
@@ -10,13 +10,11 @@ import org.eclipse.cdt.internal.core.parser.scanner.InternalFileContent
 import org.eclipse.cdt.internal.core.parser.scanner.InternalFileContentProvider
 
 import java.nio.file.Paths
-import java.util.concurrent.ConcurrentHashMap
 
 class CustomFileContentProvider(
   headerFileFinder: HeaderFileFinder,
   sourceFile: String,
-  accumulator: AstCreationPass.Accumulator,
-  contentCache: ConcurrentHashMap[String, Array[Char]] = new ConcurrentHashMap()
+  accumulator: AstCreationPass.Accumulator
 ) extends InternalFileContentProvider {
 
   override def getContentForInclusion(path: String, macroDictionary: IMacroDictionary): InternalFileContent = {
@@ -32,11 +30,7 @@ class CustomFileContentProvider(
     else { Option(path) }
     maybeFullPath.map { foundPath =>
       updateHeaderFileParserLanguage(foundPath)
-      val content =
-        contentCache.computeIfAbsent(
-          foundPath,
-          filePath => IOUtils.readLinesInFile(Paths.get(filePath)).mkString("\n").toArray
-        )
+      val content = IOUtils.readLinesInFile(Paths.get(foundPath)).mkString("\n").toArray
       FileContent.create(path, false, content).asInstanceOf[InternalFileContent]
     }.orNull
   }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/HeaderFileFinder.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/HeaderFileFinder.scala
@@ -7,6 +7,7 @@ import io.shiftleft.semanticcpg.utils.FileUtil.*
 import org.jline.utils.Levenshtein
 
 import java.nio.file.Paths
+import java.util.concurrent.ConcurrentHashMap
 
 class HeaderFileFinder(config: Config) {
 
@@ -21,12 +22,18 @@ class HeaderFileFinder(config: Config) {
     .map(p => Paths.get(p))
     .groupMap(_.fileName)(_.toString)
 
+  private val findCache = new ConcurrentHashMap[String, Option[String]]()
+
   /** Given an unresolved header file, given as a non-existing absolute path, determine whether a header file with the
     * same name can be found anywhere in the code base.
     */
-  def find(path: String): Option[String] = Paths.get(path).nameOption.flatMap { name =>
-    val matches = nameToPathMap.getOrElse(name, List())
-    matches.sortBy(x => Levenshtein.distance(x, path)).headOption
-  }
+  def find(path: String): Option[String] = findCache.computeIfAbsent(
+    path,
+    p =>
+      Paths.get(p).nameOption.flatMap { name =>
+        val matches = nameToPathMap.getOrElse(name, List())
+        matches.sortBy(x => Levenshtein.distance(x, p)).headOption
+      }
+  )
 
 }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/HeaderFileFinder.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/HeaderFileFinder.scala
@@ -19,7 +19,7 @@ class HeaderFileFinder(config: Config) {
       ignoredFilesRegex = Option(config.ignoredFilesRegex),
       ignoredFilesPath = Option(config.ignoredFiles)
     )
-    .map(p => Paths.get(p))
+    .map(path => Paths.get(path))
     .groupMap(_.fileName)(_.toString)
 
   private val findCache = new ConcurrentHashMap[String, Option[String]]()
@@ -29,10 +29,10 @@ class HeaderFileFinder(config: Config) {
     */
   def find(path: String): Option[String] = findCache.computeIfAbsent(
     path,
-    p =>
-      Paths.get(p).nameOption.flatMap { name =>
+    unresolvedPath =>
+      Paths.get(unresolvedPath).nameOption.flatMap { name =>
         val matches = nameToPathMap.getOrElse(name, List())
-        matches.sortBy(x => Levenshtein.distance(x, p)).headOption
+        matches.sortBy(candidate => Levenshtein.distance(candidate, unresolvedPath)).headOption
       }
   )
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/ParserConfig.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/ParserConfig.scala
@@ -1,7 +1,7 @@
 package io.joern.c2cpg.parser
 
 import io.joern.c2cpg.Config
-import io.joern.c2cpg.parser.JSONCompilationDatabaseParser.{CommandObject, CompilationDatabase}
+import io.joern.c2cpg.parser.JSONCompilationDatabaseParser.CompilationDatabase
 import io.joern.c2cpg.utils.IncludeAutoDiscovery
 
 import java.nio.file.{Path, Paths}

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
@@ -19,6 +19,7 @@ import org.eclipse.cdt.core.model.ILanguage
 import org.slf4j.{Logger, LoggerFactory}
 
 import java.nio.file.{Path, Paths}
+import java.util.concurrent.ConcurrentHashMap
 import scala.collection.mutable
 
 object AstCreationPass {
@@ -85,7 +86,8 @@ class AstCreationPass(
 
   private val logger: Logger = LoggerFactory.getLogger(classOf[AstCreationPass])
 
-  private val headerFileFinder: HeaderFileFinder = new HeaderFileFinder(config)
+  private val headerFileFinder: HeaderFileFinder                         = new HeaderFileFinder(config)
+  private val headerContentCache: ConcurrentHashMap[String, Array[Char]] = new ConcurrentHashMap()
 
   private var _finalAccumulator: Accumulator = Accumulator()
 
@@ -176,7 +178,7 @@ class AstCreationPass(
     val (path, language) = fileAndLanguage
     val relPath          = SourceFiles.toRelativePath(path.toString, config.inputPath)
     val (gotCpg, duration) = TimeUtils.time {
-      val cdtParser   = new CdtParser(config, headerFileFinder, compilationDatabase)
+      val cdtParser   = new CdtParser(config, headerFileFinder, compilationDatabase, headerContentCache)
       val parseResult = cdtParser.parse(path, language, accumulator)
       parseResult match {
         case Some(translationUnit) =>

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
@@ -19,7 +19,6 @@ import org.eclipse.cdt.core.model.ILanguage
 import org.slf4j.{Logger, LoggerFactory}
 
 import java.nio.file.{Path, Paths}
-import java.util.concurrent.ConcurrentHashMap
 import scala.collection.mutable
 
 object AstCreationPass {
@@ -86,8 +85,8 @@ class AstCreationPass(
 
   private val logger: Logger = LoggerFactory.getLogger(classOf[AstCreationPass])
 
-  private val headerFileFinder: HeaderFileFinder                         = new HeaderFileFinder(config)
-  private val headerContentCache: ConcurrentHashMap[String, Array[Char]] = new ConcurrentHashMap()
+  private val headerFileFinder: HeaderFileFinder = new HeaderFileFinder(config)
+  private val cdtParser: CdtParser               = new CdtParser(config, headerFileFinder, compilationDatabase)
 
   private var _finalAccumulator: Accumulator = Accumulator()
 
@@ -178,7 +177,6 @@ class AstCreationPass(
     val (path, language) = fileAndLanguage
     val relPath          = SourceFiles.toRelativePath(path.toString, config.inputPath)
     val (gotCpg, duration) = TimeUtils.time {
-      val cdtParser   = new CdtParser(config, headerFileFinder, compilationDatabase, headerContentCache)
       val parseResult = cdtParser.parse(path, language, accumulator)
       parseResult match {
         case Some(translationUnit) =>

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
@@ -86,7 +86,6 @@ class AstCreationPass(
   private val logger: Logger = LoggerFactory.getLogger(classOf[AstCreationPass])
 
   private val headerFileFinder: HeaderFileFinder = new HeaderFileFinder(config)
-  private val parser: CdtParser                  = new CdtParser(config, headerFileFinder, compilationDatabase)
 
   private var _finalAccumulator: Accumulator = Accumulator()
 
@@ -177,7 +176,8 @@ class AstCreationPass(
     val (path, language) = fileAndLanguage
     val relPath          = SourceFiles.toRelativePath(path.toString, config.inputPath)
     val (gotCpg, duration) = TimeUtils.time {
-      val parseResult = parser.parse(path, language, accumulator)
+      val cdtParser   = new CdtParser(config, headerFileFinder, compilationDatabase)
+      val parseResult = cdtParser.parse(path, language, accumulator)
       parseResult match {
         case Some(translationUnit) =>
           val fileLOC = translationUnit.getRawSignature.linesIterator.size

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/FunctionDeclNodePass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/FunctionDeclNodePass.scala
@@ -3,14 +3,12 @@ package io.joern.c2cpg.passes
 import io.joern.c2cpg.Config
 import io.joern.x2cpg.passes.frontend.MetaDataPass
 import io.joern.x2cpg.{Ast, Defines, ValidationMode}
-import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.*
+import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 import org.apache.commons.lang3.StringUtils
-
-import scala.collection.immutable.Map
 
 object FunctionDeclNodePass {
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/utils/IncludeAutoDiscovery.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/utils/IncludeAutoDiscovery.scala
@@ -36,35 +36,43 @@ object IncludeAutoDiscovery {
   private val LanguageSetting = Map("LC_ALL" -> "C")
 
   // Only check once
-  private var isGccAvailable: Option[Boolean] = None
+  @volatile private var isGccAvailable: Option[Boolean] = None
 
   // Only discover them once
-  private var systemIncludePathsC: mutable.LinkedHashSet[Path]   = mutable.LinkedHashSet.empty
-  private var systemIncludePathsCPP: mutable.LinkedHashSet[Path] = mutable.LinkedHashSet.empty
+  @volatile private var systemIncludePathsC: mutable.LinkedHashSet[Path]   = mutable.LinkedHashSet.empty
+  @volatile private var systemIncludePathsCPP: mutable.LinkedHashSet[Path] = mutable.LinkedHashSet.empty
 
   def discoverIncludePathsC(config: Config): mutable.LinkedHashSet[Path] = {
     if (!config.includePathsAutoDiscovery) return mutable.LinkedHashSet.empty
     if (systemIncludePathsC.nonEmpty) return systemIncludePathsC
-
-    if (isMSVCProject(config)) {
-      systemIncludePathsCPP = discoverMSVCPaths() // discovers paths for both languages
-      systemIncludePathsC = systemIncludePathsCPP
-      reportIncludePaths(systemIncludePathsC, "MSVC")
+    IncludeAutoDiscovery.synchronized {
+      if (systemIncludePathsC.nonEmpty) return systemIncludePathsC
+      if (isMSVCProject(config)) {
+        systemIncludePathsCPP = discoverMSVCPaths() // discovers paths for both languages
+        systemIncludePathsC = systemIncludePathsCPP
+        reportIncludePaths(systemIncludePathsC, "MSVC")
+      }
+      if (systemIncludePathsC.isEmpty && gccAvailable()) {
+        systemIncludePathsC = discoverPaths(CIncludeCommand)
+        reportIncludePaths(systemIncludePathsC, "C")
+      }
+      systemIncludePathsC
     }
-    if (systemIncludePathsC.isEmpty && gccAvailable()) {
-      systemIncludePathsC = discoverPaths(CIncludeCommand)
-      reportIncludePaths(systemIncludePathsC, "C")
-    }
-    systemIncludePathsC
   }
 
   def gccAvailable(): Boolean = {
     isGccAvailable match {
-      case Some(value) =>
-        value
+      case Some(value) => value
       case None =>
-        isGccAvailable = Option(checkForGcc())
-        isGccAvailable.get
+        IncludeAutoDiscovery.synchronized {
+          isGccAvailable match {
+            case Some(value) => value
+            case None =>
+              val result = checkForGcc()
+              isGccAvailable = Some(result)
+              result
+          }
+        }
     }
   }
 
@@ -145,17 +153,19 @@ object IncludeAutoDiscovery {
   def discoverIncludePathsCPP(config: Config): mutable.LinkedHashSet[Path] = {
     if (!config.includePathsAutoDiscovery) return mutable.LinkedHashSet.empty
     if (systemIncludePathsCPP.nonEmpty) return systemIncludePathsCPP
-
-    if (isMSVCProject(config)) {
-      systemIncludePathsCPP = discoverMSVCPaths() // discovers paths for both languages
-      systemIncludePathsC = systemIncludePathsCPP
-      reportIncludePaths(systemIncludePathsCPP, "MSVC")
+    IncludeAutoDiscovery.synchronized {
+      if (systemIncludePathsCPP.nonEmpty) return systemIncludePathsCPP
+      if (isMSVCProject(config)) {
+        systemIncludePathsCPP = discoverMSVCPaths() // discovers paths for both languages
+        systemIncludePathsC = systemIncludePathsCPP
+        reportIncludePaths(systemIncludePathsCPP, "MSVC")
+      }
+      if (systemIncludePathsCPP.isEmpty && gccAvailable()) {
+        systemIncludePathsCPP = discoverPaths(CppIncludeCommand)
+        reportIncludePaths(systemIncludePathsCPP, "CPP")
+      }
+      systemIncludePathsCPP
     }
-    if (systemIncludePathsCPP.isEmpty && gccAvailable()) {
-      systemIncludePathsCPP = discoverPaths(CppIncludeCommand)
-      reportIncludePaths(systemIncludePathsCPP, "CPP")
-    }
-    systemIncludePathsCPP
   }
 
 }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/utils/IncludeAutoDiscovery.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/utils/IncludeAutoDiscovery.scala
@@ -1,8 +1,8 @@
 package io.joern.c2cpg.utils
 
 import io.joern.c2cpg.Config
+import io.shiftleft.semanticcpg.utils.ExternalCommand
 import io.shiftleft.semanticcpg.utils.FileUtil.*
-import io.shiftleft.semanticcpg.utils.{ExternalCommand, FileUtil}
 import org.slf4j.LoggerFactory
 
 import java.nio.file.{Files, Path, Paths}


### PR DESCRIPTION
## [c2cpg] Performance fixes across AST creation pipeline

Targeted, behavior-preserving performance work, from an Opus 4.8 review of c2cpg/src/main. Addresses algorithmic complexity, redundant allocations, and concurrency issues found via profiling by me. Otherwise, findings from the LLM were manually reviewed.

### Results

Running c2cpg on https://github.com/polarphp/polarphp is down to 28sec (from 3min 20sec) on my machine.

### Changes

**Algorithmic fixes**
- Fix O(arguments × nodes) scan in `argumentTrees` — use pre-built index map instead of linear search per argument
- Fix O(n²) string concatenation in `tokenListToString` — replace `++=` accumulation with `StringBuilder`
- Fix O(nodes × captures) in `setEvaluationStrategyForCaptures` — eliminate repeated full-node scans
- Replace O(n²) `List.init` recursion with a left-fold in `fieldAccesses`
- Make `parameters()` tail-recursive to avoid intermediate sequences at each nesting level

**Allocation / hot-path fixes**
- Fix `fileName(node: IASTNode)` path handling
- Eliminate per-character tuple boxing in `genFileOffsetTable` (`zipWithIndex` → index variable)
- Eliminate per-call string allocations in `cleanType`
- Avoid hot-path `List` allocation in `expandedFromMacro`
- Replace `regex.replaceAll` with literal `replace` in `paramIsVariadic`
- Use direct array access (`apply(index)`) instead of `toList(index)` in `typeForDeclSpecifier`
- Compute `safeGetNodeType` once in `typeForIASTArrayDeclarator`
- Call `nullSafeFileLocation` once per node in `nodeOffsets` (was called twice)
- Skip redundant `normalizeSpace` in `cleanType` when input is already normalized

**Caching / concurrency fixes**
- Cache Levenshtein sort results in `HeaderFileFinder`
- Fix concurrent races in `IncludeAutoDiscovery`

Commits are small and focused on the individual findings and can be reviewed in isolation. CS integration and sptests are green.

Better review alternative: https://diffshub.com/joernio/joern/pull/6112 