### PR TITLE
[rust2cpg] collect AstGenRunner skipped files.

### DIFF
--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/AstCreator.scala
@@ -100,7 +100,7 @@ class AstCreator(val config: Config, val parseResult: ParseResult)(implicit with
     methodNode(
       node = node,
       name = name,
-      code = code(node),
+      code = name,
       fullName = composeRustFullName(name),
       signature = Some(""),
       fileName = parseResult.filename,

--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astgen/RustAstGenRunner.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astgen/RustAstGenRunner.scala
@@ -18,8 +18,8 @@ object RustAstGenRunner {
 class RustAstGenRunner(config: Config) extends AstGenRunner(RustAstGenRunner.astGenMetaData, config) {
 
   override def skippedFiles(in: Path, astGenOut: List[String]): List[String] = {
-    // TODO: extract "Skipped: <path>" entries from astGenOut. Those are files that failed in rust_ast_gen.
-    List.empty
+    // rust_ast_gen prints to stdout "Skipped: <full-file-path>" for files it failed to process.
+    astGenOut.collect { case s"Skipped: $filePath" => filePath }
   }
 
   override def runAstGenNative(in: String, out: Path, exclude: String, include: String): Try[Seq[String]] = {

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/astgen/RustAstGenRunnerTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/astgen/RustAstGenRunnerTests.scala
@@ -174,6 +174,24 @@ class RustAstGenRunnerTests extends AnyWordSpec with Matchers {
       }
     }
 
+    "collect skipped files" in {
+      FileUtil.usingTemporaryDirectory("rust2cpgTestInput") { inputDir =>
+        val config = Config().withInputPath(inputDir.toString)
+        val astGenOut =
+          List(
+            "garbage",
+            s"Skipped: ${inputDir / "src" / "broken.rs"}",
+            "  garbage ",
+            s"Skipped: ${inputDir / "src" / "utils" / "mod.rs"}",
+            "garbage "
+          )
+        new RustAstGenRunner(config).skippedFiles(inputDir, astGenOut) shouldBe List(
+          (inputDir / "src" / "broken.rs").toString,
+          (inputDir / "src" / "utils" / "mod.rs").toString
+        )
+      }
+    }
+
     "parse a project with a non-standard layout" in {
       FileUtil.usingTemporaryDirectory("rust2cpgTestInput") { inputDir =>
         writeFile(

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/MethodTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/MethodTests.scala
@@ -53,8 +53,7 @@ class MethodTests extends Rust2CpgSuite(noSysRoot = true) {
         inside(ret.astChildren.l) { case (ident: Identifier) :: Nil =>
           ident.name shouldBe "x"
           ident.code shouldBe "x"
-        // TODO: update once typeFullNames are recorded.
-        //  ident.typeFullName shouldBe "i32"
+          ident.typeFullName shouldBe "i32"
         }
       }
     }

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/OperatorTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/OperatorTests.scala
@@ -54,7 +54,6 @@ class OperatorTests extends Rust2CpgSuite(noSysRoot = true) {
       }
     }
 
-    // TODO (rust_ast_gen): confirm why it doesn't have a type
     "have the base as the first argument" in {
       inside(cpg.call.nameExact(Operators.indexAccess).argument(1).l) { case (xs: Identifier) :: Nil =>
         xs.name shouldBe "xs"
@@ -85,7 +84,6 @@ class OperatorTests extends Rust2CpgSuite(noSysRoot = true) {
       cpg.call.nameExact(Operators.indexAccess).codeExact("xs[i][j]").typeFullName.l shouldBe List("i32")
     }
 
-    // TODO (rust_ast_gen): confirm that no type for the inner is to be expected
     "have Any as typeFullName for the inner indexAccess" in {
       cpg.call.nameExact(Operators.indexAccess).codeExact("xs[i]").typeFullName.l shouldBe List(Defines.Any)
     }


### PR DESCRIPTION
Also:
- clears some stale TODOs
- the code of a method is now just its name (prior review suggestion.)