### PR TITLE
[c2cpg] Revert change at MacroHandler.argumentTrees

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroHandler.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroHandler.scala
@@ -170,13 +170,20 @@ trait MacroHandler { this: AstCreator =>
   }
 
   private def argumentTrees(arguments: List[String], ast: Ast): List[Option[Ast]] = {
-    val codeIndex: Map[String, ExpressionNew] = ast.nodes.collect {
-      case x: ExpressionNew if !x.isInstanceOf[NewFieldIdentifier] => x.code.replace(" ", "") -> x
-    }.toMap
-    arguments.zipWithIndex.map { case (arg, argIndex) =>
-      val normalizedCode = arg.replace(" ", "")
-      if (normalizedCode.isEmpty) None
-      else codeIndex.get(normalizedCode).map(node => ast.subTreeCopy(node.asInstanceOf[AstNodeNew], argIndex + 1))
+    arguments.zipWithIndex.map { case (arg, i) =>
+      val rootNode = argForCode(arg, ast)
+      rootNode.map(x => ast.subTreeCopy(x.asInstanceOf[AstNodeNew], i + 1))
+    }
+  }
+
+  private def argForCode(code: String, ast: Ast): Option[NewNode] = {
+    val normalizedCode = code.replace(" ", "")
+    if (normalizedCode == "") {
+      None
+    } else {
+      ast.nodes.collectFirst {
+        case x: ExpressionNew if !x.isInstanceOf[NewFieldIdentifier] && x.code == normalizedCode => x
+      }
     }
   }
 

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroHandler.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/MacroHandler.scala
@@ -170,20 +170,17 @@ trait MacroHandler { this: AstCreator =>
   }
 
   private def argumentTrees(arguments: List[String], ast: Ast): List[Option[Ast]] = {
-    arguments.zipWithIndex.map { case (arg, i) =>
+    arguments.zipWithIndex.map { case (arg, argIndex) =>
       val rootNode = argForCode(arg, ast)
-      rootNode.map(x => ast.subTreeCopy(x.asInstanceOf[AstNodeNew], i + 1))
+      rootNode.map(node => ast.subTreeCopy(node.asInstanceOf[AstNodeNew], argIndex + 1))
     }
   }
 
   private def argForCode(code: String, ast: Ast): Option[NewNode] = {
     val normalizedCode = code.replace(" ", "")
-    if (normalizedCode == "") {
-      None
-    } else {
-      ast.nodes.collectFirst {
-        case x: ExpressionNew if !x.isInstanceOf[NewFieldIdentifier] && x.code == normalizedCode => x
-      }
+    if (normalizedCode.isEmpty) return None
+    ast.nodes.collectFirst {
+      case expr: ExpressionNew if !expr.isInstanceOf[NewFieldIdentifier] && expr.code == normalizedCode => expr
     }
   }
 


### PR DESCRIPTION
This caused sptest expectation changes.
(semantic diff from `.collectFirst` vs. `.toMap`)