### PR TITLE
[rust2cpg] handle impls for unknown traits.

### DIFF
--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/AstCreator.scala
@@ -209,7 +209,7 @@ class AstCreator(val config: Config, val parseResult: ParseResult)(implicit with
     typeDeclNode(
       node = impl,
       name = name,
-      fullName = typeFullNameForTraitImpl(impl, implTypeFullName, traitTypeFullName),
+      fullName = impl.typeFullName.getOrElse(traitImplFullName(implTypeFullName, traitTypeFullName)),
       filename = parseResult.filename,
       code = code(impl),
       inherits = Seq(traitTypeFullName)

--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustFullNames.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustFullNames.scala
@@ -47,18 +47,6 @@ trait RustFullNames { this: AstCreator =>
     impl.typeFullName.getOrElse(typeFullNameForType(impl.typ.last))
   }
 
-  protected def typeFullNameForTraitImpl(
-    impl: RustNodeSyntax.Impl,
-    implTypeFullName: String,
-    traitTypeFullName: String
-  ): String = {
-    if (traitTypeFullName == Defines.Any) {
-      traitImplFullName(implTypeFullName, traitTypeFullName)
-    } else {
-      impl.typeFullName.getOrElse(traitImplFullName(implTypeFullName, traitTypeFullName))
-    }
-  }
-
   protected def methodFullNameForCallExpr(
     callExpr: RustNodeSyntax.CallExpr,
     nameRefs: Seq[RustNodeSyntax.NameRef],

--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
@@ -583,12 +583,16 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
   //  'impl' GenericParamList? ('const'? '!'? Type 'for')? Type WhereClause?
   //  AssocItemList
   private def visitImpl(impl: Impl): Seq[Ast] = {
-    if (impl.forKwToken.isDefined) {
+    if (impl.forKwToken.isDefined && hasResolvedTrait(impl)) {
       lowerImplFor(impl) :: Nil
     } else {
       lowerInherentImplAsDetachedAst(impl)
       Nil
     }
+  }
+
+  private def hasResolvedTrait(impl: Impl): Boolean = {
+    impl.typ.headOption.exists(typeFullNameForType(_) != Defines.Any)
   }
 
   // There can be at most one `impl X for Y` (for some X, Y) in the same file/project.

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/ImplTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/ImplTests.scala
@@ -515,6 +515,56 @@ class ImplTests extends Rust2CpgSuite(noSysRoot = true) {
     }
   }
 
+  "impl for an unknown trait" should {
+    val cpg = code("""
+        |struct Foo;
+        |impl Unknown for Foo { fn bar(&self) {} }
+        |""".stripMargin)
+
+    "have correct typeDecl" in {
+      inside(cpg.typeDecl.nameExact("Foo").l) { case typeDecl :: Nil =>
+        typeDecl.fullName shouldBe "rust2cpgtest::Foo"
+        typeDecl.inheritsFromTypeFullName shouldBe empty
+      }
+    }
+
+    "have correct methodFullName" in {
+      cpg.typeDecl.fullNameExact("rust2cpgtest::Foo").method.fullName.sorted.l shouldBe List(
+        "rust2cpgtest::Foo::<init>",
+        "rust2cpgtest::Foo::bar"
+      )
+    }
+  }
+
+  "two impls for unkwnown traits on the same type" should {
+    val cpg = code("""
+        |struct Foo;
+        |impl UnknownA for Foo { fn a(&self) {} }
+        |impl UnknownB for Foo { fn b(&self) {} }
+        |fn run(f: Foo) { f.a(); f.b(); }
+        |""".stripMargin)
+
+    "have correct typeDecl" in {
+      inside(cpg.typeDecl.nameExact("Foo").l) { case typeDecl :: Nil =>
+        typeDecl.fullName shouldBe "rust2cpgtest::Foo"
+        typeDecl.inheritsFromTypeFullName shouldBe empty
+      }
+    }
+
+    "have correct methodFullName" in {
+      cpg.typeDecl.fullNameExact("rust2cpgtest::Foo").method.fullName.sorted.l shouldBe List(
+        "rust2cpgtest::Foo::<init>",
+        "rust2cpgtest::Foo::a",
+        "rust2cpgtest::Foo::b"
+      )
+    }
+
+    "have correct call methodFullName" in {
+      cpg.call.nameExact("a").methodFullName.l shouldBe List("<unresolvedNamespace>::a")
+      cpg.call.nameExact("b").methodFullName.l shouldBe List("<unresolvedNamespace>::b")
+    }
+  }
+
   "impls for structs with lifetimes" should {
     val cpg = code("""
         |trait Bar { fn a(&self); }


### PR DESCRIPTION
Two unknown-trait impls on a same type, e.g.

```rust
impl UnknownA for Foo {}
impl UnknownB for Foo {}
```

would emit two correspondingly same-named TypeDecls `<Foo as ANY>`, which is a violation. We now only create such TypeDecl if the trait is known, and the trait methods are otherwise attached to the target type's (e.g. `Foo`) TypeDecl.