### PR TITLE
[rubysrc2cpg] fix `no AST parent` case

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForExpressionsCreator.scala
@@ -825,8 +825,7 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) {
 
     val block = blockNode(node)
     scope.pushNewScope(BlockScope(block))
-    val tmpLocal = NewLocal().name(tmp).code(tmp)
-    scope.addToScope(tmp, tmpLocal)
+    handleVariableOccurrence(tmp, node)
 
     val argumentAsts = node.elements.flatMap(elem =>
       elem match {

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -167,12 +167,9 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
       if (isClosure || isSingletonObjectMethod || isSurroundedByProgramScope) {
         Ast() // program scope members are set elsewhere
       } else {
-        // Singleton constructors that initialize @@ fields should have their members linked under the singleton class
-        val methodMember = scope.surroundingTypeFullName match {
-          case Some(astParentTfn) => memberForMethod(method, Option(NodeTypes.TYPE_DECL), Option(astParentTfn))
-          case None               => memberForMethod(method, scope.surroundingAstLabel, scope.surroundingScopeFullName)
-        }
-        Ast(memberForMethod(method, Option(NodeTypes.TYPE_DECL), astParentFullName))
+        Ast(
+          memberForMethod(method, Option(NodeTypes.TYPE_DECL), astParentFullName.orElse(scope.surroundingScopeFullName))
+        )
       }
     // For closures, we also want the method/type refs for upstream use
     val methodAst_ = {
@@ -469,7 +466,9 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
         }
 
         // The member for these types refers to the singleton class
-        val member = memberForMethod(method, Option(NodeTypes.TYPE_DECL), astParentFullName.map(x => s"$x<class>"))
+        val memberParentType     = astParentType.orElse(scope.surroundingAstLabel)
+        val memberParentFullName = astParentFullName.map(x => s"$x<class>").orElse(scope.surroundingScopeFullName)
+        val member               = memberForMethod(method, memberParentType, memberParentFullName)
         diffGraph.addNode(member)
 
         val _methodAst =

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -467,7 +467,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
 
         // The member for these types refers to the singleton class
         val memberParentType     = astParentType.orElse(scope.surroundingAstLabel)
-        val memberParentFullName = astParentFullName.map(x => s"$x<class>").orElse(scope.surroundingScopeFullName)
+        val memberParentFullName = astParentFullName.map(name => s"$name<class>").orElse(scope.surroundingScopeFullName)
         val member               = memberForMethod(method, memberParentType, memberParentFullName)
         diffGraph.addNode(member)
 

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/testfixtures/RubyCode2CpgFixture.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/testfixtures/RubyCode2CpgFixture.scala
@@ -34,7 +34,7 @@ trait RubyFrontend(disableFileContent: Boolean) extends LanguageFrontend {
       Using.resource(new RubySrc2Cpg(sharedJRubyEnv))(
         _.createCpg(config.withInputPath(sourceCodeFile.getAbsolutePath)).get
       )
-    new PostFrontendValidator(tmp, ValidationLevel.V2).run()
+    new PostFrontendValidator(tmp, ValidationLevel.V3).run()
     tmp
   }
 


### PR DESCRIPTION
- fix cases which resulted in `node has no AST parent` validation warnings for some `LOCAL` and `MEMBER` nodes
- bump validation level to V3