### PR TITLE
[rust2cpg] lower type qualified paths as field accesses.

### DIFF
--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
@@ -348,6 +348,7 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
       case tupleStructPat: TupleStructPat => createAssignmentsForTupleStructPattern(tupleStructPat, mkSourceAst)
       case wildcardPat: WildcardPat       => Nil
       case literalPat: LiteralPat         => Nil
+      case pathPat: PathPat               => Nil
       case refPat: RefPat                 => createAssignmentsForRefPattern(refPat, mkSourceAst)
       case orPat: OrPat                   => createAssignmentsForOrPattern(orPat, mkSourceAst)
       case _                              => notHandledYet(pat) :: Nil
@@ -800,14 +801,20 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
   // Path =
   //  (qualifier:Path '::')? segment:PathSegment
   private def visitPath(path: Path): Ast = {
-    lowerPathAsFieldAccess(path)
+    path.path match {
+      case None            => visitPathSegment(path.pathSegment)
+      case Some(qualifier) => lowerQualifiedPath(path, qualifier)
+    }
   }
 
-  // TODO
-  private def lowerPathAsFieldAccess(path: Path): Ast = {
-    path.path match {
-      case None    => visitPathSegment(path.pathSegment)
-      case Some(_) => notHandledYet(path)
+  // TODO: `<Foo as Bar>::baz`, etc.
+  private def lowerQualifiedPath(path: Path, qualifier: Path): Ast = {
+    qualifier.pathSegment.nameRef.flatMap(_.typeFullName) match {
+      case Some(qualifierTypeFullName) =>
+        val typeRefAst = Ast(typeRefNode(qualifier, code(qualifier), qualifierTypeFullName))
+        val fieldName  = code(path.pathSegment)
+        fieldAccessAst(path, path.pathSegment, typeRefAst, code(path), fieldName, typeFullNameForPath(path))
+      case None => notHandledYet(path)
     }
   }
 

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/EnumTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/EnumTests.scala
@@ -30,6 +30,91 @@ class EnumTests extends Rust2CpgSuite(noSysRoot = true) {
         green.typeFullName shouldBe "rust2cpgtest::Color"
       }
     }
+
+    "have correct field access" in {
+      inside(cpg.assignment.where(_.target.isIdentifier.nameExact("c")).source.l) { case (fieldAccess: Call) :: Nil =>
+        fieldAccess.methodFullName shouldBe Operators.fieldAccess
+        fieldAccess.code shouldBe "Color::Red"
+        fieldAccess.typeFullName shouldBe "rust2cpgtest::Color"
+        inside(fieldAccess.argument.sortBy(_.argumentIndex).l) {
+          case (base: TypeRef) :: (field: FieldIdentifier) :: Nil =>
+            base.code shouldBe "Color"
+            base.typeFullName shouldBe "rust2cpgtest::Color"
+            field.canonicalName shouldBe "Red"
+        }
+      }
+    }
+  }
+
+  "module-qualified unit variant" should {
+    val cpg = code("""
+        |mod m {
+        |  pub enum Color { Red }
+        |}
+        |fn main() {
+        |  let c = m::Color::Red;
+        |}
+        |""".stripMargin)
+
+    "have correct fullName" in {
+      cpg.typeDecl.nameExact("Color").fullName.l shouldBe List("rust2cpgtest::m::Color")
+    }
+
+    "have correct members" in {
+      inside(cpg.typeDecl.nameExact("Color").member.l) { case red :: Nil =>
+        red.name shouldBe "Red"
+        red.code shouldBe "Red"
+        red.typeFullName shouldBe "rust2cpgtest::m::Color"
+      }
+    }
+
+    "have correct field access" in {
+      inside(cpg.assignment.where(_.target.isIdentifier.nameExact("c")).source.l) { case (fieldAccess: Call) :: Nil =>
+        fieldAccess.name shouldBe Operators.fieldAccess
+        fieldAccess.code shouldBe "m::Color::Red"
+        fieldAccess.typeFullName shouldBe "rust2cpgtest::m::Color"
+        inside(fieldAccess.argument.sortBy(_.argumentIndex).l) {
+          case (base: TypeRef) :: (field: FieldIdentifier) :: Nil =>
+            base.code shouldBe "m::Color"
+            base.typeFullName shouldBe "rust2cpgtest::m::Color"
+            field.canonicalName shouldBe "Red"
+        }
+      }
+    }
+  }
+
+  "self-qualified unit variant" should {
+    val cpg = code("""
+        |enum Color { Red }
+        |impl Color {
+        |  fn red() -> Color { Self::Red }
+        |}
+        |""".stripMargin)
+
+    "have correct fullName" in {
+      cpg.typeDecl.nameExact("Color").fullName.l shouldBe List("rust2cpgtest::Color")
+    }
+
+    "have correct members" in {
+      inside(cpg.typeDecl.nameExact("Color").member.l) { case red :: Nil =>
+        red.name shouldBe "Red"
+        red.code shouldBe "Red"
+        red.typeFullName shouldBe "rust2cpgtest::Color"
+      }
+    }
+
+    "have correct field access" in {
+      inside(cpg.method.nameExact("red").ast.isCall.nameExact(Operators.fieldAccess).l) { case fieldAccess :: Nil =>
+        fieldAccess.code shouldBe "Self::Red"
+        fieldAccess.typeFullName shouldBe "rust2cpgtest::Color"
+        inside(fieldAccess.argument.sortBy(_.argumentIndex).l) {
+          case (base: TypeRef) :: (field: FieldIdentifier) :: Nil =>
+            base.code shouldBe "Self"
+            base.typeFullName shouldBe "rust2cpgtest::Color"
+            field.canonicalName shouldBe "Red"
+        }
+      }
+    }
   }
 
   "record variant" should {


### PR DESCRIPTION
In particular, unit-variant enum usages are now properly lowered as field accesses.