### PR TITLE
console: escape frontend args interpolated into the generated script

### DIFF
--- a/console/src/main/scala/io/joern/console/BridgeBase.scala
+++ b/console/src/main/scala/io/joern/console/BridgeBase.scala
@@ -439,8 +439,11 @@ trait PluginHandling { this: BridgeBase =>
     config.frontendArgs match {
       case Array() => ""
       case args =>
+        // Escaped as a Scala string literal, exactly as `src` is in loadOrCreateCpg above:
+        // these values are interpolated into a generated source file, so an unescaped backslash
+        // or quote yields an invalid literal and the script fails to compile rather than run.
         val quotedArgs = args.map { arg =>
-          "\"" ++ arg ++ "\""
+          "\"" ++ StringEscapeUtils.escapeJava(arg) ++ "\""
         }
         val argsString = quotedArgs.mkString(", ")
         s", args=List($argsString)"

--- a/console/src/main/scala/io/joern/console/BridgeBase.scala
+++ b/console/src/main/scala/io/joern/console/BridgeBase.scala
@@ -438,7 +438,7 @@ trait PluginHandling { this: BridgeBase =>
   private def argsStringFromConfig(config: Config): String = {
     config.frontendArgs match {
       case Array() => ""
-      case args =>
+      case args    =>
         // Escaped as a Scala string literal, exactly as `src` is in loadOrCreateCpg above:
         // these values are interpolated into a generated source file, so an unescaped backslash
         // or quote yields an invalid literal and the script fails to compile rather than run.

--- a/testDistro.py
+++ b/testDistro.py
@@ -235,6 +235,18 @@ class TestRunner:
             if result_count == 0:
                 raise RuntimeError("Result from joern-scan not found")
 
+            # Same scan, but with a --frontend-args value carrying a backslash. Those values are
+            # interpolated into a generated Scala source, so an unescaped one is not a legal string
+            # literal and the script fails to compile instead of running. The exclusion matches
+            # nothing under the input, so the expected result is unchanged.
+            proc = self.run_command([self.joern_scan_exe, "--overwrite", "--tags", "all", str(uaf_c_path),
+                                     "--frontend-args", "--exclude-regex", r".*/\.git/.*"],
+                           f"Joern-scan on {uaf_c_path} with a backslash in --frontend-args")
+
+            result_count = sum(1 for line in proc.stdout.splitlines() if expected_result in line)
+            if result_count == 0:
+                raise RuntimeError("Result from joern-scan not found with an escaped --frontend-args value")
+
     @stage
     def slice_test(self):
         """Test slicing functionality"""


### PR DESCRIPTION
`argsStringFromConfig` inserts each `--frontend-args` value into a generated Scala source with bare
quotes and no escaping. `loadOrCreateCpg`, in the same file, already escapes `src` with
`StringEscapeUtils.escapeJava` for the same reason.

Any value containing a `\` or a double quote therefore produces an invalid string literal,
and the generated script fails to COMPILE. A regex is the common case:

    joern-scan <src> --frontend-args --exclude-regex '.*/\.git/.*'

`\.` is not a legal Scala escape sequence. The scan never starts and the output is the log
banner alone. The same flag passed straight to the frontend works, so this is not a frontend
limitation:

    c2cpg.sh <src> -o out.cpg --exclude-regex '.*node_modules/.*'   # excludes correctly

`StringEscapeUtils` is already imported in this file.


### Reproducer

Same source, same flag, differing only in whether the value contains a backslash:

```sh
joern-scan /tmp/src --overwrite --tags badfn --frontend-args --exclude-regex 'plainnobackslash'
#   -> 2 results

joern-scan /tmp/src --overwrite --tags badfn --frontend-args --exclude-regex 'has\.backslash'
#   -> 0 results; /tmp/joern-scan-log.txt shows
#      "error during script execution: Error during compilation"
```

### The flag itself is fine

Passed straight to the frontend it works, which is what makes this a `joern-scan` bug.

```sh
c2cpg.sh /tmp/src -o /tmp/out.cpg --exclude-regex '.*node_modules/.*'   # excludes correctly
```

Note the failure is currently invisible: the generated script's non-zero exit is reported as 0 by
`joern-cli/src/universal/joern-scan`. This is independent of the companion PR.