### PR TITLE
[all] replace catch Exception with NonFatal across frontends

### DIFF
--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/Ghidra2Cpg.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/Ghidra2Cpg.scala
@@ -27,6 +27,7 @@ import java.io.File
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
 import scala.util.Try
+import scala.util.control.NonFatal
 
 class Ghidra2Cpg extends X2CpgFrontend {
   override type ConfigType = Config
@@ -67,7 +68,7 @@ class Ghidra2Cpg extends X2CpgFrontend {
             program.release(this)
           }
         } catch {
-          case e: Exception =>
+          case NonFatal(e) =>
             e.printStackTrace()
         } finally {
           // Closing deletes the project (since we created a temporary project)
@@ -96,7 +97,7 @@ class Ghidra2Cpg extends X2CpgFrontend {
       GhidraProgramUtilities.markProgramAnalyzed(program)
       handleProgram(program, fileAbsolutePath, cpg)
     } catch {
-      case e: Exception =>
+      case NonFatal(e) =>
         e.printStackTrace()
     } finally {
       program.endTransaction(transactionId, true)
@@ -154,7 +155,7 @@ object Types {
     try {
       types += typeName
     } catch {
-      case _: Exception => println(s" Error adding type: $typeName")
+      case NonFatal(_) => println(s" Error adding type: $typeName")
     }
     typeName
   }

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/arm/ArmFunctionPass.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/arm/ArmFunctionPass.scala
@@ -8,6 +8,8 @@ import io.joern.ghidra2cpg.utils.Utils.{createMethodNode, createReturnNode}
 import io.shiftleft.codepropertygraph.generated.nodes.NewBlock
 import io.shiftleft.codepropertygraph.generated.{Cpg, EdgeTypes, nodes}
 
+import scala.util.control.NonFatal
+
 class ArmFunctionPass(
   currentProgram: Program,
   filename: String,
@@ -33,7 +35,7 @@ class ArmFunctionPass(
       handleLocals(localDiffGraph, function, blockNode)
       handleBody(localDiffGraph, function, methodNode, blockNode)
     } catch {
-      case exception: Exception =>
+      case NonFatal(exception) =>
         exception.printStackTrace()
     }
     diffGraphBuilder.absorb(localDiffGraph)

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/DependencySrcProcessor.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/DependencySrcProcessor.scala
@@ -4,6 +4,8 @@ import io.joern.gosrc2cpg.parser.ParserKeys
 import io.joern.x2cpg.ValidationMode
 import ujson.{Arr, Obj, Value}
 
+import scala.util.control.NonFatal
+
 trait DependencySrcProcessor(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
   def buildCacheFromDepSrc(): Unit = {
@@ -13,7 +15,7 @@ trait DependencySrcProcessor(implicit withSchemaValidation: ValidationMode) { th
       // NOTE: For dependencies we are just caching the global variables Types.
       processPackageLevelGlobalVariablesAndConstants(parserResult.json)
     } catch {
-      case ex: Exception =>
+      case NonFatal(ex) =>
         logger.warn(s"Error: While processing dependency source- ${parserResult.fullPath}", ex)
     }
   }

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/InitialMainSrcProcessor.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/astcreation/InitialMainSrcProcessor.scala
@@ -9,6 +9,7 @@ import io.shiftleft.codepropertygraph.generated.DiffGraphBuilder
 import ujson.{Arr, Obj, Value}
 
 import java.io.File
+import scala.util.control.NonFatal
 
 trait InitialMainSrcProcessor(implicit withSchemaValidation: ValidationMode) { this: AstCreator =>
 
@@ -25,7 +26,7 @@ trait InitialMainSrcProcessor(implicit withSchemaValidation: ValidationMode) { t
       // NOTE: For dependencies we are just caching the global variables Types.
       processPackageLevelGlobalVariablesAndConstants(parserResult.json)
     } catch {
-      case ex: Exception =>
+      case NonFatal(ex) =>
         logger.warn(s"Error: While processing - ${parserResult.fullPath}", ex)
     }
     diffGraph

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/passes/BasePassForAstProcessing.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/passes/BasePassForAstProcessing.scala
@@ -10,6 +10,7 @@ import io.shiftleft.passes.ForkJoinParallelCpgPass
 import org.slf4j.{Logger, LoggerFactory}
 
 import java.nio.file.Path
+import scala.util.control.NonFatal
 
 abstract class BasePassForAstProcessing(
   cpg: Cpg,
@@ -30,7 +31,7 @@ abstract class BasePassForAstProcessing(
         )
       )
     } catch
-      case exception: Exception =>
+      case NonFatal(exception) =>
         logger.warn(s"Failed to process '$ast'", exception)
   }
 

--- a/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/passes/DownloadDependenciesPass.scala
+++ b/joern-cli/frontends/gosrc2cpg/src/main/scala/io/joern/gosrc2cpg/passes/DownloadDependenciesPass.scala
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory
 import java.io.File as JFile
 import java.nio.file.Paths
 import java.util.concurrent.LinkedBlockingQueue
+import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 
 class DownloadDependenciesPass(cpg: Cpg, parentGoMod: GoModHelper, goGlobal: GoGlobal, config: Config) {
@@ -66,7 +67,7 @@ class DownloadDependenciesPass(cpg: Cpg, parentGoMod: GoModHelper, goGlobal: GoG
         }
       } catch {
         case exception: InterruptedException => logger.warn("Interrupted WriterThread", exception)
-        case exc: Exception =>
+        case NonFatal(exc) =>
           logger.error("error in writer thread, ", exc)
       }
     }

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/AstCreationPass.scala
@@ -14,6 +14,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Paths}
 import scala.collection.mutable
 import scala.util.Try
+import scala.util.control.NonFatal
 
 /** Creates the AST layer from the given class file and stores all types in the given global parameter.
   * @param classFiles
@@ -70,7 +71,7 @@ class AstCreationPass(classFiles: List[ClassFile], cpg: Cpg, config: Config)
       builder.absorb(localDiff)
       logger.debug(s"Processed '${classFile.file.absolutePathAsString}'")
     } catch {
-      case e: Exception =>
+      case NonFatal(e) =>
         logger.warn(s"Failed to process '${classFile.file.absolutePathAsString}'", e)
         Iterator()
     }

--- a/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/SootAstCreationPass.scala
+++ b/joern-cli/frontends/jimple2cpg/src/main/scala/io/joern/jimple2cpg/passes/SootAstCreationPass.scala
@@ -7,6 +7,8 @@ import io.shiftleft.passes.ForkJoinParallelCpgPassWithAccumulator
 import org.slf4j.LoggerFactory
 import soot.{Scene, SootClass, SourceLocator}
 
+import scala.util.control.NonFatal
+
 /** Creates the AST layer from the given class file and stores all types in the given global parameter.
   */
 class SootAstCreationPass(cpg: Cpg, config: Config)
@@ -38,7 +40,7 @@ class SootAstCreationPass(cpg: Cpg, config: Config)
       builder.absorb(localDiff)
       logger.debug(s"Processed '$jimpleFile'")
     } catch {
-      case e: Exception =>
+      case NonFatal(e) =>
         logger.warn(s"Failed to process '$jimpleFile'", e)
     }
   }

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstCreator.scala
@@ -26,6 +26,7 @@ import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
 import scala.util.Try
+import scala.util.control.NonFatal
 import org.jetbrains.kotlin.types.KotlinType
 
 object AstCreator {
@@ -483,7 +484,7 @@ class AstCreator(
             Seq()
         }
       } catch {
-        case exception: Exception =>
+        case NonFatal(exception) =>
           logger.warn(
             s"Caught exception while processing decl in this file `$relativizedPath`:\n${decl.getText}",
             exception

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/passes/AstCreationPass.scala
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory
 
 import scala.collection.immutable.SortedMap
 import scala.collection.mutable
+import scala.util.control.NonFatal
 
 class AstCreationPass(
   filesWithMeta: Iterable[KtFileWithMeta],
@@ -79,7 +80,7 @@ class AstCreationPass(
       diffGraph.absorb(astCreator.createAst())
       logger.debug(s"Processed '${fileWithMeta.f.getVirtualFilePath}'")
     } catch {
-      case e: Exception =>
+      case NonFatal(e) =>
         logger.warn(s"Failed to process '${fileWithMeta.f.getVirtualFilePath}'", e)
     }
   }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyAstGenRunner.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/parser/RubyAstGenRunner.scala
@@ -17,6 +17,7 @@ import java.util
 import java.util.jar.JarFile
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
+import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try, Using}
 
 /** Creates a JRuby scripting environment using `ruby_ast_gen` within a temporary directory allowing for re-usable
@@ -121,7 +122,7 @@ class RubyAstGenRunner(config: Config, sharedJRubyEnv: Option[JRubyEnvironment] 
       Files.writeString(scriptTarget, mainScript, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.CREATE)
       executeWithJRuby(scriptTarget)
     } catch {
-      case tempPathException: Exception => Failure(tempPathException)
+      case NonFatal(tempPathException) => Failure(tempPathException)
     } finally {
       scriptTarget.toFile.delete()
     }

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/passes/AstCreationPass.scala
@@ -9,6 +9,8 @@ import io.shiftleft.passes.ForkJoinParallelCpgPass
 import io.shiftleft.semanticcpg.language.types.structure.NamespaceTraversal
 import org.slf4j.LoggerFactory
 
+import scala.util.control.NonFatal
+
 class AstCreationPass(cpg: Cpg, astCreators: List[AstCreator]) extends ForkJoinParallelCpgPass[AstCreator](cpg) {
 
   private val logger = LoggerFactory.getLogger(getClass)
@@ -41,7 +43,7 @@ class AstCreationPass(cpg: Cpg, astCreators: List[AstCreator]) extends ForkJoinP
       diffGraph.absorb(ast)
       logger.debug(s"Processed '${astCreator.fileName}'")
     } catch {
-      case ex: Exception =>
+      case NonFatal(ex) =>
         logger.warn(s"Failed to process '${astCreator.fileName}'", ex)
     }
   }

--- a/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/utils/SwiftTypesProvider.scala
+++ b/joern-cli/frontends/swiftsrc2cpg/src/main/scala/io/joern/swiftsrc2cpg/utils/SwiftTypesProvider.scala
@@ -16,6 +16,7 @@ import java.nio.file.attribute.BasicFileAttributes
 import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.util.matching.Regex
+import scala.util.control.NonFatal
 import scala.util.{Failure, Try, Using}
 
 /** Provides Swift type information by extracting type data from Swift compiler output. This provider uses the Swift
@@ -469,7 +470,7 @@ object SwiftTypesProvider {
       )
       resultSet.toSet
     } catch {
-      case e: Exception =>
+      case NonFatal(e) =>
         logger.warn(s"Error listing module directories under ${path.toFile.toString}: ${e.getMessage}")
         Set.empty
     }
@@ -625,7 +626,7 @@ case class SwiftTypesProvider(config: Config, parsedSwiftInvocations: Seq[Seq[St
         process.destroyForcibly()
       }
     } catch {
-      case e: Exception =>
+      case NonFatal(e) =>
         logger.debug("Batch demangling failed, falling back to per-name demangling", e)
     }
   }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/DynamicCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/DynamicCallLinker.scala
@@ -15,6 +15,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 import scala.collection.mutable
+import scala.util.control.NonFatal
 
 /** We compute the set of possible call-targets for each dynamic call, and add them as CALL edges to the graph, based on
   * call.methodFullName, method.name and method.signature, the inheritance hierarchy and the AST of typedecls and
@@ -75,7 +76,7 @@ class DynamicCallLinker(cpg: Cpg) extends CpgPass(cpg) {
       try {
         linkDynamicCall(call, dstGraph)
       } catch {
-        case exception: Exception =>
+        case NonFatal(exception) =>
           throw new RuntimeException(exception)
       }
     }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/StaticCallLinker.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/passes/callgraph/StaticCallLinker.scala
@@ -8,6 +8,8 @@ import io.shiftleft.passes.ForkJoinParallelCpgPass
 import io.shiftleft.semanticcpg.language.*
 import org.slf4j.{Logger, LoggerFactory}
 
+import scala.util.control.NonFatal
+
 class StaticCallLinker(cpg: Cpg) extends ForkJoinParallelCpgPass[Seq[Call]](cpg) with LinkingUtil {
 
   private val logger: Logger = LoggerFactory.getLogger(classOf[StaticCallLinker])
@@ -31,7 +33,7 @@ class StaticCallLinker(cpg: Cpg) extends ForkJoinParallelCpgPass[Seq[Call]](cpg)
           case _ => logger.warn(s"Unknown dispatch type on dynamic CALL ${call.code}")
         }
       } catch {
-        case exception: Exception =>
+        case NonFatal(exception) =>
           logger.error(s"Exception in StaticCallLinker: ", exception)
       }
     }

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/ArtifactFetcher.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/utils/ArtifactFetcher.scala
@@ -9,6 +9,7 @@ import java.net.http.{HttpClient, HttpRequest, HttpResponse}
 import java.nio.file.{Files, Path, StandardCopyOption}
 import java.util.Base64
 import java.util.concurrent.{CompletableFuture, ConcurrentHashMap, TimeUnit}
+import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try, Using}
 
 case class HttpArtifact(url: String, sha256: String)
@@ -97,7 +98,7 @@ class ArtifactFetcher(val cacheDir: Path) {
         None
       }
     } catch {
-      case e: Exception =>
+      case NonFatal(e) =>
         logger.warn(s"Error checking cache for ${artifact.url}: ${e.getMessage}")
         None
     }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/SourceHighlighter.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/SourceHighlighter.scala
@@ -5,6 +5,7 @@ import io.shiftleft.semanticcpg.utils.{ExternalCommand, FileUtil}
 import org.slf4j.{Logger, LoggerFactory}
 
 import java.nio.file.Files
+import scala.util.control.NonFatal
 
 /** language must be one of io.shiftleft.codepropertygraph.generated.Languages TODO: generate enums instead of Strings
   * for the languages
@@ -31,7 +32,7 @@ object SourceHighlighter {
         .mkString("\n")
       Some(highlightedCode)
     } catch {
-      case exception: Exception =>
+      case NonFatal(exception) =>
         logger.info("syntax highlighting not working. Is `source-highlight` installed?", exception)
         Some(source.code)
     } finally {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/FileUtil.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/FileUtil.scala
@@ -8,6 +8,7 @@ import java.util.zip.{ZipEntry, ZipFile}
 import scala.annotation.tailrec
 import scala.jdk.CollectionConverters.*
 import scala.util.Using
+import scala.util.control.NonFatal
 
 object FileUtil {
   def currentWorkingDirectory: Path = Paths.get("").toAbsolutePath.normalize()
@@ -37,7 +38,7 @@ object FileUtil {
       try {
         delete(file, swallowIoExceptions = true)
       } catch {
-        case _: Exception => // Ensure we don't throw from finally
+        case NonFatal(_) => // Ensure we don't throw from finally
       }
     }
   }


### PR DESCRIPTION
Addresses the review comment on #6232 (maltek): always use `NonFatal(e)` over plain `case _: Exception` unless the exception is re-thrown immediately.

Replaces all 18 broad `case _: Exception` / `case e: Exception` catches with `scala.util.control.NonFatal` across 12 modules:

- kotlin2cpg (`AstCreationPass`, `AstCreator`)
- rubysrc2cpg (`AstCreationPass`, `RubyAstGenRunner`)
- jimple2cpg (`AstCreationPass`, `SootAstCreationPass`)
- gosrc2cpg (`BasePassForAstProcessing`, `DownloadDependenciesPass`, `DependencySrcProcessor`, `InitialMainSrcProcessor`)
- swiftsrc2cpg (`SwiftTypesProvider`)
- x2cpg (`DynamicCallLinker`, `StaticCallLinker`, `ArtifactFetcher`)
- ghidra2cpg (`Ghidra2Cpg`, `ArmFunctionPass`)
- semanticcpg (`SourceHighlighter`, `FileUtil`)

`NonFatal` correctly excludes `InterruptedException`, `VirtualMachineError` and other fatal signals that should not be silently swallowed.