### PR TITLE
[javasrc2cpg] Fix logic to determine if lib/modules must be used

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
@@ -153,7 +153,7 @@ class AstCreationPass(config: Config, cpg: Cpg, sourcesOverride: Option[List[Str
     }
 
     combinedTypeSolver.addNonCachingTypeSolver(
-      JarTypeSolver.fromPath(jdkPath, config.cacheJdkTypeSolver, enableVerboseTypeLogging)
+      JarTypeSolver.fromPath(jdkPath, config.cacheJdkTypeSolver, enableVerboseTypeLogging, isJdkPath = true)
     )
 
     val sourceTypeSolver =

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/noncaching/JarTypeSolver.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/typesolvers/noncaching/JarTypeSolver.scala
@@ -220,33 +220,26 @@ object JarTypeSolver {
   def fromPath(
     inputPath: String,
     useCache: Boolean = false,
-    enableVerboseTypeLogging: Boolean = false
+    enableVerboseTypeLogging: Boolean = false,
+    isJdkPath: Boolean = false
   ): JarTypeSolver = {
     def createBuilder: JarTypeSolverBuilder = {
       val jarPaths = determineJarPathsAllowEmpty(inputPath)
       val builder  = new JarTypeSolverBuilder(enableVerboseTypeLogging)
-      if (jarPaths.nonEmpty) {
-        logger.info(s"JDK type solver: using ${jarPaths.size} jar/jmod archive(s) under $inputPath")
-        builder.withJars(jarPaths)
-      } else {
-        JrtRuntimeImageClassPath.findRuntimeImage(Paths.get(inputPath)) match {
-          case Some(imageRootPath) =>
-            logger.info(s"JDK type solver: using runtime image at $imageRootPath; search root: $inputPath)")
-            builder
-              .addRuntimeImage(imageRootPath)
-              .recover(exception =>
-                throw new IllegalArgumentException(
-                  s"Could not load JDK runtime image (jrt:) for the image root path=$imageRootPath",
-                  exception
-                )
-              )
-              .get
-          case None =>
-            throw new IllegalArgumentException(
-              s"No .jar or .jmod files found under $inputPath, and no runtime image file at .../lib/modules beneath that path"
+      logger.info(s"JAR/JDK type solver: using ${jarPaths.size} jar/jmod archive(s) under $inputPath")
+      builder.withJars(jarPaths)
+
+      if (isJdkPath && !jarPaths.exists(_.endsWith(".jmod"))) {
+        JrtRuntimeImageClassPath.findRuntimeImage(Paths.get(inputPath)).foreach { imageRootPath =>
+          logger.info(s"JDK type solver: using runtime image at $imageRootPath; search root: $inputPath)")
+          builder
+            .addRuntimeImage(imageRootPath)
+            .recover(exception =>
+              logger.warn(s"Could not load JDK runtime image (jrt:) for the image root path=$imageRootPath", exception)
             )
         }
       }
+      builder
     }
     if (useCache) {
       cache.getOrElseUpdate(inputPath, createBuilder).buildShared

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/typesolvers/JrtRuntimeImageClassPathTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/typesolvers/JrtRuntimeImageClassPathTests.scala
@@ -64,17 +64,4 @@ class JrtRuntimeImageClassPathTests extends AnyWordSpec with Matchers with Befor
       r.getCorrespondingDeclaration.getQualifiedName shouldBe "java.lang.String"
     }
   }
-
-  "JarTypeSolver.fromPath" should {
-
-    "throw IllegalArgumentException when no jars and no runtime image are found" in {
-      FileUtil.usingTemporaryDirectory("jrt-no-jars-no-modules") { tmp =>
-        val exception = the[IllegalArgumentException] thrownBy {
-          JarTypeSolver.fromPath(tmp.toString)
-        }
-        exception.getMessage should include("No .jar or .jmod files found")
-        exception.getMessage should include("no runtime image file")
-      }
-    }
-  }
 }


### PR DESCRIPTION
javasrc2cpg tries to get type information from the JDK (either for the java distribution used to invoke the frontend, or for an override via `JAVA_HOME` or `--jdk-path`).

Getting this information should look like the following:
- Try to find any `.jmod` archives
- If no jmod archives can be found, look for `<jdk_path>/lib/modules`

We generally don't want to do both since this will just use extra memory for no benefit, but the logic to determine whether `lib/modules` must be used was broken, at least for Temurin JDK which uses `lib/modules` instead of jmods. Before, if any `.jar` or `.jmod` was found, we didn't try to look for `lib/modules`. This caused the Temurin issue since `/lib/jrt-fs.jar` was found, skipping the `lib/modules` detection.

This PR updates the logic to only skip the `lib/modules` detection if a `.jmod` archive is found. This does mean it would still be broken for distributions containing jmods but not the complete standard library