### PR TITLE
[pysrc2cpg] Handle `__call__` operator.

### DIFF
--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ContextStack.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/ContextStack.scala
@@ -181,10 +181,10 @@ class ContextStack {
     contextStack.find(_.isInstanceOf[MethodContext]).get.asInstanceOf[MethodContext]
   }
 
-  def findEnclosingTypeDecl(): Option[NewNode] = {
+  def findEnclosingTypeDecl(): Option[NewTypeDecl] = {
     stack.find(_.isInstanceOf[ClassContext]) match {
       case Some(classContext: ClassContext) =>
-        Some(classContext.astParent)
+        Some(classContext.astParent.asInstanceOf[NewTypeDecl])
       case _ => None
     }
   }

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/PythonAstVisitor.scala
@@ -437,6 +437,11 @@ class PythonAstVisitor(
     contextStack.pop()
     edgeBuilder.astEdge(typeDeclNode, contextStack.astParent, contextStack.order.getAndInc)
     createBinding(methodNode, typeDeclNode)
+    if (name == Constants.callName) {
+      contextStack.findEnclosingTypeDecl().foreach { enclosingTypeDecl =>
+        createBinding(methodNode, enclosingTypeDecl)
+      }
+    }
 
     methodNode
   }

--- a/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/ClassCpgTests.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/test/scala/io/joern/pysrc2cpg/cpg/ClassCpgTests.scala
@@ -154,4 +154,18 @@ class ClassCpgTests extends PySrc2CpgFixture(withOssDataflow = false) {
     memberAssignment.code shouldBe "cls.AAA = AAA"
   }
 
+  "__call__ method should be bound into class type decl" in {
+    val cpg = code("""class Foo:
+                     |   def __call__(self, x):
+                     |     pass
+                     |""".stripMargin)
+
+    inside(cpg.typeDecl.name("Foo").l) { case List(typeDecl) =>
+      inside(typeDecl.bindsOut.l) { case List(binding) =>
+        binding.name shouldBe ""
+        binding.signature shouldBe ""
+        binding.boundMethod shouldBe cpg.method.name("__call__").head
+      }
+    }
+  }
 }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/pysrc2cpg/Constants.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/pysrc2cpg/Constants.scala
@@ -13,6 +13,7 @@ object Constants {
 
   val moduleName = "<module>"
   val initName   = "__init__"
+  val callName   = "__call__"
 }
 
 object PythonOperators {


### PR DESCRIPTION
For `__call__` operator methods we now add a binding into the
corresponding classes type decl in addition to the already existing
handling.
