### PR TITLE
[x2cpg] AstGenRunner hardening

### DIFF
--- a/joern-cli/frontends/abap2cpg/src/main/scala/io/joern/abap2cpg/Abap2Cpg.scala
+++ b/joern-cli/frontends/abap2cpg/src/main/scala/io/joern/abap2cpg/Abap2Cpg.scala
@@ -5,6 +5,7 @@ import io.joern.abap2cpg.passes.{AbapTypeInferencePass, AstCreationPass, RefEdge
 import io.joern.x2cpg.{X2Cpg, X2CpgFrontend}
 import io.joern.x2cpg.passes.base.{ContainsEdgePass, TypeEvalPass}
 import io.joern.x2cpg.passes.frontend.{MetaDataPass, TypeNodePass}
+import io.joern.x2cpg.utils.Report
 import io.shiftleft.codepropertygraph.generated.{Cpg, Languages}
 import io.shiftleft.semanticcpg.utils.FileUtil
 
@@ -19,6 +20,7 @@ class Abap2Cpg extends X2CpgFrontend {
       FileUtil.usingTemporaryDirectory("abap2cpgOut") { tmpDir =>
         MetaDataPass(cpg, Languages.ABAP, config.inputPath).createAndApply()
 
+        val report = new Report()
         val runner = new AbapAstGenRunner(config)
         val result = runner.execute(tmpDir)
 
@@ -28,9 +30,7 @@ class Abap2Cpg extends X2CpgFrontend {
         if (parsed.isEmpty) {
           logger.warn("No ABAP files were parsed. Check that the input path contains .abap files.")
         }
-        if (skipped.nonEmpty) {
-          logger.warn(s"Skipped ${skipped.size} file(s) due to parse errors.")
-        }
+        skipped.foreach(fileName => report.addSkippedFile(fileName, config.inputPath))
 
         new AstCreationPass(cpg, parsed, config).createAndApply()
         new ContainsEdgePass(cpg).createAndApply()
@@ -38,6 +38,7 @@ class Abap2Cpg extends X2CpgFrontend {
         new RefEdgePass(cpg).createAndApply()
         new AbapTypeInferencePass(cpg).createAndApply()
         new TypeEvalPass(cpg).createAndApply()
+        report.print()
       }
     }
   }

--- a/joern-cli/frontends/abap2cpg/src/main/scala/io/joern/abap2cpg/Abap2Cpg.scala
+++ b/joern-cli/frontends/abap2cpg/src/main/scala/io/joern/abap2cpg/Abap2Cpg.scala
@@ -30,9 +30,9 @@ class Abap2Cpg extends X2CpgFrontend {
         if (parsed.isEmpty) {
           logger.warn("No ABAP files were parsed. Check that the input path contains .abap files.")
         }
-        skipped.foreach(fileName => report.addSkippedFile(fileName, config.inputPath))
+        skipped.foreach(report.addSkippedFile)
 
-        new AstCreationPass(cpg, parsed, config).createAndApply()
+        new AstCreationPass(cpg, parsed, config, report).createAndApply()
         new ContainsEdgePass(cpg).createAndApply()
         TypeNodePass.withTypesFromCpg(cpg).createAndApply()
         new RefEdgePass(cpg).createAndApply()

--- a/joern-cli/frontends/abap2cpg/src/main/scala/io/joern/abap2cpg/parser/AbapAstGenRunner.scala
+++ b/joern-cli/frontends/abap2cpg/src/main/scala/io/joern/abap2cpg/parser/AbapAstGenRunner.scala
@@ -2,16 +2,12 @@ package io.joern.abap2cpg.parser
 
 import io.joern.abap2cpg.Config
 import io.joern.x2cpg.astgen.AstGenRunner
-import io.joern.x2cpg.astgen.AstGenRunner.AstGenProgramMetaData
-import io.shiftleft.semanticcpg.utils.ExternalCommand
-import org.slf4j.LoggerFactory
+import io.joern.x2cpg.astgen.AstGenRunner.{AstGenProgramMetaData, SkippedFile}
+import io.shiftleft.semanticcpg.utils.{ExternalCommand, ExternalCommandResult}
 
 import java.nio.file.Path
-import scala.util.{Failure, Success, Try}
 
 object AbapAstGenRunner {
-  private val logger = LoggerFactory.getLogger(getClass)
-
   private object astGenMetaData extends AstGenProgramMetaData(name = "abapgen", configPrefix = "abap2cpg")
 }
 
@@ -24,19 +20,14 @@ class AbapAstGenRunner(config: Config) extends AstGenRunner(AbapAstGenRunner.ast
   // abapgen has no --version flag, so always use the bundled binary
   override def hasCompatibleAstGenVersion(compatibleVersion: String, path: Option[String]): Boolean = false
 
-  override def skippedFiles(in: Path, astGenOut: List[String]): List[String] = {
-    astGenOut.collect {
-      case line if line.startsWith("ERR ") =>
-        val filename = line.stripPrefix("ERR ").takeWhile(_ != ':')
-        logger.warn(s"\t- failed to parse '$filename'")
-        Some(filename)
-      case line =>
-        logger.debug(s"\t+ $line")
-        None
-    }.flatten
+  // abapgen writes `ERR <file>` to stdout for files it failed to parse (no reason text, no per-file success lines).
+  override def skippedFiles(in: Path, runResult: ExternalCommandResult): List[SkippedFile] = {
+    runResult.stdOut.collect { case s"ERR $rest" =>
+      SkippedFile(rest.takeWhile(_ != ':').trim, "failed to parse")
+    }.toList
   }
 
-  override def runAstGenNative(in: String, out: Path, exclude: String, include: String): Try[Seq[String]] = {
-    ExternalCommand.run(Seq(astGenCommand, in, out.toString)).toTry
+  override def runAstGenNative(in: String, out: Path, exclude: String, include: String): ExternalCommandResult = {
+    ExternalCommand.run(Seq(astGenCommand, in, out.toString))
   }
 }

--- a/joern-cli/frontends/abap2cpg/src/main/scala/io/joern/abap2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/abap2cpg/src/main/scala/io/joern/abap2cpg/passes/AstCreationPass.scala
@@ -3,14 +3,16 @@ package io.joern.abap2cpg.passes
 import io.joern.abap2cpg.Config
 import io.joern.abap2cpg.parser.AbapJsonParser
 import io.joern.x2cpg.ValidationMode
+import io.joern.x2cpg.utils.{Report, TimeUtils}
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.passes.ForkJoinParallelCpgPass
 import org.slf4j.LoggerFactory
 
 import java.nio.file.Paths
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Success, Try}
 
-class AstCreationPass(cpg: Cpg, jsonFiles: List[String], config: Config) extends ForkJoinParallelCpgPass[String](cpg) {
+class AstCreationPass(cpg: Cpg, jsonFiles: List[String], config: Config, report: Report = new Report())
+    extends ForkJoinParallelCpgPass[String](cpg) {
 
   private val logger = LoggerFactory.getLogger(classOf[AstCreationPass])
   private val parser = AbapJsonParser()
@@ -20,14 +22,26 @@ class AstCreationPass(cpg: Cpg, jsonFiles: List[String], config: Config) extends
   override def runOnPart(diffGraph: DiffGraphBuilder, jsonFile: String): Unit = {
     implicit val schemaValidation: ValidationMode = ValidationMode.Enabled
 
-    parser.parseFile(Paths.get(jsonFile)) match {
-      case Success(program) =>
-        logger.debug(s"Generating CPG for: ${program.fileName}")
-        val astCreator = new AstCreator(program, program.fileName)
-        val generated  = astCreator.createAst()
-        diffGraph.absorb(generated)
-      case Failure(exception) =>
-        logger.warn(s"Failed to parse '$jsonFile': ${exception.getMessage}")
+    val ((gotCpg, filename), duration) = TimeUtils.time {
+      parser.parseFile(Paths.get(jsonFile)) match {
+        case Success(program) =>
+          report.addParsedFile(program.fileName, config.inputPath)
+          Try {
+            val astCreator = new AstCreator(program, program.fileName)
+            diffGraph.absorb(astCreator.createAst())
+          } match {
+            case Success(_) =>
+              logger.debug(s"Generated a CPG for: '${program.fileName}'")
+              (true, program.fileName)
+            case Failure(exception) =>
+              logger.warn(s"Failed to generate a CPG for: '${program.fileName}'", exception)
+              (false, program.fileName)
+          }
+        case Failure(exception) =>
+          logger.warn(s"Failed to parse '$jsonFile': ${exception.getMessage}")
+          (false, jsonFile)
+      }
     }
+    report.updateReport(filename, cpg = gotCpg, duration)
   }
 }

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/CSharpSrc2Cpg.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/CSharpSrc2Cpg.scala
@@ -42,7 +42,7 @@ class CSharpSrc2Cpg extends X2CpgFrontend {
     withNewEmptyCpg(config.outputPath, config) { (cpg, config) =>
       FileUtil.usingTemporaryDirectory("csharpsrc2cpgOut") { tmpDir =>
         val astGenResult = new DotNetAstGenRunner(config).execute(tmpDir)
-        astGenResult.skippedFiles.foreach(fileName => report.addSkippedFile(fileName, config.inputPath))
+        astGenResult.skippedFiles.foreach(report.addSkippedFile)
         val astCreators = CSharpSrc2Cpg.processAstGenRunnerResults(astGenResult.parsedFiles, config)
         val buildFiles  = findBuildFiles(config)
         val localSummary = ProgramSummaryCreator

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/CSharpSrc2Cpg.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/CSharpSrc2Cpg.scala
@@ -42,8 +42,9 @@ class CSharpSrc2Cpg extends X2CpgFrontend {
     withNewEmptyCpg(config.outputPath, config) { (cpg, config) =>
       FileUtil.usingTemporaryDirectory("csharpsrc2cpgOut") { tmpDir =>
         val astGenResult = new DotNetAstGenRunner(config).execute(tmpDir)
-        val astCreators  = CSharpSrc2Cpg.processAstGenRunnerResults(astGenResult.parsedFiles, config)
-        val buildFiles   = findBuildFiles(config)
+        astGenResult.skippedFiles.foreach(fileName => report.addSkippedFile(fileName, config.inputPath))
+        val astCreators = CSharpSrc2Cpg.processAstGenRunnerResults(astGenResult.parsedFiles, config)
+        val buildFiles  = findBuildFiles(config)
         val localSummary = ProgramSummaryCreator
           .from(astCreators, config)
           .addGlobalImports(ImplicitUsingsCollector.collect(buildFiles).toSet)

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/utils/DotNetAstGenRunner.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/utils/DotNetAstGenRunner.scala
@@ -2,21 +2,17 @@ package io.joern.csharpsrc2cpg.utils
 
 import io.joern.csharpsrc2cpg.Config
 import io.joern.x2cpg.SourceFiles
-import io.joern.x2cpg.astgen.AstGenRunner.{AstGenProgramMetaData, getClass}
+import io.joern.x2cpg.astgen.AstGenRunner.{AstGenProgramMetaData, SkippedFile}
 import io.joern.x2cpg.astgen.AstGenRunner
-import io.shiftleft.semanticcpg.utils.ExternalCommand
-import org.slf4j.LoggerFactory
+import io.shiftleft.semanticcpg.utils.{ExternalCommand, ExternalCommandResult}
 
 import java.nio.file.Path
 import scala.collection.mutable
-import scala.util.Try
 
 object DotNetAstGenRunner {
   private object astGenMetaData extends AstGenProgramMetaData(name = "dotnetastgen", configPrefix = "csharpsrc2cpg")
 }
 class DotNetAstGenRunner(config: Config) extends AstGenRunner(DotNetAstGenRunner.astGenMetaData, config) {
-
-  private val logger = LoggerFactory.getLogger(getClass)
 
   // The x86 variant seems to run well enough on MacOS M-family chips, whereas the ARM build crashes
   override val MacArm: String   = MacX86
@@ -31,45 +27,39 @@ class DotNetAstGenRunner(config: Config) extends AstGenRunner(DotNetAstGenRunner
     }
   }
 
-  override def skippedFiles(in: Path, astGenOut: List[String]): List[String] = {
-    val diagnosticMap = mutable.LinkedHashMap.empty[String, Seq[String]]
+  // dotnetastgen writes everything to stdout as `info:/warn:/fail: DotNetAstGen.Program[0] <msg>` lines. Per-file
+  // compiler errors (`fail: <reason>`) are printed without a filename, so we buffer them and attribute them once
+  // the terminating `fail: ... Error(s) encountered while parsing: <file>` line names the file. This avoids
+  // misattributing errors when multiple files' "Parsing file: ..." lines are interleaved (e.g. parallel parsing).
+  override def skippedFiles(in: Path, runResult: ExternalCommandResult): List[SkippedFile] = {
+    val diagnosticsByFile = mutable.LinkedHashMap.empty[String, Seq[String]]
+    val pendingReasons    = mutable.ListBuffer.empty[String]
 
-    def addReason(reason: String, lastFile: Option[String] = None): Unit = {
-      val key = lastFile.orElse(diagnosticMap.lastOption.map(_._1))
-
-      key.foreach { resolvedKey =>
-        diagnosticMap.updateWith(resolvedKey) {
-          case Some(existingReasons) => Some(existingReasons :+ reason)
-          case None                  => Some(List(reason))
-        }
+    def addReasons(fileName: String, reasons: Seq[String]): Unit = {
+      val relFile = SourceFiles.toRelativePath(fileName, in.toString)
+      diagnosticsByFile.updateWith(relFile) {
+        case Some(existing) => Some(existing ++ reasons)
+        case None           => Some(reasons)
       }
     }
 
-    astGenOut.map(_.strip()).foreach {
-      case s"info: DotNetAstGen.Program[0] Parsing file: $fileName" =>
-        diagnosticMap.put(SourceFiles.toRelativePath(fileName, in.toString), Nil)
-      case s"fail: DotNetAstGen.Program[0] Error(s) encountered while parsing: $_" => // ignore
-      case s"fail: DotNetAstGen.Program[0] $reason"                                => addReason(reason)
+    runResult.stdOut.map(_.strip()).foreach {
+      case s"fail: DotNetAstGen.Program[0] Error(s) encountered while parsing: $fileName" =>
+        addReasons(fileName, pendingReasons.toList)
+        pendingReasons.clear()
+      case s"fail: DotNetAstGen.Program[0] $reason" => pendingReasons += reason
       case s"warn: DotNetAstGen.Program[0] $filename does $reason, skipping..." =>
-        addReason(s"does $reason", Option(filename))
-      case s"info: DotNetAstGen.Program[0] Skipping file: $fileName" =>
-        addReason("Skipped", Option(SourceFiles.toRelativePath(fileName, in.toString)))
-      case _ => // ignore
+        addReasons(filename, Seq(s"does $reason"))
+      case s"info: DotNetAstGen.Program[0] Skipping file: $fileName" => addReasons(fileName, Seq("Skipped"))
+      case _                                                         => // ignore
     }
 
-    diagnosticMap.flatMap {
-      case (filename, Nil) =>
-        logger.debug(s"Successfully parsed '$filename'")
-        None
-      case (filename, diagnostics) =>
-        logger.warn(s"Failed to parse '$filename':\n${diagnostics.map(x => s" - $x").mkString("\n")}")
-        Option(filename)
-    }.toList
+    diagnosticsByFile.map { case (filename, diagnostics) => SkippedFile(filename, diagnostics.mkString("; ")) }.toList
   }
 
-  override def runAstGenNative(in: String, out: Path, exclude: String, include: String): Try[Seq[String]] = {
+  override def runAstGenNative(in: String, out: Path, exclude: String, include: String): ExternalCommandResult = {
     val excludeCommand = if (exclude.isEmpty) Seq.empty else Seq("-e", exclude)
-    ExternalCommand.run(Seq(astGenCommand, "-o", out.toString(), "-i", in) ++ excludeCommand).toTry
+    ExternalCommand.run(Seq(astGenCommand, "-o", out.toString(), "-i", in) ++ excludeCommand)
   }
 
 }

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/GoSrc2Cpg.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/GoSrc2Cpg.scala
@@ -49,6 +49,7 @@ class GoSrc2Cpg(goGlobalOption: Option[GoGlobal] = Option(GoGlobal())) extends X
                 DownloadDependenciesPass(cpg, goMod.get, goGlobal, config).process()
                 goGlobal.processingDependencies = false
               }
+              astGenResult.skippedFiles.foreach(fileName => report.addSkippedFile(fileName, config.inputPath))
               AstCreationPass(cpg, astGenResult.parsedFiles, config, goMod.get, goGlobal, tmpDir, report)
                 .createAndApply()
               report.print()

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/GoSrc2Cpg.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/GoSrc2Cpg.scala
@@ -49,7 +49,7 @@ class GoSrc2Cpg(goGlobalOption: Option[GoGlobal] = Option(GoGlobal())) extends X
                 DownloadDependenciesPass(cpg, goMod.get, goGlobal, config).process()
                 goGlobal.processingDependencies = false
               }
-              astGenResult.skippedFiles.foreach(fileName => report.addSkippedFile(fileName, config.inputPath))
+              astGenResult.skippedFiles.foreach(report.addSkippedFile)
               AstCreationPass(cpg, astGenResult.parsedFiles, config, goMod.get, goGlobal, tmpDir, report)
                 .createAndApply()
               report.print()

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/utils/GoAstGenRunner.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/utils/GoAstGenRunner.scala
@@ -2,14 +2,14 @@ package io.joern.gosrc2cpg.utils
 
 import io.joern.gosrc2cpg.{Config, GoSrc2Cpg}
 import io.joern.x2cpg.SourceFiles
-import io.joern.x2cpg.astgen.AstGenRunner.{AstGenProgramMetaData, AstGenRunnerResult}
+import io.joern.x2cpg.astgen.AstGenRunner.{AstGenProgramMetaData, AstGenRunnerResult, SkippedFile}
 import io.joern.x2cpg.astgen
 import io.joern.x2cpg.astgen.AstGenRunner
 import io.joern.x2cpg.utils.Environment.ArchitectureType
 import io.joern.x2cpg.utils.Environment.OperatingSystemType
 import io.joern.x2cpg.utils.Environment
 import io.shiftleft.semanticcpg.utils.FileUtil.*
-import io.shiftleft.semanticcpg.utils.{ExternalCommand, FileUtil}
+import io.shiftleft.semanticcpg.utils.{ExternalCommand, ExternalCommandResult, FileUtil}
 import org.slf4j.LoggerFactory
 
 import java.nio.file.{Path, Paths}
@@ -45,18 +45,15 @@ class GoAstGenRunner(config: Config, includeFileRegex: String = "")
     Environment.OperatingSystemType.Mac     -> Environment.ArchitectureType.ARMv8
   )
 
-  override def skippedFiles(in: Path, astGenOut: List[String]): List[String] = {
-    val skipped = astGenOut.collect {
-      case out if !out.startsWith("Converted") =>
-        val filename = out.substring(0, out.indexOf(" "))
-        val reason   = out.substring(out.indexOf(" ") + 1)
-        logger.warn(s"\t- failed to parse '${in / filename}': '$reason'")
-        Option(filename)
-      case out =>
-        logger.debug(s"\t+ $out")
-        None
-    }
-    skipped.flatten
+  // goastgen writes both success and failure lines to stdout (`Converted AST for ...` / `Failed to generate AST for
+  // <file> `); per-file diagnostics (`[ERROR] ...`) go to stderr but aren't reliably correlatable to a single file.
+  override def skippedFiles(in: Path, runResult: ExternalCommandResult): List[SkippedFile] = {
+    runResult.stdOut
+      .map(_.trim)
+      .collect { case s"Failed to generate AST for $filename" =>
+        SkippedFile(toRelativeInputPath(filename.trim, in), "failed to generate AST (see stderr for details)")
+      }
+      .toList
   }
 
   override def fileFilter(file: String, out: Path): Boolean = {
@@ -76,32 +73,26 @@ class GoAstGenRunner(config: Config, includeFileRegex: String = "")
     }
   }
 
-  override def runAstGenNative(in: String, out: Path, exclude: String, include: String): Try[Seq[String]] = {
+  override def runAstGenNative(in: String, out: Path, exclude: String, include: String): ExternalCommandResult = {
     val excludeCommand = if (exclude.isEmpty) Seq.empty else Seq("-exclude", exclude)
     val includeCommand = if (include.isEmpty) Seq.empty else Seq("-include-packages", include)
-    ExternalCommand
-      .run((astGenCommand +: excludeCommand) ++ includeCommand ++ Seq("-out", out.toString, in))
-      .toTry
+    ExternalCommand.run((astGenCommand +: excludeCommand) ++ includeCommand ++ Seq("-out", out.toString, in))
   }
 
   def executeForGo(out: Path): List[GoAstGenRunnerResult] = {
     val in = Paths.get(config.inputPath)
     logger.info(s"Running goastgen in '$config.inputPath' ...")
-    runAstGenNative(config.inputPath, out, config.ignoredFilesRegex.toString(), includeFileRegex) match {
+    val runResult = Try(runAstGenNative(config.inputPath, out, config.ignoredFilesRegex.toString(), includeFileRegex))
+    val srcFiles  = astGenOutputFiles(out)
+    val parsedModFile = filterModFile(srcFiles, out)
+    val parsed        = filterFiles(srcFiles, out)
+    runResult match {
       case Success(result) =>
-        val srcFiles = SourceFiles.determine(
-          out.toString,
-          Set(".json"),
-          ignoredFilesRegex = Option(config.ignoredFilesRegex),
-          ignoredFilesPath = Option(config.ignoredFiles)
-        )
-        val parsedModFile = filterModFile(srcFiles, out)
-        val parsed        = filterFiles(srcFiles, out)
-        val skipped       = skippedFiles(in, result.toList)
-        segregateByModule(config.inputPath, out.toString, parsedModFile, parsed, skipped)
-      case Failure(f) =>
-        logger.error("\t- running astgen failed!", f)
-        List()
+        if (!isSuccess(result)) logUnsuccessfulRun(result)
+        segregateByModule(config.inputPath, out.toString, parsedModFile, parsed, collectSkippedFiles(in, result))
+      case Failure(exception) =>
+        logger.error("\t- running goastgen failed!", exception)
+        segregateByModule(config.inputPath, out.toString, parsedModFile, parsed, List.empty)
     }
   }
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/AstCreationPass.scala
@@ -8,7 +8,6 @@ import io.joern.x2cpg.astgen.AstGenRunner.AstGenRunnerResult
 import io.joern.x2cpg.utils.{Report, TimeUtils}
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.passes.ForkJoinParallelCpgPassWithAccumulator
-import io.shiftleft.utils.IOUtils
 import org.slf4j.{Logger, LoggerFactory}
 
 import java.nio.file.Paths
@@ -36,16 +35,7 @@ class AstCreationPass(cpg: Cpg, astGenRunnerResult: AstGenRunnerResult, config: 
   override def generateParts(): Array[String] = astGenRunnerResult.parsedFiles.toArray
 
   override def finish(): Unit = {
-    astGenRunnerResult.skippedFiles.foreach { fileName =>
-      val filePath = Paths.get(config.inputPath, fileName)
-      val fileLOC = Try(IOUtils.readLinesInFile(filePath)) match {
-        case Success(fileContent) => fileContent.size
-        case Failure(exception) =>
-          logger.warn(s"Failed to read file: '$filePath'", exception)
-          -1
-      }
-      report.addReportInfo(fileName, fileLOC)
-    }
+    astGenRunnerResult.skippedFiles.foreach(fileName => report.addSkippedFile(fileName, config.inputPath))
   }
 
   override def runOnPart(

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/AstCreationPass.scala
@@ -35,7 +35,7 @@ class AstCreationPass(cpg: Cpg, astGenRunnerResult: AstGenRunnerResult, config: 
   override def generateParts(): Array[String] = astGenRunnerResult.parsedFiles.toArray
 
   override def finish(): Unit = {
-    astGenRunnerResult.skippedFiles.foreach(fileName => report.addSkippedFile(fileName, config.inputPath))
+    astGenRunnerResult.skippedFiles.foreach(report.addSkippedFile)
   }
 
   override def runOnPart(

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/utils/AstGenRunner.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/utils/AstGenRunner.scala
@@ -3,9 +3,9 @@ package io.joern.jssrc2cpg.utils
 import io.joern.jssrc2cpg.Config
 import io.joern.jssrc2cpg.preprocessing.EjsPreprocessor
 import io.joern.x2cpg.SourceFiles
-import io.joern.x2cpg.astgen.AstGenRunner.{AstGenProgramMetaData, DefaultAstGenRunnerResult}
+import io.joern.x2cpg.astgen.AstGenRunner.{AstGenProgramMetaData, SkippedFile}
 import io.shiftleft.semanticcpg.utils.FileUtil.*
-import io.shiftleft.semanticcpg.utils.{ExternalCommand, FileUtil}
+import io.shiftleft.semanticcpg.utils.{ExternalCommand, ExternalCommandResult, FileUtil}
 import io.shiftleft.utils.IOUtils
 import org.slf4j.LoggerFactory
 
@@ -106,23 +106,12 @@ class AstGenRunner(config: Config) extends io.joern.x2cpg.astgen.AstGenRunner(As
     tsArgs ++ ignoredFilesRegex ++ ignoreFileArgs
   }
 
-  override protected def skippedFiles(in: Path, astGenOut: List[String]): List[String] = {
-    val skipped = astGenOut.collect {
-      case out if out.startsWith("Parsing") =>
-        val filename = out.substring(out.indexOf(" ") + 1, out.indexOf(":") - 1)
-        val reason   = out.substring(out.indexOf(":") + 2)
-        logger.warn(s"\t- failed to parse '$filename': '$reason'")
-        Option(filename)
-      case out if !out.startsWith("Converted") && !out.startsWith("Retrieving") =>
-        val filename = out.substring(0, out.indexOf(" "))
-        val reason   = out.substring(out.indexOf(" ") + 1)
-        logger.warn(s"\t- failed to parse '$filename': '$reason'")
-        Option(filename)
-      case out =>
-        logger.debug(s"\t+ $out")
-        None
-    }
-    skipped.flatten
+  // astgen writes skip/failure diagnostics to stderr as `Parsing <abs file> : <reason>`; stdout only ever carries
+  // success/progress lines (`Converted ...`, `Retrieving ...`).
+  override protected def skippedFiles(in: Path, runResult: ExternalCommandResult): List[SkippedFile] = {
+    runResult.stdErr.collect { case s"Parsing $file : $reason" =>
+      SkippedFile(toRelativeInputPath(file, in), reason)
+    }.toList
   }
 
   override protected def fileFilter(file: String, out: Path): Boolean = {
@@ -222,7 +211,7 @@ class AstGenRunner(config: Config) extends io.joern.x2cpg.astgen.AstGenRunner(As
     else file
   }
 
-  private def processEjsFiles(in: Path, out: Path, ejsFiles: List[String]): Try[Seq[String]] = {
+  private def processEjsFiles(in: Path, out: Path, ejsFiles: List[String]): ExternalCommandResult = {
     val tmpJsFiles = ejsFiles.flatMap { ejsFilePath =>
       val ejsFile             = Paths.get(ejsFilePath)
       val maybeTranspiledFile = Paths.get(s"${ejsFilePath.stripSuffix(".ejs")}.js")
@@ -262,10 +251,12 @@ class AstGenRunner(config: Config) extends io.joern.x2cpg.astgen.AstGenRunner(As
     }
 
     tmpJsFiles.foreach(FileUtil.delete(_))
-    result.toTry
+    result
   }
 
-  private def ejsFiles(in: Path, out: Path): Try[Seq[String]] = {
+  // Note: this sub-run's workingDir is `out` (it scans the temp preprocessed files it just wrote there), so any
+  // skip/failure lines it produces reference paths under `out`, not `in`.
+  private def ejsFiles(in: Path, out: Path): ExternalCommandResult = {
     val files =
       SourceFiles.determine(
         in.toString,
@@ -274,11 +265,10 @@ class AstGenRunner(config: Config) extends io.joern.x2cpg.astgen.AstGenRunner(As
         ignoredFilesRegex = Some(config.ignoredFilesRegex),
         ignoredFilesPath = Some(config.ignoredFiles)
       )
-    if (files.nonEmpty) processEjsFiles(in, out, files)
-    else Success(Seq.empty)
+    if (files.nonEmpty) processEjsFiles(in, out, files) else ExternalCommandResult(0, Seq.empty, Seq.empty, "", None)
   }
 
-  private def vueFiles(in: Path, out: Path): Try[Seq[String]] = {
+  private def vueFiles(in: Path, out: Path): ExternalCommandResult = {
     val files = SourceFiles.determine(
       in.toString,
       Set(".vue"),
@@ -289,49 +279,46 @@ class AstGenRunner(config: Config) extends io.joern.x2cpg.astgen.AstGenRunner(As
     if (files.nonEmpty) {
       ExternalCommand
         .run((astGenCommand +: executableArgs) ++ Seq("-t", "vue", "-o", out.toString), workingDir = Option(in))
-        .toTry
     } else {
-      Success(Seq.empty)
+      ExternalCommandResult(0, Seq.empty, Seq.empty, "", None)
     }
   }
 
-  private def jsFiles(in: Path, out: Path): Try[Seq[String]] = {
+  private def jsFiles(in: Path, out: Path): ExternalCommandResult = {
     ExternalCommand
       .run((astGenCommand +: executableArgs) ++ Seq("-t", "ts", "-o", out.toString), workingDir = Option(in))
-      .toTry
   }
 
-  override protected def runAstGenNative(in: String, out: Path, exclude: String, include: String): Try[Seq[String]] = {
-    val inPath = Paths.get(in)
-    for {
-      ejsResult <- ejsFiles(inPath, out)
-      vueResult <- vueFiles(inPath, out)
-      jsResult  <- jsFiles(inPath, out)
-    } yield jsResult ++ vueResult ++ ejsResult
+  override protected def runAstGenNative(
+    in: String,
+    out: Path,
+    exclude: String,
+    include: String
+  ): ExternalCommandResult = {
+    val inPath    = Paths.get(in)
+    val ejsResult = ejsFiles(inPath, out)
+    if (!isSuccess(ejsResult)) {
+      ejsResult
+    } else {
+      val vueResult = vueFiles(inPath, out)
+      if (!isSuccess(vueResult)) {
+        io.joern.x2cpg.astgen.AstGenRunner.combine(ejsResult, vueResult)
+      } else {
+        val jsResult = jsFiles(inPath, out)
+        io.joern.x2cpg.astgen.AstGenRunner.combine(ejsResult, vueResult, jsResult)
+      }
+    }
   }
 
-  private def checkParsedFiles(files: List[String], in: Path): List[String] = {
-    val numOfParsedFiles = files.size
-    logger.info(s"Parsed $numOfParsedFiles files.")
-    if (numOfParsedFiles == 0) {
+  override protected def astGenOutputFiles(out: Path): List[String] = SourceFiles.determine(out.toString, Set(".json"))
+
+  override protected def postProcessParsedFiles(parsedFiles: List[String], in: Path): List[String] = {
+    logger.info(s"Parsed ${parsedFiles.size} files.")
+    if (parsedFiles.isEmpty) {
       logger.warn("You may want to check the DEBUG logs for a list of files that are ignored by default.")
       SourceFiles.determine(in.toString, SourceFileExtensions, ignoredDefaultRegex = Option(AstGenDefaultIgnoreRegex))
     }
-    files
-  }
-
-  override def execute(out: Path): DefaultAstGenRunnerResult = {
-    val in = Paths.get(config.inputPath)
-    runAstGenNative(config.inputPath, out, config.ignoredFilesRegex.toString(), "") match {
-      case Success(result) =>
-        val parsed  = checkParsedFiles(filterFiles(SourceFiles.determine(out.toString, Set(".json")), out), in)
-        val skipped = skippedFiles(in, result.toList)
-        DefaultAstGenRunnerResult(parsed, skipped)
-      case Failure(f) =>
-        logger.error("\t- running astgen failed!", f)
-        val parsed = checkParsedFiles(filterFiles(SourceFiles.determine(out.toString, Set(".json")), out), in)
-        DefaultAstGenRunnerResult(parsed, List.empty)
-    }
+    parsedFiles
   }
 
 }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
@@ -58,11 +58,12 @@ class RubySrc2Cpg(sharedJRubyEnv: Option[JRubyEnvironment] = None) extends X2Cpg
           astGenRunner.execute(tmpDir, config)
       }
       val report = new Report()
-      astGenResult.skippedFiles.foreach(fileName => report.addSkippedFile(fileName, config.inputPath))
+      astGenResult.skippedFiles.foreach(report.addSkippedFile)
 
       val astCreators = ConcurrentTaskUtil
         .runUsingThreadPool(
-          RubySrc2Cpg.processAstGenRunnerResults(astGenResult.parsedFiles, config, cpg.metaData.root.headOption)
+          RubySrc2Cpg
+            .processAstGenRunnerResults(astGenResult.parsedFiles, config, cpg.metaData.root.headOption, report)
         )
         .flatMap {
           case Failure(exception)  => logger.warn(s"Unable to parse Ruby file, skipping -", exception); None
@@ -86,7 +87,7 @@ class RubySrc2Cpg(sharedJRubyEnv: Option[JRubyEnvironment] = None) extends X2Cpg
 
       val programSummary = internalProgramSummary ++= dependencySummary
 
-      AstCreationPass(cpg, astCreators.map(_.withSummary(programSummary))).createAndApply()
+      AstCreationPass(cpg, astCreators.map(_.withSummary(programSummary)), report).createAndApply()
       if (config.downloadDependencies) {
         DependencySummarySolverPass(cpg, dependencySummary).createAndApply()
       }
@@ -119,13 +120,15 @@ object RubySrc2Cpg {
   def processAstGenRunnerResults(
     astFiles: List[String],
     config: Config,
-    projectRoot: Option[String]
+    projectRoot: Option[String],
+    report: Report = new Report()
   ): Iterator[() => AstCreator] = {
     astFiles.map { fileName => () =>
       val parserResult   = RubyJsonParser.readFile(Paths.get(fileName))
       val rubyProgram    = new RubyJsonToNodeCreator(fileName = fileName).visitProgram(parserResult.json)
       val sourceFileName = parserResult.fullPath
       val fileContent    = new String(Files.readAllBytes(Paths.get(sourceFileName)), Charset.defaultCharset())
+      report.addReportInfo(sourceFileName, fileContent.linesIterator.size, parsed = true)
       new AstCreator(
         sourceFileName,
         projectRoot,

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/RubySrc2Cpg.scala
@@ -17,7 +17,7 @@ import io.joern.x2cpg.frontendspecific.rubysrc2cpg.*
 import io.joern.x2cpg.passes.base.AstLinkerPass
 import io.joern.x2cpg.passes.callgraph.NaiveCallLinker
 import io.joern.x2cpg.passes.frontend.{MetaDataPass, TypeNodePass, XTypeRecoveryConfig}
-import io.joern.x2cpg.utils.ConcurrentTaskUtil
+import io.joern.x2cpg.utils.{ConcurrentTaskUtil, Report}
 import io.joern.x2cpg.{SourceFiles, X2CpgFrontend}
 import io.shiftleft.codepropertygraph.generated.{Cpg, Languages}
 import io.shiftleft.passes.CpgPassBase
@@ -57,6 +57,8 @@ class RubySrc2Cpg(sharedJRubyEnv: Option[JRubyEnvironment] = None) extends X2Cpg
           rubyAstGenRunner = Option(astGenRunner)
           astGenRunner.execute(tmpDir, config)
       }
+      val report = new Report()
+      astGenResult.skippedFiles.foreach(fileName => report.addSkippedFile(fileName, config.inputPath))
 
       val astCreators = ConcurrentTaskUtil
         .runUsingThreadPool(
@@ -89,6 +91,7 @@ class RubySrc2Cpg(sharedJRubyEnv: Option[JRubyEnvironment] = None) extends X2Cpg
         DependencySummarySolverPass(cpg, dependencySummary).createAndApply()
       }
       TypeNodePass.withTypesFromCpg(cpg).createAndApply()
+      report.print()
     }
 
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyAstGenRunner.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyAstGenRunner.scala
@@ -3,9 +3,15 @@ package io.joern.rubysrc2cpg.parser
 import io.joern.rubysrc2cpg.Config
 import io.joern.rubysrc2cpg.parser.RubyAstGenRunner.{ExecutionEnvironment, JRubyEnvironment, astGenMetaData}
 import io.joern.x2cpg.SourceFiles
-import io.joern.x2cpg.astgen.AstGenRunner.{AstGenProgramMetaData, AstGenRunnerResult, DefaultAstGenRunnerResult}
+import io.joern.x2cpg.astgen.AstGenRunner.{
+  AstGenProgramMetaData,
+  AstGenRunnerResult,
+  DefaultAstGenRunnerResult,
+  SkippedFile
+}
 import io.joern.x2cpg.astgen.AstGenRunner
 import io.joern.x2cpg.utils.{Environment, JoernRunfilesLocator}
+import io.shiftleft.semanticcpg.utils.ExternalCommandResult
 import org.jruby.RubyInstanceConfig
 import org.jruby.embed.{LocalContextScope, LocalVariableBehavior, PathType, ScriptingContainer}
 import org.slf4j.LoggerFactory
@@ -52,43 +58,38 @@ class RubyAstGenRunner(config: Config, sharedJRubyEnv: Option[JRubyEnvironment] 
     config.defaultIgnoredFilesRegex.exists(_.matches(filePath))
   }
 
-  override def skippedFiles(in: Path, astGenOut: List[String]): List[String] = {
+  // ruby_ast_gen's JRuby driver logs `[INFO]/[WARN]/[ERR]` lines across both streams; diagnostics for a file may
+  // arrive without the filename repeated, so we associate them with the most recently seen file.
+  override def skippedFiles(in: Path, runResult: ExternalCommandResult): List[SkippedFile] = {
     val diagnosticMap = mutable.LinkedHashMap.empty[String, Seq[String]]
 
-    def addReason(reason: String, lastFile: Option[String] = None) = {
-      val key = lastFile.getOrElse(diagnosticMap.last._1)
-      diagnosticMap.updateWith(key) {
-        case Some(x) => Option(x :+ reason)
-        case None    => Option(reason :: Nil)
+    def addReason(reason: String, lastFile: Option[String] = None): Unit = {
+      val key = lastFile.orElse(diagnosticMap.lastOption.map(_._1))
+      key.foreach { resolvedKey =>
+        diagnosticMap.updateWith(resolvedKey) {
+          case Some(existing) => Some(existing :+ reason)
+          case None           => Some(List(reason))
+        }
       }
     }
 
-    astGenOut.map(_.strip()).foreach {
+    (runResult.stdOut ++ runResult.stdErr).map(_.strip()).foreach {
       case s"[WARN] $reason - $fileName"  => addReason(reason, Option(fileName))
       case s"[ERR] '$fileName' - $reason" => addReason(reason, Option(fileName))
       case s"[ERR] Failed to parse $fileName: $reason" =>
         addReason(s"Failed to parse: $reason", Option(fileName))
       case s"[INFO] Processed: $fileName -> $_" => diagnosticMap.put(fileName, Nil)
-      case s"[INFO] Excluding: $fileName"       => addReason("Skipped", Option(fileName))
+      case s"[INFO] Excluding: $fileName"       => addReason("excluded by file filter", Option(fileName))
       case _                                    => // ignore
     }
 
-    diagnosticMap.flatMap {
-      case (filename, Nil) =>
-        logger.debug(s"Successfully parsed '$filename'")
-        None
-      case (filename, "Skipped" :: Nil) =>
-        logger.debug(s"Skipped '$filename' due to file filter")
-        Option(filename)
-      case (filename, diagnostics) =>
-        logger.warn(
-          s"Parsed '$filename' with the following diagnostics:\n${diagnostics.map(x => s" - $x").mkString("\n")}"
-        )
-        Option(filename)
+    diagnosticMap.collect {
+      case (filename, diagnostics) if diagnostics.nonEmpty =>
+        SkippedFile(filename, diagnostics.mkString("; "))
     }.toList
   }
 
-  override def runAstGenNative(in: String, out: Path, exclude: String, include: String): Try[Seq[String]] = {
+  override def runAstGenNative(in: String, out: Path, exclude: String, include: String): ExternalCommandResult = {
     val scriptTarget = Files.createTempFile("ruby_driver", ".rb")
     try {
       // We use the URI format as this is the best in terms of language agnostic importing
@@ -120,8 +121,6 @@ class RubyAstGenRunner(config: Config, sharedJRubyEnv: Option[JRubyEnvironment] 
       // as we expect that this may be called by multiple threads.
       Files.writeString(scriptTarget, mainScript, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.CREATE)
       executeWithJRuby(scriptTarget)
-    } catch {
-      case tempPathException: Exception => Failure(tempPathException)
     } finally {
       scriptTarget.toFile.delete()
     }
@@ -159,31 +158,36 @@ class RubyAstGenRunner(config: Config, sharedJRubyEnv: Option[JRubyEnvironment] 
         ""
       }
 
-    runAstGenNative(specifiedConfig.inputPath, out, combineIgnoreRegex, "") match {
+    val runResult = Try(runAstGenNative(specifiedConfig.inputPath, out, combineIgnoreRegex, ""))
+    val srcFiles = SourceFiles.determine(
+      out.toString(),
+      Set(".json"),
+      ignoredDefaultRegex = Option(specifiedConfig.defaultIgnoredFilesRegex),
+      ignoredFilesRegex = Option(specifiedConfig.ignoredFilesRegex),
+      ignoredFilesPath = Option(specifiedConfig.ignoredFiles)
+    )
+    val parsed = filterFiles(srcFiles, out)
+    runResult match {
       case Success(result) =>
-        val srcFiles = SourceFiles.determine(
-          out.toString(),
-          Set(".json"),
-          ignoredDefaultRegex = Option(specifiedConfig.defaultIgnoredFilesRegex),
-          ignoredFilesRegex = Option(specifiedConfig.ignoredFilesRegex),
-          ignoredFilesPath = Option(specifiedConfig.ignoredFiles)
-        )
-        val parsed  = filterFiles(srcFiles, out)
-        val skipped = skippedFiles(in, result.toList)
-        DefaultAstGenRunnerResult(parsed, skipped)
-      case Failure(f) =>
-        logger.error(s"\t- running ${astGenMetaData.name} failed!", f)
-        DefaultAstGenRunnerResult()
+        if (!isSuccess(result)) logUnsuccessfulRun(result)
+        DefaultAstGenRunnerResult(parsed, collectSkippedFiles(in, result))
+      case Failure(exception) =>
+        logger.error(s"\t- running ${astGenMetaData.name} failed!", exception)
+        DefaultAstGenRunnerResult(parsed, List.empty)
     }
   }
 
-  private def executeWithJRuby(script: Path): Try[Seq[String]] = {
+  private def executeWithJRuby(script: Path): ExternalCommandResult = {
     Using.resources(new ByteArrayOutputStream(), new ByteArrayOutputStream()) { (outStream, errStream) =>
       container.setOutput(new PrintStream(outStream))
       container.setError(new PrintStream(errStream))
-      Try {
-        container.runScriptlet(PathType.ABSOLUTE, script.toString)
-        (outStream.toString.split("\n").toIndexedSeq ++ errStream.toString.split("\n")).filterNot(_.isBlank)
+      val runResult   = Try(container.runScriptlet(PathType.ABSOLUTE, script.toString))
+      val stdOutLines = outStream.toString.split("\n").toIndexedSeq.filterNot(_.isBlank)
+      val stdErrLines = errStream.toString.split("\n").toIndexedSeq.filterNot(_.isBlank)
+      runResult match {
+        case Success(_) => ExternalCommandResult(0, stdOutLines, stdErrLines, script.toString, None)
+        case Failure(exception) =>
+          ExternalCommandResult(1, stdOutLines, stdErrLines :+ exception.getMessage, script.toString, None)
       }
     }
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/AstCreationPass.scala
@@ -2,6 +2,7 @@ package io.joern.rubysrc2cpg.passes
 
 import flatgraph.DiffGraphApplier
 import io.joern.rubysrc2cpg.astcreation.AstCreator
+import io.joern.x2cpg.utils.{Report, TimeUtils}
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.NodeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.NewTypeDecl
@@ -9,7 +10,8 @@ import io.shiftleft.passes.ForkJoinParallelCpgPass
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 import org.slf4j.LoggerFactory
 
-class AstCreationPass(cpg: Cpg, astCreators: List[AstCreator]) extends ForkJoinParallelCpgPass[AstCreator](cpg) {
+class AstCreationPass(cpg: Cpg, astCreators: List[AstCreator], report: Report = new Report())
+    extends ForkJoinParallelCpgPass[AstCreator](cpg) {
 
   private val logger = LoggerFactory.getLogger(getClass)
 
@@ -36,12 +38,17 @@ class AstCreationPass(cpg: Cpg, astCreators: List[AstCreator]) extends ForkJoinP
   }
 
   override def runOnPart(diffGraph: DiffGraphBuilder, astCreator: AstCreator): Unit = {
-    try {
-      val ast = astCreator.createAst()
-      diffGraph.absorb(ast)
-    } catch {
-      case ex: Exception =>
-        logger.error(s"Error while processing AST for file - ${astCreator.fileName} - ", ex)
+    val (gotCpg, duration) = TimeUtils.time {
+      try {
+        val ast = astCreator.createAst()
+        diffGraph.absorb(ast)
+        true
+      } catch {
+        case ex: Exception =>
+          logger.error(s"Error while processing AST for file - ${astCreator.fileName} - ", ex)
+          false
+      }
     }
+    report.updateReport(astCreator.fileName, cpg = gotCpg, duration)
   }
 }

--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/Rust2Cpg.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/Rust2Cpg.scala
@@ -21,10 +21,10 @@ class Rust2Cpg extends X2CpgFrontend {
       FileUtil.usingTemporaryDirectory("rust2cpgOut") { tmpDir =>
         val report       = new Report()
         val astGenResult = new RustAstGenRunner(config).execute(tmpDir)
-        astGenResult.skippedFiles.foreach(fileName => report.addSkippedFile(fileName, config.inputPath))
+        astGenResult.skippedFiles.foreach(report.addSkippedFile)
         val hash = HashUtil.sha256(astGenResult.parsedFiles.map(Paths.get(_)))
         new MetaDataPass(cpg, Languages.RUST, config.inputPath, Option(hash)).createAndApply()
-        new AstCreationPass(cpg, astGenResult.parsedFiles, config)(config.schemaValidation).createAndApply()
+        new AstCreationPass(cpg, astGenResult.parsedFiles, config, report)(config.schemaValidation).createAndApply()
         new RustTypeNodePass(cpg).createAndApply()
         new RustConfigFileCreationPass(cpg, config).createAndApply()
         report.print()

--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/Rust2Cpg.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/Rust2Cpg.scala
@@ -5,7 +5,7 @@ import io.joern.rust2cpg.passes.{AstCreationPass, RustConfigFileCreationPass, Ru
 import io.joern.x2cpg.X2Cpg.withNewEmptyCpg
 import io.joern.x2cpg.X2CpgFrontend
 import io.joern.x2cpg.passes.frontend.MetaDataPass
-import io.joern.x2cpg.utils.HashUtil
+import io.joern.x2cpg.utils.{HashUtil, Report}
 import io.shiftleft.codepropertygraph.generated.{Cpg, Languages}
 import io.shiftleft.semanticcpg.utils.FileUtil
 
@@ -19,12 +19,15 @@ class Rust2Cpg extends X2CpgFrontend {
   def createCpg(config: Config): Try[Cpg] = {
     withNewEmptyCpg(config.outputPath, config) { (cpg, config) =>
       FileUtil.usingTemporaryDirectory("rust2cpgOut") { tmpDir =>
+        val report       = new Report()
         val astGenResult = new RustAstGenRunner(config).execute(tmpDir)
-        val hash         = HashUtil.sha256(astGenResult.parsedFiles.map(Paths.get(_)))
+        astGenResult.skippedFiles.foreach(fileName => report.addSkippedFile(fileName, config.inputPath))
+        val hash = HashUtil.sha256(astGenResult.parsedFiles.map(Paths.get(_)))
         new MetaDataPass(cpg, Languages.RUST, config.inputPath, Option(hash)).createAndApply()
         new AstCreationPass(cpg, astGenResult.parsedFiles, config)(config.schemaValidation).createAndApply()
         new RustTypeNodePass(cpg).createAndApply()
         new RustConfigFileCreationPass(cpg, config).createAndApply()
+        report.print()
       }
     }
   }

--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astgen/RustAstGenRunner.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astgen/RustAstGenRunner.scala
@@ -2,12 +2,11 @@ package io.joern.rust2cpg.astgen
 
 import io.joern.rust2cpg.Config
 import io.joern.x2cpg.astgen.AstGenRunner
-import io.joern.x2cpg.astgen.AstGenRunner.AstGenProgramMetaData
-import io.shiftleft.semanticcpg.utils.ExternalCommand
+import io.joern.x2cpg.astgen.AstGenRunner.{AstGenProgramMetaData, SkippedFile}
+import io.shiftleft.semanticcpg.utils.{ExternalCommand, ExternalCommandResult}
 import org.slf4j.LoggerFactory
 
 import java.nio.file.Path
-import scala.util.Try
 
 object RustAstGenRunner {
   private val logger = LoggerFactory.getLogger(getClass)
@@ -17,20 +16,23 @@ object RustAstGenRunner {
 
 class RustAstGenRunner(config: Config) extends AstGenRunner(RustAstGenRunner.astGenMetaData, config) {
 
-  override def skippedFiles(in: Path, astGenOut: List[String]): List[String] = {
-    // rust_ast_gen prints to stdout "Skipped: <full-file-path>" for files it failed to process.
-    astGenOut.collect { case s"Skipped: $filePath" => filePath }
+  // rust_ast_gen prints to stdout "Skipped: <full-file-path>" for files it excluded (e.g. out-of-crate); no reason
+  // text is provided. Progress/fatal-error messages go to stderr.
+  override def skippedFiles(in: Path, runResult: ExternalCommandResult): List[SkippedFile] = {
+    runResult.stdOut.collect { case s"Skipped: $filePath" =>
+      SkippedFile(filePath, "not part of the crate/workspace")
+    }.toList
   }
 
-  override def runAstGenNative(in: String, out: Path, exclude: String, include: String): Try[Seq[String]] = {
+  override def runAstGenNative(in: String, out: Path, exclude: String, include: String): ExternalCommandResult = {
     val baseArgs       = Seq(astGenCommand, "-i", in, "-o", out.toString)
     val sysRootArgs    = if (config.noSysRoot) Seq("--no-sysroot") else Seq.empty[String]
     val resolveCfgArgs = if (config.noResolveCfg) Seq.empty[String] else Seq("--resolve-cfg")
     val args           = baseArgs ++ sysRootArgs ++ resolveCfgArgs
-    val result         = ExternalCommand.run(args).logIfFailed()
-    if (result.successful) {
+    val result         = ExternalCommand.run(args)
+    if (isSuccess(result)) {
       result.stdErr.foreach(RustAstGenRunner.logger.info)
     }
-    result.toTry
+    result
   }
 }

--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/passes/AstCreationPass.scala
@@ -4,6 +4,7 @@ import io.joern.rust2cpg.Config
 import io.joern.rust2cpg.astcreation.AstCreator
 import io.joern.rust2cpg.parser.RustJsonParser
 import io.joern.x2cpg.ValidationMode
+import io.joern.x2cpg.utils.{Report, TimeUtils}
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.passes.ForkJoinParallelCpgPass
 import org.slf4j.LoggerFactory
@@ -11,27 +12,35 @@ import org.slf4j.LoggerFactory
 import java.nio.file.Paths
 import scala.util.{Try, Success, Failure}
 
-class AstCreationPass(cpg: Cpg, parsedFiles: Seq[String], config: Config)(implicit withSchemaValidation: ValidationMode)
-    extends ForkJoinParallelCpgPass[String](cpg) {
+class AstCreationPass(cpg: Cpg, parsedFiles: Seq[String], config: Config, report: Report = new Report())(implicit
+  withSchemaValidation: ValidationMode
+) extends ForkJoinParallelCpgPass[String](cpg) {
 
   private val logger = LoggerFactory.getLogger(getClass)
 
   override def generateParts(): Array[String] = parsedFiles.toArray
 
   override def runOnPart(diffGraph: DiffGraphBuilder, jsonPath: String): Unit = {
-    RustJsonParser.readFile(Paths.get(jsonPath)) match {
-      case Success(parseResult) =>
-        Try {
-          val localDiff = new AstCreator(config, parseResult).createAst()
-          diffGraph.absorb(localDiff)
-        } match {
-          case Success(_) =>
-            logger.debug(s"Generated a CPG for '${parseResult.filename}'")
-          case Failure(exception) =>
-            logger.warn(s"Failed to generate a CPG for '${parseResult.fullPath}'", exception)
-        }
-      case Failure(exception) =>
-        logger.warn(s"Failed to parse rust_ast_gen output '$jsonPath'", exception)
+    val ((gotCpg, filename), duration) = TimeUtils.time {
+      RustJsonParser.readFile(Paths.get(jsonPath)) match {
+        case Success(parseResult) =>
+          report.addReportInfo(parseResult.filename, parseResult.loc, parsed = true)
+          Try {
+            val localDiff = new AstCreator(config, parseResult).createAst()
+            diffGraph.absorb(localDiff)
+          } match {
+            case Success(_) =>
+              logger.debug(s"Generated a CPG for '${parseResult.filename}'")
+              (true, parseResult.filename)
+            case Failure(exception) =>
+              logger.warn(s"Failed to generate a CPG for '${parseResult.fullPath}'", exception)
+              (false, parseResult.filename)
+          }
+        case Failure(exception) =>
+          logger.warn(s"Failed to parse rust_ast_gen output '$jsonPath'", exception)
+          (false, jsonPath)
+      }
     }
+    report.updateReport(filename, cpg = gotCpg, duration)
   }
 }

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/astgen/RustAstGenRunnerTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/astgen/RustAstGenRunnerTests.scala
@@ -1,7 +1,7 @@
 package io.joern.rust2cpg.astgen
 
 import io.joern.rust2cpg.Config
-import io.shiftleft.semanticcpg.utils.FileUtil
+import io.shiftleft.semanticcpg.utils.{ExternalCommandResult, FileUtil}
 import io.shiftleft.semanticcpg.utils.FileUtil.*
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -198,15 +198,16 @@ class RustAstGenRunnerTests extends AnyWordSpec with Matchers {
     "collect skipped files" in {
       FileUtil.usingTemporaryDirectory("rust2cpgTestInput") { inputDir =>
         val config = Config().withInputPath(inputDir.toString)
-        val astGenOut =
-          List(
+        val stdOut =
+          Seq(
             "garbage",
             s"Skipped: ${inputDir / "src" / "broken.rs"}",
             "  garbage ",
             s"Skipped: ${inputDir / "src" / "utils" / "mod.rs"}",
             "garbage "
           )
-        new RustAstGenRunner(config).skippedFiles(inputDir, astGenOut) shouldBe List(
+        val runResult = ExternalCommandResult(0, stdOut, Seq.empty, "", None)
+        new RustAstGenRunner(config).skippedFiles(inputDir, runResult).map(_.fileName) shouldBe List(
           (inputDir / "src" / "broken.rs").toString,
           (inputDir / "src" / "utils" / "mod.rs").toString
         )

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/passes/AstCreationPass.scala
@@ -102,7 +102,7 @@ class AstCreationPass(cpg: Cpg, astGenRunnerResult: AstGenRunnerResult, config: 
   }
 
   override def finish(): Unit = {
-    astGenRunnerResult.skippedFiles.foreach(skippedFile => report.addSkippedFile(skippedFile, config.inputPath))
+    astGenRunnerResult.skippedFiles.foreach(report.addSkippedFile)
   }
 
   private def extractFileLocalTypesMap(

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/passes/AstCreationPass.scala
@@ -12,7 +12,6 @@ import io.joern.x2cpg.frontendspecific.swiftsrc2cpg.Defines
 import io.joern.x2cpg.utils.{Report, TimeUtils}
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.passes.ForkJoinParallelCpgPassWithAccumulator
-import io.shiftleft.utils.IOUtils
 import org.slf4j.{Logger, LoggerFactory}
 
 import java.nio.file.Paths
@@ -103,16 +102,7 @@ class AstCreationPass(cpg: Cpg, astGenRunnerResult: AstGenRunnerResult, config: 
   }
 
   override def finish(): Unit = {
-    astGenRunnerResult.skippedFiles.foreach { skippedFile =>
-      val filePath = Paths.get(skippedFile)
-      val fileLOC = Try(IOUtils.readLinesInFile(filePath)) match {
-        case Success(fileContent) => fileContent.size
-        case Failure(exception) =>
-          logger.warn(s"Failed to read file: '$filePath'", exception)
-          -1
-      }
-      report.addReportInfo(skippedFile, fileLOC)
-    }
+    astGenRunnerResult.skippedFiles.foreach(skippedFile => report.addSkippedFile(skippedFile, config.inputPath))
   }
 
   private def extractFileLocalTypesMap(

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/utils/AstGenRunner.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/utils/AstGenRunner.scala
@@ -1,14 +1,14 @@
 package io.joern.swiftsrc2cpg.utils
 
 import io.joern.swiftsrc2cpg.Config
-import io.joern.x2cpg.astgen.AstGenRunner.AstGenProgramMetaData
+import io.joern.x2cpg.astgen.AstGenRunner.{AstGenProgramMetaData, SkippedFile}
 import io.joern.x2cpg.utils.Environment
 import io.joern.x2cpg.utils.Environment.{ArchitectureType, OperatingSystemType}
+import io.shiftleft.semanticcpg.utils.{ExternalCommand, ExternalCommandResult}
 import org.slf4j.LoggerFactory
 
-import java.nio.file.Path
+import java.nio.file.{Path, Paths}
 import java.util.regex.Pattern
-import scala.util.Try
 import scala.util.matching.Regex
 
 object AstGenRunner {
@@ -49,23 +49,48 @@ class AstGenRunner(config: Config) extends io.joern.x2cpg.astgen.AstGenRunner(As
     )
   )
 
-  override protected def skippedFiles(in: Path, astGenOut: List[String]): List[String] = {
-    val skipped = astGenOut.collect {
-      case out if !out.startsWith("Generated") =>
-        val filename = out.substring(out.indexOf(": `") + 3, out.indexOf("swift`") + 5)
-        val reason   = out.substring(out.indexOf("` ") + 2)
-        logger.warn(s"\t- failed to parse '$filename': '$reason'")
-        Option(filename)
-      case out =>
-        logger.debug(s"\t+ $out")
-        None
-    }
-    skipped.flatten
+  // SwiftAstGen writes everything to stdout: `Generated AST for file: `<path>`` on success, and (inferred from the
+  // previous substring-based parser, no reproducible failure fixture exists since SwiftSyntax tolerates most
+  // malformed input) some `<prefix>: `<path>.swift` <reason>` shape for failures.
+  private val FailureLine: Regex = """.*: `(.*?\.swift)`\s*(.*)""".r
+
+  override protected def skippedFiles(in: Path, runResult: ExternalCommandResult): List[SkippedFile] = {
+    runResult.stdOut
+      .collect {
+        case line if !line.startsWith("Generated") =>
+          line match {
+            case FailureLine(file, reason) => Some(SkippedFile(toRelativeInputPath(file, in), reason))
+            case _                         => None
+          }
+      }
+      .flatten
+      .toList
   }
 
-  override protected def runAstGenNative(in: String, out: Path, exclude: String, include: String): Try[Seq[String]] = {
+  // SwiftAstGen exits non-zero on Windows even on success; only treat empty output on Windows as an actual failure.
+  override protected def isSuccess(runResult: ExternalCommandResult): Boolean = {
+    runResult.exitCode == 0 || (scala.util.Properties.isWin && runResult.stdOut.nonEmpty)
+  }
+
+  override protected def logUnsuccessfulRun(runResult: ExternalCommandResult): Unit = {
+    if (scala.util.Properties.isWin && runResult.stdOut.isEmpty && runResult.stdErr.isEmpty) {
+      logger.error("""Unable to execute SwiftAstGen!
+          |On Windows systems Swift needs to be installed.
+          |Please see: https://www.swift.org/install/windows/
+          |""".stripMargin)
+    } else {
+      super.logUnsuccessfulRun(runResult)
+    }
+  }
+
+  override protected def runAstGenNative(
+    in: String,
+    out: Path,
+    exclude: String,
+    include: String
+  ): ExternalCommandResult = {
     val excludeArgs = if (exclude.nonEmpty) Seq("--exclude-regex", exclude) else Seq.empty
-    ExternalCommand.run(Seq(astGenCommand, "-o", out.toString) ++ excludeArgs, in)
+    ExternalCommand.run(Seq(astGenCommand, "-o", out.toString) ++ excludeArgs, Option(Paths.get(in)))
   }
 
 }

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/utils/ExternalCommand.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/utils/ExternalCommand.scala
@@ -1,38 +1,14 @@
 package io.joern.swiftsrc2cpg.utils
 
-import io.shiftleft.semanticcpg.utils.ExternalCommandResult
 import org.slf4j.LoggerFactory
 
 import java.io.{BufferedReader, InputStreamReader, Writer}
 import java.nio.file.Paths
-import scala.util.{Failure, Success, Try, Using}
+import scala.util.{Failure, Success, Using}
 
 object ExternalCommand {
 
   private val logger = LoggerFactory.getLogger(getClass)
-
-  def run(command: Seq[String], workingDir: String): Try[Seq[String]] = {
-    io.shiftleft.semanticcpg.utils.ExternalCommand
-      .run(command, Option(Paths.get(workingDir)), mergeStdErrInStdOut = true) match {
-      case ExternalCommandResult(0, stdOut, _, _, _) =>
-        Success(stdOut)
-      case ExternalCommandResult(_, stdOut, Nil, _, _) if stdOut.nonEmpty =>
-        // SwiftAstGen exits with exit code != 0 on Windows.
-        // To catch with we specifically handle the empty stdErr here.
-        Success(stdOut)
-      case ExternalCommandResult(_, Nil, Nil, _, _) if scala.util.Properties.isWin =>
-        // SwiftAstGen exits with exit code != 0 on Windows
-        // and empty stdOut and stdErr if the Swift runtime is not installed at all
-        Failure(new RuntimeException("""
-            | Unable to execute SwiftAstGen!
-            | On Windows systems Swift needs to be installed.
-            | Please see: https://www.swift.org/install/windows/
-            |""".stripMargin))
-      case other =>
-        Failure(new RuntimeException(other.stdOutAndError.mkString("\n")))
-
-    }
-  }
 
   /** Executes a command and returns the first stdout line that matches a predicate.
     *

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/astgen/AstGenRunner.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/astgen/AstGenRunner.scala
@@ -5,7 +5,7 @@ import io.joern.x2cpg.astgen.AstGenRunner.AstGenProgramMetaData
 import io.joern.x2cpg.utils.Environment.{ArchitectureType, OperatingSystemType}
 import io.joern.x2cpg.utils.{Environment, JoernRunfilesLocator}
 import io.joern.x2cpg.{SourceFiles, X2CpgConfig}
-import io.shiftleft.semanticcpg.utils.ExternalCommand
+import io.shiftleft.semanticcpg.utils.{ExternalCommand, ExternalCommandResult}
 import org.slf4j.LoggerFactory
 import versionsort.VersionHelper
 
@@ -29,6 +29,14 @@ object AstGenRunner {
     */
   case class DefaultAstGenRunnerResult(parsedFiles: List[String] = List.empty, skippedFiles: List[String] = List.empty)
       extends AstGenRunnerResult
+
+  /** A source file that astgen skipped or failed to parse, as reported in the tool's output.
+    * @param fileName
+    *   the file path as reported by the tool (absolute, or relative to the input directory).
+    * @param reason
+    *   the skip/failure reason as reported by the tool.
+    */
+  case class SkippedFile(fileName: String, reason: String)
 
   /** @param name
     *   the name of the AST gen executable, e.g., goastgen, dotnetastgen, swiftastgen, etc.
@@ -63,6 +71,20 @@ object AstGenRunner {
     val resolvedVersionConfigKey: String = versionConfigKey.getOrElse(s"$configPrefix.${name}_version")
   }
 
+  /** Merges the results of multiple sequential astgen invocations (e.g. jssrc2cpg's js/vue/ejs passes) into one,
+    * concatenating both output streams and keeping the last exit code.
+    */
+  def combine(results: ExternalCommandResult*): ExternalCommandResult = {
+    require(results.nonEmpty, "cannot combine an empty sequence of results")
+    ExternalCommandResult(
+      exitCode = results.last.exitCode,
+      stdOut = results.flatMap(_.stdOut),
+      stdErr = results.flatMap(_.stdErr),
+      input = results.map(_.input).mkString("; "),
+      additionalContext = results.flatMap(_.additionalContext).reduceOption((first, second) => s"$first; $second")
+    )
+  }
+
   def isExecutableFile(filePath: String): Boolean = {
     Paths.get(filePath) match {
       case path if !Files.exists(path) =>
@@ -80,6 +102,11 @@ object AstGenRunner {
   }
 }
 
+/** Base class for running the external astgen binaries and harvesting their results.
+  *
+  * The binaries have no common output convention, so both output streams are captured separately and handed to the
+  * frontend-specific [[skippedFiles]] hook.
+  */
 abstract class AstGenRunner(metaData: AstGenProgramMetaData, config: X2CpgConfig[?]) {
 
   import io.joern.x2cpg.astgen.AstGenRunner.*
@@ -178,9 +205,72 @@ abstract class AstGenRunner(metaData: AstGenProgramMetaData, config: X2CpgConfig
     }
   }
 
-  protected def skippedFiles(in: Path, astGenOut: List[String]): List[String]
+  /** Extracts the source files that astgen skipped or failed to parse from the captured run output.
+    *
+    * Implementations must be total functions: unrecognized lines (e.g. log noise on the parsed stream) are ignored,
+    * never thrown on. Use regex extractors rather than `substring`/`indexOf` surgery, which breaks on unexpected input.
+    */
+  protected def skippedFiles(in: Path, runResult: ExternalCommandResult): List[SkippedFile]
 
-  protected def runAstGenNative(in: String, out: Path, exclude: String, include: String): Try[Seq[String]]
+  /** Runs the astgen binary and returns its captured result with both output streams kept separate. Consult the stream
+    * conventions documented on [[AstGenRunner]] when implementing [[skippedFiles]].
+    */
+  protected def runAstGenNative(in: String, out: Path, exclude: String, include: String): ExternalCommandResult
+
+  /** Whether a finished run is considered successful. The default is a zero exit code; frontends whose binary has
+    * unreliable exit codes (e.g. SwiftAstGen on Windows) override this.
+    */
+  protected def isSuccess(runResult: ExternalCommandResult): Boolean = runResult.exitCode == 0
+
+  /** The astgen output files to consider for AST creation. Defaults to all `*.json` files under `out` minus the
+    * user-configured ignores. Frontends with their own filtering policy (e.g. jssrc2cpg) override this.
+    */
+  protected def astGenOutputFiles(out: Path): List[String] =
+    SourceFiles.determine(
+      out.toString,
+      Set(".json"),
+      ignoredFilesRegex = Option(config.ignoredFilesRegex),
+      ignoredFilesPath = Option(config.ignoredFiles)
+    )
+
+  /** Hook for frontend-specific post-processing of the parsed files list (e.g. jssrc2cpg's empty-result warning). */
+  protected def postProcessParsedFiles(parsedFiles: List[String], in: Path): List[String] = parsedFiles
+
+  /** Logs an unsuccessful run. Override to add frontend-specific hints (e.g. missing runtime installations). */
+  protected def logUnsuccessfulRun(runResult: ExternalCommandResult): Unit = {
+    logger.error(s"""\t- running ${metaData.name} failed with exit code ${runResult.exitCode}!
+         |\t- last stderr lines:
+         |${runResult.stdErr.takeRight(20).map(line => s"\t  $line").mkString("\n")}""".stripMargin)
+  }
+
+  /** Drives the frontend's [[skippedFiles]] hook defensively and logs each skipped file uniformly. */
+  protected final def collectSkippedFiles(in: Path, runResult: ExternalCommandResult): List[String] = {
+    val skipped = Try(skippedFiles(in, runResult)) match {
+      case Success(files) => files
+      case Failure(exception) =>
+        logger.warn(s"Unable to extract skipped files from ${metaData.name} output", exception)
+        List.empty
+    }
+    skipped.foreach(skippedFile =>
+      logger.warn(s"\t- failed to parse '${skippedFile.fileName}': '${skippedFile.reason}'")
+    )
+    skipped.map(_.fileName).distinct
+  }
+
+  /** Converts an absolute path reported by a tool into a path relative to the input directory. Handles symlinked input
+    * directories (e.g. macOS `/tmp` vs `/private/tmp`). Non-absolute or unrelated paths are returned unchanged.
+    */
+  protected def toRelativeInputPath(file: String, in: Path): String = {
+    Try {
+      val path = Paths.get(file)
+      if (!path.isAbsolute) {
+        file
+      } else {
+        val candidates = Seq(in.toAbsolutePath.normalize(), in.toFile.getCanonicalFile.toPath)
+        candidates.collectFirst { case base if path.startsWith(base) => base.relativize(path).toString }.getOrElse(file)
+      }
+    }.getOrElse(file)
+  }
 
   // Lazy so path resolution and the version probe run at most once per runner instance.
   protected lazy val astGenCommand: String = {
@@ -232,20 +322,17 @@ abstract class AstGenRunner(metaData: AstGenProgramMetaData, config: X2CpgConfig
   def execute(out: Path): AstGenRunnerResult = {
     val in = Paths.get(config.inputPath)
     logger.info(s"Running ${metaData.name} on '${config.inputPath}'")
-    runAstGenNative(config.inputPath, out, config.ignoredFilesRegex.toString(), "") match {
+    val runResult = Try(runAstGenNative(config.inputPath, out, config.ignoredFilesRegex.toString(), ""))
+    // The output directory is always scanned, even after a failed run: the binaries exit non-zero only on fatal
+    // errors and may still have written partial results up to that point.
+    val parsed = postProcessParsedFiles(filterFiles(astGenOutputFiles(out), out), in)
+    runResult match {
       case Success(result) =>
-        val srcFiles = SourceFiles.determine(
-          out.toString,
-          Set(".json"),
-          ignoredFilesRegex = Option(config.ignoredFilesRegex),
-          ignoredFilesPath = Option(config.ignoredFiles)
-        )
-        val parsed  = filterFiles(srcFiles, out)
-        val skipped = skippedFiles(in, result.toList)
-        DefaultAstGenRunnerResult(parsed, skipped)
-      case Failure(f) =>
-        logger.error(s"\t- running ${metaData.name} failed!", f)
-        DefaultAstGenRunnerResult()
+        if (!isSuccess(result)) logUnsuccessfulRun(result)
+        DefaultAstGenRunnerResult(parsed, collectSkippedFiles(in, result))
+      case Failure(exception) =>
+        logger.error(s"\t- running ${metaData.name} failed!", exception)
+        DefaultAstGenRunnerResult(parsed, List.empty)
     }
   }
 

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/Report.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/Report.scala
@@ -91,23 +91,29 @@ class Report {
     duration: Long = 0
   ): Unit = reports(fileName) = ReportEntry(loc, parsed, cpgGen, duration)
 
-  /** Records a file that the frontend did not parse (e.g. skipped or failed in astgen). The file's line count is read
-    * from disk; relative paths are resolved against `inputPath`. Unreadable files are recorded with LOC `-1`.
+  /** Records a file that the frontend did not parse (e.g. skipped or failed in astgen). LOC is not meaningful for a
+    * file that was never read, so no attempt is made to read it from disk; it is recorded as `-1`.
     */
-  def addSkippedFile(fileName: FileName, inputPath: String): Unit = {
-    val loc = Try {
-      val path = Paths.get(fileName) match {
-        case absolute if absolute.isAbsolute => absolute
-        case relative                        => Paths.get(inputPath).resolve(relative)
-      }
-      IOUtils.readLinesInFile(path).size
-    } match {
-      case Success(loc) => loc
-      case Failure(exception) =>
-        logger.warn(s"Failed to read skipped file: '$fileName'", exception)
-        -1
+  def addSkippedFile(fileName: FileName): Unit = addReportInfo(fileName, loc = -1)
+
+  /** Records a file that was successfully parsed, for frontends whose parse result does not already carry a line count.
+    * The file's line count is read from disk; relative paths are resolved against `inputPath`. Unreadable files are
+    * recorded with LOC `-1`.
+    */
+  def addParsedFile(fileName: FileName, inputPath: String): Unit =
+    addReportInfo(fileName, locOnDisk(fileName, inputPath), parsed = true)
+
+  private def locOnDisk(fileName: FileName, inputPath: String): Int = Try {
+    val path = Paths.get(fileName) match {
+      case absolute if absolute.isAbsolute => absolute
+      case relative                        => Paths.get(inputPath).resolve(relative)
     }
-    addReportInfo(fileName, loc)
+    IOUtils.readLinesInFile(path).size
+  } match {
+    case Success(loc) => loc
+    case Failure(exception) =>
+      logger.warn(s"Failed to read file: '$fileName'", exception)
+      -1
   }
 
   def updateReport(fileName: FileName, cpg: Boolean, duration: Long): Unit =

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/Report.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/Report.scala
@@ -1,8 +1,11 @@
 package io.joern.x2cpg.utils
 
+import io.shiftleft.utils.IOUtils
 import org.slf4j.LoggerFactory
 
+import java.nio.file.Paths
 import scala.collection.concurrent.TrieMap
+import scala.util.{Failure, Success, Try}
 
 object Report {
 
@@ -87,6 +90,25 @@ class Report {
     cpgGen: Boolean = false,
     duration: Long = 0
   ): Unit = reports(fileName) = ReportEntry(loc, parsed, cpgGen, duration)
+
+  /** Records a file that the frontend did not parse (e.g. skipped or failed in astgen). The file's line count is read
+    * from disk; relative paths are resolved against `inputPath`. Unreadable files are recorded with LOC `-1`.
+    */
+  def addSkippedFile(fileName: FileName, inputPath: String): Unit = {
+    val loc = Try {
+      val path = Paths.get(fileName) match {
+        case absolute if absolute.isAbsolute => absolute
+        case relative                        => Paths.get(inputPath).resolve(relative)
+      }
+      IOUtils.readLinesInFile(path).size
+    } match {
+      case Success(loc) => loc
+      case Failure(exception) =>
+        logger.warn(s"Failed to read skipped file: '$fileName'", exception)
+        -1
+    }
+    addReportInfo(fileName, loc)
+  }
 
   def updateReport(fileName: FileName, cpg: Boolean, duration: Long): Unit =
     reports.updateWith(fileName) {


### PR DESCRIPTION
`AstGenRunner`:
- New explicit contract: `runAstGenNative` returns `ExternalCommandResult` (both streams kept separate) instead of a lossy `Try[Seq[String]]`.
- New `SkippedFile(fileName, reason)` case class replaces bare filename strings.
- New hooks: `isSuccess`, `astGenOutputFiles`, `postProcessParsedFiles`, `logUnsuccessfulRun`, `collectSkippedFiles` (defensive, logs uniformly), `toRelativeInputPath` (handles symlinked tmp dirs), and combine for multi-invocation frontends.
- `execute()` is now uniform across all frontends: it always scans the output directory for partial results, even after a failed/thrown run, and always attempts to collect skipped files — six of seven frontends previously discarded everything on failure.

Per-frontend fixes:
- jssrc2cpg: fixed the dead skipped-file parser (was reading stdout, but skip lines are on stderr) — now correctly detects broken files via safe pattern matching.
- swiftsrc2cpg: moved the Windows exit-code workaround into `isSuccess`/`logUnsuccessfulRun`; replaced `substring`/`indexOf` parsing with a safe regex
- gosrc2cpg: fixed a bug where "Failed to generate AST for X" was mis-parsed as filename "Failed"; wired skipped files into Report.
- csharpsrc2cpg: fixed a real misattribution bug where compiler errors got attached to the wrong file under interleaved output — now buffers reasons until the terminating line names the file; wired into Report.
- rubysrc2cpg: same interleaving hardening pattern; `runAstGenNative` now returns a real `ExternalCommandResult` from the in-process JRuby run; added a Report (previously had none).
- abap2cpg / rust2cpg: adapted to the new contract; both gained a Report (abap2cpg had none before) that now records skipped files.