### PR TITLE
[php2cpg] fix annotation name and fullName

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForFunctionsCreator.scala
@@ -284,10 +284,10 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
   }
 
   private def astForAttribute(attribute: PhpAttribute): Ast = {
-    val name     = attribute.name
-    val fullName = composeMethodFullName(name.name)
+    val fullName = attribute.name.name
+    val name     = fullName.split("\\\\").last
     val _annotationNode =
-      annotationNode(attribute, code = name.name, attribute.name.name, fullName)
+      annotationNode(attribute, code = fullName, name, fullName)
     val argsAst = attribute.args.map(astForCallArg)
     annotationAst(_annotationNode, argsAst)
   }

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForFunctionsCreator.scala
@@ -285,7 +285,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
 
   private def astForAttribute(attribute: PhpAttribute): Ast = {
     val fullName = attribute.name.name
-    val name     = fullName.split("\\\\").last
+    val name     = fullName.split('\\').last
     val _annotationNode =
       annotationNode(attribute, code = fullName, name, fullName)
     val argsAst = attribute.args.map(astForCallArg)

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/AnnotationTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/AnnotationTests.scala
@@ -18,6 +18,7 @@ class AnnotationTests extends PhpCode2CpgFixture {
 
       inside(cpg.typeDecl("Foo").annotation.l) { case route :: Nil =>
         route.name shouldBe "Route"
+        route.fullName shouldBe "Route"
         inside(route.astChildren.l) { case arg1 :: Nil =>
           arg1.code shouldBe "\"/api\""
         }
@@ -25,6 +26,7 @@ class AnnotationTests extends PhpCode2CpgFixture {
 
       inside(cpg.method("bar").annotation.l) { case route :: Nil =>
         route.name shouldBe "Route"
+        route.fullName shouldBe "Route"
         inside(route.astChildren.l) { case arg1 :: arg2 :: Nil =>
           arg1.code shouldBe "\"/edit\""
           arg2.code shouldBe "\"hello\""
@@ -33,6 +35,27 @@ class AnnotationTests extends PhpCode2CpgFixture {
 
       inside(cpg.method.name("bar").parameter.name("pBar").annotation.l) { case someAttr :: Nil =>
         someAttr.name shouldBe "SomeAttr"
+        someAttr.fullName shouldBe "SomeAttr"
+      }
+    }
+
+    "have fullName equal to the annotation type name for namespaced attributes" in {
+      val cpg = code("""
+          |<?php
+          |namespace App;
+          |use PhpMcp\Server\Attributes\McpTool;
+          |
+          |class CalculatorElements {
+          |  #[McpTool(name: 'calculate_power')]
+          |  public function power(): float {
+          |    return 1.0;
+          |  }
+          |}
+          |""".stripMargin)
+
+      inside(cpg.method("power").annotation.l) { case mcpTool :: Nil =>
+        mcpTool.name shouldBe "McpTool"
+        mcpTool.fullName shouldBe "PhpMcp\\Server\\Attributes\\McpTool"
       }
     }
   }


### PR DESCRIPTION
- Fix the `name` and `fullName` properties of annotations

fixes https://harness.atlassian.net/browse/QT-921

```scala
Annotation(
    argumentIndex = -1,
    argumentLabel = None,
    argumentName = None,
    code = """PhpMcp\Server\Attributes\McpTool""",
    columnNumber = None,
    depthFirstOrder = -1,
    fullName = """PhpMcp\Server\Attributes\McpTool""",
    internalFlags = 0,
    lineNumber = Some(value = 26),
    name = "McpTool",
    offset = None,
    offsetEnd = None,
    order = 8
  )
```