### PR TITLE
[rust2cpg] lower method annotations.

### DIFF
--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
@@ -546,6 +546,7 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
     val retTypeFullName = fn.retType.map(_.typ).map(typeFullNameForType).getOrElse("()")
     val methodRet       = methodReturnNode(fn, retTypeFullName)
     val methodMods      = Seq[NewModifier]()
+    val attributes      = fn.attr.map(visitAttr)
 
     contextStack.pushMethod(method)
     val (paramAsts, paramAssignmentAsts) = lowerParamList(fn.paramList)
@@ -554,7 +555,14 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
       .getOrElse(blockAst(blockNode(fn), paramAssignmentAsts.toList))
     contextStack.pop()
 
-    methodAst(method = method, parameters = paramAsts, body = bodyAst, methodReturn = methodRet, modifiers = methodMods)
+    methodAstWithAnnotations(
+      method = method,
+      parameters = paramAsts,
+      body = bodyAst,
+      methodReturn = methodRet,
+      modifiers = methodMods,
+      annotations = attributes
+    )
   }
 
   // Creates:

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/AnnotationTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/AnnotationTests.scala
@@ -159,4 +159,59 @@ class AnnotationTests extends Rust2CpgSuite(noSysRoot = true) {
       }
     }
   }
+
+  "fn with two attributes" should {
+    val cpg = code("""
+        |#[inline]
+        |#[doc = "foobar"]
+        |fn foo() {}
+        |""".stripMargin)
+
+    "have correct annotations" in {
+      inside(cpg.method.nameExact("foo").annotation.sortBy(_.lineNumber).l) { case attr1 :: attr2 :: Nil =>
+        attr1.name shouldBe "inline"
+        attr1.fullName shouldBe "inline"
+        attr1.code shouldBe "#[inline]"
+
+        attr2.name shouldBe "doc"
+        attr2.fullName shouldBe "doc"
+        attr2.code shouldBe """#[doc = "foobar"]"""
+      }
+    }
+  }
+
+  "inherent method with attribute" should {
+    val cpg = code("""
+        |struct Foo;
+        |impl Foo {
+        |  #[inline]
+        |  fn bar(&self) {}
+        |}
+        |""".stripMargin)
+
+    "have correct annotation" in {
+      inside(cpg.method.nameExact("bar").annotation.l) { case attr :: Nil =>
+        attr.name shouldBe "inline"
+        attr.fullName shouldBe "inline"
+        attr.code shouldBe "#[inline]"
+      }
+    }
+  }
+
+  "trait method with attribute" should {
+    val cpg = code("""
+        |trait Foo {
+        |  #[must_use]
+        |  fn bar(&self);
+        |}
+        |""".stripMargin)
+
+    "have correct annotation" in {
+      inside(cpg.method.nameExact("bar").annotation.l) { case attr :: Nil =>
+        attr.name shouldBe "must_use"
+        attr.fullName shouldBe "must_use"
+        attr.code shouldBe "#[must_use]"
+      }
+    }
+  }
 }


### PR DESCRIPTION
Previously, only struct annotations were lowered.