### PR TITLE
joern-scan: exit non-zero when the arguments are rejected

### DIFF
--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernScan.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernScan.scala
@@ -49,8 +49,9 @@ object JoernScan extends BridgeBase {
 
   def main(args: Array[String]): Unit = {
     val (scanArgs, frontendArgs) = CpgBasedTool.splitArgs(args)
-    optionParser.parse(scanArgs, JoernScanConfig()).foreach { config =>
-      run(config, frontendArgs)
+    optionParser.parse(scanArgs, JoernScanConfig()) match {
+      case Some(config) => run(config, frontendArgs)
+      case None         => System.exit(1)
     }
   }
 
@@ -154,7 +155,7 @@ object JoernScan extends BridgeBase {
   private def runScanPlugin(config: JoernScanConfig, frontendArgs: List[String]): Unit = {
     if (config.src == "") {
       println(optionParser.usage)
-      return
+      System.exit(1)
     }
 
     if (queryNames().isEmpty) {

--- a/testDistro.py
+++ b/testDistro.py
@@ -257,6 +257,16 @@ class TestRunner:
             if proc.returncode == 0:
                 raise RuntimeError("Joern-scan exited 0 for a scan that failed")
 
+            proc = self.run_command([self.joern_scan_exe, "--this-option-does-not-exist", str(foo_path)],
+                           "Joern-scan with an unrecognised option", check=False)
+            if proc.returncode == 0:
+                raise RuntimeError("Joern-scan exited 0 for an argument list it rejected")
+
+            proc = self.run_command([self.joern_scan_exe, "--tags", "all"],
+                           "Joern-scan with no source path", check=False)
+            if proc.returncode == 0:
+                raise RuntimeError("Joern-scan exited 0 when given no source path")
+
     @stage
     def slice_test(self):
         """Test slicing functionality"""


### PR DESCRIPTION
Fixes #6241.

`joern-scan` exits 0 when it refuses to run, by two routes:

- `JoernScan.main` did `optionParser.parse(...).foreach { ... }`. A rejected argument list gives `None`, `.foreach` discards it, and the process exits 0 — after scopt has printed `Error: Unknown option --x`.
- `src` is `.optional()`, so an absent source path is not a parse error. It reaches `runScanPlugin`, which prints the usage text and returns. Also 0.

`System.exit(1)` in both places. Exit 2 is already spoken for by the query-database install path the launcher retries on, so 1 is free.

### Rebased onto master — no longer stacked

This was opened stacked on #6237, which has since merged. It is now rebased onto master and stands alone: **two commits, two files**, and the launcher change that used to appear in the diff is gone because it is upstream.

The test in `testDistro.py` needed #6237 to be meaningful, since it asserts that a refused invocation reaches *the caller* as non-zero. With #6237 merged that condition is satisfied and the assertion is live rather than pending.

### Measured

Against joern 4.0.610 (Homebrew, macOS arm64, JDK 25), with #6237's launcher in place so the JVM's status is not being discarded:

```sh
joern-scan --this-option-does-not-exist /tmp/src ; echo $?   # -> 0
joern-scan --tags all                           ; echo $?   # -> 0, usage text on stdout
```

The first was also confirmed straight against `libexec/bin/joern-scan`, bypassing the launcher, so the 0 is the JVM's own.

The second is reachable by accident rather than by typo: `--frontend-args` consumes everything after it, so a source path written last silently becomes a frontend argument and the scan runs with no input.

### Not measured — please read this before merging

**There is no sbt on this machine, so I have not compiled this change.** The Scala diff is written from reading the source; that it behaves as described afterwards is an expectation, not something I watched happen. Everything asserted about the *current* behaviour is measured on the released distribution.

`scalafmt --test` passes under the version `.scalafmt.conf` pins (3.8.1), run with the real formatter rather than matched by hand — the formatting failure on #6238 is what taught me not to trust the latter.
