### PR TITLE
[rubysrc2cpg] use surrounding type for member parent

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -168,7 +168,7 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
         Ast() // program scope members are set elsewhere
       } else {
         Ast(
-          memberForMethod(method, Option(NodeTypes.TYPE_DECL), astParentFullName.orElse(scope.surroundingScopeFullName))
+          memberForMethod(method, Option(NodeTypes.TYPE_DECL), astParentFullName.orElse(scope.surroundingTypeFullName))
         )
       }
     // For closures, we also want the method/type refs for upstream use
@@ -466,9 +466,8 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
         }
 
         // The member for these types refers to the singleton class
-        val memberParentType     = astParentType.orElse(scope.surroundingAstLabel)
-        val memberParentFullName = astParentFullName.map(name => s"$name<class>").orElse(scope.surroundingScopeFullName)
-        val member               = memberForMethod(method, memberParentType, memberParentFullName)
+        val memberParentFullName = astParentFullName.map(name => s"$name<class>").orElse(scope.surroundingTypeFullName)
+        val member               = memberForMethod(method, Option(NodeTypes.TYPE_DECL), memberParentFullName)
         diffGraph.addNode(member)
 
         val _methodAst =

--- a/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/main/scala/io/joern/rubysrc2cpg/astcreation/AstForFunctionsCreator.scala
@@ -5,7 +5,7 @@ import io.joern.rubysrc2cpg.datastructures.{ConstructorScope, MethodScope}
 import io.joern.rubysrc2cpg.passes.Defines
 import io.joern.rubysrc2cpg.passes.Defines.RubyOperators
 import io.joern.x2cpg.AstNodeBuilder.{bindingNode, closureBindingNode}
-import io.joern.x2cpg.{Ast, AstEdge, ValidationMode}
+import io.joern.x2cpg.{Ast, AstEdge, Defines as XDefines, ValidationMode}
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import io.shiftleft.codepropertygraph.generated.*
 
@@ -466,8 +466,9 @@ trait AstForFunctionsCreator(implicit withSchemaValidation: ValidationMode) { th
         }
 
         // The member for these types refers to the singleton class
-        val memberParentFullName = astParentFullName.map(name => s"$name<class>").orElse(scope.surroundingTypeFullName)
-        val member               = memberForMethod(method, Option(NodeTypes.TYPE_DECL), memberParentFullName)
+        val memberParentFullName =
+          astParentFullName.map(name => s"$name<class>").orElse(Option(XDefines.UnresolvedNamespace))
+        val member = memberForMethod(method, Option(NodeTypes.TYPE_DECL), memberParentFullName)
         diffGraph.addNode(member)
 
         val _methodAst =

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -407,6 +407,23 @@ class MethodTests extends RubyCode2CpgFixture {
 
     foo.definingTypeDecl.map(_.name) shouldBe Option("C")
     foo.astParent shouldBe cpg.typeDecl("C").head
+
+    val fooMember = cpg.member("foo").head
+    fooMember.typeDecl.name shouldBe "C"
+  }
+
+  "Singleton method with unresolvable target nested inside a method should have its member under the enclosing type decl" in {
+    val cpg = code("""
+        |class C
+        | def outer
+        |  def something.foo
+        |  end
+        | end
+        |end
+        |""".stripMargin)
+
+    val fooMember = cpg.member("foo").head
+    fooMember.typeDecl.name shouldBe "C"
   }
 
   "A Boolean method" should {

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -422,12 +422,37 @@ class MethodTests extends RubyCode2CpgFixture {
     val cpg = code("""
         |class C
         | def outer
+        |  def something.foo
+        |  end
+        | end
+        |end
+        |""".stripMargin)
+
+    val foo = cpg.method.nameExact("foo").head
+
+    foo.definingTypeDecl.map(_.name) shouldBe Option("C")
+    foo.astParent shouldBe cpg.method("outer").head
+
+    val fooMember = cpg.member("foo").head
+    fooMember.astParentFullName shouldBe "<unresolvedNamespace>"
+    fooMember.astParentType shouldBe NodeTypes.TYPE_DECL
+  }
+
+  "Singleton method with resolvable target nested inside a method should have a dangling member" in {
+    val cpg = code("""
+        |class C
+        | def outer
         |  something = ""
         |  def something.foo
         |  end
         | end
         |end
         |""".stripMargin)
+
+    val foo = cpg.method.nameExact("foo").head
+
+    foo.definingTypeDecl.map(_.name) shouldBe Option("C")
+    foo.astParent shouldBe cpg.method("outer").head
 
     val fooMember = cpg.member("foo").head
     fooMember.astParentFullName shouldBe "<unresolvedNamespace>"

--- a/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
+++ b/joern-cli/frontends/rubysrc2cpg/src/test/scala/io/joern/rubysrc2cpg/querying/MethodTests.scala
@@ -195,6 +195,10 @@ class MethodTests extends RubyCode2CpgFixture {
         }
       }
     }
+
+    val fMember = cpg.member("f").head
+    fMember.astParentFullName shouldBe s"Test0.rb:$Main.C<class>"
+    fMember.astParentType shouldBe NodeTypes.TYPE_DECL
   }
 
   "`def class << self << f(x) ... end` is represented by a METHOD inside the TYPE_DECL node" in {
@@ -398,6 +402,7 @@ class MethodTests extends RubyCode2CpgFixture {
   "Singleton methods binding to an unresolvable variable/type should bind to the next AST parent" in {
     val cpg = code("""
         |class C
+        | something = ""
         | def something.foo
         | end
         |end
@@ -409,13 +414,15 @@ class MethodTests extends RubyCode2CpgFixture {
     foo.astParent shouldBe cpg.typeDecl("C").head
 
     val fooMember = cpg.member("foo").head
-    fooMember.typeDecl.name shouldBe "C"
+    fooMember.astParentFullName shouldBe "<unresolvedNamespace>"
+    fooMember.astParentType shouldBe NodeTypes.TYPE_DECL
   }
 
-  "Singleton method with unresolvable target nested inside a method should have its member under the enclosing type decl" in {
+  "Singleton method with unresolvable target nested inside a method should have a dangling member" in {
     val cpg = code("""
         |class C
         | def outer
+        |  something = ""
         |  def something.foo
         |  end
         | end
@@ -423,7 +430,8 @@ class MethodTests extends RubyCode2CpgFixture {
         |""".stripMargin)
 
     val fooMember = cpg.member("foo").head
-    fooMember.typeDecl.name shouldBe "C"
+    fooMember.astParentFullName shouldBe "<unresolvedNamespace>"
+    fooMember.astParentType shouldBe NodeTypes.TYPE_DECL
   }
 
   "A Boolean method" should {


### PR DESCRIPTION
- use surrounding type name for member parent
- fixes a bug where a member doesn't have a TYPE_DECL as the parent