### PR TITLE
[rust2cpg] support parameter patterns.

### DIFF
--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustFullNames.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustFullNames.scala
@@ -145,6 +145,10 @@ trait RustFullNames { this: AstCreator =>
     identPat.typeFullName.getOrElse(Defines.Any)
   }
 
+  protected def typeFullNameForParam(param: RustNodeSyntax.Param): String = {
+    param.typ.map(typeFullNameForType).orElse(param.pat.map(typeFullNameForPat)).getOrElse(Defines.Any)
+  }
+
   protected def typeFullNameForPat(pat: RustNodeSyntax.Pat): String = {
     // TODO(rust_ast_gen): add typeFullName to patterns.
     pat.typeFullName.getOrElse {

--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
@@ -505,8 +505,10 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
     val methodMods      = Seq[NewModifier]()
 
     contextStack.pushMethod(method)
-    val paramAsts = visitParamList(fn.paramList)
-    val bodyAst   = fn.blockExpr.map(lowerFnBody).getOrElse(blockAst(blockNode(fn)))
+    val (paramAsts, paramAssignmentAsts) = lowerParamList(fn.paramList)
+    val bodyAst = fn.blockExpr
+      .map(lowerFnBody(_, paramAssignmentAsts))
+      .getOrElse(blockAst(blockNode(fn), paramAssignmentAsts.toList))
     contextStack.pop()
 
     methodAst(method = method, parameters = paramAsts, body = bodyAst, methodReturn = methodRet, modifiers = methodMods)
@@ -514,13 +516,14 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
 
   // Creates:
   // BLOCK {
+  //   <preStmts>
   //   <stmts>
   //   RETURN (expr) // if (expr) exists
   // }
-  private def lowerFnBody(blockExpr: BlockExpr): Ast = {
+  private def lowerFnBody(blockExpr: BlockExpr, preStmts: Seq[Ast]): Ast = {
     val stmtAsts   = blockExpr.stmtList.stmt.flatMap(visitStmt)
     val retExprAst = blockExpr.stmtList.expr.map(lowerReturnExpr).toList
-    Ast(blockNode(blockExpr)).withChildren(stmtAsts ++ retExprAst)
+    Ast(blockNode(blockExpr)).withChildren(preStmts ++ stmtAsts ++ retExprAst)
   }
 
   // Creates:
@@ -691,27 +694,33 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
   //  | (SelfParam ',')? (Param (',' Param)* ','?)?
   //  )')'
   // | '|' (Param (',' Param)* ','?)? '|'
-  private def visitParamList(paramList: ParamList): Seq[Ast] = {
+  private def lowerParamList(paramList: ParamList): (paramAsts: Seq[Ast], paramAssignmentAsts: Seq[Ast]) = {
     val selfParamAst = paramList.selfParam.map(visitSelfParam).toList
-    val paramAsts = paramList.param.zipWithIndex.map { case (param, paramIdx) =>
-      param.pat match {
-        case Some(identPat: IdentPat) =>
-          val paramNode = parameterInNode(
-            node = param,
-            name = code(identPat),
-            code = code(param),
-            index = paramIdx + 1,
-            isVariadic = false,
-            evaluationStrategy = EvaluationStrategies.BY_SHARING,
-            typeFullName = param.typ.map(typeFullNameForType).getOrElse(typeFullNameForIdentPat(identPat))
-          )
-          contextStack.declareParameter(paramNode)
-          Ast(paramNode)
-        case _ => notHandledYet(param)
+    val (paramAsts, paramAssignmentAsts) = paramList.param.zipWithIndex.map { case (param, paramIdx) =>
+      val (paramName, paramPattern) = param.pat match {
+        case Some(identPat: IdentPat) => (code(identPat.name), identPat.pat)
+        case pat                      => (contextStack.nextTmpName(), pat)
       }
-    }
+      val typeFullName = typeFullNameForParam(param)
+      val paramNode = parameterInNode(
+        node = param,
+        name = paramName,
+        code = code(param),
+        index = paramIdx + 1,
+        isVariadic = false,
+        evaluationStrategy = EvaluationStrategies.BY_SHARING,
+        typeFullName = typeFullName
+      )
+      contextStack.declareParameter(paramNode)
 
-    selfParamAst ++ paramAsts
+      val patternAssignmentAsts = paramPattern.toList.flatMap { pat =>
+        val mkParamIdentAst = () => identifierAst(pat, paramName, paramName, typeFullName)
+        createLocalsForBindings(collectPatternBindings(pat)) ++ createAssignmentsForPattern(pat, mkParamIdentAst)
+      }
+      (Ast(paramNode), patternAssignmentAsts)
+    }.unzip
+
+    (selfParamAst ++ paramAsts, paramAssignmentAsts.flatten)
   }
 
   // SelfParam =
@@ -731,16 +740,6 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
     )
     contextStack.declareParameter(paramNode)
     Ast(paramNode)
-  }
-
-  // Param =
-  //  Attr* (
-  //    Pat (':' Type)?
-  //  | Type
-  //  | '...'
-  //  )
-  private def visitParam(param: Param): Ast = {
-    notHandledYet(param)
   }
 
   // PathExpr =
@@ -1665,10 +1664,10 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
   }
 
   private def lowerClosureExprAsDetachedAst(closureExpr: ClosureExpr, method: NewMethod): Unit = {
-    val paramAsts = visitParamList(closureExpr.paramList)
+    val (paramAsts, paramAssignmentAsts) = lowerParamList(closureExpr.paramList)
     val bodyAst = closureExpr.expr match {
-      case blockExpr: BlockExpr => lowerFnBody(blockExpr)
-      case expr                 => Ast(blockNode(expr)).withChild(lowerReturnExpr(expr))
+      case blockExpr: BlockExpr => lowerFnBody(blockExpr, paramAssignmentAsts)
+      case expr                 => Ast(blockNode(expr)).withChildren(paramAssignmentAsts :+ lowerReturnExpr(expr))
     }
     val retTypeFullName = closureExpr.retType match {
       case None          => typeFullNameForExpr(closureExpr.expr)

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/MethodTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/MethodTests.scala
@@ -1,7 +1,7 @@
 package io.joern.rust2cpg.passes.ast
 
 import io.joern.rust2cpg.testfixtures.Rust2CpgSuite
-import io.shiftleft.codepropertygraph.generated.{DispatchTypes, NodeTypes}
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, NodeTypes, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal.globalNamespaceName
@@ -98,6 +98,113 @@ class MethodTests extends Rust2CpgSuite(noSysRoot = true) {
         p3.index shouldBe 3
         p3.typeFullName shouldBe "f32"
       }
+    }
+  }
+
+  "tuple pattern parameter" should {
+    val cpg = code("""
+        |fn f((a, b): (i32, bool)) {
+        | let c = a;
+        |}
+        |""".stripMargin)
+
+    "have correct parameter" in {
+      inside(cpg.method.nameExact("f").parameter.l) { case (param: MethodParameterIn) :: Nil =>
+        param.name shouldBe "<tmp>0"
+        param.code shouldBe "(a, b): (i32, bool)"
+        param.index shouldBe 1
+        param.typeFullName shouldBe "(i32, bool)"
+      }
+    }
+
+    "have correct locals" in {
+      inside(cpg.method.nameExact("f").block.local.l) { case aLocal :: bLocal :: cLocal :: Nil =>
+        aLocal.name shouldBe "a"
+        aLocal.typeFullName shouldBe "i32"
+        bLocal.name shouldBe "b"
+        bLocal.typeFullName shouldBe "bool"
+        cLocal.name shouldBe "c"
+        cLocal.typeFullName shouldBe "i32"
+      }
+    }
+
+    "have correct assignments" in {
+      inside(cpg.method.nameExact("f").block.astChildren.isCall.l) { case aAssign :: bAssign :: cAssign :: Nil =>
+        aAssign.code shouldBe "a = <tmp>0.0"
+        bAssign.code shouldBe "b = <tmp>0.1"
+        cAssign.code shouldBe "let c = a;"
+      }
+    }
+  }
+
+  "record pattern parameter" should {
+    val cpg = code("""
+        |struct Point { x: i32, y: bool }
+        |fn f(Point { x, y }: Point) {}
+        |""".stripMargin)
+
+    "have correct parameter" in {
+      inside(cpg.method.nameExact("f").parameter.l) { case (param: MethodParameterIn) :: Nil =>
+        param.name shouldBe "<tmp>0"
+        param.code shouldBe "Point { x, y }: Point"
+        param.index shouldBe 1
+        param.typeFullName shouldBe "rust2cpgtest::Point"
+      }
+    }
+
+    "have correct locals" in {
+      inside(cpg.method.nameExact("f").block.local.l) { case xLocal :: yLocal :: Nil =>
+        xLocal.name shouldBe "x"
+        xLocal.typeFullName shouldBe "i32"
+
+        yLocal.name shouldBe "y"
+        yLocal.typeFullName shouldBe "bool"
+      }
+    }
+
+    "have correct assignments" in {
+      inside(cpg.method.nameExact("f").block.astChildren.isCall.l) { case xAssign :: yAssign :: Nil =>
+        xAssign.code shouldBe "x = <tmp>0.x"
+        yAssign.code shouldBe "y = <tmp>0.y"
+      }
+    }
+  }
+
+  "@ pattern parameter" should {
+    val cpg = code("""
+        |fn f(p @ (a, b): (i32, bool)) {}
+        |""".stripMargin)
+
+    "have correct parameter" in {
+      inside(cpg.method.name("f").parameter.l) { case (param: MethodParameterIn) :: Nil =>
+        param.name shouldBe "p"
+        param.code shouldBe "p @ (a, b): (i32, bool)"
+        param.typeFullName shouldBe "(i32, bool)"
+      }
+    }
+
+    "have correct assignments" in {
+      inside(cpg.method.name("f").block.astChildren.isCall.l) { case aAssign :: bAssign :: Nil =>
+        aAssign.code shouldBe "a = p.0"
+        bAssign.code shouldBe "b = p.1"
+      }
+    }
+  }
+
+  "wildcard parameter" should {
+    val cpg = code("fn f(_: i32) {}")
+
+    "have correct parameter" in {
+      inside(cpg.method.nameExact("f").parameter.l) { case (param: MethodParameterIn) :: Nil =>
+        param.name shouldBe "<tmp>0"
+        param.code shouldBe "_: i32"
+        param.index shouldBe 1
+        param.typeFullName shouldBe "i32"
+      }
+    }
+
+    "have no assignments" in {
+      cpg.method.nameExact("f").block.astChildren shouldBe empty
     }
   }
 


### PR DESCRIPTION
Previously, only identifier patterns were supported in parameter declarations. Now, the same mechanism that lowers `let`/`match` pattern matching is also used to lower parameter patterns.