### PR TITLE
[rubysrc2cpg] fix `no AST parent` case

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -783,8 +783,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
 
       val block = blockNode(node, code(node), Defines.Any)
       scope.pushNewScope(BlockScope(block))
-      val tmpLocal = NewLocal().name(tmp).code(tmp)
-      scope.addToScope(tmp, tmpLocal)
+      handleVariableOccurrence(tmp, node)
 
       val arguments = if (node.text.startsWith("%")) {
         val argumentsType =

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CaseTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/CaseTests.scala
@@ -162,9 +162,8 @@ class CaseTests extends RubyCode2CpgFixture {
                      |        end
                      |end""".stripMargin)
 
-    val List(_, resultLocal, notResultLocal) = cpg.method.name("class_for").block.astChildren.isLocal.l
-    resultLocal.name shouldBe "result"
-    notResultLocal.name shouldBe "notResult"
+    val locals = cpg.method.name("class_for").block.astChildren.isLocal.l
+    locals.map(_.name).toSet shouldBe Set("<tmp-0>", "<tmp-2>", "result", "notResult")
 
     val block @ List(_) = cpg.method.name("class_for").block.astChildren.isBlock.l
 
@@ -172,7 +171,17 @@ class CaseTests extends RubyCode2CpgFixture {
     val List(lhs, rhs) = assign.argument.l
 
     lhs.start.isIdentifier.name.l shouldBe List("<tmp-0>")
-    rhs.start.isBlock.code.l shouldBe List("[type, location]") // where the array lowering happens
+    rhs.start.isBlock.code.l shouldBe List("[type, location]")
+
+    inside(rhs.start.isBlock.astChildren.isCall.name(Operators.assignment).l) {
+      case arrayInit :: elem0 :: elem1 :: Nil =>
+        arrayInit.code shouldBe "[type, location]"
+        inside(arrayInit.argument.l) { case (initLhs: Identifier) :: _ :: Nil =>
+          initLhs.name shouldBe "<tmp-2>"
+        }
+        elem0.code shouldBe "<tmp-2>[0] = type"
+        elem1.code shouldBe "<tmp-2>[1] = location"
+    }
 
     val headIf @ List(_)     = block.astChildren.isControlStructure.l
     val ifStmts @ List(_, _) = headIf.repeat(_.astChildren.order(3).astChildren.isControlStructure)(_.emit).l;


### PR DESCRIPTION
- fix a case which resulted in `LOCAL node has no AST parent` validation warnings