### PR TITLE
[joern-console] Fix NPE in importCode caused by REPL classloader

### DIFF
--- a/console/src/main/scala/io/joern/console/ConsoleConfig.scala
+++ b/console/src/main/scala/io/joern/console/ConsoleConfig.scala
@@ -30,7 +30,7 @@ class InstallConfig(environment: Map[String, String] = sys.env) {
       val pathToLibDir = findCodeSourceLocation(clazz, clazz.getClassLoader).map(_.getParent)
       val cwd          = FileUtil.currentWorkingDirectory
       pathToLibDir.flatMap(findRootDirectory(_)).orElse(findRootDirectory(cwd)).getOrElse {
-        val searchedDirs = pathToLibDir.map(p => s"$p and $cwd").getOrElse(cwd.toString)
+        val searchedDirs = pathToLibDir.map(path => s"$path and $cwd").getOrElse(cwd.toString)
         throw new AssertionError(s"""unable to find root installation directory
                                    | context: tried to find marker file `$rootDirectoryMarkerFilename`
                                    | started search in $searchedDirs, and searched

--- a/console/src/main/scala/io/joern/console/ConsoleConfig.scala
+++ b/console/src/main/scala/io/joern/console/ConsoleConfig.scala
@@ -26,15 +26,27 @@ class InstallConfig(environment: Map[String, String] = sys.env) {
     if (environment.contains("SHIFTLEFT_OCULAR_INSTALL_DIR")) {
       Paths.get(environment("SHIFTLEFT_OCULAR_INSTALL_DIR"))
     } else {
-      val uriToLibDir  = classOf[io.joern.console.InstallConfig].getProtectionDomain.getCodeSource.getLocation.toURI
-      val pathToLibDir = Paths.get(uriToLibDir).getParent
-      findRootDirectory(pathToLibDir).getOrElse {
-        val cwd = FileUtil.currentWorkingDirectory
-        findRootDirectory(cwd).getOrElse(throw new AssertionError(s"""unable to find root installation directory
+      val clazz        = classOf[InstallConfig]
+      val pathToLibDir = findCodeSourceLocation(clazz, clazz.getClassLoader).map(_.getParent)
+      val cwd          = FileUtil.currentWorkingDirectory
+      pathToLibDir.flatMap(findRootDirectory(_)).orElse(findRootDirectory(cwd)).getOrElse {
+        val searchedDirs = pathToLibDir.map(p => s"$p and $cwd").getOrElse(cwd.toString)
+        throw new AssertionError(s"""unable to find root installation directory
                                    | context: tried to find marker file `$rootDirectoryMarkerFilename`
-                                   | started search in both $pathToLibDir and $cwd and searched 
-                                   | $maxSearchDepth directories upwards""".stripMargin))
+                                   | started search in $searchedDirs, and searched
+                                   | $maxSearchDepth directories upwards""".stripMargin)
       }
+    }
+  }
+
+  @tailrec
+  private def findCodeSourceLocation(clazz: Class[?], cl: ClassLoader): Option[Path] = {
+    if (cl == null) None
+    else {
+      val location = Option(cl.loadClass(clazz.getName).getProtectionDomain.getCodeSource)
+        .flatMap(cs => Option(cs.getLocation))
+      if (location.isDefined) location.map(url => Paths.get(url.toURI))
+      else findCodeSourceLocation(clazz, cl.getParent)
     }
   }
 

--- a/testDistro.py
+++ b/testDistro.py
@@ -337,6 +337,11 @@ class TestRunner:
         child.expect("joern>")
         child.sendline("help")
         child.expect("Welcome to the interactive help system.")
+        child.sendline('scala.util.Try(importCode("tests/code/c")).isSuccess')
+        idx = child.expect(["res[0-9]+: Boolean = true", "res[0-9]+: Boolean = false"], timeout=10)
+        if idx == 1:
+            raise RuntimeError("Joern CLI command threw an exception inside the REPL.")
+        child.expect("joern>")
         child.sendline("exit")
         child.expect(wexpect.EOF)
 
@@ -347,6 +352,11 @@ class TestRunner:
         child.expect("joern>")
         child.sendline("help")
         child.expect("Welcome to the interactive help system.", timeout=10)
+        child.sendline('scala.util.Try(importCode("tests/code/c")).isSuccess')
+        idx = child.expect(["res[0-9]+: Boolean = true", "res[0-9]+: Boolean = false"], timeout=10)
+        if idx == 1:
+            raise RuntimeError("Joern CLI command threw an exception inside the REPL.")
+        child.expect("joern>")
         child.sendline("exit")
         child.expect(pexpect.EOF, timeout=10)
 


### PR DESCRIPTION
Scala 3.8.X's REPL interrupt instrumentation re-defines all classes through its own classloader without a `ProtectionDomain`, causing `getCodeSource().getLocation()` to return null. InstallConfig.rootPath relied on this to find the installation directory, resulting in a `NullPointerException` on `importCode`:

```scala
joern> importCode.ruby("/tmp/some/source")
java.lang.NullPointerException: Cannot invoke "java.net.URL.toURI()" because the return value of "java.security.CodeSource.getLocation()" is null
  at io.joern.console.InstallConfig.rootPath$lzyINIT1(ConsoleConfig.scala:29)
  at io.joern.console.InstallConfig.rootPath(ConsoleConfig.scala:25)
  at io.joern.console.cpgcreation.ImportCode$Frontend.apply(ImportCode.scala:131)
  ... 39 elided

```

This fix walks the classloader chain to find a parent that still has the jar's `CodeSource`. 