### PR TITLE
[rust2cpg] isTraitObject takes adjustments into account.

### DIFF
--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
@@ -570,16 +570,15 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
         val methodFullName =
           methodFullNameForCallExpr(callExpr, viewPathAsSequenceOfNameRefs(pathExpr.path).getOrElse(Nil), name)
         val typeFullName    = typeFullNameForExpr(callExpr)
-        val argExprs        = callExpr.argList.expr
-        val hasSelfReceiver = callExpr.hasSelfReceiver.isDefined && argExprs.nonEmpty
+        val args            = callExpr.argList.expr.map(visitExpr)
+        val hasSelfReceiver = callExpr.hasSelfReceiver.isDefined && args.nonEmpty
         val (dispatch, signature) =
-          if (hasSelfReceiver && isTraitObject(typeFullNameForExpr(argExprs.head))) {
+          if (hasSelfReceiver && args.head.rootType.exists(isTraitObject)) {
             // TODO: avoid this trait name extraction from the methodFullName
             (DispatchTypes.DYNAMIC_DISPATCH, Some(methodFullName.split(PathSep).dropRight(1).mkString(PathSep)))
           } else { (DispatchTypes.STATIC_DISPATCH, None) }
         val call =
           callNode(callExpr, code(callExpr), name, methodFullName, dispatch, signature, Some(typeFullName))
-        val args = argExprs.map(visitExpr)
         if (hasSelfReceiver) {
           callAst(call, args.tail, base = Some(args.head))
         } else {
@@ -1101,8 +1100,8 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
     val methodName     = code(methodCallExpr.nameRef)
     val methodFullName = methodFullNameForMethodCallExpr(methodCallExpr)
     val typeFullName   = typeFullNameForExpr(methodCallExpr)
-    val receiverType   = typeFullNameForExpr(methodCallExpr.expr)
-    val (dispatch, signature) = if (isTraitObject(receiverType)) {
+    val receiverAst    = visitExpr(methodCallExpr.expr)
+    val (dispatch, signature) = if (receiverAst.rootType.exists(isTraitObject)) {
       // TODO: avoid this trait name extraction from the methodFullName
       (DispatchTypes.DYNAMIC_DISPATCH, Some(methodFullName.split(PathSep).dropRight(1).mkString(PathSep)))
     } else { (DispatchTypes.STATIC_DISPATCH, None) }
@@ -1116,12 +1115,10 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
         signature,
         Some(typeFullName)
       )
-    val receiverAst = visitExpr(methodCallExpr.expr)
-    val args        = methodCallExpr.argList.expr.map(visitExpr)
+    val args = methodCallExpr.argList.expr.map(visitExpr)
     callAst(call, args, base = Some(receiverAst))
   }
 
-  // TODO: not accounting for the Deref trait. Depending on how it gets supported, this might need to change.
   // Currently, only `dyn` are considered dynamically dispatched. We may want to extend rust_ast_gen with semantic
   // information later.
   private def isTraitObject(receiverType: String): Boolean =

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/CallTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/CallTests.scala
@@ -475,6 +475,31 @@ class CallTestsWithSysroot extends Rust2CpgSuite(noSysRoot = false) {
     }
   }
 
+  "method call of a `Box<dyn Trait>`" should {
+    val cpg = code("""
+        |trait Tr { fn m(&self); }
+        |struct S;
+        |impl Tr for S { fn m(&self) {} }
+        |fn f(b: Box<dyn Tr>) { b.m(); }
+        |""".stripMargin)
+
+    "have the trait's methodFullName and signature" in {
+      inside(cpg.call.nameExact("m").l) { case call :: Nil =>
+        call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
+        call.methodFullName shouldBe "rust2cpgtest::Tr::m"
+        call.signature shouldBe "rust2cpgtest::Tr"
+      }
+    }
+
+    "have the adjusted trait object as receiver" in {
+      inside(cpg.call.nameExact("m").receiver.l) { case (receiver: Call) :: Nil =>
+        receiver.name shouldBe Operators.addressOf
+        receiver.code shouldBe "&*b"
+        receiver.typeFullName shouldBe "&dyn rust2cpgtest::Tr"
+      }
+    }
+  }
+
   "a `Vec` method call resolved against the sysroot" should {
     val cpg = code("""
         |fn foo(xs: Vec<i32>) -> usize {


### PR DESCRIPTION
Follow up on https://github.com/joernio/joern/pull/6043

For any expression, there may be 'adjustments' (implicit `&`, `*` operations), which change the original expression's type. Previously, when deciding if an expression denoted a trait object (`isTraitObject`), we were considering the original expression's type, not its adjusted type (which we get after visiting it.) Now we decide based on the visited expression's type, i.e. after 'adjustments'.