### PR TITLE
[CI] Fix release workflow

### DIFF
--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -56,8 +56,6 @@ jobs:
           cache: sbt
       - name: Set up sbt
         uses: sbt/setup-sbt@v1
-        with:
-          disk-cache: false # https://github.com/sbt/setup-sbt/issues/114
       - name: Delete `.rustup` directory
         run: rm -rf /home/runner/.rustup # to save disk space
         if: runner.os == 'Linux'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
           python -m pip install requests pexpect
           sbt joerncli/stage querydb/createDistribution
           python -u ./testDistro.py
-      - run: sbt ciReleaseSkipIfAlreadyReleased ciReleaseTagNextVersion ciReleaseSonatype createDistribution
+      - run: sbt ciReleaseSkipIfAlreadyReleased ciReleaseTagNextVersion ciReleaseSonatype
         env:
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ null
 /joern-cli/${sys:LOG_DIR}/
 .local
 .carabiner
+$HOME
 **/astgen-win.exe
 **/astgen-macos
 **/astgen-macos-arm

--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ null
 /gnupg-*
 /joern-cli/${sys:LOG_DIR}/
 .local
-.carabiner
+**/.carabiner
 $HOME
 **/astgen-win.exe
 **/astgen-macos

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ null
 /gnupg-*
 /joern-cli/${sys:LOG_DIR}/
 .local
+.carabiner
 **/astgen-win.exe
 **/astgen-macos
 **/astgen-macos-arm


### PR DESCRIPTION
- remove `createDistribution` (we do this in `release-github.yml`)
- ignore literal `$HOME` and `.carabiner`. Both are created by `sbt/setup-sbt` and causes `ciReleaseTagNextVersion` to fail its git-clean assertion.
- the `sbt/setup-sbt` caching issue has been fixed upstream


Motivation:
- https://github.com/joernio/joern/actions/runs/30193410151/job/89770560911
- https://github.com/sbt/setup-sbt/issues/117