### PR TITLE
[rust2cpg] support record variant enum declarations.

### DIFF
--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/AstCreator.scala
@@ -170,6 +170,20 @@ class AstCreator(val config: Config, val parseResult: ParseResult)(implicit with
     )
   }
 
+  protected def typeDeclForVariant(variant: RustNodeSyntax.Variant, enumFullName: String): NewTypeDecl = {
+    val name = code(variant.name)
+    typeDeclNode(
+      node = variant,
+      name = name,
+      fullName = combineRustFullName(enumFullName, name),
+      filename = parseResult.filename,
+      code = code(variant),
+      astParentType = contextStack.astParentType,
+      astParentFullName = contextStack.astParentFullName,
+      inherits = Seq(enumFullName)
+    )
+  }
+
   protected def typeDeclForImpl(impl: RustNodeSyntax.Impl): NewTypeDecl = {
     val implType = typeFullNameForType(impl.typ.last)
     val name     = implType.split(RustFullNames.PathSep).lastOption.getOrElse(implType)

--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
@@ -1334,7 +1334,11 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
     val enumFullName      = typeFullNameForEnum(enum_)
     val inheritsFrom      = implementedTraits.map(traitFullName => s"<$enumFullName as $traitFullName>")
     val typeDecl          = typeDeclForEnum(enum_, inheritsFrom)
-    val variantAsts       = enum_.variantList.variant.map(lowerVariant(_, typeDecl.fullName))
+
+    contextStack.pushTypeDecl(typeDecl)
+    val variantAsts = enum_.variantList.variant.map(lowerVariant(_, typeDecl.fullName))
+    contextStack.pop()
+
     Ast(typeDecl).withChildren(variantAsts)
   }
 
@@ -1342,13 +1346,23 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
   //  Attr* Visibility?
   //  Name FieldList? ('=' ConstArg)?
   private def lowerVariant(variant: Variant, enumFullName: String): Ast = variant.fieldList match {
-    case None                     => lowerUnitVariant(variant, enumFullName)
-    case Some(_: RecordFieldList) => notHandledYet(variant)
-    case Some(_: TupleFieldList)  => notHandledYet(variant)
+    case None                                   => lowerUnitVariant(variant, enumFullName)
+    case Some(recordFieldList: RecordFieldList) => lowerRecordVariant(variant, enumFullName, recordFieldList)
+    case Some(_: TupleFieldList)                => notHandledYet(variant)
   }
 
   private def lowerUnitVariant(variant: Variant, enumFullName: String): Ast = {
     Ast(memberNode(variant, code(variant.name), code(variant), enumFullName))
+  }
+
+  private def lowerRecordVariant(variant: Variant, enumFullName: String, recordFieldList: RecordFieldList): Ast = {
+    val typeDecl = typeDeclForVariant(variant, enumFullName)
+
+    contextStack.pushTypeDecl(typeDecl)
+    val ctorAst = structCtorMethodAst(variant, typeDecl, recordFieldData(recordFieldList))
+    contextStack.pop()
+
+    Ast(typeDecl).withChildren(visitRecordFieldList(recordFieldList) :+ ctorAst)
   }
 
   // Struct =
@@ -1396,7 +1410,7 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
     val typeDecl          = typeDeclForStruct(struct, inheritsFrom)
 
     contextStack.pushTypeDecl(typeDecl)
-    val ctorAst = structCtorMethodAst(struct, typeDecl, recordStructFieldData(struct))
+    val ctorAst = structCtorMethodAst(struct, typeDecl, recordFieldData(recordFieldList))
     contextStack.pop()
 
     Ast(typeDecl).withChildren(visitRecordFieldList(recordFieldList) :+ ctorAst)
@@ -1512,21 +1526,21 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
     }
   }
 
-  private def recordStructFieldData(struct: Struct): Seq[(node: RustNode, name: String, typ: String)] = {
-    struct.recordFieldList.toSeq.flatMap(_.recordField.map { field =>
+  private def recordFieldData(recordFieldList: RecordFieldList): Seq[(node: RustNode, name: String, typ: String)] = {
+    recordFieldList.recordField.map { field =>
       (node = field, name = code(field.name), typ = typeFullNameForType(field.typ))
-    })
+    }
   }
 
   private def structCtorMethodAst(
-    struct: Struct,
+    node: VariantDef,
     typeDecl: NewTypeDecl,
     fields: Seq[(node: RustNode, name: String, typ: String)]
   ): Ast = {
     val selfName = "self"
-    val method   = methodNode(struct, Defines.ConstructorMethodName).code(Defines.ConstructorMethodName)
+    val method   = methodNode(node, Defines.ConstructorMethodName).code(Defines.ConstructorMethodName)
     val selfParam = parameterInNode(
-      node = struct,
+      node = node,
       name = selfName,
       code = selfName,
       index = 0,
@@ -1566,13 +1580,13 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
     }
 
     val paramAsts = (selfParam +: fieldParams).map(Ast(_))
-    val bodyAst   = blockAst(blockNode(struct), fieldAssignAsts.toList)
+    val bodyAst   = blockAst(blockNode(node), fieldAssignAsts.toList)
     methodAst(
       method = method,
       parameters = paramAsts,
       body = bodyAst,
-      methodReturn = methodReturnNode(struct, "()"),
-      modifiers = Seq(modifierNode(struct, ModifierTypes.CONSTRUCTOR))
+      methodReturn = methodReturnNode(node, "()"),
+      modifiers = Seq(modifierNode(node, ModifierTypes.CONSTRUCTOR))
     )
   }
 

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/EnumTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/EnumTests.scala
@@ -1,6 +1,7 @@
 package io.joern.rust2cpg.passes.ast
 
 import io.joern.rust2cpg.testfixtures.Rust2CpgSuite
+import io.shiftleft.codepropertygraph.generated.ModifierTypes
 import io.shiftleft.semanticcpg.language.*
 
 class EnumTests extends Rust2CpgSuite(noSysRoot = true) {
@@ -26,6 +27,61 @@ class EnumTests extends Rust2CpgSuite(noSysRoot = true) {
         green.name shouldBe "Green"
         green.code shouldBe "Green"
         green.typeFullName shouldBe "rust2cpgtest::Color"
+      }
+    }
+  }
+
+  "record variant" should {
+    val cpg = code("""
+        |enum Color { Named { name: i32 } }
+        |fn main() {
+        |  let c = Color::Named { name: 1 };
+        |}
+        |""".stripMargin)
+
+    "have correct fullName" in {
+      cpg.typeDecl.nameExact("Named").fullName.l shouldBe List("rust2cpgtest::Color::Named")
+    }
+
+    "have correct inheritsFrom" in {
+      cpg.typeDecl
+        .fullNameExact("rust2cpgtest::Color::Named")
+        .inheritsFromTypeFullName
+        .l shouldBe List("rust2cpgtest::Color")
+    }
+
+    "have correct members" in {
+      inside(cpg.typeDecl.nameExact("Named").member.l) { case name :: Nil =>
+        name.name shouldBe "name"
+        name.code shouldBe "name: i32"
+        name.typeFullName shouldBe "i32"
+      }
+    }
+
+    "have correct constructor" in {
+      inside(cpg.typeDecl.nameExact("Named").method.l) { case init :: Nil =>
+        init.name shouldBe "<init>"
+        init.fullName shouldBe "rust2cpgtest::Color::Named::<init>"
+        init.modifier.modifierType.l shouldBe List(ModifierTypes.CONSTRUCTOR)
+        init.methodReturn.typeFullName shouldBe "()"
+      }
+    }
+
+    "have correct constructor parameters" in {
+      inside(cpg.typeDecl.nameExact("Named").method.parameter.sortBy(_.index).l) { case self :: name :: Nil =>
+        self.name shouldBe "self"
+        self.index shouldBe 0
+        self.typeFullName shouldBe "rust2cpgtest::Color::Named"
+        name.name shouldBe "name"
+        name.index shouldBe 1
+        name.typeFullName shouldBe "i32"
+      }
+    }
+
+    "have correct field assignments" in {
+      inside(cpg.typeDecl.nameExact("Named").method.body.astChildren.isCall.l) { case assign :: Nil =>
+        // TODO: pending change to self.name = name, once we remove `&` to <init> calls.
+        assign.code shouldBe "(*self).name = name"
       }
     }
   }


### PR DESCRIPTION
- generalizes `structCtorMethodAst`, which synthesizes an `<init>` method given the parameters
- supports enum record variants by handling them as record structs inheriting from the enum they belong to