### PR TITLE
[rust2cpg] fix dangling identifiers in qualified paths.

### DIFF
--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
@@ -778,10 +778,9 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
 
   // TODO
   private def lowerPathAsFieldAccess(path: Path): Ast = {
-    val lhs = path.path.map(lowerPathAsFieldAccess)
-    lhs match {
-      case None      => visitPathSegment(path.pathSegment)
-      case Some(lhs) => notHandledYet(path)
+    path.path match {
+      case None    => visitPathSegment(path.pathSegment)
+      case Some(_) => notHandledYet(path)
     }
   }
 

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/DeclarationTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/DeclarationTests.scala
@@ -1299,4 +1299,23 @@ class DeclarationTests extends Rust2CpgSuite(noSysRoot = true) {
       }
     }
   }
+
+  "let to a same-named module-qualified path" should {
+    val cpg = code("""
+        |mod entry {
+        |  pub const KIND: i32 = 1;
+        |}
+        |
+        |fn main() {
+        |  let entry = 1;
+        |  let kind = entry::KIND;
+        |}
+        |""".stripMargin)
+
+    "have correct REF edges for the locals" in {
+      cpg.local.nameExact("entry").referencingIdentifiers.inAssignment.code.l shouldBe List("let entry = 1;")
+    }
+
+    // TODO: qualified path lowering.
+  }
 }


### PR DESCRIPTION
Qualified paths are not really handled yet, but this fixes a bug in which their LHS was being visited even if discarded afterward, potentially creating wrong REF edges.