### PR TITLE
[rust2cpg] add dynamicTypeHint to implicit cast adjustments.

### DIFF
--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
@@ -152,7 +152,14 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
     val exprCode     = exprAst.rootCodeOrEmpty
     val typeFullName = cast.target
     val castNode     = operatorCallNode(expr, s"$exprCode as $typeFullName", Operators.cast, Some(typeFullName))
-    val typeRefAst   = Ast(typeRefNode(expr, typeFullName, typeFullName))
+
+    // When we implicitly cast to a trait object, we lose the original concrete type.
+    // Save it as a dynamic type hint, to help with dynamic dispatch calls.
+    if (isTraitObject(typeFullName) && !isTraitObject(cast.source)) {
+      castNode.dynamicTypeHintFullName(Seq(stripReference(cast.source)))
+    }
+
+    val typeRefAst = Ast(typeRefNode(expr, typeFullName, typeFullName))
     callAst(castNode, Seq(typeRefAst, exprAst))
   }
 
@@ -1121,8 +1128,13 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
 
   // Currently, only `dyn` are considered dynamically dispatched. We may want to extend rust_ast_gen with semantic
   // information later.
-  private def isTraitObject(receiverType: String): Boolean =
-    receiverType.stripPrefix("&").stripPrefix("mut ").startsWith("dyn ")
+  private def isTraitObject(typeFullName: String): Boolean = {
+    stripReference(typeFullName).startsWith("dyn ")
+  }
+
+  private def stripReference(typeFullName: String): String = {
+    typeFullName.stripPrefix("&").stripPrefix("mut ")
+  }
 
   // AwaitExpr =
   //  Attr* Expr '.' 'await'

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/OperatorTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/OperatorTests.scala
@@ -293,3 +293,47 @@ class OperatorTests extends Rust2CpgSuite(noSysRoot = true) {
     }
   }
 }
+
+class OperatorTestsWithSysroot extends Rust2CpgSuite(noSysRoot = false) {
+
+  "adjustment to a trait object" should {
+    val cpg = code("""
+        |trait Foo { fn a(&self); }
+        |trait Bar: Foo { fn b(&self); }
+        |
+        |struct Baz;
+        |impl Foo for Baz { fn a(&self) {} }
+        |impl Bar for Baz { fn b(&self) {} }
+        |
+        |fn baz_bar() { let x: &dyn Bar = &Baz; }
+        |fn baz_bar_mut(mut baz: Baz) { let x: &mut dyn Bar = &mut baz; }
+        |fn bar_foo(x: &dyn Bar) { let y: &dyn Foo = x; }
+        |""".stripMargin)
+
+    "have the concrete type as dynamic type hint" in {
+      inside(cpg.method.name("baz_bar").block.assignment.source.l) { case (cast: Call) :: Nil =>
+        cast.name shouldBe Operators.cast
+        cast.code shouldBe "&*&Baz as &dyn rust2cpgtest::Bar"
+        cast.typeFullName shouldBe "&dyn rust2cpgtest::Bar"
+        cast.dynamicTypeHintFullName shouldBe Seq("rust2cpgtest::Baz")
+      }
+    }
+
+    "have the concrete type as dynamic type hint via mut" in {
+      inside(cpg.method.name("baz_bar_mut").block.assignment.source.l) { case (cast: Call) :: Nil =>
+        cast.name shouldBe Operators.cast
+        cast.code shouldBe "&*&mut baz as &mut dyn rust2cpgtest::Bar"
+        cast.typeFullName shouldBe "&mut dyn rust2cpgtest::Bar"
+        cast.dynamicTypeHintFullName shouldBe Seq("rust2cpgtest::Baz")
+      }
+    }
+
+    "have no dynamic type hint when casting from another trait object" in {
+      inside(cpg.method.name("bar_foo").block.assignment.source.l) { case (cast: Call) :: Nil =>
+        cast.name shouldBe Operators.cast
+        cast.code shouldBe "&*x as &dyn rust2cpgtest::Foo"
+        cast.dynamicTypeHintFullName shouldBe Seq()
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add dynamicTypeHintFullName to implicit casts ('adjustments') when going from a concrete type to a trait type, helping with some dynamic dispatch flows.