### PR TITLE
[rust2cpg] add constructor method to structs.

### DIFF
--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
@@ -4,7 +4,13 @@ import io.joern.rust2cpg.parser.RustNodeSyntax.*
 import io.joern.x2cpg.datastructures.Stack.*
 import io.joern.x2cpg.utils.AstPropertiesUtil.RootProperties
 import io.joern.x2cpg.{Ast, Defines, ValidationMode}
-import io.shiftleft.codepropertygraph.generated.nodes.{NewFile, NewModifier, NewNamespaceBlock}
+import io.shiftleft.codepropertygraph.generated.nodes.{
+  ExpressionNew,
+  NewFile,
+  NewModifier,
+  NewNamespaceBlock,
+  NewTypeDecl
+}
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EvaluationStrategies, ModifierTypes, Operators}
 import io.joern.rust2cpg.parser.RustNodeSyntaxExtensions.*
 
@@ -818,37 +824,79 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
 
   // RecordExpr =
   //  Attr* Path RecordExprFieldList
-  // Lowers a record expression e.g. `Foo { x: 1, y: 2 }` into an alloc-followed-by-field-assignments-block:
+  private def visitRecordExpr(recordExpr: RecordExpr): Ast = {
+    recordExpr.recordExprFieldList.expr match {
+      case None       => recordCtorCallAst(recordExpr)
+      case Some(base) => recordCtorCallWithSpreadAst(recordExpr, base)
+    }
+  }
+
+  // Lowers a record expression e.g. `Foo { x: 1, y: 2 }` as follows:
   // BLOCK
   //   LOCAL tmp
   //   tmp = <operator>.alloc
-  //   tmp.x = 1
-  //   tmp.y = 2
+  //   Foo::<init>(&tmp, x:1, y:2)
   //   tmp
-  // In case of spreads e.g. `Foo { x: y, ..bar }` we include the assignment `tmp = bar` for flow purposes.
-  private def visitRecordExpr(recordExpr: RecordExpr): Ast = {
+  private def recordCtorCallAst(recordExpr: RecordExpr): Ast = {
     val structType = typeFullNameForExpr(recordExpr)
-    val fieldList  = recordExpr.recordExprFieldList
     val tmpName    = "tmp"
 
-    allocBlockAst(recordExpr, tmpName, structType) { mktmpIdent =>
-      // tmp = base
-      val spreadAssignAst = fieldList.expr.map { base =>
-        val tmpAst = mktmpIdent(recordExpr)
-        callAst(assignmentNode(recordExpr, s"$tmpName = ${code(base)}"), Seq(tmpAst, visitExpr(base)))
-      }.toSeq
+    allocBlockAst(recordExpr, tmpName, structType) { mkTmp =>
 
-      // tmp.x = 1; tmp.y = 2; etc.
-      val fieldAssignAsts = fieldList.recordExprField.map { field =>
+      val initCall = callNode(
+        recordExpr,
+        code(recordExpr),
+        Defines.ConstructorMethodName,
+        combineRustFullName(structType, Defines.ConstructorMethodName),
+        DispatchTypes.STATIC_DISPATCH,
+        None,
+        Some("()")
+      )
+
+      val addressOfTmp = {
+        val addressOf = operatorCallNode(recordExpr, s"&$tmpName", Operators.addressOf, Some(s"&$structType"))
+        callAst(addressOf, Seq(mkTmp(recordExpr)))
+      }
+
+      val fieldArgs = recordExpr.recordExprFieldList.recordExprField.map { field =>
+        val fieldName = field.nameRef.orElse(viewExprAsNameRef(field.expr)).map(code)
+        val argAst    = visitExpr(field.expr)
+        argAst.root.foreach { case expr: ExpressionNew => expr.argumentName(fieldName) }
+        argAst
+      }
+      callAst(initCall, fieldArgs, base = Some(addressOfTmp)) :: Nil
+    }
+  }
+
+  // Lowers a spread record expression e.g. `Foo { x: 1, ..base }` as follows:
+  // BLOCK
+  //   LOCAL tmp
+  //   tmp = <operator>.alloc
+  //   tmp = base
+  //   tmp.x = y
+  //   tmp
+  private def recordCtorCallWithSpreadAst(recordExpr: RecordExpr, base: Expr): Ast = {
+    val structType = typeFullNameForExpr(recordExpr)
+    val tmpName    = "tmp"
+
+    allocBlockAst(recordExpr, tmpName, structType) { mkTmp =>
+      // tmp = base
+      val spreadAssignAst = {
+        val tmpAst = mkTmp(recordExpr)
+        callAst(assignmentNode(recordExpr, s"$tmpName = ${code(base)}"), Seq(tmpAst, visitExpr(base)))
+      }
+
+      // tmp.x = 1; etc.
+      val fieldAssignAsts = recordExpr.recordExprFieldList.recordExprField.map { field =>
         val fieldNameRef = field.nameRef.orElse(viewExprAsNameRef(field.expr)).get
         val fieldName    = code(fieldNameRef)
         val fieldType    = typeFullNameForExpr(field.expr)
-        val baseAst      = mktmpIdent(field)
+        val baseAst      = mkTmp(field)
         val lhs = fieldAccessAst(fieldNameRef, fieldNameRef, baseAst, s"$tmpName.$fieldName", fieldName, fieldType)
         callAst(assignmentNode(field, s"$tmpName.$fieldName = ${code(field.expr)}"), Seq(lhs, visitExpr(field.expr)))
       }
 
-      spreadAssignAst ++ fieldAssignAsts
+      spreadAssignAst +: fieldAssignAsts
     }
   }
 
@@ -957,14 +1005,81 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
   //  | TupleFieldList WhereClause? ';'
   //  )
   private def visitStruct(struct: Struct): Ast = {
+    val typeDecl = typeDeclForStruct(struct)
     (struct.recordFieldList, struct.tupleFieldList) match {
       case (Some(recordFieldList), _) =>
-        Ast(typeDeclForStruct(struct)).withChildren(visitRecordFieldList(recordFieldList))
+        methodAstParentStack.push(typeDecl)
+        val ctorAst = structCtorMethodAst(struct, typeDecl)
+        methodAstParentStack.pop()
+        Ast(typeDecl).withChildren(visitRecordFieldList(recordFieldList) :+ ctorAst)
       case (None, Some(tupleFieldList)) =>
-        Ast(typeDeclForStruct(struct)).withChildren(visitTupleFieldList(tupleFieldList))
+        Ast(typeDecl).withChildren(visitTupleFieldList(tupleFieldList))
       case (None, None) =>
-        Ast(typeDeclForStruct(struct))
+        Ast(typeDecl)
     }
+  }
+
+  private def structFieldData(struct: Struct): Seq[(node: RustNode, name: String, typ: String)] = {
+    struct.recordFieldList.toSeq.flatMap(_.recordField.map { field =>
+      (node = field, name = code(field.name), typ = typeFullNameForType(field.typ))
+    })
+  }
+
+  private def structCtorMethodAst(struct: Struct, typeDecl: NewTypeDecl): Ast = {
+    val selfName = "self"
+    val fields   = structFieldData(struct)
+    val method   = methodNode(struct, Defines.ConstructorMethodName).code(Defines.ConstructorMethodName)
+    val selfParam = parameterInNode(
+      node = struct,
+      name = selfName,
+      code = selfName,
+      index = 0,
+      isVariadic = false,
+      evaluationStrategy = EvaluationStrategies.BY_SHARING,
+      typeFullName = typeDecl.fullName
+    )
+    val fieldParams = fields.zipWithIndex.map { case (fieldData, idx) =>
+      parameterInNode(
+        node = fieldData.node,
+        name = fieldData.name,
+        code = fieldData.name,
+        index = idx + 1,
+        isVariadic = false,
+        evaluationStrategy = EvaluationStrategies.BY_SHARING,
+        typeFullName = fieldData.typ
+      )
+    }
+
+    // (*self).x = x; etc.
+    val fieldAssignAsts = fields.zip(fieldParams).map { case (fieldData, fieldParam) =>
+      val selfIdent = identifierNode(fieldData.node, selfName, selfName, s"&${typeDecl.fullName}")
+      val selfAst   = Ast(selfIdent).withRefEdge(selfIdent, selfParam) // TODO: remove once ref linker is in.
+      val derefSelf = callAst(
+        operatorCallNode(fieldData.node, s"*$selfName", Operators.indirection, Some(typeDecl.fullName)),
+        Seq(selfAst)
+      )
+      val lhs = fieldAccessAst(
+        fieldData.node,
+        fieldData.node,
+        derefSelf,
+        s"(*$selfName).${fieldData.name}",
+        fieldData.name,
+        fieldData.typ
+      )
+      val rhsIdent = identifierNode(fieldData.node, fieldData.name, fieldData.name, fieldData.typ)
+      val rhs      = Ast(rhsIdent).withRefEdge(rhsIdent, fieldParam) // TODO: remove once ref linker is in.
+      callAst(assignmentNode(fieldData.node, s"(*$selfName).${fieldData.name} = ${fieldData.name}"), Seq(lhs, rhs))
+    }
+
+    val paramAsts = (selfParam +: fieldParams).map(Ast(_))
+    val bodyAst   = blockAst(blockNode(struct), fieldAssignAsts.toList)
+    methodAst(
+      method = method,
+      parameters = paramAsts,
+      body = bodyAst,
+      methodReturn = methodReturnNode(struct, "()"),
+      modifiers = Seq(modifierNode(struct, ModifierTypes.CONSTRUCTOR))
+    )
   }
 
   // RecordFieldList =

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/OperatorTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/OperatorTests.scala
@@ -120,7 +120,7 @@ class OperatorTests extends Rust2CpgSuite(noSysRoot = true) {
         |""".stripMargin)
 
     "lower to a fieldAccess call" in {
-      inside(cpg.call.nameExact(Operators.fieldAccess).l) { case fieldAccess :: Nil =>
+      inside(cpg.method.name("get_bar").call.nameExact(Operators.fieldAccess).l) { case fieldAccess :: Nil =>
         fieldAccess.code shouldBe "self.bar"
         fieldAccess.methodFullName shouldBe Operators.fieldAccess
         fieldAccess.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
@@ -129,22 +129,24 @@ class OperatorTests extends Rust2CpgSuite(noSysRoot = true) {
     }
 
     "have the lhs as the first argument" in {
-      inside(cpg.call.nameExact(Operators.fieldAccess).argument(1).l) { case (deref: Call) :: Nil =>
-        deref.name shouldBe Operators.indirection
-        deref.code shouldBe "*self"
-        deref.typeFullName shouldBe "rust2cpgtest::Foo"
-        inside(deref.argument.l) { case (self: Identifier) :: Nil =>
-          self.name shouldBe "self"
-          self.code shouldBe "self"
-          self.typeFullName shouldBe "&rust2cpgtest::Foo"
-        }
+      inside(cpg.method.name("get_bar").call.nameExact(Operators.fieldAccess).argument(1).l) {
+        case (deref: Call) :: Nil =>
+          deref.name shouldBe Operators.indirection
+          deref.code shouldBe "*self"
+          deref.typeFullName shouldBe "rust2cpgtest::Foo"
+          inside(deref.argument.l) { case (self: Identifier) :: Nil =>
+            self.name shouldBe "self"
+            self.code shouldBe "self"
+            self.typeFullName shouldBe "&rust2cpgtest::Foo"
+          }
       }
     }
 
     "have the field as the second argument" in {
-      inside(cpg.call.nameExact(Operators.fieldAccess).argument(2).l) { case (field: FieldIdentifier) :: Nil =>
-        field.code shouldBe "bar"
-        field.canonicalName shouldBe "bar"
+      inside(cpg.method.name("get_bar").call.nameExact(Operators.fieldAccess).argument(2).l) {
+        case (field: FieldIdentifier) :: Nil =>
+          field.code shouldBe "bar"
+          field.canonicalName shouldBe "bar"
       }
     }
   }

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/StructTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/StructTests.scala
@@ -1,7 +1,7 @@
 package io.joern.rust2cpg.passes.ast
 
 import io.joern.rust2cpg.testfixtures.Rust2CpgSuite
-import io.shiftleft.codepropertygraph.generated.{DispatchTypes, NodeTypes, Operators}
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, ModifierTypes, NodeTypes, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal.globalNamespaceName
@@ -34,6 +34,45 @@ class StructTests extends Rust2CpgSuite(noSysRoot = true) {
         y.name shouldBe "y"
         y.code shouldBe "y: i32"
         y.typeFullName shouldBe "i32"
+      }
+    }
+
+    "have a constructor method" in {
+      inside(cpg.typeDecl.nameExact("Foo").method.l) { case init :: Nil =>
+        init.name shouldBe "<init>"
+        init.fullName shouldBe "rust2cpgtest::Foo::<init>"
+        init.modifier.modifierType.l shouldBe List(ModifierTypes.CONSTRUCTOR)
+        init.methodReturn.typeFullName shouldBe "()"
+      }
+    }
+
+    "have one parameter per field, plus self" in {
+      inside(cpg.typeDecl.nameExact("Foo").method.parameter.sortBy(_.index).l) {
+        case paramSelf :: paramX :: paramY :: Nil =>
+          paramSelf.name shouldBe "self"
+          paramSelf.index shouldBe 0
+          paramSelf.typeFullName shouldBe "rust2cpgtest::Foo"
+          paramX.name shouldBe "x"
+          paramX.index shouldBe 1
+          paramX.typeFullName shouldBe "i32"
+          paramY.name shouldBe "y"
+          paramY.index shouldBe 2
+          paramY.typeFullName shouldBe "i32"
+      }
+    }
+
+    "have one field assignment per parameter" in {
+      inside(cpg.typeDecl.nameExact("Foo").method.body.astChildren.isCall.l) { case assignX :: assignY :: Nil =>
+        assignX.code shouldBe "(*self).x = x"
+        inside(assignX.argument(1)) { case fieldAccess: Call =>
+          fieldAccess.code shouldBe "(*self).x"
+          fieldAccess.methodFullName shouldBe Operators.fieldAccess
+        }
+        inside(assignX.argument(2)) { case ident: Identifier =>
+          ident.name shouldBe "x"
+          ident.typeFullName shouldBe "i32"
+        }
+        assignY.code shouldBe "(*self).y = y"
       }
     }
   }
@@ -166,7 +205,7 @@ class StructTests extends Rust2CpgSuite(noSysRoot = true) {
         |""".stripMargin)
 
     "lower to a fieldAccess call" in {
-      inside(cpg.call.nameExact(Operators.fieldAccess).l) { case fieldAccess :: Nil =>
+      inside(cpg.method.nameExact("foo").call.nameExact(Operators.fieldAccess).l) { case fieldAccess :: Nil =>
         fieldAccess.code shouldBe "point.x"
         fieldAccess.methodFullName shouldBe Operators.fieldAccess
         fieldAccess.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
@@ -175,18 +214,20 @@ class StructTests extends Rust2CpgSuite(noSysRoot = true) {
     }
 
     "have the lhs as the first argument" in {
-      inside(cpg.call.nameExact(Operators.fieldAccess).argument(1).l) { case (base: Identifier) :: Nil =>
-        base.code shouldBe "point"
-        base.argumentIndex shouldBe 1
-        base.typeFullName shouldBe "rust2cpgtest::Point"
+      inside(cpg.method.nameExact("foo").call.nameExact(Operators.fieldAccess).argument(1).l) {
+        case (base: Identifier) :: Nil =>
+          base.code shouldBe "point"
+          base.argumentIndex shouldBe 1
+          base.typeFullName shouldBe "rust2cpgtest::Point"
       }
     }
 
     "have the field as the second argument" in {
-      inside(cpg.call.nameExact(Operators.fieldAccess).argument(2).l) { case (field: FieldIdentifier) :: Nil =>
-        field.code shouldBe "x"
-        field.canonicalName shouldBe "x"
-        field.argumentIndex shouldBe 2
+      inside(cpg.method.nameExact("foo").call.nameExact(Operators.fieldAccess).argument(2).l) {
+        case (field: FieldIdentifier) :: Nil =>
+          field.code shouldBe "x"
+          field.canonicalName shouldBe "x"
+          field.argumentIndex shouldBe 2
       }
     }
   }
@@ -216,7 +257,7 @@ class StructTests extends Rust2CpgSuite(noSysRoot = true) {
       inside(cpg.method.name("main").body.astChildren.isBlock.l) { case block :: Nil =>
         block.code shouldBe "Foo { x: 1, y: 2 }"
         block.typeFullName shouldBe "rust2cpgtest::Foo"
-        block.astChildren.size shouldBe 5 // 1 (local) + 1 (.alloc) + 2 (tmp.x = v) + 1 (ident)
+        block.astChildren.size shouldBe 4 // 1 (local) + 1 (.alloc) + 1 (<init> call) + 1 (ident)
       }
     }
 
@@ -245,62 +286,40 @@ class StructTests extends Rust2CpgSuite(noSysRoot = true) {
       }
     }
 
-    "the block's third child is a field assignment" in {
-      inside(cpg.block.codeExact("Foo { x: 1, y: 2 }").astChildren.order(3).l) { case (assign: Call) :: Nil =>
-        assign.code shouldBe "tmp.x = 1"
+    "the block's third child is a constructor call" in {
+      inside(cpg.block.codeExact("Foo { x: 1, y: 2 }").astChildren.order(3).l) { case (init: Call) :: Nil =>
+        init.name shouldBe "<init>"
+        init.methodFullName shouldBe "rust2cpgtest::Foo::<init>"
+        init.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+        init.typeFullName shouldBe "()"
 
-        inside(assign.argument(1)) { case fieldAccess: Call =>
-          fieldAccess.code shouldBe "tmp.x"
-          fieldAccess.methodFullName shouldBe Operators.fieldAccess
-          fieldAccess.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+        inside(init.argument(0)) { case addressOf: Call =>
+          addressOf.name shouldBe Operators.addressOf
+          addressOf.code shouldBe "&tmp"
+          addressOf.typeFullName shouldBe "&rust2cpgtest::Foo"
 
-          inside(fieldAccess.argument(1)) { case tmp: Identifier =>
-            tmp.code shouldBe "tmp"
+          inside(addressOf.argument(1)) { case tmp: Identifier =>
+            tmp.name shouldBe "tmp"
             tmp.typeFullName shouldBe "rust2cpgtest::Foo"
-          }
-
-          inside(fieldAccess.argument(2)) { case fieldIdent: FieldIdentifier =>
-            fieldIdent.code shouldBe "x"
-            fieldIdent.canonicalName shouldBe "x"
           }
         }
 
-        inside(assign.argument(2)) { case lit: Literal =>
+        inside(init.argument(1)) { case lit: Literal =>
           lit.code shouldBe "1"
           lit.typeFullName shouldBe "i32"
-        }
-      }
-    }
-
-    "the block's fourth child is a field assignment" in {
-      inside(cpg.block.codeExact("Foo { x: 1, y: 2 }").astChildren.order(4).l) { case (assign: Call) :: Nil =>
-        assign.code shouldBe "tmp.y = 2"
-
-        inside(assign.argument(1)) { case fieldAccess: Call =>
-          fieldAccess.code shouldBe "tmp.y"
-          fieldAccess.methodFullName shouldBe Operators.fieldAccess
-          fieldAccess.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
-
-          inside(fieldAccess.argument(1)) { case tmp: Identifier =>
-            tmp.code shouldBe "tmp"
-            tmp.typeFullName shouldBe "rust2cpgtest::Foo"
-          }
-
-          inside(fieldAccess.argument(2)) { case fieldIdent: FieldIdentifier =>
-            fieldIdent.code shouldBe "y"
-            fieldIdent.canonicalName shouldBe "y"
-          }
+          lit.argumentName shouldBe Some("x")
         }
 
-        inside(assign.argument(2)) { case lit: Literal =>
+        inside(init.argument(2)) { case lit: Literal =>
           lit.code shouldBe "2"
           lit.typeFullName shouldBe "i32"
+          lit.argumentName shouldBe Some("y")
         }
       }
     }
 
-    "the block's fifth child is an identifier" in {
-      inside(cpg.block.codeExact("Foo { x: 1, y: 2 }").astChildren.order(5).l) { case (ident: Identifier) :: Nil =>
+    "the block's fourth child is an identifier" in {
+      inside(cpg.block.codeExact("Foo { x: 1, y: 2 }").astChildren.order(4).l) { case (ident: Identifier) :: Nil =>
         ident.name shouldBe "tmp"
         ident.typeFullName shouldBe "rust2cpgtest::Foo"
       }
@@ -315,22 +334,37 @@ class StructTests extends Rust2CpgSuite(noSysRoot = true) {
         |}
         |""".stripMargin)
 
-    "source the shorthand field write from the in-scope identifier" in {
-      inside(cpg.block.codeExact("Foo { x, y: 2 }").astChildren.order(3).l) { case (assign: Call) :: Nil =>
-        assign.code shouldBe "tmp.x = x"
-
-        inside(assign.argument(1)) { case fieldAccess: Call =>
-          fieldAccess.code shouldBe "tmp.x"
-          fieldAccess.methodFullName shouldBe Operators.fieldAccess
-
-          inside(fieldAccess.argument(2)) { case fieldIdent: FieldIdentifier =>
-            fieldIdent.code shouldBe "x"
-            fieldIdent.canonicalName shouldBe "x"
-          }
+    "source the shorthand field argument from the in-scope identifier" in {
+      inside(cpg.call.nameExact("<init>").l) { case init :: Nil =>
+        inside(init.argument(1)) { case ident: Identifier =>
+          ident.name shouldBe "x"
+          ident.argumentName shouldBe Some("x")
         }
 
-        inside(assign.argument(2)) { case ident: Identifier =>
-          ident.name shouldBe "x"
+        inside(init.argument(2)) { case lit: Literal =>
+          lit.code shouldBe "2"
+          lit.argumentName shouldBe Some("y")
+        }
+      }
+    }
+  }
+
+  "an internal record expression of a unit struct" should {
+    val cpg = code("""
+        |struct Bar;
+        |fn main() {
+        | Bar {};
+        |}
+        |""".stripMargin)
+
+    "lower into a constructor call with only the receiver argument" in {
+      inside(cpg.call.nameExact("<init>").l) { case init :: Nil =>
+        init.methodFullName shouldBe "rust2cpgtest::Bar::<init>"
+
+        inside(init.argument.l.sortBy(_.argumentIndex)) { case (addressOf: Call) :: Nil =>
+          addressOf.name shouldBe Operators.addressOf
+          addressOf.code shouldBe "&tmp"
+          addressOf.typeFullName shouldBe "&rust2cpgtest::Bar"
         }
       }
     }
@@ -394,7 +428,7 @@ class StructTests extends Rust2CpgSuite(noSysRoot = true) {
         |""".stripMargin)
 
     "lower to a fieldAccess call" in {
-      inside(cpg.call.nameExact(Operators.fieldAccess).l) { case fieldAccess :: Nil =>
+      inside(cpg.method.nameExact("foo").call.nameExact(Operators.fieldAccess).l) { case fieldAccess :: Nil =>
         fieldAccess.code shouldBe "pair.0"
         fieldAccess.methodFullName shouldBe Operators.fieldAccess
         fieldAccess.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
@@ -403,18 +437,20 @@ class StructTests extends Rust2CpgSuite(noSysRoot = true) {
     }
 
     "have the lhs as the first argument" in {
-      inside(cpg.call.nameExact(Operators.fieldAccess).argument(1).l) { case (base: Identifier) :: Nil =>
-        base.code shouldBe "pair"
-        base.argumentIndex shouldBe 1
-        base.typeFullName shouldBe "rust2cpgtest::Pair"
+      inside(cpg.method.nameExact("foo").call.nameExact(Operators.fieldAccess).argument(1).l) {
+        case (base: Identifier) :: Nil =>
+          base.code shouldBe "pair"
+          base.argumentIndex shouldBe 1
+          base.typeFullName shouldBe "rust2cpgtest::Pair"
       }
     }
 
     "have the positional index as the second argument" in {
-      inside(cpg.call.nameExact(Operators.fieldAccess).argument(2).l) { case (field: FieldIdentifier) :: Nil =>
-        field.code shouldBe "0"
-        field.canonicalName shouldBe "0"
-        field.argumentIndex shouldBe 2
+      inside(cpg.method.nameExact("foo").call.nameExact(Operators.fieldAccess).argument(2).l) {
+        case (field: FieldIdentifier) :: Nil =>
+          field.code shouldBe "0"
+          field.canonicalName shouldBe "0"
+          field.argumentIndex shouldBe 2
       }
     }
   }


### PR DESCRIPTION
Previously, record (struct) literals were created inline (`.alloc` followed by the field assignments.) For dataflow purposes involving dynamic dispatch, we now switch to an `.alloc` followed by a constructor method `<init>` (which gets created when we visit the `struct` declaration.) Less overall nodes is another argument for this change.

NB: only "complete" record expressions e.g. `Foo { x: y }` are handled. In particular, `Foo { x: y, ..bar }` (where `bar` is being spread) or tuple-like literals are not changed here.