### PR TITLE
[sbt] Simplify UrlRetry

### DIFF
--- a/project/UrlRetry.scala
+++ b/project/UrlRetry.scala
@@ -1,120 +1,61 @@
-import java.io.{File, IOException}
+import java.io.File
 import java.net.{HttpURLConnection, URL}
 import scala.concurrent.duration.*
 
 object UrlRetry {
 
-  /** Set of transient HTTP status codes that are considered safe to retry:
-    *   - 408: Request Timeout – server timed out waiting for the request
-    *   - 425: Too Early – server unwilling to process a possibly replayed request
-    *   - 429: Too Many Requests – client is being rate-limited
-    *   - 500: Internal Server Error – generic server-side failure
-    *   - 502: Bad Gateway – upstream server returned an invalid response
-    *   - 503: Service Unavailable – server temporarily overloaded or down
-    *   - 504: Gateway Timeout – upstream server didn't respond in time
-    */
-  private val TransientStatusCodes: Set[Int] =
-    Set(408, 425, 429, 500, 502, 503, 504)
-
-  /** Base type for HTTP-related failures. */
-  sealed abstract class HttpException(message: String) extends RuntimeException(message)
-
-  /** Thrown when we got an HTTP response with a status code. */
   final case class HttpStatusException(status: Int, url: URL, msg: String)
-      extends HttpException(s"HTTP $status for $url: $msg")
+      extends RuntimeException(s"HTTP $status for $url: $msg")
 
-  /** Marker exception used to trigger retries (for transient HTTP statuses). */
-  final case class TransientHttpException(status: Int, url: URL, msg: String)
-      extends HttpException(s"Transient HTTP $status for $url: $msg")
-
-  /** Retries a block that uses URL.openConnection (or any other network I/O) up to `maxRetries`.
-    *
-    *   - Retries for transient HTTP status codes (defaults in TransientStatusCodes) and IOExceptions.
-    *   - Retry interval and backoff are configurable.
-    *   - Backoff is applied multiplicatively.
-    *
-    * Notes:
-    *   - The `block` should perform the full request and either: (a) throw on non-2xx (via `openAndCheck` below), or
-    *     (b) return some value you define after inspecting the response code.
+  /** Retries `block` up to `maxRetries` times on any exception.
+    * Waits `baseInterval * backoffFactor^(retry-1)` before each retry (exponential backoff).
     */
-  def withTransientHttpRetries[T](maxRetries: Int, baseInterval: FiniteDuration, backoffFactor: Double)(
-    block: => T
-  ): T = {
+  private def withRetries[T](maxRetries: Int, baseInterval: FiniteDuration, backoffFactor: Double)(block: => T): T = {
     require(maxRetries >= 1, "maxRetries must be >= 1")
     require(baseInterval.toMillis >= 0, "baseInterval must be >= 0")
     require(backoffFactor >= 1.0, "backoffFactor must be >= 1.0")
 
-    def sleepForAttempt(attempt: Int): Unit = {
-      // attempt is 1-based; attempt 1 means "first try" => no sleep before it
-      if (attempt > 1) {
-        val multiplier = math.pow(backoffFactor, attempt - 2) // before 2nd try => pow(...,0)
-        val delayMs    = (baseInterval.toMillis.toDouble * multiplier).toLong
+    def loop(attempt: Int, lastError: Option[Throwable]): T = {
+      lastError.foreach { e =>
+        println(s"[WARN] Attempt $attempt/$maxRetries failed with: ${e.getMessage}")
+        val delayMs = (baseInterval.toMillis.toDouble * math.pow(backoffFactor, attempt - 2)).toLong
         if (delayMs > 0) Thread.sleep(delayMs)
       }
-    }
-
-    def loop(attempt: Int, lastError: Throwable): T = {
-      if (attempt > 1) println(s"[WARN] Attempt $attempt/$maxRetries failed with: ${lastError.getMessage}")
-      sleepForAttempt(attempt)
-      try {
-        block
-      } catch {
-        case e: TransientHttpException if TransientStatusCodes.contains(e.status) =>
+      try block
+      catch {
+        case e: Throwable =>
           if (attempt >= maxRetries) throw e
-          loop(attempt + 1, e)
-        case e: IOException =>
-          if (attempt >= maxRetries) throw e
-          loop(attempt + 1, e)
-        // If it's an HTTP exception but not transient -> do not retry
-        case e: HttpException =>
-          throw e
-        // Non-HTTP failures are not retried
-        case other: Throwable =>
-          throw other
+          loop(attempt + 1, Some(e))
       }
     }
 
-    // First attempt has no prior error; provide a dummy Throwable
-    loop(attempt = 1, lastError = new RuntimeException("No attempts yet"))
+    loop(attempt = 1, lastError = None)
   }
 
-  /** Helper that opens a connection, and throws:
-    *   - TransientHttpException for transient statuses
-    *   - HttpStatusException for all other non-2xx statuses
-    *
-    * You can use this inside `withTransientHttpRetries` to ensure retry behavior is based on HTTP status.
-    */
-  def openAndCheck(url: URL): HttpURLConnection = {
-    val conn = url.openConnection().asInstanceOf[HttpURLConnection]
-
-    // Trigger the request; for GET, calling getResponseCode initiates the connection
+  /** Opens a connection to `url` and returns it if the response is 2xx, otherwise throws [[HttpStatusException]]. */
+  private def openAndCheck(url: URL): HttpURLConnection = {
+    val conn   = url.openConnection().asInstanceOf[HttpURLConnection]
     val status = conn.getResponseCode
-    if (status >= 200 && status <= 299) {
-      conn
-    } else {
+    if (status >= 200 && status <= 299) conn
+    else {
       val msg = Option(conn.getResponseMessage).getOrElse("no message")
-      // Ensure connection resources are released on failure
       conn.disconnect()
-      if (TransientStatusCodes.contains(status)) throw TransientHttpException(status, url, msg)
-      else throw HttpStatusException(status, url, msg)
+      throw HttpStatusException(status, url, msg)
     }
   }
 
-  /** Downloads a URL to a local file with retries for transient HTTP statuses and IOExceptions. */
+  /** Downloads `url` to `localFile`, retrying on any error. */
   def downloadWithRetries(
     url: URL,
     localFile: File,
     maxRetries: Int = 5,
-    baseInterval: FiniteDuration = 2.seconds,
-    backoffFactor: Double = 2.0
+    baseInterval: FiniteDuration = 5.seconds,
+    backoffFactor: Double = 3.0
   ): Unit = {
-    withTransientHttpRetries(maxRetries, baseInterval, backoffFactor) {
+    withRetries(maxRetries, baseInterval, backoffFactor) {
       val conn = openAndCheck(url)
-      try {
-        sbt.io.Using.bufferedInputStream(conn.getInputStream) { inputStream =>
-          sbt.IO.transfer(inputStream, localFile)
-        }
-      } finally conn.disconnect()
+      try sbt.io.Using.bufferedInputStream(conn.getInputStream)(sbt.IO.transfer(_, localFile))
+      finally conn.disconnect()
     }
   }
 }

--- a/project/UrlRetry.scala
+++ b/project/UrlRetry.scala
@@ -1,6 +1,7 @@
 import java.io.File
 import java.net.{HttpURLConnection, URL}
 import scala.concurrent.duration.*
+import scala.util.control.NonFatal
 
 object UrlRetry {
 
@@ -15,21 +16,20 @@ object UrlRetry {
     require(baseInterval.toMillis >= 0, "baseInterval must be >= 0")
     require(backoffFactor >= 1.0, "backoffFactor must be >= 1.0")
 
-    def loop(attempt: Int, lastError: Option[Throwable]): T = {
-      lastError.foreach { e =>
-        println(s"[WARN] Attempt $attempt/$maxRetries failed with: ${e.getMessage}")
-        val delayMs = (baseInterval.toMillis.toDouble * math.pow(backoffFactor, attempt - 2)).toLong
-        if (delayMs > 0) Thread.sleep(delayMs)
-      }
-      try block
-      catch {
-        case e: Throwable =>
+    def loop(attempt: Int): T = {
+      try {
+        block
+      } catch {
+        case NonFatal(e) =>
+          println(s"[WARN] Attempt $attempt/$maxRetries failed with: ${e.getMessage}")
           if (attempt >= maxRetries) throw e
-          loop(attempt + 1, Some(e))
+          val delayMs = (baseInterval.toMillis.toDouble * math.pow(backoffFactor, attempt - 1)).toLong
+          if (delayMs > 0) Thread.sleep(delayMs)
+          loop(attempt + 1)
       }
     }
 
-    loop(attempt = 1, lastError = None)
+    loop(attempt = 1)
   }
 
   /** Opens a connection to `url` and returns it if the response is 2xx, otherwise throws [[HttpStatusException]]. */
@@ -54,8 +54,11 @@ object UrlRetry {
   ): Unit = {
     withRetries(maxRetries, baseInterval, backoffFactor) {
       val conn = openAndCheck(url)
-      try sbt.io.Using.bufferedInputStream(conn.getInputStream)(sbt.IO.transfer(_, localFile))
-      finally conn.disconnect()
+      try {
+        sbt.io.Using.bufferedInputStream(conn.getInputStream)(sbt.IO.transfer(_, localFile))
+      } finally {
+        conn.disconnect()
+      }
     }
   }
 }


### PR DESCRIPTION
We don't check for transient http errors anymore. Simply retry on anything other than 2xx as Github gave a few 404s in the past making the whole approach useless.