### PR TITLE
[pysrc2cpg] Change <metaClassCallHandler> and <fakeNew> lowering.

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
@@ -547,7 +547,7 @@ class PythonAstVisitor(
     // We do this to model the __init__ call in a visible way for the data flow tracker.
     // This is done because very often the __init__ call is hidden in a super().__new__ call
     // and we cant yet handle super().
-    val fakeNewMethod = createFakeNewMethod(initParameters)
+    val fakeNewMethod = createFakeNewMethod(initParameters, instanceTypeDeclFullName)
 
     val fakeNewMember = nodeBuilder.memberNode("<fakeNew>", fakeNewMethod.fullName)
     edgeBuilder.astEdge(fakeNewMember, metaTypeDeclNode, contextStack.order.getAndInc)
@@ -732,11 +732,10 @@ class PythonAstVisitor(
   }
 
   /** Creates the method which handles a call to the meta class object. This process is also known as creating a new
-    * instance object, e.g. obj = MyClass(p1). The purpose of the generated function is to adapt between the special
-    * cased instance creation call and a normal call to __new__ (for now <fakeNew>). The adaption is required to in
-    * order to provide TYPE_REF(meta class) as instance argument to __new__/<fakeNew>. So the <metaClassCallHandler>
-    * looks like: def <metaClassCallHandler>(p1): return DYNAMIC_CALL(receiver=TYPE_REF(meta class).<fakeNew>, instance
-    * \= TYPE_REF(meta class), p1)
+    * instance object, e.g. obj = MyClass(p1). This method mimics the semantically relevant parts of the CPython default
+    * implementation of __call__ which is a call to __new__(for now <fakeNew>) and a call to __init__. So the
+    * <metaClassCallHandler> looks like: def <metaClassCallHandler>(arguments): __newInstance =
+    * metaClassTypeRef.<fakeNew>(arguments) __newInstance.<init>(arguments) return __newInstance
     */
   // TODO handle kwArg
   private def createMetaClassCallHandlerMethod(
@@ -777,9 +776,32 @@ class PythonAstVisitor(
           None
         )
 
-        val returnNode = createReturn(Some(fakeNewCall), None, lineAndColumn)
+        val assignmentToNewInstance =
+          createAssignment(createIdentifierNode("__newInstance", Store, lineAndColumn), fakeNewCall, lineAndColumn)
 
-        returnNode :: Nil
+        val (initArguments, initKeywordArguments) = createArguments(parametersWithoutSelf, lineAndColumn)
+        val argumentWithInstance                  = mutable.ArrayBuffer.empty[nodes.NewNode]
+        argumentWithInstance.append(createIdentifierNode("__newInstance", Load, lineAndColumn))
+        argumentWithInstance.appendAll(initArguments)
+
+        val initCall = createInstanceCall(
+          createFieldAccess(
+            createIdentifierNode("__newInstance", Load, lineAndColumn),
+            Constants.initName,
+            lineAndColumn
+          ),
+          createIdentifierNode("__newInstance", Load, lineAndColumn),
+          "",
+          lineAndColumn,
+          initArguments,
+          initKeywordArguments,
+          None
+        )
+
+        val returnNode =
+          createReturn(Some(createIdentifierNode("__newInstance", Load, lineAndColumn)), None, lineAndColumn)
+
+        assignmentToNewInstance :: initCall :: returnNode :: Nil
       },
       returns = None,
       isAsync = false,
@@ -793,11 +815,11 @@ class PythonAstVisitor(
   /** Creates a <fakeNew> method which mimics the behaviour of a default __new__ method (the one you would get if no
     * implementation is present). The reason we use a fake version of the __new__ method it that we wont be able to
     * correctly track through most custom __new__ implementations as they usually call "super.__init__()" and we cannot
-    * yet handle "super". The fake __new__ looks like: {{{def <fakeNew>(cls, p1): __newInstance =
-    * STATIC_CALL(<operator>.alloc) cls.__init__(__newIstance, p1) return __newInstance}}}
+    * yet handle "super". The fake __new__ looks like: def <fakeNew>(cls, arguments): return
+    * STATIC_CALL(<operator>.alloc)
     */
   // TODO handle kwArg
-  private def createFakeNewMethod(initParameters: ast.Arguments): nodes.NewMethod = {
+  private def createFakeNewMethod(initParameters: ast.Arguments, instanceTypeDeclFullName: String): nodes.NewMethod = {
     val newMethodName         = "<fakeNew>"
     val newMethodStubFullName = calculateFullNameFromContext(newMethodName)
 
@@ -820,33 +842,15 @@ class PythonAstVisitor(
       bodyProvider = () => {
         val allocatorCall =
           createNAryOperatorCall(() => ("<operator>.alloc", "<operator>.alloc"), Nil, lineAndColumn)
-        val assignmentToNewInstance =
-          createAssignment(createIdentifierNode("__newInstance", Store, lineAndColumn), allocatorCall, lineAndColumn)
 
-        val (arguments, keywordArguments) = createArguments(parametersWithoutSelf, lineAndColumn)
-        val argumentWithInstance          = mutable.ArrayBuffer.empty[nodes.NewNode]
-        argumentWithInstance.append(createIdentifierNode("__newInstance", Load, lineAndColumn))
-        argumentWithInstance.appendAll(arguments)
+        val returnNode = createReturn(Some(allocatorCall), None, lineAndColumn)
 
-        val initCall = createXDotYCall(
-          () => createIdentifierNode("cls", Load, lineAndColumn),
-          Constants.initName,
-          xMayHaveSideEffects = false,
-          lineAndColumn,
-          argumentWithInstance,
-          keywordArguments,
-          None
-        )
-
-        val returnNode =
-          createReturn(Some(createIdentifierNode("__newInstance", Load, lineAndColumn)), None, lineAndColumn)
-
-        assignmentToNewInstance :: initCall :: returnNode :: Nil
+        returnNode :: Nil
       },
       returns = None,
       isAsync = false,
       methodRefNode = None,
-      returnTypeHint = None,
+      returnTypeHint = Some(instanceTypeDeclFullName),
       lineAndColumn,
       reservedNames = Nil
     )

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/ClassCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/ClassCpgTests.scala
@@ -1,7 +1,7 @@
 package io.joern.pysrc2cpg.cpg
 
 import io.joern.pysrc2cpg.testfixtures.PySrc2CpgFixture
-import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, nodes}
 import io.shiftleft.semanticcpg.language.*
 
 class ClassCpgTests extends PySrc2CpgFixture(withOssDataflow = false) {
@@ -96,6 +96,7 @@ class ClassCpgTests extends PySrc2CpgFixture(withOssDataflow = false) {
 
       val initCall = handlerMethod.topLevelExpressions.isCall.l(1)
       initCall.code shouldBe "__newInstance.__init__(x)"
+      initCall.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
       initCall.receiver.code.head shouldBe "__newInstance.__init__"
       initCall.argument(0).code shouldBe "__newInstance"
       initCall.argument(1).code shouldBe "x"

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/ClassCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/ClassCpgTests.scala
@@ -1,7 +1,7 @@
 package io.joern.pysrc2cpg.cpg
 
 import io.joern.pysrc2cpg.testfixtures.PySrc2CpgFixture
-import io.shiftleft.codepropertygraph.generated.nodes.Call
+import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language.*
 
 class ClassCpgTests extends PySrc2CpgFixture(withOssDataflow = false) {
@@ -73,6 +73,38 @@ class ClassCpgTests extends PySrc2CpgFixture(withOssDataflow = false) {
 
     }
 
+    "have correct metaClassHandler implementation" in {
+      val cpg = code("""class Foo:
+                       |  def __init__(self, x):
+                       |    pass
+                       |""".stripMargin)
+
+      val handlerMethod = cpg.method.name("<metaClassCallHandler>").head
+      handlerMethod.fullName shouldBe "Test0.py:<module>.Foo.<metaClassCallHandler>"
+      handlerMethod.lineNumber shouldBe Some(2)
+
+      handlerMethod.parameter.size shouldBe 1
+      val xParameter = handlerMethod.parameter.head
+      xParameter.name shouldBe "x"
+
+      val newInstanceAssign = handlerMethod.topLevelExpressions.isCall.l(0)
+      newInstanceAssign.code shouldBe "__newInstance = class Foo<meta>(...).<fakeNew>(x)"
+      val fakeNewCall = newInstanceAssign.argumentOption(2).isCall.head
+      fakeNewCall.receiver.code.head shouldBe "class Foo<meta>(...).<fakeNew>"
+      fakeNewCall.argument(0).code shouldBe "class Foo<meta>(...)"
+      fakeNewCall.argument(1).code shouldBe "x"
+
+      val initCall = handlerMethod.topLevelExpressions.isCall.l(1)
+      initCall.code shouldBe "__newInstance.__init__(x)"
+      initCall.receiver.code.head shouldBe "__newInstance.__init__"
+      initCall.argument(0).code shouldBe "__newInstance"
+      initCall.argument(1).code shouldBe "x"
+
+      val returnStmt = handlerMethod.topLevelExpressions.l(2).asInstanceOf[nodes.Return]
+      returnStmt.code shouldBe "return __newInstance"
+      returnStmt.astChildren.head.code shouldBe "__newInstance"
+    }
+
     "have correct full name for func1 method in class" in {
       val cpg = code("""class Foo:
                        |  def func1(self):
@@ -117,7 +149,7 @@ class ClassCpgTests extends PySrc2CpgFixture(withOssDataflow = false) {
 
     val List(bodyMethod)          = cpg.method.name("<body>").l
     val List(block)               = bodyMethod.topLevelExpressions.l
-    val List(_, memberAssignment) = block.astChildren.collectAll[Call].l
+    val List(_, memberAssignment) = block.astChildren.collectAll[nodes.Call].l
     memberAssignment.code shouldBe "cls.AAA = AAA"
   }
 


### PR DESCRIPTION
Move call to `__init__` function from `<fakeNew>` to `<metaClassCallHandler>`
to reflect what CPython implementation is doing.
This results in dataflows from and to `__init__` that do not have
`<fakeNew>` on the path anymore which always was an ugly artifact.
It also saves a few expansion steps by not going via
`__init__<metaClassAdapter>` since we now call `__init__` directly on the
new instance obtained by `<fakeNew>`.
