### PR TITLE
[rust2cpg] support unit-variant enum declarations.

### DIFF
--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/AstCreator.scala
@@ -157,6 +157,18 @@ class AstCreator(val config: Config, val parseResult: ParseResult)(implicit with
     )
   }
 
+  protected def typeDeclForEnum(enum_ : RustNodeSyntax.Enum): NewTypeDecl = {
+    typeDeclNode(
+      node = enum_,
+      name = code(enum_.name),
+      fullName = typeFullNameForEnum(enum_),
+      filename = parseResult.filename,
+      code = code(enum_),
+      astParentType = contextStack.astParentType,
+      astParentFullName = contextStack.astParentFullName
+    )
+  }
+
   protected def typeDeclForImpl(impl: RustNodeSyntax.Impl): NewTypeDecl = {
     val implType = typeFullNameForType(impl.typ.last)
     val name     = implType.split(RustFullNames.PathSep).lastOption.getOrElse(implType)

--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustFullNames.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustFullNames.scala
@@ -39,6 +39,10 @@ trait RustFullNames { this: AstCreator =>
     struct.typeFullName.getOrElse(composeRustFullName(code(struct.name)))
   }
 
+  protected def typeFullNameForEnum(enum_ : RustNodeSyntax.Enum): String = {
+    enum_.typeFullName.getOrElse(composeRustFullName(code(enum_.name)))
+  }
+
   protected def methodFullNameForCallExpr(
     callExpr: RustNodeSyntax.CallExpr,
     nameRefs: Seq[RustNodeSyntax.NameRef],

--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
@@ -53,7 +53,7 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
 
   private def visitItem(item: Item): Seq[Ast] = item match {
     case const: Const           => visitConst(const)
-    case x: Enum                => notHandledYet(x) :: Nil
+    case enum_ : Enum           => visitEnum(enum_) :: Nil
     case x: ExternBlock         => notHandledYet(x) :: Nil
     case x: ExternCrate         => notHandledYet(x) :: Nil
     case fn: Fn                 => visitFn(fn) :: Nil
@@ -1323,6 +1323,30 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
     val callNode     = operatorCallNode(tryExpr, code(tryExpr), RustOperators.tryUnwrap, Some(typeFullName))
     val exprAst      = visitExpr(tryExpr.expr)
     callAst(callNode, Seq(exprAst))
+  }
+
+  // Enum =
+  //  Attr* Visibility?
+  //  'enum' Name GenericParamList? WhereClause?
+  //  VariantList
+  // TODO(rust_ast_gen): implementedTraits, so we can populate inheritsFrom.
+  private def visitEnum(enum_ : Enum): Ast = {
+    val typeDecl    = typeDeclForEnum(enum_)
+    val variantAsts = enum_.variantList.variant.map(lowerVariant(_, typeDecl.fullName))
+    Ast(typeDecl).withChildren(variantAsts)
+  }
+
+  // Variant =
+  //  Attr* Visibility?
+  //  Name FieldList? ('=' ConstArg)?
+  private def lowerVariant(variant: Variant, enumFullName: String): Ast = variant.fieldList match {
+    case None                     => lowerUnitVariant(variant, enumFullName)
+    case Some(_: RecordFieldList) => notHandledYet(variant)
+    case Some(_: TupleFieldList)  => notHandledYet(variant)
+  }
+
+  private def lowerUnitVariant(variant: Variant, enumFullName: String): Ast = {
+    Ast(memberNode(variant, code(variant.name), code(variant), enumFullName))
   }
 
   // Struct =

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/EnumTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/EnumTests.scala
@@ -1,0 +1,32 @@
+package io.joern.rust2cpg.passes.ast
+
+import io.joern.rust2cpg.testfixtures.Rust2CpgSuite
+import io.shiftleft.semanticcpg.language.*
+
+class EnumTests extends Rust2CpgSuite(noSysRoot = true) {
+
+  "unit variant" should {
+    val cpg = code("""
+        |enum Color { Red, Green }
+        |fn main() {
+        |  let c = Color::Red;
+        |}
+        |""".stripMargin)
+
+    "have correct fullName" in {
+      cpg.typeDecl.nameExact("Color").fullName.l shouldBe List("rust2cpgtest::Color")
+    }
+
+    "have correct members" in {
+      inside(cpg.typeDecl.nameExact("Color").member.l) { case red :: green :: Nil =>
+        red.name shouldBe "Red"
+        red.code shouldBe "Red"
+        red.typeFullName shouldBe "rust2cpgtest::Color"
+
+        green.name shouldBe "Green"
+        green.code shouldBe "Green"
+        green.typeFullName shouldBe "rust2cpgtest::Color"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Anything more than basic unit variants requires astgen updates first, which I'm going to tackle next.