### PR TITLE
[rust2cpg] handle unnamed const declarations.

### DIFF
--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
@@ -235,10 +235,14 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
   //  ('=' body:Expr)?
   //  WhereClause? ';'
   private def visitConst(const: Const): Seq[Ast] = {
-    (const.name.flatMap(_.identToken), const.expr) match {
-      case (Some(identToken), Some(rhsExpr)) =>
+    (const.name.flatMap(_.identToken), const.underscoreToken, const.expr) match {
+      case (Some(identToken), None, Some(rhsExpr)) =>
         val typeFullName = typeFullNameForType(const.typ)
-        lowerIdentifierDecl(identToken, visitExpr(rhsExpr), typeFullName, code(const))
+        lowerIdentifierDecl(identToken, code(identToken), visitExpr(rhsExpr), typeFullName, code(const))
+      case (None, Some(underscoreToken), Some(rhsExpr)) =>
+        val tmpName      = contextStack.nextTmpName()
+        val typeFullName = typeFullNameForType(const.typ)
+        lowerIdentifierDecl(underscoreToken, tmpName, visitExpr(rhsExpr), typeFullName, code(const))
       case _ => notHandledYet(const) :: Nil
     }
   }
@@ -251,7 +255,7 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
     (static.name.identToken, static.expr) match {
       case (Some(identToken), Some(rhsExpr)) =>
         val typeFullName = typeFullNameForType(static.typ)
-        lowerIdentifierDecl(identToken, visitExpr(rhsExpr), typeFullName, code(static))
+        lowerIdentifierDecl(identToken, code(identToken), visitExpr(rhsExpr), typeFullName, code(static))
       case _ => notHandledYet(static) :: Nil
     }
   }
@@ -503,14 +507,14 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
   // - LOCAL (lhsToken) with given typeFullName
   // - CALL (assignment) for lhsToken = rhsAst
   private def lowerIdentifierDecl(
-    lhsToken: IdentToken,
+    lhsToken: RustToken,
+    lhsName: String,
     rhsAst: Ast,
     typeFullName: String,
     declCode: String
   ): Seq[Ast] = {
-    val lhsName       = code(lhsToken)
-    val local         = localAst(lhsToken, lhsName, code(lhsToken), typeFullName)
-    val lhsAst        = identifierAst(lhsToken, lhsName, code(lhsToken), typeFullName)
+    val local         = localAst(lhsToken, lhsName, lhsName, typeFullName)
+    val lhsAst        = identifierAst(lhsToken, lhsName, lhsName, typeFullName)
     val assignmentAst = callAst(assignmentNode(lhsToken, declCode), Seq(lhsAst, rhsAst))
 
     Seq(local, assignmentAst)

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/DeclarationTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/DeclarationTests.scala
@@ -1446,4 +1446,28 @@ class DeclarationTests extends Rust2CpgSuite(noSysRoot = true) {
       }
     }
   }
+
+  "unnamed top-level const" should {
+    val cpg = code("""
+        |fn foo() {}
+        |const _: () = {
+        |  foo();
+        |};
+        |""".stripMargin)
+
+    "have correct assignment" in {
+      inside(cpg.assignment.l) { case assignment :: Nil =>
+        assignment.code shouldBe "const _: () = {\n  foo();\n};"
+        inside(assignment.argument.sortBy(_.argumentIndex).l) { case (lhs: Identifier) :: (rhs: Block) :: Nil =>
+          lhs.name shouldBe "<tmp>0"
+          lhs.typeFullName shouldBe "()"
+          inside(rhs.astChildren.l) { case (foo: Call) :: Nil =>
+            foo.name shouldBe "foo"
+            foo.methodFullName shouldBe "rust2cpgtest::foo"
+            foo.code shouldBe "foo()"
+          }
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
`const _: () = { ... }` are what derive macros typically lower as. Previously, these were fully discarded. Now, we handle them as if the LHS `_` was a fresh identifier (cf. `nextTmpName`).