### PR TITLE
[rust2cpg] fix fn's methodFullName to include generic type parameters.

### DIFF
--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/ContextStack.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/ContextStack.scala
@@ -38,6 +38,17 @@ object ContextStack {
   }
 
   @tailrec
+  private def parentIsMethod(stack: List[Context]): Boolean = stack match {
+    case (_: GlobalMethodContext) :: _ => false
+    case (_: MethodContext) :: _       => true
+    case (_: NamespaceContext) :: _    => false
+    case (_: TypeDeclContext) :: _     => false
+    case (_: LocalContext) :: tail     => parentIsMethod(tail)
+    case (_: BlockContext) :: tail     => parentIsMethod(tail)
+    case Nil                           => false
+  }
+
+  @tailrec
   def lookup(name: String, stack: List[Context]): Option[NewLocal | NewMethodParameterIn] = {
     stack match {
       case Nil                         => None
@@ -121,6 +132,10 @@ class ContextStack {
 
   def rustParentFullName: String = {
     rustItemParentFullName(stack)
+  }
+
+  def parentIsMethod: Boolean = {
+    ContextStack.parentIsMethod(stack)
   }
 
   def resolvedVariableReferences: Seq[(NewIdentifier, NewLocal | NewMethodParameterIn)] = {

--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
@@ -431,7 +431,14 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
   // 'fn' Name GenericParamList? ParamList RetType? WhereClause?
   // (body:BlockExpr | ';')
   private def visitFn(fn: Fn): Ast = {
-    val method          = methodNode(node = fn, name = code(fn.name))
+    val name = code(fn.name)
+    // TODO(rust_ast_gen): nested fns fullNames don't carry the outer method fn name, e.g.
+    //  crate::main::nested_fn is just crate::nested_fn. The same applies to its calls, their
+    //  methodFullName (from rust_ast_gen) is also without the outer method name.
+    val fullName =
+      if (contextStack.parentIsMethod) composeRustFullName(name)
+      else fn.methodFullName.getOrElse(composeRustFullName(name))
+    val method          = methodNode(node = fn, name = name).fullName(fullName)
     val retTypeFullName = fn.retType.map(_.typ).map(typeFullNameForType).getOrElse("()")
     val methodRet       = methodReturnNode(fn, retTypeFullName)
     val methodMods      = Seq[NewModifier]()

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/ImplTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/ImplTests.scala
@@ -48,6 +48,24 @@ class ImplTests extends Rust2CpgSuite(noSysRoot = true) {
     }
   }
 
+  "method inside generic impl" should {
+    val cpg = code("""
+        |struct Foo<T> { v: T }
+        |impl<T> Foo<T> {
+        |  fn bar<U>(&self, u: U) {}
+        |}
+        |fn run(f: Foo<i32>) { f.bar(1); }
+        |""".stripMargin)
+
+    "have correct fullName" in {
+      cpg.method.nameExact("bar").fullName.l shouldBe List("rust2cpgtest::Foo<T>::bar<U>")
+    }
+
+    "have the same fullName as the one at the call site" in {
+      cpg.call.nameExact("bar").methodFullName.l shouldBe List("rust2cpgtest::Foo<T>::bar<U>")
+    }
+  }
+
   "an inherent method with a `&mut self` and an explicit parameter" should {
     val cpg = code("""
         |struct Foo;

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/MethodTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/MethodTests.scala
@@ -102,6 +102,25 @@ class MethodTests extends Rust2CpgSuite(noSysRoot = true) {
     }
   }
 
+  "generic fn" should {
+    val cpg = code("""
+        |fn id<T>(x: T) -> T {
+        | x
+        |}
+        |fn main() {
+        | id(1);
+        |}
+        |""".stripMargin)
+
+    "have generic parameters in the fullName" in {
+      cpg.method.name("id").fullName.l shouldBe List("rust2cpgtest::id<T>")
+    }
+
+    "have the same fullName as the one at the call site" in {
+      cpg.call.name("id").methodFullName.l shouldBe List("rust2cpgtest::id<T>")
+    }
+  }
+
   "a nested fn" should {
     val cpg = code("""
         |fn outer() {


### PR DESCRIPTION
Method fullNames weren't carrying generic type arguments, but their calls do, so they weren't matching.