### PR TITLE
Synchronize Scala format with CS repo.

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -3,4 +3,6 @@ runner.dialect = scala3
 preset = IntelliJ
 maxColumn = 120
 align.preset = true
+rewrite.trailingCommas.style = keep
+rewrite.trailingCommas.allowFolding = false
 project.excludeFilters = [".*\\.sbt$", ".*\\.sc$", "project/.*\\.scala", "linter-rules/input/.*\\.scala"]


### PR DESCRIPTION
The changes do not result in any immediate refactoring,
they just make the formatter less eager when it comes to removing
tralling commas and folding of comma separated entities.
