### PR TITLE
[rubysrc2cpg] fix `should have at most one incoming AST edge` case

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -964,7 +964,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
           }
           .toList
         val rescueNode = controlStructureNode(x.thenClause.asStatementList, ControlStructureTypes.CATCH, "catch")
-        Ast(rescueNode).withChild(astForStatementList(x.thenClause.asStatementList).withChildren(variables))
+        Ast(rescueNode).withChild(astForStatementList(x.thenClause.asStatementList))
       }
     val elseAst = node.elseClause.map { x =>
       val astForClause = controlStructureNode(x.thenClause.asStatementList, ControlStructureTypes.ELSE, "else")

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/ControlStructureTests.scala
@@ -389,7 +389,6 @@ class ControlStructureTests extends RubyCode2CpgFixture {
         body.ast.isLiteral.code.l shouldBe List("1")
 
         rescue1Struct.controlStructureType shouldBe ControlStructureTypes.CATCH
-        rescue1Struct.ast.isLocal.code.l shouldBe List("e")
         rescue1Struct.ast.isLiteral.code.l shouldBe List("2")
 
         rescue2Struct.controlStructureType shouldBe ControlStructureTypes.CATCH


### PR DESCRIPTION
- fix an issue that caused a `should have at most one incoming AST edge` validation check failure on some LOCAL nodes. 
- `handleVariableOccurrence` on line 958 has a side-effect that directly adds the AST edge to `diffGraph`. 