### PR TITLE
[rust2cpg] support patterns in `for` expressions.

### DIFF
--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
@@ -1005,44 +1005,30 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
   // ForExpr =
   //  Attr* Label? 'for' Pat 'in' iterable:Expr
   //  loop_body:BlockExpr
-  private def visitForExpr(forExpr: ForExpr): Ast = {
-    // TODO: only handling `for x in expr` with `x` an identifier.
-    forExpr.pat match {
-      case identPat: IdentPat =>
-        identPat.name.identToken match {
-          case Some(identToken) => lowerForExprWithIdentPattern(forExpr, identPat)
-          case None =>
-            notHandledYet(forExpr)
-            visitBlockExpr(forExpr.blockExpr)
-        }
-      case _ =>
-        notHandledYet(forExpr)
-        visitBlockExpr(forExpr.blockExpr)
-    }
-  }
-
-  // Lowering `for x in y` as follows:
+  //
+  // Lowering `for pat in y` as follows:
   // BLOCK {
   //   LOCAL tmp
   //   tmp = y.into_iter()
   //   WHILE (UNKNOWN) {
-  //     LOCAL x
-  //     x = tmp.next()
+  //     LOCAL tmp2
+  //     <createLocalsForBindings(pat)>
+  //     tmp2 = tmp.next()
+  //     <createAssignmentsForPattern(pat, tmp2)>
   //     body
   //   }
   // }
   // NB: the condition is currently UNKNOWN. A more faithful lowering would be:
   // WHILE (TRUE) {
   //  match tmp.next() {
-  //    Some(x) => body
-  //    None    => break
+  //    Some(pat) => body
+  //    None      => break
   //  }
-  // But we currently don't lower `match` expressions.
-  // TODO: revisit once match expressions are handled.
-  private def lowerForExprWithIdentPattern(forExpr: ForExpr, identPat: IdentPat): Ast = {
-    val iterable    = forExpr.expr
-    val tmpName     = contextStack.nextTmpName()
-    val tmpLocalAst = localAst(iterable, tmpName, tmpName, Defines.Any)
+  private def visitForExpr(forExpr: ForExpr): Ast = {
+    val iterable     = forExpr.expr
+    val tmpName      = contextStack.nextTmpName()
+    val tmpLocalAst  = localAst(iterable, tmpName, tmpName, Defines.Any)
+    val typeFullName = typeFullNameForPat(forExpr.pat)
 
     // tmp = y.into_iter()
     val intoIterAssignAst = {
@@ -1066,36 +1052,43 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
       )
     }
 
-    // LOCAL x; x = tmp.next()
-    val lhsName      = code(identPat)
-    val typeFullName = typeFullNameForIdentPat(identPat)
-    val localAst_    = localAst(identPat, lhsName, lhsName, typeFullName)
-    val nextAssignAst = {
+    // tmp.next()
+    def mkNextAst(): Ast = {
       val nextName = "next"
-      val nextCode = s"$tmpName.$nextName()"
-      val lhsAst   = identifierAst(identPat, lhsName, lhsName, typeFullName)
       val nextTypeFullName = typeFullName match {
         case Defines.Any => Defines.Any
         case other       => s"core::option::Option<$other>"
       }
       val nextCall = callNode(
-        node = identPat,
-        code = nextCode,
+        node = forExpr.pat,
+        code = s"$tmpName.$nextName()",
         name = nextName,
         methodFullName = combineRustFullName(Defines.UnresolvedNamespace, nextName),
         dispatchType = DispatchTypes.STATIC_DISPATCH,
         signature = None,
         typeFullName = Some(nextTypeFullName)
       )
-      val tmpIdentAst = identifierAst(identPat, tmpName, tmpName, Defines.Any)
-      callAst(
-        assignmentNode(identPat, s"$lhsName = $nextCode"),
-        Seq(lhsAst, callAst(nextCall, Seq.empty, base = Some(tmpIdentAst)))
-      )
+      callAst(nextCall, Seq.empty, base = Some(identifierAst(forExpr.pat, tmpName, tmpName, Defines.Any)))
+    }
+
+    val bindings  = collectPatternBindings(forExpr.pat)
+    val localAsts = createLocalsForBindings(bindings)
+    val bindingAsts = if (bindings.length == 1) {
+      localAsts ++ createAssignmentsForPattern(forExpr.pat, mkNextAst)
+    } else {
+      val itemName       = contextStack.nextTmpName()
+      val itemLocalAst   = localAst(forExpr.pat, itemName, itemName, typeFullName)
+      val mkItemIdentAst = () => identifierAst(forExpr.pat, itemName, itemName, typeFullName)
+      val nextAst        = mkNextAst()
+      val itemAssignAst =
+        callAst(assignmentNode(forExpr.pat, s"$itemName = ${nextAst.rootCodeOrEmpty}"), Seq(mkItemIdentAst(), nextAst))
+      val assignments = createAssignmentsForPattern(forExpr.pat, mkItemIdentAst)
+
+      (itemLocalAst +: localAsts) ++ (itemAssignAst +: assignments)
     }
 
     val stmts        = visitStmtList(forExpr.blockExpr.stmtList)
-    val bodyAst      = Ast(blockNode(forExpr.blockExpr)).withChildren(Seq(localAst_, nextAssignAst) ++ stmts)
+    val bodyAst      = Ast(blockNode(forExpr.blockExpr)).withChildren(bindingAsts ++ stmts)
     val conditionAst = Ast(unknownNode(forExpr, code(forExpr)))
     val whileLoopAst = whileAst(forExpr, Some(conditionAst), Seq(bodyAst))
 

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/ForTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/ForTests.scala
@@ -2,7 +2,7 @@ package io.joern.rust2cpg.passes.ast
 
 import io.joern.rust2cpg.testfixtures.Rust2CpgSuite
 import io.joern.x2cpg.Defines
-import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes}
+import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, Operators}
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.semanticcpg.language.*
 
@@ -134,6 +134,163 @@ class ForTestsWithSysroot extends Rust2CpgSuite(noSysRoot = false) {
       inside(cpg.call.nameExact("foo").argument.l) { case (ident: Identifier) :: Nil =>
         ident.name shouldBe "x"
         ident.typeFullName shouldBe "i32"
+      }
+    }
+  }
+
+  "for loop over tuple pattern" should {
+    val cpg = code("""
+        |fn main(pairs: Vec<(i32, bool)>) {
+        | for (x, y) in pairs {
+        |  foo(x, y);
+        | };
+        |}
+        |""".stripMargin)
+
+    "have correct block children" in {
+      inside(cpg.method.nameExact("main").block.astChildren.isBlock.astChildren.l) {
+        case (tmp: Local) :: (intoIter: Call) :: (loop: ControlStructure) :: Nil =>
+          tmp.name shouldBe "<tmp>0"
+          intoIter.code shouldBe "<tmp>0 = pairs.into_iter()"
+          loop.controlStructureType shouldBe ControlStructureTypes.WHILE
+      }
+    }
+
+    "have correct into_iter assignment" in {
+      inside(cpg.assignment.where(_.target.isIdentifier.nameExact("<tmp>0")).argument.sortBy(_.argumentIndex).l) {
+        case (lhs: Identifier) :: (rhs: Call) :: Nil =>
+          lhs.name shouldBe "<tmp>0"
+          rhs.name shouldBe "into_iter"
+          rhs.code shouldBe "pairs.into_iter()"
+          rhs.methodFullName shouldBe s"${Defines.UnresolvedNamespace}::into_iter"
+          rhs.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+          // TODO(rust_ast_gen): typeFullName for into_iter()/tmp0.
+          pendingUntilFixed(
+            rhs.typeFullName shouldBe "alloc::vec::into_iter::IntoIter<(i32, bool), alloc::alloc::Global>"
+          )
+
+          inside(rhs.argument.l) { case (pairs: Identifier) :: Nil =>
+            pairs.name shouldBe "pairs"
+            pairs.typeFullName shouldBe "alloc::vec::Vec<(i32, bool), alloc::alloc::Global>"
+          }
+      }
+    }
+
+    "have correct locals" in {
+      inside(cpg.whileBlock.astChildren.isBlock.astChildren.isLocal.l) { case tmp :: xLocal :: yLocal :: Nil =>
+        tmp.name shouldBe "<tmp>1"
+        tmp.typeFullName shouldBe "(i32, bool)"
+        xLocal.name shouldBe "x"
+        xLocal.typeFullName shouldBe "i32"
+        yLocal.name shouldBe "y"
+        yLocal.typeFullName shouldBe "bool"
+      }
+    }
+
+    "have correct next assignment" in {
+      inside(cpg.assignment.where(_.target.isIdentifier.nameExact("<tmp>1")).argument.sortBy(_.argumentIndex).l) {
+        case (lhs: Identifier) :: (rhs: Call) :: Nil =>
+          lhs.name shouldBe "<tmp>1"
+          lhs.typeFullName shouldBe "(i32, bool)"
+
+          rhs.name shouldBe "next"
+          rhs.code shouldBe "<tmp>0.next()"
+          // TODO(rust_ast_gen): methodFullName for next().
+          rhs.methodFullName shouldBe s"${Defines.UnresolvedNamespace}::next"
+          rhs.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+          rhs.typeFullName shouldBe "core::option::Option<(i32, bool)>"
+      }
+    }
+
+    "have correct binding assignments" in {
+      inside(cpg.assignment.where(_.target.isIdentifier.nameExact("x")).source.l) { case (fieldAccess: Call) :: Nil =>
+        fieldAccess.methodFullName shouldBe Operators.fieldAccess
+        fieldAccess.code shouldBe "<tmp>1.0"
+        fieldAccess.typeFullName shouldBe "i32"
+      }
+
+      inside(cpg.assignment.where(_.target.isIdentifier.nameExact("y")).source.l) { case (fieldAccess: Call) :: Nil =>
+        fieldAccess.methodFullName shouldBe Operators.fieldAccess
+        fieldAccess.code shouldBe "<tmp>1.1"
+        fieldAccess.typeFullName shouldBe "bool"
+      }
+    }
+  }
+
+  "for loop over record pattern" should {
+    val cpg = code("""
+        |struct Point { x: i32, y: bool }
+        |fn main(points: Vec<Point>) {
+        | for Point { x, y } in points {
+        |  foo(x, y);
+        | };
+        |}
+        |""".stripMargin)
+
+    "have correct block children" in {
+      inside(cpg.method.nameExact("main").block.astChildren.isBlock.astChildren.l) {
+        case (tmp: Local) :: (intoIter: Call) :: (loop: ControlStructure) :: Nil =>
+          tmp.name shouldBe "<tmp>0"
+          intoIter.code shouldBe "<tmp>0 = points.into_iter()"
+          loop.controlStructureType shouldBe ControlStructureTypes.WHILE
+      }
+    }
+
+    "have correct into_iter assignment" in {
+      inside(cpg.assignment.where(_.target.isIdentifier.nameExact("<tmp>0")).argument.sortBy(_.argumentIndex).l) {
+        case (lhs: Identifier) :: (rhs: Call) :: Nil =>
+          lhs.name shouldBe "<tmp>0"
+          rhs.name shouldBe "into_iter"
+          rhs.code shouldBe "points.into_iter()"
+          rhs.methodFullName shouldBe s"${Defines.UnresolvedNamespace}::into_iter"
+          rhs.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+          // TODO(rust_ast_gen): typeFullName for into_iter()/tmp0.
+          pendingUntilFixed(
+            rhs.typeFullName shouldBe "alloc::vec::into_iter::IntoIter<rust2cpgtest::Point, alloc::alloc::Global>"
+          )
+
+          inside(rhs.argument.l) { case (points: Identifier) :: Nil =>
+            points.name shouldBe "points"
+            points.typeFullName shouldBe "alloc::vec::Vec<rust2cpgtest::Point, alloc::alloc::Global>"
+          }
+      }
+    }
+
+    "have correct locals" in {
+      inside(cpg.whileBlock.astChildren.isBlock.astChildren.isLocal.l) { case tmp :: xLocal :: yLocal :: Nil =>
+        tmp.name shouldBe "<tmp>1"
+        // TODO(rust_ast_gen): typeFullName for patterns.
+        pendingUntilFixed(tmp.typeFullName shouldBe "rust2cpgtest::Point")
+        xLocal.name shouldBe "x"
+        xLocal.typeFullName shouldBe "i32"
+        yLocal.name shouldBe "y"
+        yLocal.typeFullName shouldBe "bool"
+      }
+    }
+
+    "have correct next assignment" in {
+      inside(cpg.assignment.where(_.target.isIdentifier.nameExact("<tmp>1")).argument.sortBy(_.argumentIndex).l) {
+        case (lhs: Identifier) :: (rhs: Call) :: Nil =>
+          lhs.name shouldBe "<tmp>1"
+          rhs.name shouldBe "next"
+          rhs.code shouldBe "<tmp>0.next()"
+          // TODO(rust_ast_gen): methodFullName for next().
+          rhs.methodFullName shouldBe s"${Defines.UnresolvedNamespace}::next"
+          rhs.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+      }
+    }
+
+    "have correct binding assignments" in {
+      inside(cpg.assignment.where(_.target.isIdentifier.nameExact("x")).source.l) { case (fieldAccess: Call) :: Nil =>
+        fieldAccess.methodFullName shouldBe Operators.fieldAccess
+        fieldAccess.code shouldBe "<tmp>1.x"
+        fieldAccess.typeFullName shouldBe "i32"
+      }
+
+      inside(cpg.assignment.where(_.target.isIdentifier.nameExact("y")).source.l) { case (fieldAccess: Call) :: Nil =>
+        fieldAccess.methodFullName shouldBe Operators.fieldAccess
+        fieldAccess.code shouldBe "<tmp>1.y"
+        fieldAccess.typeFullName shouldBe "bool"
       }
     }
   }


### PR DESCRIPTION
Originally, only identifiers were allowed. But ever since the support for `let pat = expr` was introduced, this is mostly about wiring the same mechanics in. The astgen TODOS were already found in other tests - once fixed, it shall be easier to find where to update the tests.