### PR TITLE
[x2cpg][CI] fix flaky FrontendHTTPServerTests and REPL tests on Windows

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/server/FrontendHTTPClient.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/server/FrontendHTTPClient.scala
@@ -40,7 +40,7 @@ case class FrontendHTTPClient(port: Int) {
     })
     HttpRequest
       .newBuilder()
-      .uri(URI.create(s"http://localhost:$port/run"))
+      .uri(URI.create(s"http://127.0.0.1:$port/run"))
       .header("Content-Type", "application/json")
       .POST(BodyPublishers.ofString(body.render()))
       .build()

--- a/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/server/FrontendHTTPServerTests.scala
+++ b/joern-cli/frontends/x2cpg/src/test/scala/io/joern/x2cpg/utils/server/FrontendHTTPServerTests.scala
@@ -24,7 +24,7 @@ class FrontendHTTPServerTests extends AnyWordSpec with Matchers {
   private def post(port: Int, body: String, method: String = "POST"): HttpResponse[String] = {
     val builder = HttpRequest
       .newBuilder()
-      .uri(URI.create(s"http://localhost:$port/run"))
+      .uri(URI.create(s"http://127.0.0.1:$port/run"))
       .header("Content-Type", "application/json")
 
     val req = method match {

--- a/testDistro.py
+++ b/testDistro.py
@@ -347,29 +347,29 @@ class TestRunner:
         """Joern CLI Windows test"""
         import wexpect
         child = wexpect.spawn(f"{self.joern_exe} --nocolors")
-        child.expect("joern>")
+        child.expect("joern>", timeout=60)
         child.sendline("help")
-        child.expect("Welcome to the interactive help system.")
+        child.expect("Welcome to the interactive help system.", timeout=30)
         child.sendline('scala.util.Try(importCode("tests/code/c")).isSuccess')
-        idx = child.expect(["res[0-9]+: Boolean = true", "res[0-9]+: Boolean = false"], timeout=10)
+        idx = child.expect(["res[0-9]+: Boolean = true", "res[0-9]+: Boolean = false"], timeout=60)
         if idx == 1:
             raise RuntimeError("Joern CLI command threw an exception inside the REPL.")
-        child.expect("joern>")
+        child.expect("joern>", timeout=30)
         child.sendline("exit")
-        child.expect(wexpect.EOF)
+        child.expect(wexpect.EOF, timeout=30)
 
     def _joerncli_unix_test(self):
         """Joern CLI Linux and MacOS test"""
         import pexpect
         child = pexpect.spawn(f"{self.joern_exe} --nocolors")
-        child.expect("joern>")
+        child.expect("joern>", timeout=60)
         child.sendline("help")
-        child.expect("Welcome to the interactive help system.", timeout=10)
+        child.expect("Welcome to the interactive help system.", timeout=30)
         child.sendline('scala.util.Try(importCode("tests/code/c")).isSuccess')
-        idx = child.expect(["res[0-9]+: Boolean = true", "res[0-9]+: Boolean = false"], timeout=10)
+        idx = child.expect(["res[0-9]+: Boolean = true", "res[0-9]+: Boolean = false"], timeout=60)
         if idx == 1:
             raise RuntimeError("Joern CLI command threw an exception inside the REPL.")
-        child.expect("joern>")
+        child.expect("joern>", timeout=30)
         child.sendline("exit")
         child.expect(pexpect.EOF, timeout=10)
 


### PR DESCRIPTION
### FrontendHTTPServer

On Windows, `localhost` resolves to both `::1` (IPv6) and `127.0.0.1`
(IPv4), with `::1` listed first. `FrontendHTTPServer.startup()` binds
via `new InetSocketAddress(0)` which resolves to `0.0.0.0` (IPv4
wildcard only). When `HttpClient` picks `::1` first the connection
either fails outright or stalls during TCP fallback; on a loaded CI
machine this can exhaust the 10-second latch window, producing the
intermittent failure:

```
- should not deadlock when called while a handler is in flight *** FAILED ***
  false was not equal to true (FrontendHTTPServerTests.scala:116)
```
E.g., https://github.com/joernio/joern/actions/runs/31480359962/job/93744360643

Fix: use `127.0.0.1` instead of `localhost` in `FrontendHTTPClient.buildRequest()` and the test's `post()` helper. The server is bound to `0.0.0.0` so IPv4 loopback is always reachable.

### REPL tests

Increase REPL test timeouts for loaded Windows CI runners
Commit https://github.com/joernio/joern/commit/ad8ac91344c9598b6a48caba0e05d2621bc479d7 added `importCode("tests/code/c")` to the joerncli REPL
test with a 10-second timeout. On loaded Windows CI machines c2cpg can
easily exceed that, causing an intermittent `wexpect` timeout failure.
Raise the ceiling to 60s for JVM startup and `importCode`, and add
explicit 30s timeouts for all other expect calls that were previously
using undocumented defaults.