### PR TITLE
[CI] Switch to platform-specific Github releases

### DIFF
--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -2,13 +2,25 @@ name: release to github
 on:
   workflow_dispatch: # triggered by 'release' workflow via github REST api
 jobs:
-  release-github:
-    concurrency: release
-    runs-on: ubuntu-latest
+  build-distribution:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux-x86_64
+          - os: ubuntu-24.04-arm
+            platform: linux-arm64
+          - os: macos-13
+            platform: macos-x86_64
+          - os: macos-latest
+            platform: macos-arm64
+          - os: windows-latest
+            platform: windows-x86_64
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Set up JDK
@@ -31,7 +43,52 @@ jobs:
         run: rm -rf /home/runner/.cargo
         if: runner.os == 'Linux'
       - run: sbt stage createDistribution
-      - run: sha512sum target/joern-cli.zip > target/joern-cli.zip.sha512
+      - run: sha512sum target/joern-cli-${{ matrix.platform }}.zip > target/joern-cli-${{ matrix.platform }}.zip.sha512
+        if: runner.os != 'Windows'
+      - name: Generate SHA512 checksum
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $hash = (Get-FileHash -Algorithm SHA512 "target\joern-cli-${{ matrix.platform }}.zip").Hash.ToLower()
+          "$hash  joern-cli-${{ matrix.platform }}.zip" | Out-File -Encoding ASCII "target\joern-cli-${{ matrix.platform }}.zip.sha512"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ matrix.platform }}
+          path: |
+            target/joern-cli-${{ matrix.platform }}.zip
+            target/joern-cli-${{ matrix.platform }}.zip.sha512
+          retention-days: 1
+      - uses: actions/upload-artifact@v4
+        if: matrix.platform == 'linux-x86_64'
+        with:
+          name: querydb
+          path: querydb/target/querydb.zip
+          retention-days: 1
+
+  release-github:
+    needs: build-distribution
+    concurrency: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: sbt
+      - uses: sbt/setup-sbt@v1
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: dist-*
+          path: target/dist
+          merge-multiple: true
+      - uses: actions/download-artifact@v4
+        with:
+          name: querydb
+          path: querydb/target
       - run: sbt "querydb/runMain io.joern.dumpq.Main"
       - name: Check if release exists
         id: check_release
@@ -55,7 +112,15 @@ jobs:
           prerelease: false
           files: |
             ./joern-install.sh
-            target/joern-cli.zip
-            target/joern-cli.zip.sha512
+            target/dist/joern-cli-linux-x86_64.zip
+            target/dist/joern-cli-linux-x86_64.zip.sha512
+            target/dist/joern-cli-linux-arm64.zip
+            target/dist/joern-cli-linux-arm64.zip.sha512
+            target/dist/joern-cli-macos-x86_64.zip
+            target/dist/joern-cli-macos-x86_64.zip.sha512
+            target/dist/joern-cli-macos-arm64.zip
+            target/dist/joern-cli-macos-arm64.zip.sha512
+            target/dist/joern-cli-windows-x86_64.zip
+            target/dist/joern-cli-windows-x86_64.zip.sha512
             querydb/target/querydb.zip
             /tmp/querydb.json

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -32,12 +32,14 @@ jobs:
             platform: linux-x86_64
           - os: ubuntu-24.04-arm
             platform: linux-arm64
-          - os: macos-13
+          - os: macos-15-intel
             platform: macos-x86_64
           - os: macos-latest
             platform: macos-arm64
           - os: windows-latest
             platform: windows-x86_64
+          - os: windows-11-arm
+            platform: windows-arm64
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write
@@ -80,7 +82,7 @@ jobs:
             target/joern-cli-${{ matrix.platform }}.zip
             target/joern-cli-${{ matrix.platform }}.zip.sha512
           retention-days: 1
-      - name: Dump query database and upload artifacts
+      - name: Dump query database
         if: matrix.platform == 'linux-x86_64'
         run: sbt "querydb/runMain io.joern.dumpq.Main"
       - uses: actions/upload-artifact@v4
@@ -128,5 +130,7 @@ jobs:
             target/dist/joern-cli-macos-arm64.zip.sha512
             target/dist/joern-cli-windows-x86_64.zip
             target/dist/joern-cli-windows-x86_64.zip.sha512
+            target/dist/joern-cli-windows-arm64.zip
+            target/dist/joern-cli-windows-arm64.zip.sha512
             querydb-artifacts/querydb.zip
             querydb-artifacts/querydb.json

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -2,7 +2,29 @@ name: release to github
 on:
   workflow_dispatch: # triggered by 'release' workflow via github REST api
 jobs:
+  check-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      exists: ${{ steps.check.outputs.exists }}
+    steps:
+      - name: Check if release exists
+        id: check
+        run: |
+          if gh release view "${{ github.ref_name }}" > /dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Release ${{ github.ref_name }} already exists, skipping"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "Release ${{ github.ref_name }} does not exist, will create it"
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
   build-distribution:
+    needs: check-release
+    if: needs.check-release.outputs.exists == 'false'
     strategy:
       matrix:
         include:
@@ -58,11 +80,16 @@ jobs:
             target/joern-cli-${{ matrix.platform }}.zip
             target/joern-cli-${{ matrix.platform }}.zip.sha512
           retention-days: 1
+      - name: Dump query database and upload artifacts
+        if: matrix.platform == 'linux-x86_64'
+        run: sbt "querydb/runMain io.joern.dumpq.Main"
       - uses: actions/upload-artifact@v4
         if: matrix.platform == 'linux-x86_64'
         with:
           name: querydb
-          path: querydb/target/querydb.zip
+          path: |
+            querydb/target/querydb.zip
+            /tmp/querydb.json
           retention-days: 1
 
   release-github:
@@ -73,13 +100,6 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v7
-      - name: Set up JDK
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: 21
-          cache: sbt
-      - uses: sbt/setup-sbt@v1
       - uses: actions/download-artifact@v4
         with:
           pattern: dist-*
@@ -88,22 +108,8 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: querydb
-          path: querydb/target
-      - run: sbt "querydb/runMain io.joern.dumpq.Main"
-      - name: Check if release exists
-        id: check_release
-        run: |
-          if gh release view "${{ github.ref_name }}" > /dev/null 2>&1; then
-            echo "exists=true" >> $GITHUB_OUTPUT
-            echo "Release ${{ github.ref_name }} already exists, will skip creation"
-          else
-            echo "exists=false" >> $GITHUB_OUTPUT
-            echo "Release ${{ github.ref_name }} does not exist, will create it"
-          fi
-        env:
-          GH_TOKEN: ${{ github.token }}
+          path: querydb-artifacts
       - name: Create Release and Upload Assets
-        if: steps.check_release.outputs.exists == 'false'
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
@@ -122,5 +128,5 @@ jobs:
             target/dist/joern-cli-macos-arm64.zip.sha512
             target/dist/joern-cli-windows-x86_64.zip
             target/dist/joern-cli-windows-x86_64.zip.sha512
-            querydb/target/querydb.zip
-            /tmp/querydb.json
+            querydb-artifacts/querydb.zip
+            querydb-artifacts/querydb.json

--- a/README.md
+++ b/README.md
@@ -96,6 +96,15 @@ docker run --rm -it -v /tmp:/tmp -v $(pwd):/app:rw -w /app -t ghcr.io/joernio/jo
 ## Releases
 A new release is [created automatically](.github/workflows/release.yml) once per day. Contributers can also manually run the [release workflow](https://github.com/joernio/joern/actions/workflows/release.yml) if they need the release sooner.
 
+Each release publishes platform-specific distribution zips:
+- `joern-cli-linux-x86_64.zip`
+- `joern-cli-linux-arm64.zip`
+- `joern-cli-macos-x86_64.zip`
+- `joern-cli-macos-arm64.zip`
+- `joern-cli-windows-x86_64.zip`
+
+`joern-install.sh` detects the current platform automatically and downloads the correct zip.
+
 ## Developers
 
 ### Contribution Guidelines

--- a/README.md
+++ b/README.md
@@ -102,8 +102,9 @@ Each release publishes platform-specific distribution zips:
 - `joern-cli-macos-x86_64.zip`
 - `joern-cli-macos-arm64.zip`
 - `joern-cli-windows-x86_64.zip`
+- `joern-cli-windows-arm64.zip`
 
-`joern-install.sh` detects the current platform automatically and downloads the correct zip.
+`joern-install.sh` detects the current platform automatically and downloads the correct zip. Windows users should download the appropriate zip directly from the [releases page](https://github.com/joernio/joern/releases/latest) and extract it manually.
 
 ## Developers
 

--- a/build.sbt
+++ b/build.sbt
@@ -93,7 +93,8 @@ createDistribution := {
     case (Environment.OperatingSystemType.Linux, Environment.ArchitectureType.ARMv8) => "linux-arm64"
     case (Environment.OperatingSystemType.Mac, Environment.ArchitectureType.X86)     => "macos-x86_64"
     case (Environment.OperatingSystemType.Mac, Environment.ArchitectureType.ARMv8)   => "macos-arm64"
-    case (Environment.OperatingSystemType.Windows, _)                                => "windows-x86_64"
+    case (Environment.OperatingSystemType.Windows, Environment.ArchitectureType.ARMv8) => "windows-arm64"
+    case (Environment.OperatingSystemType.Windows, _)                                 => "windows-x86_64"
     case _                                                                            => "unknown"
   }
   val distributionFile    = file(s"target/joern-cli-$platformSuffix.zip")

--- a/build.sbt
+++ b/build.sbt
@@ -88,13 +88,19 @@ ThisBuild / scalacOptions ++= Seq(
 
 lazy val createDistribution = taskKey[File]("Create a complete Joern distribution")
 createDistribution := {
-  val distributionFile = file("target/joern-cli.zip")
-  val zip              = (joerncli / Universal / packageBin).value
-
+  val platformSuffix = (Environment.operatingSystem, Environment.architecture) match {
+    case (Environment.OperatingSystemType.Linux, Environment.ArchitectureType.X86)   => "linux-x86_64"
+    case (Environment.OperatingSystemType.Linux, Environment.ArchitectureType.ARMv8) => "linux-arm64"
+    case (Environment.OperatingSystemType.Mac, Environment.ArchitectureType.X86)     => "macos-x86_64"
+    case (Environment.OperatingSystemType.Mac, Environment.ArchitectureType.ARMv8)   => "macos-arm64"
+    case (Environment.OperatingSystemType.Windows, _)                                => "windows-x86_64"
+    case _                                                                            => "unknown"
+  }
+  val distributionFile    = file(s"target/joern-cli-$platformSuffix.zip")
+  val zip                 = (joerncli / Universal / packageBin).value
   IO.copyFile(zip, distributionFile)
   val querydbDistribution = (querydb / createDistribution).value
-
-  println(s"created distribution - resulting files: $distributionFile")
+  println(s"created distribution - resulting files: $distributionFile, $querydbDistribution")
   distributionFile
 }
 

--- a/joern-cli/frontends/abap2cpg/build.sbt
+++ b/joern-cli/frontends/abap2cpg/build.sbt
@@ -38,19 +38,15 @@ lazy val AbapgenMacArm   = "abapgen-macos-arm"
 lazy val abapgenDlUrl = settingKey[String]("abapgen download url")
 abapgenDlUrl := s"https://github.com/joernio/astgen-monorepo/releases/download/abap-astgen/v${abapgenVersion.value}/"
 
-lazy val abapgenBinaryNames = taskKey[Seq[String]]("abapgen binary names for current or all platforms")
+lazy val abapgenBinaryNames = taskKey[Seq[String]]("abapgen binary names for current platform")
 abapgenBinaryNames := {
-  if (sys.props.get("ALL_PLATFORMS").contains("TRUE")) {
-    Seq(AbapgenWinX86, AbapgenLinuxX86, AbapgenLinuxArm, AbapgenMacX86, AbapgenMacArm)
-  } else {
-    (Environment.operatingSystem, Environment.architecture) match {
-      case (Environment.OperatingSystemType.Windows, _)                                => Seq(AbapgenWinX86)
-      case (Environment.OperatingSystemType.Linux, Environment.ArchitectureType.X86)   => Seq(AbapgenLinuxX86)
-      case (Environment.OperatingSystemType.Linux, Environment.ArchitectureType.ARMv8) => Seq(AbapgenLinuxArm)
-      case (Environment.OperatingSystemType.Mac, Environment.ArchitectureType.X86)     => Seq(AbapgenMacX86)
-      case (Environment.OperatingSystemType.Mac, Environment.ArchitectureType.ARMv8)   => Seq(AbapgenMacArm)
-      case _ => Seq(AbapgenWinX86, AbapgenLinuxX86, AbapgenLinuxArm, AbapgenMacX86, AbapgenMacArm)
-    }
+  (Environment.operatingSystem, Environment.architecture) match {
+    case (Environment.OperatingSystemType.Windows, _)                                => Seq(AbapgenWinX86)
+    case (Environment.OperatingSystemType.Linux, Environment.ArchitectureType.X86)   => Seq(AbapgenLinuxX86)
+    case (Environment.OperatingSystemType.Linux, Environment.ArchitectureType.ARMv8) => Seq(AbapgenLinuxArm)
+    case (Environment.OperatingSystemType.Mac, Environment.ArchitectureType.X86)     => Seq(AbapgenMacX86)
+    case (Environment.OperatingSystemType.Mac, Environment.ArchitectureType.ARMv8)   => Seq(AbapgenMacArm)
+    case _ => Seq(AbapgenWinX86, AbapgenLinuxX86, AbapgenLinuxArm, AbapgenMacX86, AbapgenMacArm)
   }
 }
 
@@ -71,14 +67,6 @@ abapgenDlTask := {
 }
 
 Compile / compile := ((Compile / compile) dependsOn abapgenDlTask).value
-
-lazy val abapgenSetAllPlatforms = taskKey[Unit]("Set ALL_PLATFORMS flag")
-abapgenSetAllPlatforms := { System.setProperty("ALL_PLATFORMS", "TRUE") }
-
-stage := Def
-  .sequential(abapgenSetAllPlatforms, Universal / stage)
-  .andFinally(System.setProperty("ALL_PLATFORMS", "FALSE"))
-  .value
 
 Universal / packageName       := name.value
 Universal / topLevelDirectory := None

--- a/joern-cli/frontends/csharpsrc2cpg/build.sbt
+++ b/joern-cli/frontends/csharpsrc2cpg/build.sbt
@@ -40,8 +40,6 @@ lazy val AstgenLinux    = "dotnetastgen-linux"
 lazy val AstgenLinuxArm = "dotnetastgen-linux-arm64"
 lazy val AstgenMac      = "dotnetastgen-macos"
 
-lazy val AllPlatforms = Seq(AstgenWin, AstgenLinux, AstgenLinuxArm, AstgenMac)
-
 lazy val astGenDlUrl = settingKey[String]("astgen download url")
 astGenDlUrl := s"https://github.com/joernio/astgen-monorepo/releases/download/dotnet-astgen/v${astGenVersion.value}/"
 
@@ -53,12 +51,10 @@ def hasCompatibleAstGenVersion(astGenVersion: String): Boolean = {
   }
 }
 
-lazy val astGenBinaryNames = taskKey[Seq[String]]("asstgen binary names")
+lazy val astGenBinaryNames = taskKey[Seq[String]]("astgen binary names")
 astGenBinaryNames := {
   if (hasCompatibleAstGenVersion(astGenVersion.value)) {
     Seq.empty
-  } else if (sys.props.get("ALL_PLATFORMS").contains("TRUE")) {
-    AllPlatforms
   } else {
     Environment.operatingSystem match {
       case Environment.OperatingSystemType.Windows => Seq(AstgenWin)
@@ -69,7 +65,7 @@ astGenBinaryNames := {
         }
       case Environment.OperatingSystemType.Mac => Seq(AstgenMac)
       case Environment.OperatingSystemType.Unknown =>
-        AllPlatforms
+        Seq(AstgenWin, AstgenLinux, AstgenLinuxArm, AstgenMac)
     }
   }
 }
@@ -92,14 +88,6 @@ astGenDlTask := {
 }
 
 Compile / compile := ((Compile / compile) dependsOn astGenDlTask).value
-
-lazy val astGenSetAllPlatforms = taskKey[Unit](s"Set ALL_PLATFORMS")
-astGenSetAllPlatforms := { System.setProperty("ALL_PLATFORMS", "TRUE") }
-
-stage := Def
-  .sequential(astGenSetAllPlatforms, Universal / stage)
-  .andFinally(System.setProperty("ALL_PLATFORMS", "FALSE"))
-  .value
 
 Universal / packageName       := name.value
 Universal / topLevelDirectory := None

--- a/joern-cli/frontends/gosrc2cpg/build.sbt
+++ b/joern-cli/frontends/gosrc2cpg/build.sbt
@@ -52,8 +52,6 @@ lazy val goAstGenBinaryNames = taskKey[Seq[String]]("goastgen binary names")
 goAstGenBinaryNames := {
   if (hasCompatibleAstGenVersion(goAstGenVersion.value)) {
     Seq.empty
-  } else if (sys.props.get("ALL_PLATFORMS").contains("TRUE")) {
-    Seq(GoAstgenWin, GoAstgenLinux, GoAstgenLinuxArm, GoAstgenMac, GoAstgenMacArm)
   } else {
     Environment.operatingSystem match {
       case Environment.OperatingSystemType.Windows =>
@@ -91,14 +89,6 @@ goAstGenDlTask := {
 }
 
 Compile / compile := ((Compile / compile) dependsOn goAstGenDlTask).value
-
-lazy val goAstGenSetAllPlatforms = taskKey[Unit](s"Set ALL_PLATFORMS")
-goAstGenSetAllPlatforms := { System.setProperty("ALL_PLATFORMS", "TRUE") }
-
-stage := Def
-  .sequential(goAstGenSetAllPlatforms, Universal / stage)
-  .andFinally(System.setProperty("ALL_PLATFORMS", "FALSE"))
-  .value
 
 /** write the astgen version to the manifest for downstream usage */
 Compile / packageBin / packageOptions +=

--- a/joern-cli/frontends/jssrc2cpg/build.sbt
+++ b/joern-cli/frontends/jssrc2cpg/build.sbt
@@ -56,8 +56,6 @@ lazy val astGenBinaryNames = taskKey[Seq[String]]("astgen binary names")
 astGenBinaryNames := {
   if (hasCompatibleAstGenVersion(astGenVersion.value)) {
     Seq.empty
-  } else if (sys.props.get("ALL_PLATFORMS").contains("TRUE")) {
-    Seq(AstgenWinAmd64, AstgenLinuxAmd64, AstgenLinuxArmV8, AstgenMacAmd64, AstgenMacArmV8)
   } else {
     (Environment.operatingSystem, Environment.architecture) match {
       case (Environment.OperatingSystemType.Windows, _)                                => Seq(AstgenWinAmd64)
@@ -87,14 +85,6 @@ astGenDlTask := {
 }
 
 Compile / compile := ((Compile / compile) dependsOn astGenDlTask).value
-
-lazy val astGenSetAllPlatforms = taskKey[Unit](s"Set ALL_PLATFORMS")
-astGenSetAllPlatforms := { System.setProperty("ALL_PLATFORMS", "TRUE") }
-
-stage := Def
-  .sequential(astGenSetAllPlatforms, Universal / stage)
-  .andFinally(System.setProperty("ALL_PLATFORMS", "FALSE"))
-  .value
 
 Universal / packageName       := name.value
 Universal / topLevelDirectory := None

--- a/joern-cli/frontends/rust2cpg/build.sbt
+++ b/joern-cli/frontends/rust2cpg/build.sbt
@@ -52,8 +52,6 @@ lazy val astGenBinaryNames = taskKey[Seq[String]]("rust_ast_gen binary names")
 astGenBinaryNames := {
   if (hasCompatibleAstGenVersion(astGenVersion.value)) {
     Seq.empty
-  } else if (sys.props.get("ALL_PLATFORMS").contains("TRUE")) {
-    Seq(AstgenWin, AstgenWinArm, AstgenLinux, AstgenLinuxArm, AstgenMac, AstgenMacArm)
   } else {
     Environment.operatingSystem match {
       case Environment.OperatingSystemType.Windows =>
@@ -103,14 +101,6 @@ rustNodeSyntaxDlTask := {
 }
 
 Compile / sourceGenerators += rustNodeSyntaxDlTask
-
-lazy val astGenSetAllPlatforms = taskKey[Unit](s"Set ALL_PLATFORMS")
-astGenSetAllPlatforms := { System.setProperty("ALL_PLATFORMS", "TRUE") }
-
-stage := Def
-  .sequential(astGenSetAllPlatforms, Universal / stage)
-  .andFinally(System.setProperty("ALL_PLATFORMS", "FALSE"))
-  .value
 
 Universal / packageName       := name.value
 Universal / topLevelDirectory := None

--- a/joern-cli/frontends/swiftsrc2cpg/build.sbt
+++ b/joern-cli/frontends/swiftsrc2cpg/build.sbt
@@ -61,8 +61,6 @@ lazy val astGenBinaryNames = taskKey[Seq[String]]("astgen binary names")
 astGenBinaryNames := {
   if (hasCompatibleAstGenVersion(astGenVersion.value)) {
     Seq.empty
-  } else if (sys.props.get("ALL_PLATFORMS").contains("TRUE")) {
-    Seq(AstgenWin, AstgenLinux, AstgenLinuxArm, AstgenMac)
   } else {
     Environment.operatingSystem match {
       case Environment.OperatingSystemType.Windows =>
@@ -97,14 +95,6 @@ astGenDlTask := {
 }
 
 Compile / compile := ((Compile / compile) dependsOn astGenDlTask).value
-
-lazy val astGenSetAllPlatforms = taskKey[Unit](s"Set ALL_PLATFORMS")
-astGenSetAllPlatforms := { System.setProperty("ALL_PLATFORMS", "TRUE") }
-
-stage := Def
-  .sequential(astGenSetAllPlatforms, Universal / stage)
-  .andFinally(System.setProperty("ALL_PLATFORMS", "FALSE"))
-  .value
 
 Universal / packageName       := name.value
 Universal / topLevelDirectory := None

--- a/joern-install.sh
+++ b/joern-install.sh
@@ -154,18 +154,40 @@ mkdir -p $JOERN_INSTALL_DIR
 check_installed "curl"
 check_installed "unzip"
 
+detect_platform() {
+  OS=$(uname -s)
+  ARCH=$(uname -m)
+  case "$OS" in
+    Linux)
+      case "$ARCH" in
+        aarch64|arm64) echo "linux-arm64" ;;
+        *)             echo "linux-x86_64" ;;
+      esac ;;
+    Darwin)
+      case "$ARCH" in
+        arm64) echo "macos-arm64" ;;
+        *)     echo "macos-x86_64" ;;
+      esac ;;
+    *)
+      echo "linux-x86_64" ;;
+  esac
+}
+
+PLATFORM=$(detect_platform)
+JOERN_ZIP="joern-cli-${PLATFORM}.zip"
+
 if [ $NO_DOWNLOAD = true ]; then
     sbt createDistribution
     sbt clean
 else
   if [ "$JOERN_VERSION" = "" ]; then
-    curl -L "https://github.com/joernio/joern/releases/latest/download/joern-cli.zip" -o "$SCRIPT_ABS_DIR/joern-cli.zip"
+    curl -L "https://github.com/joernio/joern/releases/latest/download/${JOERN_ZIP}" -o "$SCRIPT_ABS_DIR/${JOERN_ZIP}"
   else
-    curl -L "https://github.com/joernio/joern/releases/download/$JOERN_VERSION/joern-cli.zip" -o "$SCRIPT_ABS_DIR/joern-cli.zip"
+    curl -L "https://github.com/joernio/joern/releases/download/$JOERN_VERSION/${JOERN_ZIP}" -o "$SCRIPT_ABS_DIR/${JOERN_ZIP}"
   fi
 fi
 
-unzip -qo -d "$JOERN_INSTALL_DIR" "$SCRIPT_ABS_DIR"/joern-cli.zip
+unzip -qo -d "$JOERN_INSTALL_DIR" "$SCRIPT_ABS_DIR"/${JOERN_ZIP}
 
 if [ $INTERACTIVE = false ] && [ "$(whoami)" != "root" ]; then
   echo "==============================================================="


### PR DESCRIPTION
Our Github releases (`joern-cli.zip`) was sitting slightly above 2GB in total size which is not allowed (https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases#storage-and-bandwidth-quotas).

With platform-specific releases we are now a bit below that 2GB limit (e.g., for `joern-cli-macos-arm64.zip` with 1.7GB).