### PR TITLE
[rust2cpg] lower `use` statements.

### DIFF
--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
@@ -8,6 +8,7 @@ import io.joern.x2cpg.{Ast, Defines, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.nodes.{
   ExpressionNew,
   NewFile,
+  NewImport,
   NewMethod,
   NewModifier,
   NewNamespaceBlock,
@@ -66,7 +67,7 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
     case trait_ : Trait         => visitTrait(trait_) :: Nil
     case x: TypeAlias           => notHandledYet(x) :: Nil
     case x: Union               => notHandledYet(x) :: Nil
-    case x: Use                 => notHandledYet(x) :: Nil
+    case use: Use               => visitUse(use)
     case x: AsmExpr             => notHandledYet(x) :: Nil
   }
 
@@ -1605,5 +1606,52 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
     val methodRet = methodReturnNode(closureExpr, retTypeFullName)
     val modifiers = Seq(ModifierTypes.VIRTUAL, ModifierTypes.LAMBDA).map(modifierNode(closureExpr, _))
     addDetachedAst(methodAst(method, paramAsts, bodyAst, methodRet, modifiers))
+  }
+
+  // Use =
+  //  Attr* Visibility?
+  //  'use' UseTree ';'
+  //
+  // UseTree =
+  //  (Path? '::')? ('*' | UseTreeList)
+  // | Path Rename?
+  //
+  // UseTreeList =
+  //  '{' (UseTree (',' UseTree)* ','?)? '}'
+  private def visitUse(use: Use): Seq[Ast] = {
+    lowerUse(use, use.useTree, Nil).map(Ast(_))
+  }
+
+  private def lowerUse(use: Use, tree: UseTree, prefix: Seq[Path]): Seq[NewImport] = {
+    val path = prefix ++ tree.path
+    tree.useTreeList match {
+      case Some(useTreeList)                => useTreeList.useTree.flatMap(lowerUse(use, _, path))
+      case None if tree.starToken.isDefined => lowerWildcardImport(use, path).toList
+      case None                             => lowerNamedImport(use, path, tree.rename).toList
+    }
+  }
+
+  private def lowerWildcardImport(use: Use, prefix: Seq[Path]): Option[NewImport] = {
+    if (prefix.isEmpty) {
+      None
+    } else {
+      Some(mkImport(use, prefix, "*").isWildcard(true))
+    }
+  }
+
+  private def lowerNamedImport(use: Use, prefix: Seq[Path], alias: Option[Rename]): Option[NewImport] = {
+    prefix.lastOption.flatMap { last =>
+      code(last.pathSegment) match {
+        // `use a::b::{self}` means `use a::b as b`
+        case "self" => lowerNamedImport(use, prefix.init ++ last.path, alias)
+        case name =>
+          val renamedAs = alias.flatMap(rename => rename.name.orElse(rename.underscoreToken)).map(code)
+          Some(mkImport(use, prefix, renamedAs.getOrElse(name)))
+      }
+    }
+  }
+
+  private def mkImport(use: Use, path: Seq[Path], importedAs: String): NewImport = {
+    newImportNode(code(use), path.map(code).mkString(PathSep), importedAs, use)
   }
 }

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/UseTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/UseTests.scala
@@ -1,0 +1,140 @@
+package io.joern.rust2cpg.passes.ast
+
+import io.joern.rust2cpg.testfixtures.Rust2CpgSuite
+import io.shiftleft.codepropertygraph.generated.nodes.*
+import io.shiftleft.semanticcpg.language.*
+
+class UseTests extends Rust2CpgSuite(noSysRoot = true) {
+
+  "use" should {
+    val cpg = code("use std::collections::HashMap;")
+
+    "have correct properties" in {
+      inside(cpg.imports.l) { case use :: Nil =>
+        use.code shouldBe "use std::collections::HashMap;"
+        use.importedEntity shouldBe Some("std::collections::HashMap")
+        use.importedAs shouldBe Some("HashMap")
+        use.isWildcard shouldBe None
+      }
+    }
+  }
+
+  "rename" should {
+    val cpg = code("use std::collections::HashMap as Map;")
+
+    "have correct properties" in {
+      inside(cpg.imports.l) { case use :: Nil =>
+        use.code shouldBe "use std::collections::HashMap as Map;"
+        use.importedEntity shouldBe Some("std::collections::HashMap")
+        use.importedAs shouldBe Some("Map")
+      }
+    }
+  }
+
+  "underscore rename" should {
+    val cpg = code("use foo::Bar as _;")
+
+    "have correct properties" in {
+      inside(cpg.imports.l) { case use :: Nil =>
+        use.importedEntity shouldBe Some("foo::Bar")
+        use.importedAs shouldBe Some("_")
+      }
+    }
+  }
+
+  "wildcard" should {
+    val cpg = code("use std::io::*;")
+
+    "have correct properties" in {
+      inside(cpg.imports.l) { case use :: Nil =>
+        use.code shouldBe "use std::io::*;"
+        use.importedEntity shouldBe Some("std::io")
+        use.importedAs shouldBe Some("*")
+        use.isWildcard shouldBe Some(true)
+      }
+    }
+  }
+
+  "nested wildcard" should {
+    val cpg = code("use a::{b::*};")
+
+    "have correct properties" in {
+      inside(cpg.imports.l) { case use :: Nil =>
+        use.importedEntity shouldBe Some("a::b")
+        use.importedAs shouldBe Some("*")
+        use.isWildcard shouldBe Some(true)
+      }
+    }
+  }
+
+  "relative paths" should {
+    val cpg = code("""
+        |use crate::a::B;
+        |use super::x::Y;
+        |use self::m::N;
+        |""".stripMargin)
+
+    "have correct properties" in {
+      inside(cpg.imports.sortBy(_.lineNumber).l) { case useB :: useY :: useN :: Nil =>
+        useB.importedEntity shouldBe Some("crate::a::B")
+        useB.importedAs shouldBe Some("B")
+        useY.importedEntity shouldBe Some("super::x::Y")
+        useY.importedAs shouldBe Some("Y")
+        useN.importedEntity shouldBe Some("self::m::N")
+        useN.importedAs shouldBe Some("N")
+      }
+    }
+  }
+
+  "use without prefix" should {
+    val cpg = code("use {a, b::C};")
+
+    "have correct properties" in {
+      inside(cpg.imports.sortBy(_.code).l) { case useA :: useC :: Nil =>
+        useA.importedEntity shouldBe Some("a")
+        useA.importedAs shouldBe Some("a")
+        useC.importedEntity shouldBe Some("b::C")
+        useC.importedAs shouldBe Some("C")
+      }
+    }
+  }
+
+  "nested use tree" should {
+    val cpg = code("use a::{b::C, d::{E as F, self}};")
+
+    "have correct properties" in {
+      inside(cpg.imports.sortBy(_.code).l) { case useC :: useE :: useD :: Nil =>
+        useC.importedEntity shouldBe Some("a::b::C")
+        useC.importedAs shouldBe Some("C")
+        useE.importedEntity shouldBe Some("a::d::E")
+        useE.importedAs shouldBe Some("F")
+        useD.importedEntity shouldBe Some("a::d")
+        useD.importedAs shouldBe Some("d")
+      }
+    }
+
+  }
+
+  "trailing self" should {
+    val cpg = code("use std::io::self;")
+
+    "have correct properties" in {
+      inside(cpg.imports.l) { case use :: Nil =>
+        use.importedEntity shouldBe Some("std::io")
+        use.importedAs shouldBe Some("io")
+      }
+    }
+  }
+
+  "renamed self" should {
+    val cpg = code("use m::{self as alias};")
+
+    "have correct properties" in {
+      inside(cpg.imports.l) { case use :: Nil =>
+        use.importedEntity shouldBe Some("m")
+        use.importedAs shouldBe Some("alias")
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Not super needed (since resolution happens in the astgen), but a major source of log pollution with `notHandledYet`.