### PR TITLE
[x2cpg] Use SourceFiles.determine to find supported build files

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -1,6 +1,7 @@
 package io.joern.javasrc2cpg
 
 import io.joern.javasrc2cpg.passes.{AstCreationPass, OuterClassRefPass, TypeInferencePass}
+import io.joern.x2cpg.SourceFiles
 import io.joern.x2cpg.X2Cpg.withNewEmptyCpg
 import io.joern.x2cpg.passes.frontend.{JavaConfigFileCreationPass, MetaDataPass, TypeNodePass}
 import io.joern.x2cpg.X2CpgFrontend
@@ -41,11 +42,8 @@ object JavaSrc2Cpg {
   val language: String                  = Languages.JAVASRC
   val sourceFileExtensions: Set[String] = Set(".java")
 
-  val DefaultIgnoredFilesRegex: List[Regex] =
-    List(".git", ".mvn", ".gradle", "test").map(Pattern.quote).flatMap { directory =>
-      List(s"(^|\\\\)$directory($$|\\\\)".r.unanchored, s"(^|/)$directory($$|/)".r.unanchored)
-    }
-  val DefaultConfig: Config = Config()
+  val DefaultIgnoredFilesRegex: List[Regex] = SourceFiles.JvmDefaultIgnoredFolders
+  val DefaultConfig: Config                 = Config()
 
   def showEnv(): Unit = {
     JavaSrcEnvVar.values.foreach { envVar =>

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -5,6 +5,7 @@ import io.joern.x2cpg.SourceFiles
 import io.joern.x2cpg.X2Cpg.withNewEmptyCpg
 import io.joern.x2cpg.passes.frontend.{JavaConfigFileCreationPass, MetaDataPass, TypeNodePass}
 import io.joern.x2cpg.X2CpgFrontend
+import io.joern.x2cpg.frontendspecific.javasrc2cpg.JvmDefaultIgnoredFolders
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.Languages
 import org.slf4j.LoggerFactory
@@ -42,7 +43,7 @@ object JavaSrc2Cpg {
   val language: String                  = Languages.JAVASRC
   val sourceFileExtensions: Set[String] = Set(".java")
 
-  val DefaultIgnoredFilesRegex: List[Regex] = SourceFiles.JvmDefaultIgnoredFolders
+  val DefaultIgnoredFilesRegex: List[Regex] = JvmDefaultIgnoredFolders
   val DefaultConfig: Config                 = Config()
 
   def showEnv(): Unit = {

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/SourceFiles.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/SourceFiles.scala
@@ -258,6 +258,18 @@ object SourceFiles {
     ignoredFilesRegex: Option[Regex] = None,
     ignoredFilesPath: Option[Seq[String]] = None
   )(implicit visitOptions: Seq[FileVisitOption] = Seq(FileVisitOption.FOLLOW_LINKS)): List[String] = {
+    determinePaths(inputPath, sourceFileExtensions, ignoredDefaultRegex, ignoredFilesRegex, ignoredFilesPath).map(
+      _.toString
+    )
+  }
+
+  def determinePaths(
+    inputPath: String,
+    sourceFileExtensions: Set[String],
+    ignoredDefaultRegex: Option[Seq[Regex]] = None,
+    ignoredFilesRegex: Option[Regex] = None,
+    ignoredFilesPath: Option[Seq[String]] = None
+  )(implicit visitOptions: Seq[FileVisitOption] = Seq(FileVisitOption.FOLLOW_LINKS)): List[Path] = {
     val dir = Paths.get(inputPath)
     assertExists(dir)
     val visitor = new FailsafeFileVisitor(
@@ -268,19 +280,8 @@ object SourceFiles {
       ignoredFilesPath
     )
     Files.walkFileTree(dir, visitOptions.toSet.asJava, Int.MaxValue, visitor)
-    val matchingFiles = visitor.files().map(_.toString)
-    matchingFiles.toList.sorted
+    visitor.files().toList.sorted
   }
-
-  def determine(
-    inputPath: Path,
-    sourceFileExtensions: Set[String],
-    ignoredDefaultRegex: Option[Seq[Regex]] = None,
-    ignoredFilesRegex: Option[Regex] = None,
-    ignoredFilesPath: Option[Seq[String]] = None
-  )(implicit visitOptions: Seq[FileVisitOption] = Seq(FileVisitOption.FOLLOW_LINKS)): List[Path] =
-    determine(inputPath.toString, sourceFileExtensions, ignoredDefaultRegex, ignoredFilesRegex, ignoredFilesPath)
-      .map(Path.of(_))
 
   /** Asserts that a given file exists and is readable.
     *

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/SourceFiles.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/SourceFiles.scala
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory
 import java.io.FileNotFoundException
 import java.nio.file.{FileVisitOption, FileVisitResult, FileVisitor, Files, LinkOption, Path, Paths}
 import java.nio.file.attribute.BasicFileAttributes
+import java.util.regex.Pattern
 import scala.jdk.CollectionConverters.SetHasAsJava
 import scala.util.matching.Regex
 import scala.util.Try
@@ -18,6 +19,16 @@ object SourceFiles {
   private[x2cpg] val DefaultMaxFileSizeBytes: Long = Integer.MAX_VALUE - 2L
 
   private def DefaultMaxFileSizeString: String = s"${DefaultMaxFileSizeBytes}B"
+
+  /** Regexes matching common JVM build-tool / IDE / VCS folder names. Used to prune tree traversal so we don't descend
+    * into caches, generated output, repo metadata, or test roots.
+    */
+  val JvmDefaultIgnoredFolders: List[Regex] =
+    List(".git", ".mvn", ".gradle", "build", "target", "out", "node_modules", ".idea", "test")
+      .map(Pattern.quote)
+      .flatMap { name =>
+        List(s"(^|\\\\)$name($$|\\\\)".r.unanchored, s"(^|/)$name($$|/)".r.unanchored)
+      }
 
   /** A failsafe implementation of a [[FileVisitor]] that continues iterating through files even if an [[IOException]]
     * occurs during traversal.
@@ -260,6 +271,16 @@ object SourceFiles {
     val matchingFiles = visitor.files().map(_.toString)
     matchingFiles.toList.sorted
   }
+
+  def determine(
+    inputPath: Path,
+    sourceFileExtensions: Set[String],
+    ignoredDefaultRegex: Option[Seq[Regex]] = None,
+    ignoredFilesRegex: Option[Regex] = None,
+    ignoredFilesPath: Option[Seq[String]] = None
+  )(implicit visitOptions: Seq[FileVisitOption] = Seq(FileVisitOption.FOLLOW_LINKS)): List[Path] =
+    determine(inputPath.toString, sourceFileExtensions, ignoredDefaultRegex, ignoredFilesRegex, ignoredFilesPath)
+      .map(Path.of(_))
 
   /** Asserts that a given file exists and is readable.
     *

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/SourceFiles.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/SourceFiles.scala
@@ -258,18 +258,6 @@ object SourceFiles {
     ignoredFilesRegex: Option[Regex] = None,
     ignoredFilesPath: Option[Seq[String]] = None
   )(implicit visitOptions: Seq[FileVisitOption] = Seq(FileVisitOption.FOLLOW_LINKS)): List[String] = {
-    determinePaths(inputPath, sourceFileExtensions, ignoredDefaultRegex, ignoredFilesRegex, ignoredFilesPath).map(
-      _.toString
-    )
-  }
-
-  def determinePaths(
-    inputPath: String,
-    sourceFileExtensions: Set[String],
-    ignoredDefaultRegex: Option[Seq[Regex]] = None,
-    ignoredFilesRegex: Option[Regex] = None,
-    ignoredFilesPath: Option[Seq[String]] = None
-  )(implicit visitOptions: Seq[FileVisitOption] = Seq(FileVisitOption.FOLLOW_LINKS)): List[Path] = {
     val dir = Paths.get(inputPath)
     assertExists(dir)
     val visitor = new FailsafeFileVisitor(
@@ -280,7 +268,8 @@ object SourceFiles {
       ignoredFilesPath
     )
     Files.walkFileTree(dir, visitOptions.toSet.asJava, Int.MaxValue, visitor)
-    visitor.files().toList.sorted
+    val matchingFiles = visitor.files().map(_.toString)
+    matchingFiles.toList.sorted
   }
 
   /** Asserts that a given file exists and is readable.

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/SourceFiles.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/SourceFiles.scala
@@ -6,7 +6,6 @@ import org.slf4j.LoggerFactory
 import java.io.FileNotFoundException
 import java.nio.file.{FileVisitOption, FileVisitResult, FileVisitor, Files, LinkOption, Path, Paths}
 import java.nio.file.attribute.BasicFileAttributes
-import java.util.regex.Pattern
 import scala.jdk.CollectionConverters.SetHasAsJava
 import scala.util.matching.Regex
 import scala.util.Try
@@ -19,16 +18,6 @@ object SourceFiles {
   private[x2cpg] val DefaultMaxFileSizeBytes: Long = Integer.MAX_VALUE - 2L
 
   private def DefaultMaxFileSizeString: String = s"${DefaultMaxFileSizeBytes}B"
-
-  /** Regexes matching common JVM build-tool / IDE / VCS folder names. Used to prune tree traversal so we don't descend
-    * into caches, generated output, repo metadata, or test roots.
-    */
-  val JvmDefaultIgnoredFolders: List[Regex] =
-    List(".git", ".mvn", ".gradle", "build", "target", "out", "node_modules", ".idea", "test")
-      .map(Pattern.quote)
-      .flatMap { name =>
-        List(s"(^|\\\\)$name($$|\\\\)".r.unanchored, s"(^|/)$name($$|/)".r.unanchored)
-      }
 
   /** A failsafe implementation of a [[FileVisitor]] that continues iterating through files even if an [[IOException]]
     * occurs during traversal.

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/javasrc2cpg/package.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/javasrc2cpg/package.scala
@@ -4,6 +4,9 @@ import io.joern.x2cpg.passes.frontend.XTypeRecoveryConfig
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.passes.CpgPassBase
 
+import java.util.regex.Pattern
+import scala.util.matching.Regex
+
 package object javasrc2cpg {
 
   object ParameterNames {
@@ -15,4 +18,13 @@ package object javasrc2cpg {
       new JavaTypeHintCallLinker(cpg)
   }
 
+  /** Regexes matching common JVM build-tool / IDE / VCS folder names. Used to prune tree traversal so we don't descend
+    * into caches, generated output, repo metadata, or test roots.
+    */
+  val JvmDefaultIgnoredFolders: List[Regex] =
+    List(".git", ".mvn", ".gradle", "build", "target", "out", "node_modules", ".idea", "test")
+      .map(Pattern.quote)
+      .flatMap { name =>
+        List(s"(^|\\\\)$name($$|\\\\)".r.unanchored, s"(^|/)$name($$|/)".r.unanchored)
+      }
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/DependencyResolver.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/DependencyResolver.scala
@@ -127,17 +127,17 @@ object DependencyResolver {
       }
       .toList
 
-    // Keep only the top-most build file on each directory branch. After sorting by path,
-    // any nested build file appears immediately after its ancestor's build file, so we can
-    // drop it by checking a prefix against the last kept directory.
-    perDirectory
-      .sortBy(_.toString)
+    // Keep only the top-most build file on each directory branch. Sort by path depth so
+    // that a parent build file is always visited before any of its descendants, then drop
+    // any candidate whose directory sits under an already-kept one.
+    val foundBuildFiles = perDirectory
+      .sortBy(_.getNameCount)
       .foldLeft(List.empty[Path]) { (kept, buildFile) =>
-        kept.headOption match {
-          case Some(top) if buildFile.getParent.startsWith(top.getParent) => kept
-          case _                                                          => buildFile :: kept
-        }
+        if (kept.exists(k => buildFile.getParent.startsWith(k.getParent))) kept
+        else buildFile :: kept
       }
       .reverse
+    logger.debug(s"Found build files:\n - ${foundBuildFiles.mkString("\n - ")}")
+    foundBuildFiles
   }
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/DependencyResolver.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/DependencyResolver.scala
@@ -1,10 +1,10 @@
 package io.joern.x2cpg.utils.dependency
 
-import io.shiftleft.semanticcpg.utils.{ExternalCommand, FileUtil}
-import FileUtil.*
+import io.joern.x2cpg.SourceFiles
+import io.shiftleft.semanticcpg.utils.ExternalCommand
 import org.slf4j.LoggerFactory
 
-import java.nio.file.{Files, Path}
+import java.nio.file.Path
 import scala.util.{Failure, Success}
 
 enum GradleConfigKeys {
@@ -17,8 +17,8 @@ case class DependencyResolverParams(
 )
 
 object DependencyResolver {
-  private val logger              = LoggerFactory.getLogger(getClass)
-  private val MaxSearchDepth: Int = 4
+  private val logger                           = LoggerFactory.getLogger(getClass)
+  private val BuildFileExtensions: Set[String] = Set(".gradle", ".gradle.kts", "pom.xml")
 
   def getCoordinates(
     projectDir: Path,
@@ -106,26 +106,34 @@ object DependencyResolver {
     file.toString.endsWith("pom.xml")
   }
 
-  private[dependency] def findSupportedBuildFiles(currentDir: Path, depth: Int = 0): List[Path] = {
-    if (depth >= MaxSearchDepth) {
-      logger.info("findSupportedBuildFiles reached max depth before finding build files")
-      Nil
-    } else {
-      val (childDirectories, childFiles) = currentDir.listFiles().partition(Files.isDirectory(_))
-      // Only fetch dependencies once for projects with both a build.gradle and a pom.xml file
-      val childFileList = childFiles.toList
-      childFileList
-        .find(isGradleBuildFile)
-        .orElse(childFileList.find(isMavenBuildFile)) match {
-        case Some(buildFile) => buildFile :: Nil
+  private[dependency] def findSupportedBuildFiles(currentDir: Path): List[Path] = {
+    val allBuildFiles = SourceFiles
+      .determine(currentDir.toString, BuildFileExtensions)
+      .map(Path.of(_))
 
-        case None if childDirectories.isEmpty => Nil
-
-        case None =>
-          childDirectories.flatMap { dir =>
-            findSupportedBuildFiles(dir, depth + 1)
-          }.toList
+    // Only fetch dependencies once for projects with both a build.gradle and a pom.xml file
+    // by grouping per parent directory and preferring Gradle over Maven.
+    val perDirectory = allBuildFiles
+      .groupBy(_.getParent)
+      .values
+      .flatMap { filesInDir =>
+        filesInDir
+          .find(isGradleBuildFile)
+          .orElse(filesInDir.find(isMavenBuildFile))
       }
-    }
+      .toList
+
+    // Keep only the top-most build file on each directory branch. After sorting by path,
+    // any nested build file appears immediately after its ancestor's build file, so we can
+    // drop it by checking a prefix against the last kept directory.
+    perDirectory
+      .sortBy(_.toString)
+      .foldLeft(List.empty[Path]) { (kept, buildFile) =>
+        kept.headOption match {
+          case Some(top) if buildFile.getParent.startsWith(top.getParent) => kept
+          case _                                                          => buildFile :: kept
+        }
+      }
+      .reverse
   }
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/DependencyResolver.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/DependencyResolver.scala
@@ -1,6 +1,7 @@
 package io.joern.x2cpg.utils.dependency
 
 import io.joern.x2cpg.SourceFiles
+import io.joern.x2cpg.frontendspecific.javasrc2cpg.JvmDefaultIgnoredFolders
 import io.shiftleft.semanticcpg.utils.ExternalCommand
 import org.slf4j.LoggerFactory
 
@@ -110,7 +111,7 @@ object DependencyResolver {
       .determine(
         currentDir.toAbsolutePath.toString,
         BuildFileSuffixes,
-        ignoredDefaultRegex = Some(SourceFiles.JvmDefaultIgnoredFolders)
+        ignoredDefaultRegex = Some(JvmDefaultIgnoredFolders)
       )
       .map(Path.of(_))
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/DependencyResolver.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/DependencyResolver.scala
@@ -106,8 +106,8 @@ object DependencyResolver {
     MavenBuildFileSuffixes.exists(file.toString.endsWith)
 
   private[dependency] def findSupportedBuildFiles(currentDir: Path): List[Path] = {
-    val allBuildFiles = SourceFiles.determine(
-      currentDir,
+    val allBuildFiles = SourceFiles.determinePaths(
+      currentDir.toAbsolutePath.toString,
       BuildFileSuffixes,
       ignoredDefaultRegex = Some(SourceFiles.JvmDefaultIgnoredFolders)
     )

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/DependencyResolver.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/DependencyResolver.scala
@@ -17,8 +17,10 @@ case class DependencyResolverParams(
 )
 
 object DependencyResolver {
-  private val logger                           = LoggerFactory.getLogger(getClass)
-  private val BuildFileExtensions: Set[String] = Set(".gradle", ".gradle.kts", "pom.xml")
+  private val logger                               = LoggerFactory.getLogger(getClass)
+  private val GradleBuildFileSuffixes: Set[String] = Set(".gradle", ".gradle.kts")
+  private val MavenBuildFileSuffixes: Set[String]  = Set("pom.xml")
+  private val BuildFileSuffixes: Set[String]       = GradleBuildFileSuffixes ++ MavenBuildFileSuffixes
 
   def getCoordinates(
     projectDir: Path,
@@ -97,19 +99,18 @@ object DependencyResolver {
     }
   }
 
-  private[dependency] def isGradleBuildFile(file: Path): Boolean = {
-    val pathString = file.toString
-    pathString.endsWith(".gradle") || pathString.endsWith(".gradle.kts")
-  }
+  private[dependency] def isGradleBuildFile(file: Path): Boolean =
+    GradleBuildFileSuffixes.exists(file.toString.endsWith)
 
-  private[dependency] def isMavenBuildFile(file: Path): Boolean = {
-    file.toString.endsWith("pom.xml")
-  }
+  private[dependency] def isMavenBuildFile(file: Path): Boolean =
+    MavenBuildFileSuffixes.exists(file.toString.endsWith)
 
   private[dependency] def findSupportedBuildFiles(currentDir: Path): List[Path] = {
-    val allBuildFiles = SourceFiles
-      .determine(currentDir.toString, BuildFileExtensions)
-      .map(Path.of(_))
+    val allBuildFiles = SourceFiles.determine(
+      currentDir,
+      BuildFileSuffixes,
+      ignoredDefaultRegex = Some(SourceFiles.JvmDefaultIgnoredFolders)
+    )
 
     // Only fetch dependencies once for projects with both a build.gradle and a pom.xml file
     // by grouping per parent directory and preferring Gradle over Maven.

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/DependencyResolver.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/dependency/DependencyResolver.scala
@@ -106,11 +106,13 @@ object DependencyResolver {
     MavenBuildFileSuffixes.exists(file.toString.endsWith)
 
   private[dependency] def findSupportedBuildFiles(currentDir: Path): List[Path] = {
-    val allBuildFiles = SourceFiles.determinePaths(
-      currentDir.toAbsolutePath.toString,
-      BuildFileSuffixes,
-      ignoredDefaultRegex = Some(SourceFiles.JvmDefaultIgnoredFolders)
-    )
+    val allBuildFiles = SourceFiles
+      .determine(
+        currentDir.toAbsolutePath.toString,
+        BuildFileSuffixes,
+        ignoredDefaultRegex = Some(SourceFiles.JvmDefaultIgnoredFolders)
+      )
+      .map(Path.of(_))
 
     // Only fetch dependencies once for projects with both a build.gradle and a pom.xml file
     // by grouping per parent directory and preferring Gradle over Maven.

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/dependency/DependencyResolverTests.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/dependency/DependencyResolverTests.scala
@@ -90,4 +90,28 @@ class DependencyResolverTests extends AnyWordSpec with Matchers {
       dependencyFiles.find(_.endsWith("slf4j-api-1.7.36.jar")) should not be empty
     }
   }
+
+  "findSupportedBuildFiles" should {
+    "deduplicate nested Gradle build files to the top-most per branch" in {
+      FileUtil.usingTemporaryDirectory("DependencyResolverTests") { tmpDir =>
+        val relFiles = Seq(
+          "attackerapp/build.gradle",
+          "attackerapp/app/build.gradle",
+          "vulnerableapp/build.gradle",
+          "vulnerableapp/app/build.gradle"
+        )
+        relFiles.foreach { rel =>
+          val f = tmpDir / rel
+          f.createWithParentsIfNotExists(createParents = true)
+          Files.writeString(f, "")
+        }
+
+        val found = DependencyResolver.findSupportedBuildFiles(tmpDir)
+        found.map(_.toString) should contain theSameElementsAs Seq(
+          (tmpDir / "attackerapp/build.gradle").toString,
+          (tmpDir / "vulnerableapp/build.gradle").toString
+        )
+      }
+    }
+  }
 }


### PR DESCRIPTION
This PR replaces https://github.com/joernio/joern/pull/5959 using `SourceFiles.determine` as suggested by @max-leuthaeuser and filtering the results afterwards. 

It also moves the `JvmDefaultIgnoreRegex` previously used in javasrc2cpg into x2cpg to have it available for the DependencyResolver to avoid traversing these directories when looking for build files.