### PR TITLE
[rust2cpg] lower tuple (struct) patterns with rest.

### DIFF
--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
@@ -356,41 +356,34 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
   }
 
   private def createAssignmentsForTuplePattern(tuplePat: TuplePat, mkSourceAst: () => Ast): Seq[Ast] = {
-    if (tuplePat.pat.exists(_.isInstanceOf[RestPat])) {
-      // TODO: patterns (x, .., y). From rust_ast_gen, we should type patterns as well.
-      notHandledYet(tuplePat) :: Nil
-    } else {
-      tuplePat.pat.zipWithIndex.flatMap { case (pat, index) =>
-        val fieldName = index.toString
-        val fieldType = typeFullNameForPat(pat)
-        def fieldAccess(): Ast = {
-          val sourceAst  = mkSourceAst()
-          val accessCode = s"${sourceAst.rootCodeOrEmpty}.$fieldName"
-          fieldAccessAst(pat, pat, sourceAst, accessCode, fieldName, fieldType)
-        }
-        createAssignmentsForPattern(pat, fieldAccess)
-      }
-    }
+    createAssignmentsForTupleElements(tuplePat, tuplePat.pat, mkSourceAst)
   }
 
   private def createAssignmentsForTupleStructPattern(
     tupleStructPat: TupleStructPat,
     mkSourceAst: () => Ast
   ): Seq[Ast] = {
-    if (tupleStructPat.pat.exists(_.isInstanceOf[RestPat])) {
-      // TODO: patterns Foo(x, .., y). From rust_ast_gen, we should type patterns as well.
-      notHandledYet(tupleStructPat) :: Nil
-    } else {
-      tupleStructPat.pat.zipWithIndex.flatMap { case (pat, index) =>
-        val fieldName = index.toString
-        val fieldType = typeFullNameForPat(pat)
-        def fieldAccess(): Ast = {
-          val sourceAst  = mkSourceAst()
-          val accessCode = s"${sourceAst.rootCodeOrEmpty}.$fieldName"
-          fieldAccessAst(pat, pat, sourceAst, accessCode, fieldName, fieldType)
-        }
-        createAssignmentsForPattern(pat, fieldAccess)
+    createAssignmentsForTupleElements(tupleStructPat, tupleStructPat.pat, mkSourceAst)
+  }
+
+  // TODO(rust_ast_gen): how many elements the tuple has, so we know how many elements to skip after RestPat.
+  private def createAssignmentsForTupleElements(pat: Pat, elements: Seq[Pat], mkSourceAst: () => Ast): Seq[Ast] = {
+    val (prefix, fromRest) = elements.span(!_.isInstanceOf[RestPat])
+    val assignments = prefix.zipWithIndex.flatMap { case (element, index) =>
+      val fieldName = index.toString
+      val fieldType = typeFullNameForPat(element)
+      def mkFieldAccess(): Ast = {
+        val sourceAst       = mkSourceAst()
+        val fieldAccessCode = s"${sourceAst.rootCodeOrEmpty}.$fieldName"
+        fieldAccessAst(element, element, sourceAst, fieldAccessCode, fieldName, fieldType)
       }
+      createAssignmentsForPattern(element, mkFieldAccess)
+    }
+    val bindingsAfterRest = fromRest.drop(1).flatMap(collectPatternBindings)
+    if (bindingsAfterRest.isEmpty) {
+      assignments
+    } else {
+      assignments :+ notHandledYet(pat)
     }
   }
 

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/DeclarationTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/DeclarationTests.scala
@@ -1348,4 +1348,102 @@ class DeclarationTests extends Rust2CpgSuite(noSysRoot = true) {
       }
     }
   }
+
+  "let with tuple pattern and trailing rest, one binding" should {
+    val cpg = code("""
+        |fn foo(t: (i32, bool)) {
+        | let (a, ..) = t;
+        |}
+        |""".stripMargin)
+
+    "have correct children" in {
+      inside(cpg.method.nameExact("foo").block.astChildren.l) { case (aLocal: Local) :: (aAssign: Call) :: Nil =>
+        aLocal.name shouldBe "a"
+        aLocal.typeFullName shouldBe "i32"
+        aAssign.code shouldBe "a = t.0"
+      }
+    }
+
+    "have correct assignment" in {
+      inside(cpg.assignment.codeExact("a = t.0").argument.sortBy(_.argumentIndex).l) {
+        case (lhs: Identifier) :: (rhs: Call) :: Nil =>
+          lhs.name shouldBe "a"
+          lhs.typeFullName shouldBe "i32"
+          rhs.name shouldBe Operators.fieldAccess
+          rhs.typeFullName shouldBe "i32"
+          inside(rhs.argument.sortBy(_.argumentIndex).l) { case (base: Identifier) :: (field: FieldIdentifier) :: Nil =>
+            base.name shouldBe "t"
+            field.canonicalName shouldBe "0"
+          }
+      }
+    }
+  }
+
+  "let with tuple pattern and trailing rest, two bindings" should {
+    val cpg = code("""
+        |fn foo(t: (i32, bool, &str)) {
+        | let (a, b, ..) = t;
+        |}
+        |""".stripMargin)
+
+    "have correct children" in {
+      inside(cpg.method.nameExact("foo").block.astChildren.l) {
+        case (tmp: Local) :: (aLocal: Local) :: (bLocal: Local) :: (tmpAssign: Call) ::
+            (aAssign: Call) :: (bAssign: Call) :: Nil =>
+          tmp.name shouldBe "<tmp>0"
+          tmp.typeFullName shouldBe "(i32, bool, &str)"
+          tmpAssign.code shouldBe "<tmp>0 = t"
+
+          aLocal.name shouldBe "a"
+          aLocal.typeFullName shouldBe "i32"
+          aAssign.code shouldBe "a = <tmp>0.0"
+
+          bLocal.name shouldBe "b"
+          bLocal.typeFullName shouldBe "bool"
+          bAssign.code shouldBe "b = <tmp>0.1"
+      }
+    }
+  }
+
+  "let with tuple struct pattern, no bindings" should {
+    val cpg = code("""
+        |struct Foo(i32, bool);
+        |fn foo(f: Foo) {
+        | let Foo(..) = f;
+        |}
+        |""".stripMargin)
+
+    "have correct children" in {
+      inside(cpg.method.nameExact("foo").block.astChildren.l) { case (tmp: Local) :: (tmpAssign: Call) :: Nil =>
+        tmp.name shouldBe "<tmp>0"
+        tmpAssign.code shouldBe "<tmp>0 = f"
+      }
+    }
+  }
+
+  "let with tuple pattern and bindings after rest, two bindings" should {
+    val cpg = code("""
+        |fn foo(t: (i32, bool, &str)) {
+        | let (a, .., b) = t;
+        |}
+        |""".stripMargin)
+
+    "have correct children" in {
+      inside(cpg.method.nameExact("foo").block.astChildren.l) {
+        case (tmp: Local) :: (aLocal: Local) :: (bLocal: Local) :: (tmpAssign: Call) ::
+            (aAssign: Call) :: (bAssign: Unknown) :: Nil =>
+          tmp.name shouldBe "<tmp>0"
+          tmpAssign.code shouldBe "<tmp>0 = t"
+
+          aLocal.name shouldBe "a"
+          aLocal.typeFullName shouldBe "i32"
+          aAssign.code shouldBe "a = <tmp>0.0"
+
+          // TODO: update once we lower elements after `..`.
+          bLocal.name shouldBe "b"
+          bLocal.typeFullName shouldBe "&str"
+          bAssign.code shouldBe "(a, .., b)"
+      }
+    }
+  }
 }


### PR DESCRIPTION
Previously, tuple (and tuple struct) patterns with "rest", e.g. `(a, ..)`, were discarded. The main problem is knowing how many elements `..` is skipping in e.g. `(a, .., b)`, and the only good way is to have the astgen tell us that - we could inspect the type, but we would be counting `,` which requires another small parser, and only works if we get the type, hence why it's probably best to retrieve that directly from astgen.

Now, at least the "prefix" elements before the `..` are properly handled. Those after the prefix continue to be lowered as unknown nodes until we make another astgen release.