### PR TITLE
[rust2cpg] fix `self` parameters typeFullNames.

### DIFF
--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustFullNames.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustFullNames.scala
@@ -129,6 +129,19 @@ trait RustFullNames { this: AstCreator =>
     expr.typeFullName.getOrElse(Defines.Any)
   }
 
+  protected def typeFullNameForSelfParam(selfParam: RustNodeSyntax.SelfParam): String = {
+    selfParam.typeFullName.getOrElse {
+      val enclosingType = enclosingTypeDeclFullName.getOrElse(Defines.Any)
+      selfParam.typ match {
+        case Some(typ) => typeFullNameForType(typ)
+        case None if selfParam.ampToken.isDefined =>
+          val mut = Option.when(selfParam.mutKwToken.isDefined)("mut ").getOrElse("")
+          s"&$mut$enclosingType"
+        case None => enclosingType
+      }
+    }
+  }
+
   protected def typeFullNameForTupleExpr(tupleExpr: RustNodeSyntax.TupleExpr): String = {
     tupleExpr.typeFullName.getOrElse {
       val childTypes = tupleExpr.expr.map(typeFullNameForExpr)

--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
@@ -523,14 +523,7 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
   // SelfParam =
   //  Attr* ( ('&' Lifetime?)? 'mut'? Name | 'mut'? Name ':' Type )
   private def visitSelfParam(selfParam: SelfParam): Ast = {
-    val enclosingType = enclosingTypeDeclFullName.getOrElse(Defines.Any)
-    val typeFullName = selfParam.typ match {
-      case Some(typ) => typeFullNameForType(typ)
-      case None if selfParam.ampToken.isDefined =>
-        val mut = Option.when(selfParam.mutKwToken.isDefined)("mut ").getOrElse("")
-        s"&$mut$enclosingType"
-      case None => enclosingType
-    }
+    val typeFullName = typeFullNameForSelfParam(selfParam)
     val evaluationStrategy =
       if (selfParam.ampToken.isDefined) EvaluationStrategies.BY_SHARING else EvaluationStrategies.BY_VALUE
     val paramNode = parameterInNode(

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/ImplTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/ImplTests.scala
@@ -256,10 +256,14 @@ class ImplTests extends Rust2CpgSuite(noSysRoot = true) {
     val cpg = code("""
         |trait Bar {
         |  fn do_stuff(&self) -> i32;
+        |  fn do_mut(&mut self);
+        |  fn do_take(self);
         |}
         |struct Foo;
         |impl Bar for Foo {
         |  fn do_stuff(&self) -> i32 { 1 }
+        |  fn do_mut(&mut self) {}
+        |  fn do_take(self) {}
         |}
         |""".stripMargin)
 
@@ -282,18 +286,44 @@ class ImplTests extends Rust2CpgSuite(noSysRoot = true) {
         .fullNameExact("<rust2cpgtest::Foo as rust2cpgtest::Bar>")
         .method
         .fullName
-        .l shouldBe List("<rust2cpgtest::Foo as rust2cpgtest::Bar>::do_stuff")
+        .sorted
+        .l shouldBe List(
+        "<rust2cpgtest::Foo as rust2cpgtest::Bar>::do_mut",
+        "<rust2cpgtest::Foo as rust2cpgtest::Bar>::do_stuff",
+        "<rust2cpgtest::Foo as rust2cpgtest::Bar>::do_take"
+      )
     }
 
-    "have correct self properties" in {
+    "have correct `&self` properties" in {
       inside(cpg.method.fullNameExact("<rust2cpgtest::Foo as rust2cpgtest::Bar>::do_stuff").parameter.l) {
         case self :: Nil =>
           self.name shouldBe "self"
           self.index shouldBe 0
           self.order shouldBe 0
           self.evaluationStrategy shouldBe EvaluationStrategies.BY_SHARING
-          // TODO(rust_ast_gen): resolve self/Self.
-          pendingUntilFixed(self.typeFullName shouldBe "&rust2cpgtest::Foo")
+          self.typeFullName shouldBe "&rust2cpgtest::Foo"
+      }
+    }
+
+    "have correct `&mut self` properties" in {
+      inside(cpg.method.fullNameExact("<rust2cpgtest::Foo as rust2cpgtest::Bar>::do_mut").parameter.l) {
+        case self :: Nil =>
+          self.name shouldBe "self"
+          self.index shouldBe 0
+          self.order shouldBe 0
+          self.evaluationStrategy shouldBe EvaluationStrategies.BY_SHARING
+          self.typeFullName shouldBe "&mut rust2cpgtest::Foo"
+      }
+    }
+
+    "have correct `self` properties" in {
+      inside(cpg.method.fullNameExact("<rust2cpgtest::Foo as rust2cpgtest::Bar>::do_take").parameter.l) {
+        case self :: Nil =>
+          self.name shouldBe "self"
+          self.index shouldBe 0
+          self.order shouldBe 0
+          self.evaluationStrategy shouldBe EvaluationStrategies.BY_VALUE
+          self.typeFullName shouldBe "rust2cpgtest::Foo"
       }
     }
 


### PR DESCRIPTION
Inside `impl Trait` blocks, `self` was getting its typeFullName from the enclosing TypeDecl - but since `impl Traits` are themselves lowered as TypeDecls, this is now incorrect.