### PR TITLE
[x2cpg][c2cpg] Fix broken Report handling

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
@@ -205,7 +205,6 @@ class AstCreationPass(
               false
           }
         case None =>
-          report.addReportInfo(relPath, -1)
           false
       }
     }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/Report.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/Report.scala
@@ -87,6 +87,10 @@ class Report {
   ): Unit = reports(fileName) = ReportEntry(loc, parsed, cpgGen, duration)
 
   def updateReport(fileName: FileName, cpg: Boolean, duration: Long): Unit =
-    reports.updateWith(fileName)(_.map(_.copy(cpgGen = cpg, duration = duration)))
+    reports.updateWith(fileName) {
+      case Some(existing) => Some(existing.copy(cpgGen = cpg, duration = duration))
+      // files whose parse result could not be read never got an addReportInfo call; still record them
+      case None => Some(ReportEntry(loc = -1, parsed = false, cpgGen = cpg, duration = duration))
+    }
 
 }


### PR DESCRIPTION
Files whose parse result could not be read never got an addReportInfo call but the report should record that. c2cpg was the only one doing it explicitly.