### PR TITLE
console: map PYTHONSRC to the ImportCode member named python

### DIFF
--- a/console/src/main/scala/io/joern/console/BridgeBase.scala
+++ b/console/src/main/scala/io/joern/console/BridgeBase.scala
@@ -429,7 +429,12 @@ trait PluginHandling { this: BridgeBase =>
           case Languages.C | Languages.NEWC => "c"
           case Languages.JAVA               => "jvm"
           case Languages.JAVASRC            => "java"
-          case lang                         => lang.toLowerCase
+          // ImportCode exposes this frontend as `python` (ImportCode.scala carries Languages
+          // .PYTHONSRC on `def python`), so the default toLowerCase below generates
+          // `importCode.pythonsrc`, which does not compile. Same class as the JAVASRC line
+          // above, which is already special-cased for exactly this reason.
+          case Languages.PYTHONSRC => "python"
+          case lang                => lang.toLowerCase
         }
         .getOrElse("c")
     )

--- a/console/src/main/scala/io/joern/console/BridgeBase.scala
+++ b/console/src/main/scala/io/joern/console/BridgeBase.scala
@@ -429,12 +429,8 @@ trait PluginHandling { this: BridgeBase =>
           case Languages.C | Languages.NEWC => "c"
           case Languages.JAVA               => "jvm"
           case Languages.JAVASRC            => "java"
-          // ImportCode exposes this frontend as `python` (ImportCode.scala carries Languages
-          // .PYTHONSRC on `def python`), so the default toLowerCase below generates
-          // `importCode.pythonsrc`, which does not compile. Same class as the JAVASRC line
-          // above, which is already special-cased for exactly this reason.
-          case Languages.PYTHONSRC => "python"
-          case lang                => lang.toLowerCase
+          case Languages.PYTHONSRC          => "python"
+          case lang                         => lang.toLowerCase
         }
         .getOrElse("c")
     )


### PR DESCRIPTION
`languageFromConfig` already carries a table for the case where a `Languages` value and its `ImportCode` member name differ — `JAVASRC` is special-cased to `"java"` because `ImportCode` exposes it as `def java`. `PYTHONSRC` was missed, so it falls through to `lang.toLowerCase` and the generated script says `importCode.pythonsrc`.

The compiler names the fix itself:

```
value pythonsrc is not a member of io.joern.console.cpgcreation.ImportCode[...]
  - did you mean io.joern.console.cpgcreation.ImportCode[...].python?
```

### This is the default path, not an opt-in

`cpgcreation/package.scala` returns `Some(Languages.PYTHONSRC)` for any file ending `.py`, and `ImportCode.scala` binds that same value to the member `python`. So auto-detection — what `joern-scan <dir>` does with no `--language` — produces the one spelling that does not compile. **Every Python repository fails to scan.**

### Reproducer

Measured against joern 4.0.610 (Homebrew, macOS arm64, JDK 25):

```sh
mkdir -p /tmp/src && printf 'import os\ndef bad(p):\n    os.system("ls " + p)\n' > /tmp/src/v.py
joern-scan /tmp/src --overwrite --tags all
#   /tmp/joern-scan-log.txt:
#     importCode.pythonsrc("/tmp/src")
#     value pythonsrc is not a member of ... - did you mean ....python?
#     error during script execution: Error during compilation
```

On a stock launcher that failure arrives as **exit 0** with the log banner as the only output, so a caller reads it as a clean scan of a repository with no findings. That amplifier is #6237; this is one of the faults it was hiding.

I checked the other members against their `Languages` values while I was in there — kotlin, golang, csharpsrc, php, abap all agree. Python was the only remaining gap.

### Not measured

**There is no sbt on this machine, so I have not compiled this.** The one-line change follows the `JAVASRC` line directly above it, and the failure it fixes is measured on the released distribution, but the after state is an expectation rather than something I watched. `scalafmt --test` passes with the repo's pinned 3.8.1 — the formatting is scalafmt's own output, not hand-matched.


Closes: https://github.com/joernio/joern/issues/5708
