### PR TITLE
[rust2cpg] add virtual modifiers to trait-impl methods.

### DIFF
--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
@@ -356,7 +356,9 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
       case implTrait :: implType :: Nil =>
         val typeDecl = typeDeclForTraitImpl(impl, implTrait, implType)
         methodAstParentStack.push(typeDecl)
-        val methodAsts = impl.assocItemList.assocItem.collect { case fn: Fn => visitFn(fn) }
+        val methodAsts = impl.assocItemList.assocItem.collect { case fn: Fn =>
+          visitFn(fn).withChild(Ast(NewModifier().modifierType(ModifierTypes.VIRTUAL)))
+        }
         methodAstParentStack.pop()
         Ast(typeDecl).withChildren(methodAsts)
       case _ => notHandledYet(impl)
@@ -389,7 +391,9 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
       code = code(trait_)
     )
     methodAstParentStack.push(typeDecl)
-    val methodAsts = trait_.assocItemList.toSeq.flatMap(_.assocItem).collect { case fn: Fn => visitFn(fn) }
+    val methodAsts = trait_.assocItemList.toSeq.flatMap(_.assocItem).collect { case fn: Fn =>
+      visitFn(fn).withChild(Ast(NewModifier().modifierType(ModifierTypes.VIRTUAL)))
+    }
     methodAstParentStack.pop()
     Ast(typeDecl).withChildren(methodAsts)
   }

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/ImplTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/ImplTests.scala
@@ -1,7 +1,7 @@
 package io.joern.rust2cpg.passes.ast
 
 import io.joern.rust2cpg.testfixtures.Rust2CpgSuite
-import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EvaluationStrategies, Operators}
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EvaluationStrategies, ModifierTypes, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.utils.FileUtil.PathExt
@@ -37,6 +37,10 @@ class ImplTests extends Rust2CpgSuite(noSysRoot = true) {
 
     "be an AST child of the corresponding TYPE_DECL" in {
       cpg.typeDecl.nameExact("Foo").method.nameExact("bar").fullName.l shouldBe List("rust2cpgtest::Foo::bar")
+    }
+
+    "have no modifiers" in {
+      cpg.method.nameExact("bar").modifier shouldBe empty
     }
 
     "not create a duplicate TYPE_DECL" in {
@@ -286,6 +290,14 @@ class ImplTests extends Rust2CpgSuite(noSysRoot = true) {
         .methodReturn
         .typeFullName
         .l shouldBe List("i32")
+    }
+
+    "have a virtual modifier on the trait-impl method" in {
+      cpg.method
+        .fullNameExact("<rust2cpgtest::Foo as rust2cpgtest::Bar>::do_stuff")
+        .modifier
+        .modifierType
+        .l shouldBe List(ModifierTypes.VIRTUAL)
     }
   }
 

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/MethodTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/MethodTests.scala
@@ -25,6 +25,10 @@ class MethodTests extends Rust2CpgSuite(noSysRoot = true) {
         main.astParentFullName shouldBe s"$libPath:rust2cpgtest::$globalNamespaceName"
       }
     }
+
+    "have no modifiers" in {
+      cpg.method.name("main").modifier shouldBe empty
+    }
   }
 
   "a fn with a single parameter and a tail expression" should {

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/TraitTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/TraitTests.scala
@@ -1,7 +1,7 @@
 package io.joern.rust2cpg.passes.ast
 
 import io.joern.rust2cpg.testfixtures.Rust2CpgSuite
-import io.shiftleft.codepropertygraph.generated.EvaluationStrategies
+import io.shiftleft.codepropertygraph.generated.{EvaluationStrategies, ModifierTypes}
 import io.shiftleft.semanticcpg.language.*
 
 class TraitTests extends Rust2CpgSuite(noSysRoot = true) {
@@ -37,6 +37,11 @@ class TraitTests extends Rust2CpgSuite(noSysRoot = true) {
     "have correct return typeFullName" in {
       cpg.method.nameExact("a").methodReturn.typeFullName.l shouldBe List("()")
       cpg.method.nameExact("b").methodReturn.typeFullName.l shouldBe List("i32")
+    }
+
+    "have a virtual modifiers" in {
+      cpg.method.nameExact("a").modifier.modifierType.l shouldBe List(ModifierTypes.VIRTUAL)
+      cpg.method.nameExact("b").modifier.modifierType.l shouldBe List(ModifierTypes.VIRTUAL)
     }
 
     "lower the method without a body" in {


### PR DESCRIPTION
Adds the virtual modifier to `trait` and `impl Trait` methods, for dataflow purposes involving dynamic dispatch.