### PR TITLE
[x2cpg,javasrc2cpg,jimple2cpg,jssrc2cpg,swiftsrc2cpg,csharpsrc2cpg] lower throw statements as ControlStructure

### DIFF
--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/Constants.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/Constants.scala
@@ -7,7 +7,6 @@ object Constants {
 }
 
 object CSharpOperators {
-  val throws: String  = "<operators>.throw"
   val unknown: String = "<operators>.unknown"
   val await: String   = "<operator>.await"
 }

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -1,6 +1,5 @@
 package io.joern.csharpsrc2cpg.astcreation
 
-import io.joern.csharpsrc2cpg.CSharpOperators
 import io.joern.csharpsrc2cpg.parser.DotNetJsonAst.*
 import io.joern.csharpsrc2cpg.parser.{DotNetNodeInfo, ParserKeys}
 import io.joern.x2cpg.{Ast, ValidationMode}
@@ -302,8 +301,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
       case Some(_expr: ujson.Obj) => astForNode(createDotNetNodeInfo(_expr))
       case _                      => Seq.empty[Ast]
     }
-    val throwCall = operatorCallNode(throwStmt, CSharpOperators.throws, Some(getTypeFullNameFromAstNode(argsAst)))
-    Seq(callAst(throwCall, argsAst))
+    Seq(throwAst(throwStmt, argsAst))
   }
 
   protected def astForTryStatement(tryStmt: DotNetNodeInfo): Seq[Ast] = {

--- a/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/ControlStructureTests.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/test/scala/io/joern/csharpsrc2cpg/querying/ast/ControlStructureTests.scala
@@ -1,12 +1,11 @@
 package io.joern.csharpsrc2cpg.querying.ast
 
-import io.joern.csharpsrc2cpg.CSharpOperators
 import io.joern.csharpsrc2cpg.testfixtures.CSharpCode2CpgFixture
 import io.joern.x2cpg.Defines
 import io.shiftleft.codepropertygraph.generated.ControlStructureTypes
-import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.codepropertygraph.generated.nodes.Block
 import io.shiftleft.codepropertygraph.generated.nodes.Call
+import io.shiftleft.codepropertygraph.generated.nodes.ControlStructure
 import io.shiftleft.codepropertygraph.generated.nodes.JumpTarget
 import io.shiftleft.semanticcpg.language.*
 
@@ -17,18 +16,17 @@ class ControlStructureTests extends CSharpCode2CpgFixture {
         |throw new Exception("Error!");
         |""".stripMargin))
 
-    "create a throw operation with exception constructor" in {
-      inside(cpg.call.nameExact(CSharpOperators.throws).headOption) { case Some(x: Call) =>
-        x.methodFullName shouldBe CSharpOperators.throws
-        x.code shouldBe "throw new Exception(\"Error!\");"
-        x.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+    "create a throw control structure with exception constructor" in {
+      inside(cpg.controlStructure.controlStructureTypeExact(ControlStructureTypes.THROW).headOption) {
+        case Some(throwNode: ControlStructure) =>
+          throwNode.code shouldBe "throw new Exception(\"Error!\");"
 
-        inside(x.argumentOption(1)) { case Some(exp: Call) =>
-          exp.code shouldBe "new Exception(\"Error!\")"
-          exp.name shouldBe Defines.ConstructorMethodName
-          exp.typeFullName shouldBe "System.Exception"
-        }
-
+          inside(throwNode.astChildren.isCall.headOption) { case Some(exp: Call) =>
+            exp.code shouldBe "new Exception(\"Error!\")"
+            exp.name shouldBe Defines.ConstructorMethodName
+            exp.typeFullName shouldBe "System.Exception"
+            throwNode.argumentOut.l shouldBe List(exp)
+          }
       }
     }
   }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForSimpleStatementsCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/statements/AstForSimpleStatementsCreator.scala
@@ -352,17 +352,7 @@ trait AstForSimpleStatementsCreator { this: AstCreator =>
   }
 
   private[statements] def astForThrow(stmt: ThrowStmt): Ast = {
-    val throwNode = NewCall()
-      .name("<operator>.throw")
-      .methodFullName("<operator>.throw")
-      .lineNumber(line(stmt))
-      .columnNumber(column(stmt))
-      .code(code(stmt))
-      .dispatchType(DispatchTypes.STATIC_DISPATCH)
-
-    val args = astsForExpression(stmt.getExpression, ExpectedType.empty)
-
-    callAst(throwNode, args)
+    throwAst(stmt, astsForExpression(stmt.getExpression, ExpectedType.empty))
   }
 
   private[statements] def astForCatchClause(catchClause: CatchClause): Ast = {

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ControlStructureTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/ControlStructureTests.scala
@@ -763,6 +763,26 @@ class NewControlStructureTests extends JavaSrcCode2CpgFixture {
     }
   }
 
+  "`throw` statements" should {
+    val cpg = code("""
+        |public class Foo {
+        |  public static void foo(Exception ex) {
+        |    throw ex;
+        |  }
+        |}
+        |""".stripMargin)
+
+    "lower as a THROW control structure with the thrown expression as its argument" in {
+      inside(cpg.controlStructure.controlStructureTypeExact(ControlStructureTypes.THROW).l) {
+        case List(throwNode: ControlStructure) =>
+          throwNode.code shouldBe "throw ex;"
+          val List(thrownExpr) = throwNode.astChildren.l
+          thrownExpr.code shouldBe "ex"
+          throwNode.argumentOut.l shouldBe List(thrownExpr)
+      }
+    }
+  }
+
   "`for-loop` statements" should {
     val cpg = code("""
         |public class Foo {

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/astcreation/statements/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/astcreation/statements/AstForStatementsCreator.scala
@@ -126,18 +126,8 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
   }
 
   private def astsForThrowStmt(throwStmt: ThrowStmt): Seq[Ast] = {
-    val opAst = astsForValue(throwStmt.getOp, throwStmt)
-    val throwNode = NewCall()
-      .name("<operator>.throw")
-      .methodFullName("<operator>.throw")
-      .lineNumber(line(throwStmt))
-      .columnNumber(column(throwStmt))
-      .code(s"throw new ${throwStmt.getOp.getType}()")
-      .dispatchType(DispatchTypes.STATIC_DISPATCH)
-    Seq(
-      Ast(throwNode)
-        .withChildren(opAst)
-    )
+    val codeStr = s"throw new ${throwStmt.getOp.getType}()"
+    Seq(throwAst(throwStmt, astsForValue(throwStmt.getOp, throwStmt), Some(codeStr)))
   }
 
   private def astsForMonitorStmt(monitorStmt: MonitorStmt): Seq[Ast] = {

--- a/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/dataflow/TryTests.scala
+++ b/joern-cli/frontends/jimple2cpg/src/test/scala/io/joern/jimple2cpg/querying/dataflow/TryTests.scala
@@ -197,9 +197,8 @@ class TryTests extends JimpleDataFlowCodeToCpgSuite {
     }
 
     "find a path if `MALICIOUS` is assigned in `FINALLY`" in {
-      // Jimple's flat AST evaluates multiple paths that will end at the FINALLY sink but it is a conservative result
       val (source, sink) = getConstSourceSink("test7")
-      sink.reachableBy(source).size shouldBe 3
+      sink.reachableBy(source).size shouldBe 2
     }
 
     "not find a path if `MALICIOUS` is reassigned in both TRY/CATCH" in {

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -298,25 +298,24 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
   }
 
   protected def astForUnaryExpression(unaryExpr: BabelNodeInfo): Ast = {
-    val op = unaryExpr.json("operator").str match {
-      case "void"   => "<operator>.void"
-      case "throw"  => "<operator>.throw"
-      case "delete" => Operators.delete
-      case "!"      => Operators.logicalNot
-      case "+"      => Operators.plus
-      case "-"      => Operators.minus
-      case "~"      => "<operator>.bitNot"
-      case "typeof" => Operators.instanceOf
-      case other =>
-        logger.warn(s"Unknown update operator: '$other'")
-        Operators.assignment
-    }
-
     val argumentAst = astForNodeWithFunctionReference(unaryExpr.json("argument"))
-
-    val node    = callNode(unaryExpr, unaryExpr.code, op, DispatchTypes.STATIC_DISPATCH)
-    val argAsts = List(argumentAst)
-    callAst(node, argAsts)
+    unaryExpr.json("operator").str match {
+      case "throw" => throwAst(unaryExpr, List(argumentAst))
+      case op =>
+        val operator = op match {
+          case "void"   => "<operator>.void"
+          case "delete" => Operators.delete
+          case "!"      => Operators.logicalNot
+          case "+"      => Operators.plus
+          case "-"      => Operators.minus
+          case "~"      => "<operator>.bitNot"
+          case "typeof" => Operators.instanceOf
+          case other =>
+            logger.warn(s"Unknown update operator: '$other'")
+            Operators.assignment
+        }
+        callAst(callNode(unaryExpr, unaryExpr.code, operator, DispatchTypes.STATIC_DISPATCH), List(argumentAst))
+    }
   }
 
   protected def astForSequenceExpression(seq: BabelNodeInfo): Ast = {

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/astcreation/AstForStatementsCreator.scala
@@ -181,11 +181,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) { t
   }
 
   protected def astForThrowStatement(throwStmt: BabelNodeInfo): Ast = {
-    val argumentAst = astForNodeWithFunctionReference(throwStmt.json("argument"))
-    val throwCallNode =
-      callNode(throwStmt, throwStmt.code, "<operator>.throw", DispatchTypes.STATIC_DISPATCH)
-    val argAsts = List(argumentAst)
-    callAst(throwCallNode, argAsts)
+    throwAst(throwStmt, List(astForNodeWithFunctionReference(throwStmt.json("argument"))))
   }
 
   private def astsForSwitchCase(switchCase: BabelNodeInfo): List[Ast] = {

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/JsClassesAstCreationPassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/ast/JsClassesAstCreationPassTests.scala
@@ -2,8 +2,8 @@ package io.joern.jssrc2cpg.passes.ast
 
 import io.joern.jssrc2cpg.testfixtures.JsSrc2CpgSuite
 import io.joern.x2cpg.Defines
-import io.shiftleft.codepropertygraph.generated.{ModifierTypes, Operators}
-import io.shiftleft.codepropertygraph.generated.nodes.{Identifier, MethodRef}
+import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, ModifierTypes, Operators}
+import io.shiftleft.codepropertygraph.generated.nodes.{ControlStructure, Identifier, MethodRef}
 import io.shiftleft.semanticcpg.language.*
 
 class JsClassesAstCreationPassTests extends JsSrc2CpgSuite {
@@ -314,11 +314,12 @@ class JsClassesAstCreationPassTests extends JsSrc2CpgSuite {
     "have correct structure for throw new exceptions" in {
       val cpg             = code("function foo() { throw new Foo(); }")
       val List(fooBlock)  = cpg.method.nameExact("foo").astChildren.isBlock.l
-      val List(throwCall) = fooBlock.astChildren.isCall.codeExact("throw new Foo();").l
-      throwCall.name shouldBe "<operator>.throw"
+      val List(throwNode) = fooBlock.astChildren.isControlStructure.codeExact("throw new Foo();").l
+      throwNode.controlStructureType shouldBe ControlStructureTypes.THROW
 
-      val List(newCallBlock) = throwCall.astChildren.isBlock.codeExact("new Foo()").l
-      val tmpName            = "_tmp_0"
+      val List(newCallBlock) = throwNode.astChildren.isBlock.codeExact("new Foo()").l
+      throwNode.argumentOut.l shouldBe List(newCallBlock)
+      val tmpName = "_tmp_0"
 
       val List(localTmp) = newCallBlock.astChildren.isLocal.l
       localTmp.name shouldBe tmpName

--- a/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/cfg/JsClassesCfgCreationPassTests.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/passes/cfg/JsClassesCfgCreationPassTests.scala
@@ -67,8 +67,7 @@ class JsClassesCfgCreationPassTests extends CfgTestFixture(() => new JsSrcCfgTes
       succOf("Foo") should contain theSameElementsAs expected(("_tmp_0", 1, AlwaysEdge))
       succOf("_tmp_0", 1) should contain theSameElementsAs expected(("new Foo()", AlwaysEdge))
       succOf("new Foo()", NodeTypes.CALL) should contain theSameElementsAs expected(("_tmp_0", 2, AlwaysEdge))
-      succOf("_tmp_0", 2) should contain theSameElementsAs expected(("new Foo()", AlwaysEdge))
-      succOf("new Foo()") should contain theSameElementsAs expected(("throw new Foo()", AlwaysEdge))
+      succOf("_tmp_0", 2) should contain theSameElementsAs expected(("throw new Foo()", AlwaysEdge))
       succOf("throw new Foo()") should contain theSameElementsAs expected(("RET", AlwaysEdge))
     }
   }

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForStmtSyntaxCreator.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/astcreation/AstForStmtSyntaxCreator.scala
@@ -537,12 +537,7 @@ trait AstForStmtSyntaxCreator(implicit withSchemaValidation: ValidationMode) {
   private def astForThenStmtSyntax(node: ThenStmtSyntax): Ast = notHandledYet(node)
 
   private def astForThrowStmtSyntax(node: ThrowStmtSyntax): Ast = {
-    val op  = "<operator>.throw"
-    val tpe = fullnameProvider.typeFullname(node).getOrElse(Defines.Any)
-    registerType(tpe)
-    val callNode_ = createStaticCallNode(node, code(node), op, op, tpe)
-    val exprAst   = astForNode(node.expression)
-    callAst(callNode_, List(exprAst))
+    throwAst(node, List(astForNode(node.expression)))
   }
 
   private def astForWhileStmtSyntax(node: WhileStmtSyntax): Ast = {

--- a/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/ControlStructureTests.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/test/scala/io/joern/swiftsrc2cpg/passes/ast/ControlStructureTests.scala
@@ -112,4 +112,20 @@ class ControlStructureTests extends SwiftSrc2CpgSuite {
     }
   }
 
+  "`throw` statements lower as a THROW control structure" in {
+    val cpg = code("""
+      |func method() {
+      |  throw MyError.someCase
+      |}
+      |""".stripMargin)
+
+    inside(cpg.controlStructure.controlStructureTypeExact(ControlStructureTypes.THROW).l) {
+      case List(throwNode: ControlStructure) =>
+        throwNode.code shouldBe "throw MyError.someCase"
+        val List(thrownExpr) = throwNode.astChildren.l
+        thrownExpr.code shouldBe "MyError.someCase"
+        throwNode.argumentOut.l shouldBe List(thrownExpr)
+    }
+  }
+
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/internal/ControlStructureAstBuilder.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/internal/ControlStructureAstBuilder.scala
@@ -392,6 +392,32 @@ private[x2cpg] trait ControlStructureAstBuilder[Node, NodeProcessor] {
   def gotoAst(node: Node, codeStr: String, labelName: String): Ast =
     jumpAst(node, ControlStructureTypes.GOTO, codeStr, Option(labelName))
 
+  /** Creates an AST for a `throw` statement.
+    *
+    * When `thrownExprAsts` contains exactly one element it is attached directly; when it contains more than one they
+    * are first wrapped in a synthetic block via `wrapMultipleInBlock`. The resulting child is connected via an
+    * `ARGUMENT` edge so that the CFG creator can reach it via `_argumentOut`.
+    *
+    * @param node
+    *   the source AST node representing the `throw` statement (used for position and code)
+    * @param thrownExprAsts
+    *   ASTs for the thrown expression(s); pass an empty sequence when there is no operand
+    * @param code
+    *   explicit source-code string; falls back to `this.code(node)` when absent
+    */
+  def throwAst(node: Node, thrownExprAsts: Seq[Ast], code: Option[String] = None): Ast = {
+    val throwNode = controlStructureFromNode(node, ControlStructureTypes.THROW, code)
+    thrownExprAsts match {
+      case Nil => Ast(throwNode)
+      case _ =>
+        val argAst = wrapMultipleInBlock(thrownExprAsts, line(node))
+        argAst.root match {
+          case Some(argRoot) => Ast(throwNode).withChild(argAst).withArgEdge(throwNode, argRoot)
+          case None          => Ast(throwNode).withChild(argAst)
+        }
+    }
+  }
+
   /** Creates an AST for a `try-catch-finally` statement.
     *
     * The try body, catch clauses, and optional finally block receive `TRY_BODY`, `CATCH_BODY`, and `FINALLY_BODY` edges


### PR DESCRIPTION
- Add `throwAst` helper to `x2cpg`'s `ControlStructureAstBuilder`. It wraps multiple thrown-expression ASTs via `wrapMultipleInBlock`, attaches the result as a child, and wires an `ARGUMENT` edge so the CFG creator can reach it via `_argumentOut`.
- Fix `javasrc2cpg`, `jimple2cpg`, `jssrc2cpg`, `swiftsrc2cpg`, and `csharpsrc2cpg`, which were all emitting a `<operator>.throw` `Call` node instead of a `ControlStructure` with type `THROW`. This caused the CFG creator's `cfgForThrowStatement` to be bypassed, leaving throw statements with an empty CFG fringe (no edge to the exit node).
- Remove the now-unused `CSharpOperators.throws` constant.
- One commit per frontend.