### PR TITLE
[rust2cpg] inline nested tail macro call expansion.

### DIFF
--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
@@ -1433,7 +1433,15 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
   //  statements:Stmt*
   //  Expr?
   private def visitMacroStmts(macroStmts: MacroStmts): Seq[Ast] = {
-    macroStmts.stmt.flatMap(visitStmt) ++ macroStmts.expr.map(visitExpr).toList
+    val stmtAsts = macroStmts.stmt.flatMap(visitStmt)
+
+    // When the tail expr is itself another macro call, expand and inline it.
+    val tailExprAst = macroStmts.expr.toList.flatMap {
+      case macroExpr: MacroExpr => visitMacroCall(macroExpr.macroCall)
+      case expr                 => visitExpr(expr) :: Nil
+    }
+
+    stmtAsts ++ tailExprAst
   }
 
   // MacroItems =

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/MacroTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/MacroTests.scala
@@ -68,6 +68,35 @@ class MacroTests extends Rust2CpgSuite(noSysRoot = true) {
     }
   }
 
+  "nested tail macro call yielding two statements" should {
+    val cpg = code("""
+        |macro_rules! inner { ($x:ident) => { $x += 1; $x += 2; }; }
+        |macro_rules! outer { ($x:ident) => { inner!{$x} }; }
+        |fn main() {
+        | let mut x = 3;
+        | outer!(x);
+        |}
+        |""".stripMargin)
+
+    "inline the expanded statements" in {
+      cpg.method.nameExact("main").block.astChildren.isCall.code.l shouldBe List("let mut x = 3;", "x+=1", "x+=2")
+    }
+  }
+
+  "nested tail macro call yielding an expression" should {
+    val cpg = code("""
+        |macro_rules! inner { () => { 2 }; }
+        |macro_rules! outer { () => { inner!() }; }
+        |fn main() {
+        | outer!();
+        |}
+        |""".stripMargin)
+
+    "inline the expanded expression" in {
+      cpg.method.nameExact("main").block.astChildren.code.l shouldBe List("2")
+    }
+  }
+
   "a type macro" should {
     val cpg = code("""
         |macro_rules! int_type { () => { i128 }; }


### PR DESCRIPTION
A macro call may expand into a macro stmt list, which may contain a tail expression (to be returned), which itself may be another macro call. Previously, we were visiting the tail expression but if it did not produce a single expression, the entire sub-ast would be discarded, yielding an Unknown node. Worse still, resolved identifiers (via ContextStack) under the discarded sub-ast would have ref edges, but since they were discarded would not have proper astParent.