### PR TITLE
[rubysrc2cpg] downgrade jruby version

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -128,7 +128,7 @@ JSSRC2CPG_ASTGEN_VERSION = "3.47.0"
 
 SWIFTSRC2CPG_ASTGEN_VERSION = "0.4.2"
 
-RUBYSRC2CPG_ASTGEN_VERSION = "0.59.2"
+RUBYSRC2CPG_ASTGEN_VERSION = "0.59.4"
 
 RUBYSRC2CPG_TYPE_STUBS_VERSION = "0.6.0"
 
@@ -205,42 +205,42 @@ http_file(
 http_archive(
     name = "rubysrc2cpg_astgen_macos_arm",
     build_file = "//joern-cli/frontends/rubysrc2cpg:rubysrc2cpg_astgen.BUILD",
-    sha256 = "18c823845ef9ef5d064faad07f386e0849e09843544f0a433fd0228ae0392875",
+    sha256 = "959620abbfaacdf8756d09c0f3ad0096c5b7fe4b5d415dda9650a1434844e593",
     url = "https://github.com/joernio/astgen-monorepo/releases/download/ruby-astgen%2Fv{}/ruby_ast_gen-macos-arm_v{}.zip".format(RUBYSRC2CPG_ASTGEN_VERSION, RUBYSRC2CPG_ASTGEN_VERSION),
 )
 
 http_archive(
     name = "rubysrc2cpg_astgen_macos_x86",
     build_file = "//joern-cli/frontends/rubysrc2cpg:rubysrc2cpg_astgen.BUILD",
-    sha256 = "0d4c160e5f2f1f4d4de5749e6ffa21961cff4457d061a7176b8fd7682a37329c",
+    sha256 = "660151ca65b0bea72a2db70dc3a9f5d87106c6fc735645045e8d3af75ba998a7",
     url = "https://github.com/joernio/astgen-monorepo/releases/download/ruby-astgen%2Fv{}/ruby_ast_gen-macos_v{}.zip".format(RUBYSRC2CPG_ASTGEN_VERSION, RUBYSRC2CPG_ASTGEN_VERSION),
 )
 
 http_archive(
     name = "rubysrc2cpg_astgen_linux_arm",
     build_file = "//joern-cli/frontends/rubysrc2cpg:rubysrc2cpg_astgen.BUILD",
-    sha256 = "e6e15e10d8535cf20659502ac04589956dcd20f2ae027ff9cb20d731d8286e9a",
+    sha256 = "ebaa577b71a88132dce64a1ea7b767b4109120fb1ae8e117fb02acbd29388d83",
     url = "https://github.com/joernio/astgen-monorepo/releases/download/ruby-astgen%2Fv{}/ruby_ast_gen-linux-arm_v{}.zip".format(RUBYSRC2CPG_ASTGEN_VERSION, RUBYSRC2CPG_ASTGEN_VERSION),
 )
 
 http_archive(
     name = "rubysrc2cpg_astgen_linux_x86",
     build_file = "//joern-cli/frontends/rubysrc2cpg:rubysrc2cpg_astgen.BUILD",
-    sha256 = "6ced36c454474f72f25a0533dc6298f6ea4b7c6b05ea7964dad4796cafa033ba",
+    sha256 = "b270552288515f5f30a531ef5599a6298e14174cf6bd75b48335da3cee8484df",
     url = "https://github.com/joernio/astgen-monorepo/releases/download/ruby-astgen%2Fv{}/ruby_ast_gen-linux_v{}.zip".format(RUBYSRC2CPG_ASTGEN_VERSION, RUBYSRC2CPG_ASTGEN_VERSION),
 )
 
 http_archive(
     name = "rubysrc2cpg_astgen_win_arm",
     build_file = "//joern-cli/frontends/rubysrc2cpg:rubysrc2cpg_astgen.BUILD",
-    sha256 = "d55f95e8174b204015639d545a9f16f80fe9c620e3291b99ad5c16d849d9001a",
+    sha256 = "156aaf6d05499fb6d1ad1db3156edb68d172bc8dce0e42c108160d3e09a32d88",
     url = "https://github.com/joernio/astgen-monorepo/releases/download/ruby-astgen%2Fv{}/ruby_ast_gen-win-arm_v{}.zip".format(RUBYSRC2CPG_ASTGEN_VERSION, RUBYSRC2CPG_ASTGEN_VERSION),
 )
 
 http_archive(
     name = "rubysrc2cpg_astgen_win_x86",
     build_file = "//joern-cli/frontends/rubysrc2cpg:rubysrc2cpg_astgen.BUILD",
-    sha256 = "ecf7f126e47eeefb07bf3d72fa39ca3d3e403d50e91d26db0497c8930f7a10a4",
+    sha256 = "3a8957649cdc613321a89ef6fc1cbc010c4bb2ccb7f141e7bb39c3e443776b64",
     url = "https://github.com/joernio/astgen-monorepo/releases/download/ruby-astgen%2Fv{}/ruby_ast_gen-win_v{}.zip".format(RUBYSRC2CPG_ASTGEN_VERSION, RUBYSRC2CPG_ASTGEN_VERSION),
 )
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/resources/application.conf
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/resources/application.conf
@@ -1,4 +1,4 @@
 rubysrc2cpg {
-    ruby_ast_gen_version: "0.59.2"
+    ruby_ast_gen_version: "0.59.4"
     joern_type_stubs_version: "0.6.0"
 }

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -21,7 +21,7 @@ object Versions {
   val gradleTooling          = "8.3"
   val jacksonDatabind        = "2.17.0"
   val javaParser             = "3.28.0"
-  val jRuby                  = "10.0.6.0"
+  val jRuby                  = "9.4.15.0"
   val json4s                 = "4.0.7"
   val lombok                 = "1.18.42"
   val mavenArtifact          = "3.9.16"


### PR DESCRIPTION
- downgrade the jruby version to 9.4. (jruby 10 targets Java 21, which we are avoiding)