### PR TITLE
[semanticcpg]: don't dedup tag traversal

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/importresolver/ResolvedImportAsTagTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/importresolver/ResolvedImportAsTagTraversal.scala
@@ -31,12 +31,12 @@ class ResolvedImportAsTagTraversal(steps: Iterator[Tag]) extends AnyVal {
 
   @Doc(info = "Parses these tags as EvaluatedImport classes")
   def _toEvaluatedImport: Iterator[EvaluatedImport] = {
-    steps.flatMap(_._toEvaluatedImport)
+    steps.dedupBy(tag => (tag.name, tag.value, tag._taggedByIn.headOption)).flatMap(_._toEvaluatedImport)
   }
 
   @Doc(info = "If these tags represent resolved imports, will attempt to find the CPG entities referred to")
   def resolvedEntity: Iterator[AstNode] = {
-    steps.flatMap(_.resolvedEntity)
+    steps.dedupBy(tag => (tag.name, tag.value, tag._taggedByIn.headOption)).flatMap(_.resolvedEntity)
   }
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/StoredNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/StoredNodeMethods.scala
@@ -7,12 +7,7 @@ import io.shiftleft.semanticcpg.language.*
 import scala.jdk.CollectionConverters.*
 
 class StoredNodeMethods(val node: StoredNode) extends AnyVal with NodeExtension {
-  def tag: Iterator[Tag] = {
-    node._taggedByOut
-      .cast[Tag]
-      .distinctBy(tag => (tag.name, tag.value))
-  }
+  def tag: Iterator[Tag] = node._taggedByOut.cast[Tag]
 
-  def file: Iterator[File] =
-    Iterator.single(node).file
+  def file: Iterator[File] = Iterator.single(node).file
 }


### PR DESCRIPTION
best case of the deduping is that it hides bugs, worst case is it hides intentional tags - e.g. tags on tags are allowed, and those tags on the tags can differ even when name and value don't.

the type recovery depends on this deduplication though, so we add it back there