### PR TITLE
[all] standardize per-file processing log messages across all frontends

### DIFF
--- a/joern-cli/frontends/abap2cpg/src/main/scala/io/joern/abap2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/abap2cpg/src/main/scala/io/joern/abap2cpg/passes/AstCreationPass.scala
@@ -22,12 +22,12 @@ class AstCreationPass(cpg: Cpg, jsonFiles: List[String], config: Config) extends
 
     parser.parseFile(Paths.get(jsonFile)) match {
       case Success(program) =>
-        logger.debug(s"Generating CPG for: ${program.fileName}")
         val astCreator = new AstCreator(program, program.fileName)
         val generated  = astCreator.createAst()
         diffGraph.absorb(generated)
+        logger.debug(s"Processed '${program.fileName}'")
       case Failure(exception) =>
-        logger.warn(s"Failed to parse '$jsonFile': ${exception.getMessage}")
+        logger.warn(s"Failed to process '$jsonFile'", exception)
     }
   }
 }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/passes/AstCreationPass.scala
@@ -195,7 +195,7 @@ class AstCreationPass(
                 config.schemaValidation
               ).createAst()
             diffGraph.absorb(localDiff)
-            logger.debug(s"Generated a CPG for: '$relPath'")
+            logger.debug(s"Processed ‘$relPath’")
             true
           } catch {
             case s: StackOverflowError =>
@@ -204,10 +204,10 @@ class AstCreationPass(
                 *   - `StackOverflowError` is a `VirtualMachineError`. Without an explicit catch, failing type analysis
                 *     in a single problematic file would crash the whole process.
                 */
-              logger.warn(s"Failed to generate a CPG for: '$relPath' (error during type analysis)", s)
+              logger.warn(s"Failed to process ‘$relPath’", s)
               false
             case other: Throwable =>
-              logger.warn(s"Failed to generate a CPG for: '$relPath'", other)
+              logger.warn(s"Failed to process ‘$relPath’", other)
               false
           }
         case None =>

--- a/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/csharpsrc2cpg/src/main/scala/io/joern/csharpsrc2cpg/passes/AstCreationPass.scala
@@ -27,10 +27,10 @@ class AstCreationPass(cpg: Cpg, astCreators: Seq[AstCreator], report: Report)
         diffGraph.absorb(localDiff)
       } match {
         case Failure(exception) =>
-          logger.warn(s"Failed to generate a CPG for: '$fullPath'", exception)
+          logger.warn(s"Failed to process '$fullPath'", exception)
           (false, astCreator.relativeFileName)
         case Success(_) =>
-          logger.info(s"Generated a CPG for: '$fullPath'")
+          logger.debug(s"Processed '$fullPath'")
           (true, astCreator.relativeFileName)
       }
     }

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/passes/AstCreationPass.scala
@@ -35,10 +35,10 @@ class AstCreationPass(
         diffGraph.absorb(localDiff)
       } match {
         case Failure(exception) =>
-          logger.warn(s"Failed to generate a CPG for: '${astCreator.parserResult.fullPath}'", exception)
+          logger.warn(s"Failed to process '${astCreator.parserResult.fullPath}'", exception)
           (false, astCreator.relPathFileName)
         case Success(_) =>
-          logger.info(s"Generated a CPG for: '${astCreator.parserResult.fullPath}'")
+          logger.debug(s"Processed '${astCreator.parserResult.fullPath}'")
           (true, astCreator.relPathFileName)
       }
     }

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/passes/BasePassForAstProcessing.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/passes/BasePassForAstProcessing.scala
@@ -31,7 +31,7 @@ abstract class BasePassForAstProcessing(
       )
     } catch
       case exception: Exception =>
-        logger.error(s"error while processing file $ast", exception)
+        logger.warn(s"Failed to process '$ast'", exception)
   }
 
   def processAst(diffGraph: DiffGraphBuilder, astCreator: AstCreator): Unit

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/passes/DependencySrcProcessorPass.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/passes/DependencySrcProcessorPass.scala
@@ -25,9 +25,9 @@ class DependencySrcProcessorPass(
       astCreator.buildCacheFromDepSrc()
     } match {
       case Failure(exception) =>
-        logger.warn(s"Failed to build the pre processing cache: '${astCreator.parserResult.fullPath}'", exception)
+        logger.warn(s"Failed to build the pre processing cache for '${astCreator.parserResult.fullPath}'", exception)
       case Success(_) =>
-        logger.info(s"Generated pre processing cache for: '${astCreator.parserResult.fullPath}'")
+        logger.debug(s"Generated pre processing cache for '${astCreator.parserResult.fullPath}'")
     }
   }
 }

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/passes/InitialMainSrcPass.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/passes/InitialMainSrcPass.scala
@@ -25,9 +25,9 @@ class InitialMainSrcPass(
       diffGraph.absorb(astCreator.buildCacheFromMainSrc())
     } match {
       case Failure(exception) =>
-        logger.warn(s"Failed to build the pre processing cache: '${astCreator.parserResult.fullPath}'", exception)
+        logger.warn(s"Failed to build the pre processing cache for '${astCreator.parserResult.fullPath}'", exception)
       case Success(_) =>
-        logger.info(s"Generated pre processing cache for: '${astCreator.parserResult.fullPath}'")
+        logger.debug(s"Generated pre processing cache for '${astCreator.parserResult.fullPath}'")
     }
   }
 }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/astcreation/AstCreator.scala
@@ -224,10 +224,10 @@ class AstCreator(
       Ast(namespaceBlock).withChildren(typeDeclAsts).withChildren(importNodes)
     } catch {
       case exception: UnsolvedSymbolException =>
-        logger.warn(s"Unsolved symbol exception caught in $filename", exception)
+        logger.warn(s"Unsolved symbol exception caught in '$filename'", exception)
         Ast()
       case t: Throwable =>
-        logger.warn(s"Parsing file $filename failed", t)
+        logger.warn(s"Failed to process '$filename'", t)
         Ast()
     }
   }
@@ -276,7 +276,7 @@ class AstCreator(
       // This is really, really ugly, but there's a bug in the JavaParser symbol solver that can lead to
       // unterminated recursion in some cases where types cannot be resolved.
       case e: StackOverflowError =>
-        logger.debug(s"Caught StackOverflowError in $filename")
+        logger.debug(s"Caught StackOverflowError in '$filename'")
         Failure(e)
     }
   }

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
@@ -67,8 +67,9 @@ class AstCreationPass(config: Config, cpg: Cpg, sourcesOverride: Option[List[Str
           )(config.schemaValidation, config.disableTypeFallback)
             .createAst()
         )
+        logger.debug(s"Processed '$filename'")
 
-      case None => logger.warn(s"Skipping AST creation for $filename")
+      case None => logger.warn(s"Failed to process '$filename'")
     }
   }
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/SourceParser.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/SourceParser.scala
@@ -78,16 +78,15 @@ class SourceParser(
     parseResult.getProblems.asScala.toList match {
       case Nil => // Just carry on as usual
       case problems =>
-        logger.warn(s"Encountered problems while parsing file ${file.fileName}:")
-        problems.foreach { problem =>
-          logger.warn(s"- ${problem.getMessage}")
-        }
+        logger.warn(
+          s"Encountered problems while parsing '${file.fileName}': ${problems.map(_.getMessage).mkString("; ")}"
+        )
     }
 
     parseResult.getResult.toScala match {
       case Some(result) if result.getParsed == Parsedness.PARSED => Some(result)
       case _ =>
-        logger.warn(s"Failed to parse file ${file.fileName}")
+        logger.warn(s"Failed to process '${file.fileName}'")
         None
     }
   }

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreationPass.scala
@@ -68,9 +68,10 @@ class AstCreationPass(classFiles: List[ClassFile], cpg: Cpg, config: Config)
         )
           .createAst()
       builder.absorb(localDiff)
+      logger.debug(s"Processed '${classFile.file.absolutePathAsString}'")
     } catch {
       case e: Exception =>
-        logger.warn(s"Exception on AST creation for ${classFile.file.absolutePathAsString}", e)
+        logger.warn(s"Failed to process '${classFile.file.absolutePathAsString}'", e)
         Iterator()
     }
   }

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/SootAstCreationPass.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/SootAstCreationPass.scala
@@ -36,9 +36,10 @@ class SootAstCreationPass(cpg: Cpg, config: Config)
       // sootClass.setApplicationClass()
       val localDiff = new AstCreator(jimpleFile, part, accumulator)(config.schemaValidation).createAst()
       builder.absorb(localDiff)
+      logger.debug(s"Processed '$jimpleFile'")
     } catch {
       case e: Exception =>
-        logger.warn(s"Cannot parse: $part", e)
+        logger.warn(s"Failed to process '$jimpleFile'", e)
     }
   }
 

--- a/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/jssrc2cpg/src/main/scala/io/joern/jssrc2cpg/passes/AstCreationPass.scala
@@ -63,10 +63,10 @@ class AstCreationPass(cpg: Cpg, astGenRunnerResult: AstGenRunnerResult, config: 
             diffGraph.absorb(localDiff)
           } match {
             case Failure(exception) =>
-              logger.warn(s"Failed to generate a CPG for: '${parseResult.filename}'", exception)
+              logger.warn(s"Failed to process '${parseResult.filename}'", exception)
               (false, parseResult.filename)
             case Success(_) =>
-              logger.debug(s"Generated a CPG for: '${parseResult.filename}'")
+              logger.debug(s"Processed '${parseResult.filename}'")
               (true, parseResult.filename)
           }
         case Failure(exception) =>

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Kotlin2Cpg.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/Kotlin2Cpg.scala
@@ -229,7 +229,7 @@ class Kotlin2Cpg extends X2CpgFrontend with UsesService {
   def createCpg(config: Config): Try[Cpg] = {
     withNewEmptyCpg(config.outputPath, config) { (cpg, config) =>
       val sourceDir = config.inputPath
-      logger.info(s"Starting CPG generation for input directory `$sourceDir`.")
+      logger.info(s"Starting CPG generation for input directory '$sourceDir'.")
 
       checkSourceDir(sourceDir)
       logMaxHeapSize()
@@ -410,7 +410,7 @@ class Kotlin2Cpg extends X2CpgFrontend with UsesService {
       // TODO: support Windows paths
       val willFilter = SourceFilesPicker.shouldFilter(fwp.relativizedPath)
       if (willFilter) {
-        logger.debug(s"Filtered file at `${fwp.f.getVirtualFilePath}`.")
+        logger.debug(s"Filtered file at '${fwp.f.getVirtualFilePath}'.")
       }
       willFilter
     }

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstCreator.scala
@@ -121,7 +121,7 @@ class AstCreator(
   protected val typeInfoProvider = new TypeInfoProvider(bindingContext)
 
   def createAst(): DiffGraphBuilder = {
-    logger.debug(s"Started parsing file `${fileWithMeta.filename}`.")
+    logger.debug(s"Started parsing file '${fileWithMeta.filename}'.")
     val defaultTypes = Set(TypeConstants.JavaLangObject, TypeConstants.Kotlin)
     defaultTypes.foreach(registerType)
     storeInDiffGraph(astForFile(fileWithMeta))

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForDeclarationsCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForDeclarationsCreator.scala
@@ -490,7 +490,7 @@ trait AstForDeclarationsCreator(implicit withSchemaValidation: ValidationMode) {
   private def astsForDestructuringDeclarationWithVarRHS(expr: KtDestructuringDeclaration): Seq[Ast] = {
     val typedInit = Option(expr.getInitializer).collect { case e: KtNameReferenceExpression => e }
     if (typedInit.isEmpty) {
-      logger.warn(s"Unhandled case for destructuring declaration: `${expr.getText}` in this file `$relativizedPath`.")
+      logger.warn(s"Unhandled case for destructuring declaration: `${expr.getText}` in this file '$relativizedPath'.")
       return Seq()
     }
 

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForStatementsCreator.scala
@@ -335,7 +335,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
             astForSubjectExpression
         }
       case _ =>
-        logger.warn(s"Subject Expression empty in this file `$relativizedPath`.")
+        logger.warn(s"Subject Expression empty in this file '$relativizedPath'.")
         Ast()
     }
 
@@ -367,7 +367,7 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
     val subjectExpressionAsts = Option(expr.getSubjectExpression) match {
       case Some(subjectExpression) => astsForExpression(subjectExpression, None)
       case _ =>
-        logger.warn(s"Subject Expression empty in this file `$relativizedPath`.")
+        logger.warn(s"Subject Expression empty in this file '$relativizedPath'.")
         Seq.empty
     }
     val subjectBlock    = blockNode(expr.getSubjectExpression, "", "")

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/files/SourceFilesPicker.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/files/SourceFilesPicker.scala
@@ -65,7 +65,7 @@ object SourceFilesPicker {
         val relativized = SourceFiles.toRelativePath(fileName, forDir)
         val willFilter  = SourceFilesPicker.shouldFilter(relativized)
         if (willFilter) {
-          logger.debug(s"Filtered file at `$fileName`.")
+          logger.debug(s"Filtered file at '$fileName'.")
         }
         willFilter
       }

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreationPass.scala
@@ -75,8 +75,13 @@ class AstCreationPass(
         accumulator.samInfoEntriesByImplClass,
         disableFileContent
       )
-    diffGraph.absorb(astCreator.createAst())
-    logger.debug(s"AST created for file at `${fileWithMeta.f.getVirtualFilePath}`.")
+    try {
+      diffGraph.absorb(astCreator.createAst())
+      logger.debug(s"Processed '${fileWithMeta.f.getVirtualFilePath}'")
+    } catch {
+      case e: Exception =>
+        logger.warn(s"Failed to process '${fileWithMeta.f.getVirtualFilePath}'", e)
+    }
   }
 
 }

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/ConfigPass.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/ConfigPass.scala
@@ -14,7 +14,7 @@ class ConfigPass(fileContentsAtPath: Iterable[FileContentAtPath], cpg: Cpg)
   override def generateParts(): Array[FileContentAtPath] = fileContentsAtPath.toArray
 
   override def runOnPart(diffGraph: DiffGraphBuilder, fileContent: FileContentAtPath): Unit = {
-    logger.debug(s"Adding file `${fileContent.filename}` as config.")
+    logger.debug(s"Adding file '${fileContent.filename}' as config.")
     val configNode = NewConfigFile().name(fileContent.relativizedPath).content(fileContent.content)
     diffGraph.addNode(configNode)
   }

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/PhpParser.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/parser/PhpParser.scala
@@ -59,9 +59,10 @@ class PhpParser private (phpParserPath: String, phpIniPath: String, disableFileC
     val phpFile = jsonObject.flatMap { jsonObject =>
       Try(Domain.fromJson(jsonObject)) match {
         case Success(phpFile) =>
+          logger.debug(s"Processed '$filename'")
           Some(phpFile)
         case Failure(e) =>
-          logger.error(s"Failed to generate intermediate AST for $filename", e)
+          logger.warn(s"Failed to process '$filename'", e)
           None
       }
     }
@@ -85,11 +86,11 @@ class PhpParser private (phpParserPath: String, phpIniPath: String, disableFileC
       case Success(option) =>
         result.append((filename, option, infoLines.mkString))
         if (option.isEmpty) {
-          logger.error(s"Parsing json string for $filename resulted in null return value")
+          logger.warn(s"Failed to process '$filename': null result from parser")
         }
       case Failure(exception) =>
         result.append((filename, None, infoLines.mkString))
-        logger.error(s"Parsing json string for $filename failed with exception", exception)
+        logger.warn(s"Failed to process '$filename'", exception)
     }
 
     result

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/AstParsingPass.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/passes/AstParsingPass.scala
@@ -44,7 +44,7 @@ trait AstParsingPass(config: Config, parser: PhpParser) { this: ForkJoinParallel
     parser.parseFiles(part).foreach {
       case PhpParseResult(fileName, Some(result), _) => processPart(builder, fileName, result)
       case PhpParseResult(fileName, None, _) =>
-        logger.warn(s"Could not parse file $fileName. Results will be missing!")
+        logger.warn(s"Failed to process '$fileName'")
         None
     }
   }

--- a/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/CodeToCpg.scala
+++ b/joern-cli/frontends/pysrc2cpg/src/main/scala/io/joern/pysrc2cpg/CodeToCpg.scala
@@ -31,6 +31,7 @@ class CodeToCpg(
       astVisitor.convert(astRoot)
 
       diffGraph.absorb(astVisitor.createAst())
+      logger.debug(s"Processed '${inputPair.relFileName}'")
     } catch {
       case exception: Throwable =>
         val lineBreakWasCorrected = lineBreakCorrectedCode != inputPair.content
@@ -55,10 +56,7 @@ class CodeToCpg(
     val nodeBuilder = new NodeBuilder(diffGraph)
     nodeBuilder.fileNode(relFileName, contentOption)
 
-    logger.warn(
-      s"Failed to convert${if (lineBreakWasCorrected) " line break corrected " else " "}file ${relFileName}",
-      exception
-    )
+    logger.warn(s"Failed to process '$relFileName'", exception)
   }
 }
 

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/AstCreationPass.scala
@@ -39,9 +39,10 @@ class AstCreationPass(cpg: Cpg, astCreators: List[AstCreator]) extends ForkJoinP
     try {
       val ast = astCreator.createAst()
       diffGraph.absorb(ast)
+      logger.debug(s"Processed '${astCreator.fileName}'")
     } catch {
       case ex: Exception =>
-        logger.error(s"Error while processing AST for file - ${astCreator.fileName} - ", ex)
+        logger.warn(s"Failed to process '${astCreator.fileName}'", ex)
     }
   }
 }

--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/passes/AstCreationPass.scala
@@ -26,9 +26,9 @@ class AstCreationPass(cpg: Cpg, parsedFiles: Seq[String], config: Config)(implic
           diffGraph.absorb(localDiff)
         } match {
           case Success(_) =>
-            logger.debug(s"Generated a CPG for '${parseResult.filename}'")
+            logger.debug(s"Processed '${parseResult.filename}'")
           case Failure(exception) =>
-            logger.warn(s"Failed to generate a CPG for '${parseResult.fullPath}'", exception)
+            logger.warn(s"Failed to process '${parseResult.fullPath}'", exception)
         }
       case Failure(exception) =>
         logger.warn(s"Failed to parse rust_ast_gen output '$jsonPath'", exception)

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/passes/AstCreationPass.scala
@@ -154,10 +154,10 @@ class AstCreationPass(cpg: Cpg, astGenRunnerResult: AstGenRunnerResult, config: 
             diffGraph.absorb(localDiff)
           } match {
             case Failure(exception) =>
-              logger.warn(s"Failed to generate a CPG for: '${parseResult.filename}'", exception)
+              logger.warn(s"Failed to process '${parseResult.filename}'", exception)
               (false, parseResult.filename)
             case Success(_) =>
-              logger.debug(s"Generated a CPG for: '${parseResult.filename}'")
+              logger.debug(s"Processed '${parseResult.filename}'")
               (true, parseResult.filename)
           }
         case Failure(exception) =>


### PR DESCRIPTION
Unifies how all frontends log per-file processing results, which was inconsistent in level, phrasing, and quoting.

**Standard applied across all 13 frontends:**
- Success: `log.debug(s"Processed '$file'")`
- Failure: `log.warn(s"Failed to process '$file'", throwable)`

**Specific changes:**
- Replace inaccurate `"Generated a CPG for"` phrasing (each pass contributes a diffgraph, not a full CPG)
- Downgrade success logs from `info` → `debug` where applicable (gosrc2cpg, csharpsrc2cpg)
- Downgrade per-file failure logs from `error` → `warn` (rubysrc2cpg, php2cpg) — these are all recoverable
- Add missing success/failure log lines where absent (kotlin2cpg, jimple2cpg, rubysrc2cpg, pysrc2cpg, javasrc2cpg, php2cpg)
- Replace backtick-quoted file paths with single-quoted paths (kotlin2cpg)
- Pass throwable as second argument instead of inlining `exception.getMessage` in the string

Partially for QT-1348.