### PR TITLE
[CI] cancel in-progress PR workflow runs on push 

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,5 +1,8 @@
 name: pr
 on: pull_request
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
 jobs:
   formatting:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add a concurrency group to prevent multiple runs of the same workflow for the same pull request, ensuring that only the latest run is active. `cancel-in-progress: true` automatically cancels any in-progress runs for the same pull request.