### PR TITLE
[SBT] Unify test fork settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -119,7 +119,10 @@ ThisBuild / resolvers ++= Seq(
   "Google Maven" at "https://maven.google.com/"
 )
 
-ThisBuild / Test / fork := true
+ThisBuild / Test / fork               := true
+ThisBuild / Test / testForkedParallel := true
+
+trapExit := false
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 

--- a/joern-cli/frontends/csharpsrc2cpg/build.sbt
+++ b/joern-cli/frontends/csharpsrc2cpg/build.sbt
@@ -31,7 +31,6 @@ libraryDependencies ++= Seq(
 Compile / doc / scalacOptions ++= Seq("-doc-title", "semanticcpg apidocs", "-doc-version", version.value)
 
 compile / javacOptions ++= Seq("-Xlint:all", "-Xlint:-cast", "-g")
-Test / fork := false
 
 enablePlugins(JavaAppPackaging, LauncherJarPlugin)
 

--- a/joern-cli/frontends/ghidra2cpg/build.sbt
+++ b/joern-cli/frontends/ghidra2cpg/build.sbt
@@ -21,8 +21,9 @@ excludeDependencies ++= Seq(
 
 enablePlugins(JavaAppPackaging, LauncherJarPlugin)
 
-fork        := true
 Test / scalacOptions += "-language:implicitConversions"
+Test / testForkedParallel := false // ghidra is not thread-safe
+
 javaOptions := Seq(
   "-Djava.protocol.handler.pkgs=ghidra.framework.protocol",
   "-Djdk.serialFilterFactory=ghidra.framework.remote.GhidraSerialFilterFactory"

--- a/joern-cli/frontends/javasrc2cpg/build.sbt
+++ b/joern-cli/frontends/javasrc2cpg/build.sbt
@@ -19,8 +19,6 @@ libraryDependencies ++= Seq(
 )
 
 enablePlugins(JavaAppPackaging, LauncherJarPlugin)
-trapExit                      := false
-Global / onChangedBuildSource := ReloadOnSourceChanges
 
 lazy val packTestCode = taskKey[Unit]("Packs test code for JarTypeReader into jars.")
 packTestCode := {

--- a/joern-cli/frontends/jimple2cpg/build.sbt
+++ b/joern-cli/frontends/jimple2cpg/build.sbt
@@ -16,5 +16,5 @@ libraryDependencies ++= Seq(
 dependencyOverrides += "com.google.guava" % "guava" % "33.5.0-jre" // required currently because of the dependencies of soot 4.7.1
 
 enablePlugins(JavaAppPackaging, LauncherJarPlugin)
-trapExit    := false
-Test / fork := true
+
+Test / testForkedParallel := false // soot is not thread-safe

--- a/joern-cli/frontends/jssrc2cpg/build.sbt
+++ b/joern-cli/frontends/jssrc2cpg/build.sbt
@@ -31,7 +31,6 @@ libraryDependencies ++= Seq(
 Compile / doc / scalacOptions ++= Seq("-doc-title", "semanticcpg apidocs", "-doc-version", version.value)
 
 compile / javacOptions ++= Seq("-Xlint:all", "-Xlint:-cast", "-g")
-Test / fork := false
 
 enablePlugins(JavaAppPackaging, LauncherJarPlugin)
 

--- a/joern-cli/frontends/kotlin2cpg/build.sbt
+++ b/joern-cli/frontends/kotlin2cpg/build.sbt
@@ -23,6 +23,5 @@ libraryDependencies ++= Seq(
 )
 
 enablePlugins(JavaAppPackaging, LauncherJarPlugin)
-trapExit    := false
-Test / fork := true
+
 Test / javaOptions ++= Seq("-ea")

--- a/joern-cli/frontends/php2cpg/build.sbt
+++ b/joern-cli/frontends/php2cpg/build.sbt
@@ -39,7 +39,6 @@ phpParseInstallTask := {
 Compile / compile := ((Compile / compile) dependsOn phpParseInstallTask).value
 
 enablePlugins(JavaAppPackaging, LauncherJarPlugin)
-Global / onChangedBuildSource := ReloadOnSourceChanges
 
 /** write the php parser version to the manifest for downstream usage */
 Compile / packageBin / packageOptions +=

--- a/joern-cli/frontends/pysrc2cpg/build.sbt
+++ b/joern-cli/frontends/pysrc2cpg/build.sbt
@@ -13,8 +13,6 @@ libraryDependencies ++= Seq(
 )
 
 enablePlugins(JavaAppPackaging, LauncherJarPlugin)
-trapExit                      := false
-Global / onChangedBuildSource := ReloadOnSourceChanges
 
 val javaCCTask = taskKey[Seq[File]]("Generate compiler code with JavaCC")
 javaCCTask / fileInputs += baseDirectory.value.toGlob / "pythonGrammar.jj"

--- a/joern-cli/frontends/swiftsrc2cpg/build.sbt
+++ b/joern-cli/frontends/swiftsrc2cpg/build.sbt
@@ -37,7 +37,6 @@ libraryDependencies ++= Seq(
 Compile / doc / scalacOptions ++= Seq("-doc-title", "semanticcpg apidocs", "-doc-version", version.value)
 
 compile / javacOptions ++= Seq("-Xlint:all", "-Xlint:-cast", "-g")
-Test / fork := false
 
 enablePlugins(JavaAppPackaging, LauncherJarPlugin)
 


### PR DESCRIPTION
~~For whatever reasons these~~ Because of global state in the past three frontends still had fork off.

- For swiftsrc2cpg this brings a full test run down to 80 seconds (was: 4 minutes) locally on my machine. The CI here should also benefit.
- No frontend doing a hard `exit(1)` can crash the sbt shell anymore.
- Now its explicitly documented (in the SBT file) if a frontend is not thread-safe (jimple with soot and gidhra)

The actual PR that brought that in was: https://github.com/joernio/joern/pull/2180
But what was actually missing is:
`ThisBuild / Test / testForkedParallel := true`
With that, forking + testsuite-parallelism works.