### PR TITLE
[javasrc2cpg] Make warnings when loading archives clearer

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
@@ -179,7 +179,11 @@ class AstCreationPass(config: Config, cpg: Cpg, sourcesOverride: Option[List[Str
               logger.debug(s"Added JarTypeSolver for jar at $path")
             }
           case Failure(exception) =>
-            logger.warn(s"Could not create JarTypeSolver for jar at $path", exception)
+            logger.warn(
+              s"Could not create type solver for archive at $path (${exception.getMessage}). " +
+                s"Types from this archive may be unresolved."
+            )
+            logger.debug(s"Could not create type solver for archive at $path", exception)
         }
       }
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/noncaching/JarTypeSolver.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/noncaching/JarTypeSolver.scala
@@ -140,7 +140,11 @@ class JarTypeSolverBuilder(enableVerboseTypeLogging: Boolean) {
           )
 
         case Failure(e) =>
-          logger.warn(s"Could not load jar at path $archivePath", e.getMessage())
+          logger.warn(
+            s"Could not load archive at $archivePath for type resolution (${e.getMessage}). " +
+              s"Types from this archive may be unresolved."
+          )
+          logger.debug(s"Could not load archive at $archivePath", e)
       }
     }
   }
@@ -192,7 +196,11 @@ class JarTypeSolverBuilder(enableVerboseTypeLogging: Boolean) {
       }
     } catch {
       case ioException: IOException =>
-        logger.warn(s"Could not register exported packages for archive at $archivePath", ioException.getMessage())
+        logger.warn(
+          s"Could not read module exports from archive at $archivePath (${ioException.getMessage}). " +
+            s"Module-scoped type lookups for this archive may fail."
+        )
+        logger.debug(s"Could not read module exports from archive at $archivePath", ioException)
     }
   }
 }


### PR DESCRIPTION
Ran into this when debugging something completely different. Current message style doesn't really tell me the implications, so as a user I don't know what the warning means. This PR changes the style and adds a bit more information about the consequences. It also adds a second log line with the stack trace in debug level.

Examples:
```
WARN  JarTypeSolverBuilder  Could not read module exports from archive at <path> (Invalid CEN header (invalid zip64 extra data field size)). Module-scoped type lookups for this archive may fail.
DEBUG JarTypeSolverBuilder  Could not read module exports from archive at <path>
  <stack trace>
```

```
WARN AstCreationPass Could not create type solver for archive at <path> (<reason>). Types from this archive may be unresolved.
DEBUG AstCreationPass Could not create type solver for archive at <path>
  <stack trace>
```