### PR TITLE
[rust2cpg] support or-patterns.

### DIFF
--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
@@ -349,6 +349,7 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
       case wildcardPat: WildcardPat       => Nil
       case literalPat: LiteralPat         => Nil
       case refPat: RefPat                 => createAssignmentsForRefPattern(refPat, mkSourceAst)
+      case orPat: OrPat                   => createAssignmentsForOrPattern(orPat, mkSourceAst)
       case _                              => notHandledYet(pat) :: Nil
     }
   }
@@ -452,6 +453,32 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
       callAst(operatorCallNode(refPat.pat, derefCode, Operators.indirection, Some(typeFullName)), Seq(sourceAst))
     }
     createAssignmentsForPattern(refPat.pat, mkIndirection)
+  }
+
+  private def createAssignmentsForOrPattern(orPat: OrPat, mkSourceAst: () => Ast): Seq[Ast] = {
+    if (collectPatternBindings(orPat).isEmpty) {
+      Nil
+    } else {
+      val sourceAst     = mkSourceAst()
+      val tmpName       = contextStack.nextTmpName()
+      val typeFullName  = sourceAst.rootType.getOrElse(Defines.Any)
+      val tmpLocalAst   = localAst(orPat, tmpName, tmpName, typeFullName)
+      val mkTmpIdentAst = () => identifierAst(orPat, tmpName, tmpName, typeFullName)
+
+      val tmpAssignAst =
+        callAst(assignmentNode(orPat, s"$tmpName = ${sourceAst.rootCodeOrEmpty}"), Seq(mkTmpIdentAst(), sourceAst))
+
+      def mkBranchAst(pat: Pat): Ast = {
+        blockAst(blockNode(pat), createAssignmentsForPattern(pat, mkTmpIdentAst).toList)
+      }
+
+      val branchesAst = orPat.pat.foldRight(Option.empty[Ast]) { (pat, elseAst) =>
+        val conditionAst = Ast(unknownNode(pat, code(pat)))
+        Option(ifThenElseAst(pat, Some(conditionAst), mkBranchAst(pat), elseAst))
+      }
+
+      tmpLocalAst +: tmpAssignAst +: branchesAst.toList
+    }
   }
 
   private def collectPatternBindings(pat: Pat): Seq[(IdentToken, String)] = pat match {

--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
@@ -474,7 +474,7 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
 
       val branchesAst = orPat.pat.foldRight(Option.empty[Ast]) { (pat, elseAst) =>
         val conditionAst = Ast(unknownNode(pat, code(pat)))
-        Option(ifThenElseAst(pat, Some(conditionAst), mkBranchAst(pat), elseAst))
+        Some(ifThenElseAst(pat, Some(conditionAst), mkBranchAst(pat), elseAst))
       }
 
       tmpLocalAst +: tmpAssignAst +: branchesAst.toList

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/DeclarationTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/DeclarationTests.scala
@@ -2,7 +2,7 @@ package io.joern.rust2cpg.passes.ast
 
 import io.joern.rust2cpg.testfixtures.Rust2CpgSuite
 import io.joern.x2cpg.Defines
-import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
+import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.*
 
@@ -1317,5 +1317,35 @@ class DeclarationTests extends Rust2CpgSuite(noSysRoot = true) {
     }
 
     // TODO: qualified path lowering.
+  }
+
+  "let with an or-pattern" should {
+    val cpg = code("""
+        |fn foo(t: (i32, i32)) {
+        | let ((a, 0) | (0, a)) = t;
+        | bar(a);
+        |}
+        |""".stripMargin)
+
+    "have correct locals" in {
+      inside(cpg.method.nameExact("foo").block.local.l) { case aLocal :: tmpLocal :: Nil =>
+        aLocal.name shouldBe "a"
+        aLocal.typeFullName shouldBe "i32"
+        tmpLocal.name shouldBe "<tmp>0"
+        tmpLocal.typeFullName shouldBe "(i32, i32)"
+      }
+    }
+
+    "have correct if control structure" in {
+      inside(cpg.ifBlock.l) { case ifNode :: elseIfNode :: Nil =>
+        ifNode.condition.code.l shouldBe List("(a, 0)")
+        ifNode.whenTrue.isBlock.assignment.code.l shouldBe List("a = <tmp>0.0")
+        ifNode.whenFalse.l shouldBe List(elseIfNode)
+
+        elseIfNode.condition.code.l shouldBe List("(0, a)")
+        elseIfNode.whenTrue.isBlock.assignment.code.l shouldBe List("a = <tmp>0.1")
+        elseIfNode.whenFalse.l shouldBe empty
+      }
+    }
   }
 }

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/MatchTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/MatchTests.scala
@@ -112,4 +112,45 @@ class MatchTests extends Rust2CpgSuite(noSysRoot = true) {
     }
   }
 
+  "match with an or-pattern case" should {
+    val cpg = code("""
+        |struct Point { x: i32, y: i32 }
+        |
+        |fn foo(p: Point) {
+        |  match p {
+        |  Point { x: 0, y: a } | Point { x: a, y: 0 } => bar(a),
+        |  _ => 0,
+        |  };
+        |}
+        |""".stripMargin)
+
+    "have correct locals" in {
+      inside(cpg.local.l) { case tmp0 :: aLocal :: tmp1 :: Nil =>
+        tmp0.name shouldBe "<tmp>0"
+        tmp0.typeFullName shouldBe "rust2cpgtest::Point"
+        aLocal.name shouldBe "a"
+        aLocal.typeFullName shouldBe "i32"
+        tmp1.name shouldBe "<tmp>1"
+        tmp1.typeFullName shouldBe "rust2cpgtest::Point"
+      }
+    }
+
+    "have correct assignments" in {
+      cpg.method.nameExact("foo").block.assignment.code.sorted.l shouldBe
+        List("<tmp>0 = p", "<tmp>1 = <tmp>0", "a = <tmp>1.x", "a = <tmp>1.y")
+    }
+
+    "have correct if control structure" in {
+      inside(cpg.ifBlock.l) { case ifNode :: elseIfNode :: Nil =>
+        ifNode.condition.code.l shouldBe List("Point { x: 0, y: a }")
+        ifNode.whenTrue.isBlock.assignment.code.l shouldBe List("a = <tmp>1.y")
+        ifNode.whenFalse.l shouldBe List(elseIfNode)
+
+        elseIfNode.condition.code.l shouldBe List("Point { x: a, y: 0 }")
+        elseIfNode.whenTrue.isBlock.assignment.code.l shouldBe List("a = <tmp>1.x")
+        elseIfNode.whenFalse.l shouldBe empty
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
Matching an expression `expr` against a pattern `pat1 | pat2` becomes:

```
LOCAL tmp = expr
IF UNKNOWN(pat1) {
  // lower pat1 against tmp
} 
ELSE { 
  IF UNKNOWN(pat2) {
    // lower pat2 against tmp
  }
}
```