### PR TITLE
[rust2cpg] add ctor for tuple/unit structs.

### DIFF
--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
@@ -62,7 +62,7 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
     case macroDef: MacroDef     => visitMacroDef(macroDef)
     case module: Module         => visitModule(module)
     case static: Static         => visitStatic(static)
-    case struct: Struct         => visitStruct(struct) :: Nil
+    case struct: Struct         => visitStruct(struct)
     case trait_ : Trait         => visitTrait(trait_) :: Nil
     case x: TypeAlias           => notHandledYet(x) :: Nil
     case x: Union               => notHandledYet(x) :: Nil
@@ -1132,33 +1132,169 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
   //    WhereClause? (RecordFieldList | ';')
   //  | TupleFieldList WhereClause? ';'
   //  )
-  private def visitStruct(struct: Struct): Ast = {
+  private def visitStruct(struct: Struct): Seq[Ast] = {
+    (struct.recordFieldList, struct.tupleFieldList) match {
+      case (Some(recordFieldList), _)   => lowerRecordStruct(struct, recordFieldList) :: Nil
+      case (None, Some(tupleFieldList)) => lowerTupleStruct(struct, tupleFieldList)
+      case (None, None)                 => lowerUnitStruct(struct) :: Nil
+    }
+  }
+
+  // `struct Foo;` becomes:
+  // TYPE_DECL Foo
+  //   CONSTRUCTOR <init>(&self: Foo) -> () {}
+  private def lowerUnitStruct(struct: Struct): Ast = {
     val implementedTraits = struct.implementedTraits.getOrElse(Nil)
     val structFullName    = composeRustFullName(code(struct.name))
     val inheritsFrom      = implementedTraits.map(traitFullName => s"<$structFullName as $traitFullName>")
     val typeDecl          = typeDeclForStruct(struct, inheritsFrom)
-    (struct.recordFieldList, struct.tupleFieldList) match {
-      case (Some(recordFieldList), _) =>
-        methodAstParentStack.push(typeDecl)
-        val ctorAst = structCtorMethodAst(struct, typeDecl)
-        methodAstParentStack.pop()
-        Ast(typeDecl).withChildren(visitRecordFieldList(recordFieldList) :+ ctorAst)
-      case (None, Some(tupleFieldList)) =>
-        Ast(typeDecl).withChildren(visitTupleFieldList(tupleFieldList))
-      case (None, None) =>
-        Ast(typeDecl)
+
+    methodAstParentStack.push(typeDecl)
+    val ctorAst = structCtorMethodAst(struct, typeDecl, Nil)
+    methodAstParentStack.pop()
+
+    Ast(typeDecl).withChild(ctorAst)
+  }
+
+  // `struct Foo { x: T, ... }` becomes:
+  // TYPE_DECL Foo
+  //   MEMBER x: T
+  //   ...
+  //   CONSTRUCTOR <init>(&self: Foo, x: T, ...) -> () {
+  //     (*self).x = x
+  //     ...
+  //   }
+  private def lowerRecordStruct(struct: Struct, recordFieldList: RecordFieldList): Ast = {
+    val implementedTraits = struct.implementedTraits.getOrElse(Nil)
+    val structFullName    = composeRustFullName(code(struct.name))
+    val inheritsFrom      = implementedTraits.map(traitFullName => s"<$structFullName as $traitFullName>")
+    val typeDecl          = typeDeclForStruct(struct, inheritsFrom)
+
+    methodAstParentStack.push(typeDecl)
+    val ctorAst = structCtorMethodAst(struct, typeDecl, recordStructFieldData(struct))
+    methodAstParentStack.pop()
+
+    Ast(typeDecl).withChildren(visitRecordFieldList(recordFieldList) :+ ctorAst)
+  }
+
+  // `struct Foo(T1, T2, ...);` becomes:
+  //  TYPE_DECL Foo
+  //    MEMBER 0: T1
+  //    MEMBER 1: T2
+  //    ...
+  //    CONSTRUCTOR <init>(&self: Foo, 0: T1, 1: T2, ...)` -> () {
+  //      (*self).0 = 0
+  //      (*self).1 = 1
+  //      ...
+  //    }
+  //  METHOD Foo(0: T1, 1: T2, ...) -> Foo {
+  //    LOCAL tmp
+  //    tmp = <operator>.alloc
+  //    Foo::<init>(&tmp, 0, 1)
+  //    return tmp
+  //  }
+  // NB: tuple struct literals, e.g. `Foo(1, 2)`, are regular calls, hence the extra method.
+  private def lowerTupleStruct(struct: Struct, tupleFieldList: TupleFieldList): Seq[Ast] = {
+    val implementedTraits = struct.implementedTraits.getOrElse(Nil)
+    val structFullName    = composeRustFullName(code(struct.name))
+    val inheritsFrom      = implementedTraits.map(traitFullName => s"<$structFullName as $traitFullName>")
+    val typeDecl          = typeDeclForStruct(struct, inheritsFrom)
+    val fields            = tupleStructFieldData(tupleFieldList)
+
+    methodAstParentStack.push(typeDecl)
+    val ctorAst = structCtorMethodAst(struct, typeDecl, fields)
+    methodAstParentStack.pop()
+
+    val typeDeclAst    = Ast(typeDecl).withChildren(visitTupleFieldList(tupleFieldList) :+ ctorAst)
+    val ctorWrapperAst = tupleStructCtorWrapperAst(struct, typeDecl, fields)
+
+    Seq(typeDeclAst, ctorWrapperAst)
+  }
+
+  private def tupleStructCtorWrapperAst(
+    struct: Struct,
+    typeDecl: NewTypeDecl,
+    fields: Seq[(node: RustNode, name: String, typ: String)]
+  ): Ast = {
+    val tmpName  = "tmp"
+    val fnName   = code(struct.name)
+    val fullName = struct.methodFullName.getOrElse(composeRustFullName(fnName))
+    val method   = methodNode(struct, fnName).code(fnName).fullName(fullName)
+
+    val fieldParams = fields.zipWithIndex.map { case (fieldData, index) =>
+      parameterInNode(
+        node = fieldData.node,
+        name = fieldData.name,
+        code = fieldData.name,
+        index = index + 1,
+        isVariadic = false,
+        evaluationStrategy = EvaluationStrategies.BY_SHARING,
+        typeFullName = fieldData.typ
+      )
+    }
+
+    val local = localNode(struct, tmpName, tmpName, typeDecl.fullName)
+
+    // tmp = <operator>.alloc
+    val allocAssignAst = {
+      val allocCall   = operatorCallNode(struct, Operators.alloc, Operators.alloc, Some(typeDecl.fullName))
+      val tmpIdentAst = Ast(identifierNode(struct, tmpName, tmpName, typeDecl.fullName))
+      callAst(assignmentNode(struct, s"$tmpName = ${Operators.alloc}"), Seq(tmpIdentAst, Ast(allocCall)))
+    }
+
+    // Foo::<init>(&tmp, 0, 1, ...)
+    val initCallAst = {
+      val initName = Defines.ConstructorMethodName
+      val initCode = s"$fnName::$initName(${(s"&$tmpName" +: fields.map(_.name)).mkString(", ")})"
+      val initCall = callNode(
+        node = struct,
+        code = initCode,
+        name = initName,
+        methodFullName = combineRustFullName(typeDecl.fullName, initName),
+        dispatchType = DispatchTypes.STATIC_DISPATCH,
+        signature = None,
+        typeFullName = Some("()")
+      )
+      val addressOfTmp = {
+        val addressOf   = operatorCallNode(struct, s"&$tmpName", Operators.addressOf, Some(s"&${typeDecl.fullName}"))
+        val tmpIdentAst = Ast(identifierNode(struct, tmpName, tmpName, typeDecl.fullName))
+        callAst(addressOf, Seq(tmpIdentAst))
+      }
+      val fieldArgs = fields.map { fieldData =>
+        Ast(identifierNode(fieldData.node, fieldData.name, fieldData.name, fieldData.typ))
+      }
+
+      callAst(initCall, fieldArgs, base = Some(addressOfTmp))
+    }
+
+    // return tmp
+    val retAst = returnAst(
+      returnNode(struct, s"return $tmpName"),
+      Seq(Ast(identifierNode(struct, tmpName, tmpName, typeDecl.fullName)))
+    )
+
+    val bodyAst = blockAst(blockNode(struct), List(Ast(local), allocAssignAst, initCallAst, retAst))
+    methodAst(method, fieldParams.map(Ast(_)), bodyAst, methodReturnNode(struct, typeDecl.fullName))
+  }
+
+  private def tupleStructFieldData(tupleFieldList: TupleFieldList): Seq[(node: RustNode, name: String, typ: String)] = {
+    tupleFieldList.tupleField.zipWithIndex.map { case (field, index) =>
+      (node = field, name = index.toString, typ = typeFullNameForType(field.typ))
     }
   }
 
-  private def structFieldData(struct: Struct): Seq[(node: RustNode, name: String, typ: String)] = {
+  private def recordStructFieldData(struct: Struct): Seq[(node: RustNode, name: String, typ: String)] = {
     struct.recordFieldList.toSeq.flatMap(_.recordField.map { field =>
       (node = field, name = code(field.name), typ = typeFullNameForType(field.typ))
     })
   }
 
-  private def structCtorMethodAst(struct: Struct, typeDecl: NewTypeDecl): Ast = {
+  private def structCtorMethodAst(
+    struct: Struct,
+    typeDecl: NewTypeDecl,
+    fields: Seq[(node: RustNode, name: String, typ: String)]
+  ): Ast = {
     val selfName = "self"
-    val fields   = structFieldData(struct)
     val method   = methodNode(struct, Defines.ConstructorMethodName).code(Defines.ConstructorMethodName)
     val selfParam = parameterInNode(
       node = struct,

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/ImplTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/ImplTests.scala
@@ -133,6 +133,7 @@ class ImplTests extends Rust2CpgSuite(noSysRoot = true) {
 
     "lower each as an AST child of the corresponding TYPE_DECL" in {
       cpg.typeDecl.nameExact("Foo").method.fullName.sorted.l shouldBe List(
+        "rust2cpgtest::Foo::<init>",
         "rust2cpgtest::Foo::a",
         "rust2cpgtest::Foo::b"
       )
@@ -152,6 +153,7 @@ class ImplTests extends Rust2CpgSuite(noSysRoot = true) {
 
     "merge all methods under the same TYPE_DECL" in {
       cpg.typeDecl.nameExact("Foo").method.fullName.sorted.l shouldBe List(
+        "rust2cpgtest::Foo::<init>",
         "rust2cpgtest::Foo::a",
         "rust2cpgtest::Foo::b"
       )
@@ -187,6 +189,7 @@ class ImplTests extends Rust2CpgSuite(noSysRoot = true) {
 
     "merge all methods under the same TYPE_DECL" in {
       cpg.typeDecl.nameExact("Foo").method.fullName.sorted.l shouldBe List(
+        "rust2cpgtest::Foo::<init>",
         "rust2cpgtest::Foo::a",
         "rust2cpgtest::Foo::b"
       )

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/StructTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/StructTests.scala
@@ -102,6 +102,91 @@ class StructTests extends Rust2CpgSuite(noSysRoot = true) {
         one.typeFullName shouldBe "bool"
       }
     }
+
+    "have a constructor method" in {
+      inside(cpg.typeDecl.nameExact("Pair").method.l) { case init :: Nil =>
+        init.name shouldBe "<init>"
+        init.fullName shouldBe "rust2cpgtest::Pair::<init>"
+        init.modifier.modifierType.l shouldBe List(ModifierTypes.CONSTRUCTOR)
+        init.methodReturn.typeFullName shouldBe "()"
+      }
+    }
+
+    "have correct constructor parameters" in {
+      inside(cpg.typeDecl.nameExact("Pair").method.parameter.sortBy(_.index).l) {
+        case paramSelf :: param0 :: param1 :: Nil =>
+          paramSelf.name shouldBe "self"
+          paramSelf.index shouldBe 0
+          paramSelf.typeFullName shouldBe "rust2cpgtest::Pair"
+
+          param0.name shouldBe "0"
+          param0.index shouldBe 1
+          param0.typeFullName shouldBe "i32"
+
+          param1.name shouldBe "1"
+          param1.index shouldBe 2
+          param1.typeFullName shouldBe "bool"
+      }
+    }
+
+    "have an assignment for each parameter" in {
+      inside(cpg.typeDecl.nameExact("Pair").method.body.astChildren.isCall.l) { case assign0 :: assign1 :: Nil =>
+        assign0.code shouldBe "(*self).0 = 0"
+        inside(assign0.argument(1)) { case fieldAccess: Call =>
+          fieldAccess.code shouldBe "(*self).0"
+          fieldAccess.methodFullName shouldBe Operators.fieldAccess
+        }
+        inside(assign0.argument(2)) { case ident: Identifier =>
+          ident.name shouldBe "0"
+          ident.typeFullName shouldBe "i32"
+        }
+        assign1.code shouldBe "(*self).1 = 1"
+      }
+    }
+
+    "have a standalone ctor wrapper" in {
+      inside(cpg.method.nameExact("Pair").l) { case ctor :: Nil =>
+        ctor.fullName shouldBe "rust2cpgtest::Pair"
+        ctor.astParentType shouldBe NodeTypes.METHOD
+        ctor.astParentFullName shouldBe s"$libPath:rust2cpgtest::$globalNamespaceName"
+        ctor.modifier shouldBe empty
+        ctor.methodReturn.typeFullName shouldBe "rust2cpgtest::Pair"
+      }
+    }
+
+    "have correct ctor wrapper parameters" in {
+      inside(cpg.method.nameExact("Pair").parameter.sortBy(_.index).l) { case param0 :: param1 :: Nil =>
+        param0.name shouldBe "0"
+        param0.index shouldBe 1
+        param0.typeFullName shouldBe "i32"
+
+        param1.name shouldBe "1"
+        param1.index shouldBe 2
+        param1.typeFullName shouldBe "bool"
+      }
+    }
+
+    "have correct ctor wrapper body" in {
+      inside(cpg.method.nameExact("Pair").body.astChildren.isCall.l) { case allocAssign :: initCall :: Nil =>
+        allocAssign.code shouldBe s"tmp = ${Operators.alloc}"
+        initCall.name shouldBe "<init>"
+        initCall.methodFullName shouldBe "rust2cpgtest::Pair::<init>"
+        initCall.code shouldBe "Pair::<init>(&tmp, 0, 1)"
+
+        inside(initCall.argument.sortBy(_.argumentIndex).l) {
+          case (addressOf: Call) :: (arg0: Identifier) :: (arg1: Identifier) :: Nil =>
+            addressOf.code shouldBe "&tmp"
+            addressOf.argumentIndex shouldBe 0
+            addressOf.typeFullName shouldBe "&rust2cpgtest::Pair"
+
+            arg0.name shouldBe "0"
+            arg0.typeFullName shouldBe "i32"
+
+            arg1.name shouldBe "1"
+            arg1.typeFullName shouldBe "bool"
+        }
+      }
+    }
   }
 
   "a top-level tuple struct with one field" should {
@@ -126,6 +211,27 @@ class StructTests extends Rust2CpgSuite(noSysRoot = true) {
     "have no members" in {
       cpg.typeDecl.nameExact("Empty").member shouldBe empty
     }
+
+    "have a constructor method" in {
+      inside(cpg.typeDecl.nameExact("Empty").method.l) { case init :: Nil =>
+        init.name shouldBe "<init>"
+        init.fullName shouldBe "rust2cpgtest::Empty::<init>"
+        init.modifier.modifierType.l shouldBe List(ModifierTypes.CONSTRUCTOR)
+        inside(init.parameter.l) { case self :: Nil =>
+          self.name shouldBe "self"
+          self.index shouldBe 0
+          self.typeFullName shouldBe "rust2cpgtest::Empty"
+        }
+      }
+    }
+
+    "have a standalone ctor wrapper" in {
+      inside(cpg.method.nameExact("Empty").l) { case ctorFn :: Nil =>
+        ctorFn.fullName shouldBe "rust2cpgtest::Empty"
+        ctorFn.parameter shouldBe empty
+        ctorFn.methodReturn.typeFullName shouldBe "rust2cpgtest::Empty"
+      }
+    }
   }
 
   "a top-level unit struct" should {
@@ -137,6 +243,19 @@ class StructTests extends Rust2CpgSuite(noSysRoot = true) {
 
     "have no members" in {
       cpg.typeDecl.nameExact("Bar").member shouldBe empty
+    }
+
+    "have a constructor method" in {
+      inside(cpg.typeDecl.nameExact("Bar").method.l) { case init :: Nil =>
+        init.name shouldBe "<init>"
+        init.fullName shouldBe "rust2cpgtest::Bar::<init>"
+        init.modifier.modifierType.l shouldBe List(ModifierTypes.CONSTRUCTOR)
+        inside(init.parameter.l) { case self :: Nil =>
+          self.name shouldBe "self"
+          self.index shouldBe 0
+          self.typeFullName shouldBe "rust2cpgtest::Bar"
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Follow up on https://github.com/joernio/joern/pull/6120

Now, all three `struct` variants have a constructor method. The interesting case is tuple structs, e.g. `struct Foo(i32, i32)`, since to create such a value one would write e.g. `Foo(1, 2)` which is a regular Rust call node, including having a proper `methodFullName`. Thus, for these we synthesize an extra method e.g. `Foo(i32,i32) -> Foo` to match those calls, whose body allocates and invokes the corresponding `<init>` constructor method.