### PR TITLE
[rust2cpg] add rust-src to CI and re-enable flaky test.

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -33,6 +33,7 @@ jobs:
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
+          components: rust-src
       - run: sbt scalafmtCheck test
       - name: Test distribution
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -90,6 +90,7 @@ jobs:
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
+          components: rust-src
       - name: Run tests
         run: sbt clean test
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,7 @@ jobs:
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
+          components: rust-src
       - run: sbt scalafmtCheck test
       - name: Test distribution
         run: |

--- a/.github/workflows/upgrade-deps.yml
+++ b/.github/workflows/upgrade-deps.yml
@@ -28,6 +28,7 @@ jobs:
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
+          components: rust-src
       - uses: sbt/setup-sbt@f6db8ab474efba716fc7f04441ab33714e4825af # v1.5.4
       - name: Upgrade all (internal) dependencies
         run: ./updateDependencies.sh --non-interactive

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/astgen/RustAstGenRunnerTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/astgen/RustAstGenRunnerTests.scala
@@ -43,8 +43,7 @@ class RustAstGenRunnerTests extends AnyWordSpec with Matchers {
       }
     }
 
-    // TODO: flaky on CI (Windows). When it fails, consistently returns `main.rs.json` but not `lib.rs.json`.
-    "parse a workspace project with crates/" ignore {
+    "parse a workspace project with crates/" in {
       FileUtil.usingTemporaryDirectory("rust2cpgTestInput") { inputDir =>
         writeFile(
           inputDir / "Cargo.toml",


### PR DESCRIPTION
rust-analyzer implicitly installs the `rust-src` component if it's not already installed. The hypothesis is that this flakiness results from a race-condition. Thus, installing it before running any tests.