### PR TITLE
[console] override undertow-core to 2.3.26.Final (CVE-2025-12543)

### DIFF
--- a/console/build.sbt
+++ b/console/build.sbt
@@ -23,6 +23,9 @@ libraryDependencies ++= Seq(
   "org.scalatest"        %% "scalatest"            % Versions.scalatest % Test
 )
 
+// cask pins undertow-core 2.3.18.Final (CVE-2025-12543) — force the fixed release
+dependencyOverrides += "io.undertow" % "undertow-core" % Versions.undertow
+
 Test / compile := (Test / compile)
   .dependsOn(Projects.c2cpg / stage, Projects.jssrc2cpg / stage, Projects.swiftsrc2cpg / stage)
   .value

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -6,6 +6,9 @@ object Versions {
   // causes problems upstreams.
   val antlr      = "4.7.2"
   val cask       = "0.9.5" // 0.9.5 is actually the latest release, not 0.10.2 ¯\_(ツ)_/¯ - check the cask git commits...
+  // every cask release (incl. 0.11.3) pins undertow-core 2.3.18.Final, which is affected by
+  // CVE-2025-12543 (fixed in 2.3.21.Final) — so we override the transitive dependency
+  val undertow   = "2.3.26.Final"
   val catsCore   = "2.12.0"
   val catsEffect = "3.5.4"
   val cfr        = "0.152"


### PR DESCRIPTION
## Summary

`console` depends on `cask`, and every cask release up to and including 0.11.3 pins `io.undertow:undertow-core:2.3.18.Final`, which is affected by **CVE-2025-12543** (CRITICAL, fixed in 2.3.21.Final). Since the jar ships in the `joern-cli` distribution's `lib/`, security scanners (AWS Inspector, trivy, grype) flag every Joern installation.

Because the pin lives upstream in cask itself, bumping cask can't resolve this — so this PR adds a `dependencyOverrides` for the transitive dependency instead, pinning `undertow-core` to 2.3.26.Final (the latest 2.3.x maintenance release).

## Changes
- `project/Versions.scala`: add `Versions.undertow = "2.3.26.Final"` with a comment explaining the cask pin
- `console/build.sbt`: `dependencyOverrides += "io.undertow" % "undertow-core" % Versions.undertow`

`dependencyOverrides` (rather than a direct dependency) keeps joern from taking ownership of a library it only uses through cask — if a future cask release drops or bumps undertow, the override quietly follows.

## Validation
`sbt console/evicted` resolves `undertow-core:2.3.26.Final` (xnio transitives move up with it). Undertow 2.3.x is Red Hat's maintenance line, so 2.3.18 → 2.3.26 is a drop-in patch-level move for cask's usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)