### PR TITLE
[docs] Fix Docker image tags in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,18 +79,18 @@ There is an experimental partial Bazel build setup. Check bazel.md for further d
 ## Docker based execution
 
 ```
-docker run --rm -it -v /tmp:/tmp -v $(pwd):/app:rw -w /app -t ghcr.io/joernio/joern joern
+docker run --rm -it -v /tmp:/tmp -v $(pwd):/app:rw -w /app -t ghcr.io/joernio/joern:master joern
 ```
 
 To run joern in server mode:
 
 ```
-docker run --rm -it -v /tmp:/tmp -v $(pwd):/app:rw -w /app -t ghcr.io/joernio/joern joern --server
+docker run --rm -it -v /tmp:/tmp -v $(pwd):/app:rw -w /app -t ghcr.io/joernio/joern:master joern --server
 ```
 
 Almalinux 9 requires the CPU to support SSE4.2. For kvm64 VM use the Almalinux 8 version instead.
 ```
-docker run --rm -it -v /tmp:/tmp -v $(pwd):/app:rw -w /app -t ghcr.io/joernio/joern-alma8 joern
+docker run --rm -it -v /tmp:/tmp -v $(pwd):/app:rw -w /app -t ghcr.io/joernio/joern-alma8:master joern
 ```
 
 ## Releases


### PR DESCRIPTION
- Docker images are tagged `:master` (not `:latest`) because the containers workflow is triggered on a schedule/dispatch rather than a semver tag push — `docker/metadata-action` uses the branch name as the tag in that case
- Fixes `ghcr.io/joernio/joern:latest: not found` errors when following the README
