### PR TITLE
x2cpg AstGenRunner: a bare name means PATH, so stop absolutising it against the CWD

### DIFF
--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/astgen/AstGenRunner.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/astgen/AstGenRunner.scala
@@ -188,7 +188,14 @@ abstract class AstGenRunner(metaData: AstGenProgramMetaData, config: X2CpgConfig
     val astGenVersion = conf.getString(metaData.resolvedVersionConfigKey)
     val resolvedPath  = resolveAstGenPath(astGenVersion)
     logger.info(s"Using ${metaData.name} from '$resolvedPath'")
-    Paths.get(resolvedPath).toAbsolutePath.toString
+    // Do NOT absolutise a bare name. resolveAstGenPath returns `metaData.name` -- a name with no
+    // separator -- to mean "found on the system PATH". Paths.get(name).toAbsolutePath resolves that
+    // against the process working directory, turning "on PATH" into "in the current directory", so
+    // the binary is looked for at <cwd>/astgen and the run fails with
+    //   Cannot run program "<cwd>/astgen" ... error: 2 (No such file or directory)
+    // even though it is on PATH. Leave a bare name bare and let the process launcher do the lookup.
+    if (Paths.get(resolvedPath).getNameCount == 1 && !Paths.get(resolvedPath).isAbsolute) resolvedPath
+    else Paths.get(resolvedPath).toAbsolutePath.toString
   }
 
   /** Resolution order:


### PR DESCRIPTION
`resolveAstGenPath` documents its own resolution order, and the second branch returns `metaData.name`(bare name, no seperator) to *mean* "found on the system PATH", after `hasCompatibleAstGenVersion` has confirmed it is there:

```scala
.orElse(Option.when(hasCompatibleAstGenVersion(astGenVersion, None))(metaData.name))
```

`astGenCommand` then discards that meaning one line later:

```scala
Paths.get(resolvedPath).toAbsolutePath.toString
```

`Paths.get("astgen").toAbsolutePath` resolves against the process working directory, so "on PATH" silently becomes "in the current directory" and the frontend looks for `<cwd>/astgen`.

### Measured

`jssrc2cpg`, with `astgen` on PATH in **both** runs, the only difference being the working directory:

| cwd | result |
|---|---|
| without `./astgen` | `Cannot run program "<cwd>/astgen"`, CPG 4,607 bytes, **0 methods** |
| with `./astgen` | CPG 55,398 bytes, **27 methods** |

### The part that makes it quiet

The exception is caught and an empty CPG is written, so nothing downstream can tell the frontend never ran. A repository with no methods reads as a repository with no findings. Whether a frontend that could not run its AST generator should emit a graph at all seems worth deciding separately; this change only fixes the resolution.

This affects every `AstGenRunner` subclass resolving via PATH rather than the bundled binary — `jssrc2cpg`, `gosrc2cpg`, `rust2cpg`, `swiftsrc2cpg`.

### Not measured

**There is no sbt on this machine, so I have not compiled this.** The guard is `getNameCount == 1 && !isAbsolute`, which leaves every absolute and multi-segment path on exactly the previous code path and changes only the bare-name case that the branch above deliberately produces. `scalafmt --test` passes with the repo's pinned 3.8.1.
