### PR TITLE
[linter-rules] Fix unordered collection usage

### DIFF
--- a/joern-cli/frontends/abap2cpg/src/main/scala/io/joern/abap2cpg/parser/AbapJsonParser.scala
+++ b/joern-cli/frontends/abap2cpg/src/main/scala/io/joern/abap2cpg/parser/AbapJsonParser.scala
@@ -32,9 +32,9 @@ class AbapJsonParser {
     val allStmts   = json("statements").arr.toSeq
 
     // --- state machine variables ---
-    val classDefs = mutable.LinkedHashMap.empty[String, ClassDef] // name -> def (sigs only)
-    val classSigs = mutable.ArrayBuffer.empty[MethodDef]          // sigs in current CLASS DEF
-    val bodies    = mutable.HashMap.empty[String, StatementList]  // UPPER(name) -> body
+    val classDefs = mutable.LinkedHashMap.empty[String, ClassDef]      // name -> def (sigs only)
+    val classSigs = mutable.ArrayBuffer.empty[MethodDef]               // sigs in current CLASS DEF
+    val bodies    = mutable.LinkedHashMap.empty[String, StatementList] // UPPER(name) -> body
 
     var currentClass: Option[String] = None
     var inClassDef                   = false

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
@@ -19,15 +19,19 @@ import org.eclipse.cdt.core.model.ILanguage
 import org.slf4j.{Logger, LoggerFactory}
 
 import java.nio.file.{Path, Paths}
+import scala.collection.immutable.ListMap
 import scala.collection.mutable
 
 object AstCreationPass {
 
+  // LinkedHash* collections: ForkJoinParallelCpgPassWithAccumulator merges accumulators in
+  // part (i.e. sorted file) order, so insertion order — and thus iteration order — is
+  // deterministic across runs. mergeWith must stay associative for this to hold.
   case class Accumulator(
-    usedTypes: mutable.HashSet[String] = mutable.HashSet.empty,
-    methodDeclarations: mutable.HashMap[String, FunctionDeclNodePass.MethodInfo] = mutable.HashMap.empty,
-    methodDefinitions: mutable.HashSet[String] = mutable.HashSet.empty,
-    headerIncludes: mutable.HashMap[String, HeaderFileParserLanguage] = mutable.HashMap.empty
+    usedTypes: mutable.LinkedHashSet[String] = mutable.LinkedHashSet.empty,
+    methodDeclarations: mutable.LinkedHashMap[String, FunctionDeclNodePass.MethodInfo] = mutable.LinkedHashMap.empty,
+    methodDefinitions: mutable.LinkedHashSet[String] = mutable.LinkedHashSet.empty,
+    headerIncludes: mutable.LinkedHashMap[String, HeaderFileParserLanguage] = mutable.LinkedHashMap.empty
   ) {
     def registerType(typeName: String): Unit = usedTypes.add(typeName)
 
@@ -94,10 +98,12 @@ class AstCreationPass(
 
   def typesSeen(): Set[String] = _finalAccumulator.usedTypes.toSet
 
+  // ListMap preserves the accumulator's deterministic insertion order; `toMap` would
+  // re-hash into an unordered immutable.HashMap
   def unhandledMethodDeclarations(): Map[String, FunctionDeclNodePass.MethodInfo] =
-    _finalAccumulator.methodDeclarations.filterNot { case (k, _) =>
+    ListMap.from(_finalAccumulator.methodDeclarations.filterNot { case (k, _) =>
       _finalAccumulator.methodDefinitions.contains(k)
-    }.toMap
+    })
 
   def headerIncludes(): Map[String, HeaderFileParserLanguage] = _finalAccumulator.headerIncludes.toMap
 

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreationPass.scala
@@ -32,8 +32,14 @@ class AstCreationPass(
     // We want the SAM types to have a deterministic iteration order. in onAccumulatorComplete
     // we sort by key by converting to a sorted map.
 
-    // TypeNodePass sorts the types so using a regular sets for the types are fine
-    AstCreationPass.Accumulator(mutable.HashSet.empty[String], mutable.HashMap.empty[String, AstCreator.SamImplInfo])
+    // TypeNodePass sorts the types, so iteration order of usedTypes does not matter.
+    // LinkedHash* collections regardless: accumulators are merged in part order (sorted
+    // files), so insertion order — and thus iteration order — is deterministic across runs.
+    // mergeAccumulator must stay associative for this to hold.
+    AstCreationPass.Accumulator(
+      mutable.LinkedHashSet.empty[String],
+      mutable.LinkedHashMap.empty[String, AstCreator.SamImplInfo]
+    )
   }
 
   override def mergeAccumulator(left: AstCreationPass.Accumulator, right: AstCreationPass.Accumulator): Unit = {
@@ -77,7 +83,7 @@ class AstCreationPass(
 
 object AstCreationPass {
   case class Accumulator(
-    usedTypes: mutable.HashSet[String],
-    samInfoEntriesByImplClass: mutable.HashMap[String, AstCreator.SamImplInfo]
+    usedTypes: mutable.LinkedHashSet[String],
+    samInfoEntriesByImplClass: mutable.LinkedHashMap[String, AstCreator.SamImplInfo]
   )
 }

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/passes/AstCreationPass.scala
@@ -16,6 +16,7 @@ import io.shiftleft.utils.IOUtils
 import org.slf4j.{Logger, LoggerFactory}
 
 import java.nio.file.Paths
+import scala.collection.immutable.ListMap
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
 import scala.util.{Failure, Success, Try}
@@ -38,12 +39,15 @@ class AstCreationPass(cpg: Cpg, astGenRunnerResult: AstGenRunnerResult, config: 
   def extensionMethodFullNameMapping(): Map[String, String]             = collectedExtensionMethodFullNameMapping
   def memberPropertyMapping(): Map[String, String]                      = collectedMemberPropertyMapping
 
+  // LinkedHash* collections: accumulators are merged in part order (sorted files), so
+  // insertion order — and thus iteration order — is deterministic across runs.
+  // mergeAccumulator must stay associative for this to hold.
   override def createAccumulator(): AstCreationPass.Accumulator = AstCreationPass.Accumulator(
-    usedTypes = mutable.HashSet.empty,
-    extensionInheritMapping = mutable.HashMap.empty,
-    extensionMethodFullNameMapping = mutable.HashMap.empty,
-    extensionMemberMapping = mutable.HashMap.empty,
-    memberPropertyMapping = mutable.HashMap.empty
+    usedTypes = mutable.LinkedHashSet.empty,
+    extensionInheritMapping = mutable.LinkedHashMap.empty,
+    extensionMethodFullNameMapping = mutable.LinkedHashMap.empty,
+    extensionMemberMapping = mutable.LinkedHashMap.empty,
+    memberPropertyMapping = mutable.LinkedHashMap.empty
   )
 
   override def mergeAccumulator(left: AstCreationPass.Accumulator, right: AstCreationPass.Accumulator): Unit = {
@@ -75,7 +79,9 @@ class AstCreationPass(cpg: Cpg, astGenRunnerResult: AstGenRunnerResult, config: 
   override def onAccumulatorComplete(builder: DiffGraphBuilder, accumulator: AstCreationPass.Accumulator): Unit = {
     collectedTypes = accumulator.usedTypes.toSet.removedAll(Defines.SwiftTypes)
     collectedExtensionInherits = accumulator.extensionInheritMapping.view.mapValues(_.toSet).toMap
-    collectedExtensionMembers = accumulator.extensionMemberMapping.view.mapValues(_.toList).toMap
+    // ListMap preserves the accumulator's deterministic insertion order for ExtensionsPass;
+    // `toMap` would re-hash into an unordered immutable.HashMap
+    collectedExtensionMembers = ListMap.from(accumulator.extensionMemberMapping.view.mapValues(_.toList))
     collectedExtensionMethodFullNameMapping = accumulator.extensionMethodFullNameMapping.toMap
     collectedMemberPropertyMapping = accumulator.memberPropertyMapping.toMap
   }
@@ -186,11 +192,11 @@ object AstCreationPass {
     *   Mapping from member fullName to method fullName from its computed property.
     */
   case class Accumulator(
-    usedTypes: mutable.HashSet[String],
-    extensionInheritMapping: mutable.HashMap[String, mutable.HashSet[String]],
-    extensionMethodFullNameMapping: mutable.HashMap[String, String],
-    extensionMemberMapping: mutable.HashMap[String, mutable.ArrayBuffer[MemberInfo]],
-    memberPropertyMapping: mutable.HashMap[String, String]
+    usedTypes: mutable.LinkedHashSet[String],
+    extensionInheritMapping: mutable.LinkedHashMap[String, mutable.LinkedHashSet[String]],
+    extensionMethodFullNameMapping: mutable.LinkedHashMap[String, String],
+    extensionMemberMapping: mutable.LinkedHashMap[String, mutable.ArrayBuffer[MemberInfo]],
+    memberPropertyMapping: mutable.LinkedHashMap[String, String]
   ) {
 
     def addExtensionMember(
@@ -209,7 +215,7 @@ object AstCreationPass {
     def addExtensionInherits(extensionFullName: String, inheritNames: Seq[String]): Unit = {
       extensionInheritMapping.updateWith(extensionFullName) {
         case Some(set) => Some(set ++= inheritNames)
-        case None      => Some(mutable.HashSet.from(inheritNames))
+        case None      => Some(mutable.LinkedHashSet.from(inheritNames))
       }
     }
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/MethodStubCreator.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/base/MethodStubCreator.scala
@@ -24,7 +24,9 @@ case class CallSummary(
 class MethodStubCreator(cpg: Cpg) extends CpgPass(cpg) {
 
   override def run(dstGraph: DiffGraphBuilder): Unit = {
-    val methodToParameterCount = mutable.HashMap[String, mutable.HashSet[CallSummary]]()
+    // LinkedHash* collections: this pass is single-threaded and populated in cpg.call
+    // (node) order, so insertion order — and thus iteration order — is deterministic.
+    val methodToParameterCount = mutable.LinkedHashMap[String, mutable.LinkedHashSet[CallSummary]]()
 
     for {
       call <- cpg.call
@@ -32,7 +34,7 @@ class MethodStubCreator(cpg: Cpg) extends CpgPass(cpg) {
         cpg.method.fullNameExact(call.methodFullName).isEmpty
     } {
       methodToParameterCount
-        .getOrElseUpdate(call.methodFullName, mutable.HashSet.empty[CallSummary])
+        .getOrElseUpdate(call.methodFullName, mutable.LinkedHashSet.empty[CallSummary])
         .add(
           CallSummary(
             call.name,

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/Report.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/Report.scala
@@ -55,10 +55,8 @@ class Report {
 
   def print(): Unit = {
     // reports is a concurrent TrieMap: rows are sorted by unique file name below and the LOC
-    // total sums Longs, so neither result depends on encounter order. (A trailing
-    // `scalafix:ok` cannot suppress here: the diagnostic sits exactly at the term's end.)
-    // scalafix:off UnorderedIteration
-    val rows = reports.toSeq
+    // total sums Longs, so neither result depends on encounter order.
+    val rows = reports.toSeq // scalafix:ok UnorderedIteration
       .sortBy(_._1)
       .zipWithIndex
       .view
@@ -72,13 +70,12 @@ class Report {
       Seq(
         "Total",
         "",
-        s"${reports.filter(_._2.loc >= 0).map(_._2.loc).sum}",
+        s"${reports.filter(_._2.loc >= 0).map(_._2.loc).sum}", // scalafix:ok UnorderedIteration
         s"${reports.count(_._2.parsed)}/$numOfReports",
         s"${reports.count(_._2.cpgGen)}/$numOfReports",
         ""
       )
     )
-    // scalafix:on UnorderedIteration
     val table = header ++ rows ++ footer
     logger.info(s"Report:${System.lineSeparator()}${formatTable(table)}")
   }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/Report.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/Report.scala
@@ -54,6 +54,10 @@ class Report {
   }
 
   def print(): Unit = {
+    // reports is a concurrent TrieMap: rows are sorted by unique file name below and the LOC
+    // total sums Longs, so neither result depends on encounter order. (A trailing
+    // `scalafix:ok` cannot suppress here: the diagnostic sits exactly at the term's end.)
+    // scalafix:off UnorderedIteration
     val rows = reports.toSeq
       .sortBy(_._1)
       .zipWithIndex
@@ -74,6 +78,7 @@ class Report {
         ""
       )
     )
+    // scalafix:on UnorderedIteration
     val table = header ++ rows ++ footer
     logger.info(s"Report:${System.lineSeparator()}${formatTable(table)}")
   }

--- a/linter-rules/input/src/main/scala/fix/UnorderedIterationTestCases.scala
+++ b/linter-rules/input/src/main/scala/fix/UnorderedIterationTestCases.scala
@@ -286,6 +286,11 @@ object UnorderedIterationTestCases {
     hashMap.foreach { case (key, value) => println(s"$key=$value") } // scalafix:ok UnorderedIteration
   }
 
+  // Boundary case: trailing suppression where the flagged term is the statement's last token
+  def suppressedLastTokenOfStatement(): Unit = {
+    val xs = hashSet.toSeq // scalafix:ok UnorderedIteration
+  }
+
   // --- Immutable HashMap ---
 
   val immutableHashMap: immutable.HashMap[String, Int] = immutable.HashMap.empty

--- a/linter-rules/src/main/scala/fix/UnorderedIteration.scala
+++ b/linter-rules/src/main/scala/fix/UnorderedIteration.scala
@@ -343,8 +343,8 @@ class UnorderedIteration extends SemanticRule("UnorderedIteration") {
       .map(typeSym => typeSym.info.map(_.displayName).getOrElse(typeSym.displayName))
       .getOrElse(term.symbol.displayName)
 
-  // Note: the diagnostic is a zero-width position at the term's end, i.e. it is reported on the
-  // expression's last line — for multi-line calls, suppression comments must be placed there.
+  // scalafix's `scalafix:ok` escape range is end-exclusive ([owner line start, owner.end)) and
+  // matches on the diagnostic's start offset, so the diagnostic is anchored at the term's start.
   private def lintDiagnostic(term: Term, typeName: String, methodName: String): Patch =
     Patch.lint(
       Diagnostic(
@@ -352,7 +352,7 @@ class UnorderedIteration extends SemanticRule("UnorderedIteration") {
         message = s"Iteration over unordered collection $typeName via .$methodName — " +
           "iteration order is non-deterministic. Use a sorted or ordered collection, " +
           "or suppress with `// scalafix:ok UnorderedIteration` if order does not matter here.",
-        position = Position.Range(term.pos.input, term.pos.end, term.pos.end)
+        position = term.pos
       )
     )
 


### PR DESCRIPTION
Most fixes are quite easy to grasp, I guess,
For the changes w.r.t. `LinkedHash*` collections on the Accumulators:
`ForkJoinParallelCpgPassWithAccumulator` merges accumulators in part order (sorted files), so insertion order - and thus iteration order - is deterministic across runs. `mergeAccumulator` must stay associative for this to hold.