### PR TITLE
joern-scan: propagate the JVM exit status instead of the retry test's

### DIFF
--- a/joern-cli/src/universal/joern-scan
+++ b/joern-cli/src/universal/joern-scan
@@ -15,6 +15,10 @@ fi
 
 echo "Writing logs to: /tmp/joern-scan-log.txt"
 $SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -Dlog4j.configurationFile="$SCRIPT_ABS_DIR"/conf/log4j2.xml -J-XX:+UseStringDeduplication "$@" 2> /tmp/joern-scan-log.txt
-if [ $? -eq 2 ]; then
+status=$?
+if [ $status -eq 2 ]; then
   $SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -Dlog4j.configurationFile="$SCRIPT_ABS_DIR"/conf/log4j2.xml -J-XX:+UseStringDeduplication "$@" 2> /tmp/joern-scan-log.txt
+  status=$?
 fi
+
+exit $status

--- a/testDistro.py
+++ b/testDistro.py
@@ -235,6 +235,16 @@ class TestRunner:
             if result_count == 0:
                 raise RuntimeError("Result from joern-scan not found")
 
+            # A scan that failed must not reach the caller as a success. The launcher used to exit
+            # with the status of its retry test rather than the JVM's, so every non-zero exit
+            # except 2 arrived as 0 and "scanned, found nothing" was indistinguishable from
+            # "never scanned".
+            missing_path = Path(tmp_dir) / "no-such-directory"
+            proc = self.run_command([self.joern_scan_exe, str(missing_path)],
+                           f"Joern-scan on nonexistent path {missing_path}", check=False)
+            if proc.returncode == 0:
+                raise RuntimeError("Joern-scan exited 0 for a scan that failed")
+
     @stage
     def slice_test(self):
         """Test slicing functionality"""


### PR DESCRIPTION
The script's last command is `if [ $? -eq 2 ]`, so the script exits with the status of the IF,
not of the scan. When the JVM exits 2 the retry runs as intended; every other non-zero exit is
reported to the caller as 0.

That means Joern currently gives a non-zero exit for an unrecognised option, a dead frontend and a
generated script that fails to compile, and surface as success.

A caller in CI cannot distinguish 'scanned, found nothing' from 'never scanned', because both
are exit 0 and the second also produces an artifact (the log banner).

PR approach: Capture the status before the test, refresh it after the retry, and exit with it.

### Reproducer

```sh
printf '#include <string.h>\nvoid f(int c,char**v){char b[8];if(c>1)strcpy(b,v[1]);}\n' > /tmp/src/v.c
joern-scan /tmp/src --overwrite --frontend-args --exclude-regex '.*/\.git/.*'
echo $?     # 0, and the output is the "Writing logs to:" banner alone
```

The scan never ran — the generated script failed to compile (that is a separate defect, see the
companion PR #6238 ) — but the caller is told it succeeded.

### Verified

Against joern 4.0.610 (Homebrew, macOS arm64), patching the installed launcher in place:

| case | before | after |
|---|---|---|
| scan that fails | exit 0, 41-byte artifact | **exit 1** |
| healthy scan | exit 0, 2 findings | **exit 0, 2 findings** |

`sh -n` passes on the patched script.
