### PR TITLE
fix(semanticcpg): close per-entry streams in FileUtil.unzipTo (silent truncation of large archives)

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/FileUtil.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/FileUtil.scala
@@ -179,8 +179,13 @@ object FileUtil {
       zipFilter: ZipEntry => Boolean = _ => true,
       bufferSize: Int = 8192
     ): destination.type = {
-      Using.Manager { use =>
-        val zipFile = use(new ZipFile(p.absolutePathAsString, Charset.defaultCharset()))
+      // Each entry's input/output streams are closed immediately (nested Using.resource) rather
+      // than being registered with a single Using.Manager for the whole archive. Registering them
+      // with the Manager keeps every per-entry stream open until the entire archive is extracted,
+      // leaking one file descriptor (and one zlib Inflater) per entry. On large archives this
+      // exhausts a per-process resource limit part-way through, and because the failure is not
+      // surfaced the extraction is silently truncated to the first N entries.
+      Using.resource(new ZipFile(p.absolutePathAsString, Charset.defaultCharset())) { zipFile =>
         val entries = zipFile.entries().asScala.filter(zipFilter)
 
         entries.foreach { entry =>
@@ -191,9 +196,11 @@ object FileUtil {
           )
 
           if (!entry.isDirectory) {
-            val zipStream    = use(zipFile.getInputStream(entry))
-            val outputStream = use(Files.newOutputStream(child))
-            pipeTo(zipStream, outputStream, Array.ofDim[Byte](bufferSize))
+            Using.resource(zipFile.getInputStream(entry)) { zipStream =>
+              Using.resource(Files.newOutputStream(child)) { outputStream =>
+                pipeTo(zipStream, outputStream, Array.ofDim[Byte](bufferSize))
+              }
+            }
           }
         }
       }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/FileUtil.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/FileUtil.scala
@@ -179,12 +179,6 @@ object FileUtil {
       zipFilter: ZipEntry => Boolean = _ => true,
       bufferSize: Int = 8192
     ): destination.type = {
-      // Each entry's input/output streams are closed immediately (nested Using.resource) rather
-      // than being registered with a single Using.Manager for the whole archive. Registering them
-      // with the Manager keeps every per-entry stream open until the entire archive is extracted,
-      // leaking one file descriptor (and one zlib Inflater) per entry. On large archives this
-      // exhausts a per-process resource limit part-way through, and because the failure is not
-      // surfaced the extraction is silently truncated to the first N entries.
       Using.resource(new ZipFile(p.absolutePathAsString, Charset.defaultCharset())) { zipFile =>
         val entries = zipFile.entries().asScala.filter(zipFilter)
 

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/utils/FileUtilTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/utils/FileUtilTests.scala
@@ -24,7 +24,6 @@ class FileUtilTests extends AnyWordSpec with Matchers {
 
   "FileUtil.unzipTo" should {
 
-    // Every entry of a many-entry archive must be extracted.
     "extract every entry of an archive with many entries" in {
       FileUtil.usingTemporaryDirectory("unzip-many") { workDir =>
         val n   = 5000
@@ -40,8 +39,6 @@ class FileUtilTests extends AnyWordSpec with Matchers {
       }
     }
 
-    // A mid-extraction failure must propagate. Extracting "a" as a regular file and then "a/b",
-    // which needs "a" to be a directory, fails part-way through and must throw.
     "propagate a mid-extraction failure" in {
       FileUtil.usingTemporaryDirectory("unzip-fail") { workDir =>
         val zip = workDir.resolve("collide.zip")

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/utils/FileUtilTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/utils/FileUtilTests.scala
@@ -24,9 +24,7 @@ class FileUtilTests extends AnyWordSpec with Matchers {
 
   "FileUtil.unzipTo" should {
 
-    // Guards against per-entry resource accumulation silently truncating the output: every
-    // entry must be extracted. (Reliably reproducing the truncation itself requires exceeding
-    // an environment-specific resource limit, so this is a functional invariant check.)
+    // Every entry of a many-entry archive must be extracted.
     "extract every entry of an archive with many entries" in {
       FileUtil.usingTemporaryDirectory("unzip-many") { workDir =>
         val n   = 5000
@@ -42,12 +40,9 @@ class FileUtilTests extends AnyWordSpec with Matchers {
       }
     }
 
-    // Guards against the failure being swallowed: with the previous implementation the
-    // Using.Manager result Try was discarded and `destination` was returned unconditionally,
-    // so a mid-extraction failure was reported as a successful (partial) extraction. It must
-    // now propagate. Here "a" is extracted as a regular file, then "a/b" needs "a" to be a
-    // directory, which fails part-way through.
-    "surface a mid-extraction failure instead of returning a partial extraction as success" in {
+    // A mid-extraction failure must propagate. Extracting "a" as a regular file and then "a/b",
+    // which needs "a" to be a directory, fails part-way through and must throw.
+    "propagate a mid-extraction failure" in {
       FileUtil.usingTemporaryDirectory("unzip-fail") { workDir =>
         val zip = workDir.resolve("collide.zip")
         writeZip(zip, Seq("a" -> "x", "a/b" -> "y"))

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/utils/FileUtilTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/utils/FileUtilTests.scala
@@ -1,0 +1,60 @@
+package io.shiftleft.semanticcpg.utils
+
+import io.shiftleft.semanticcpg.utils.FileUtil.*
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import java.util.zip.{ZipEntry, ZipOutputStream}
+import scala.jdk.CollectionConverters.*
+import scala.util.Using
+
+class FileUtilTests extends AnyWordSpec with Matchers {
+
+  private def writeZip(zip: Path, entries: Seq[(String, String)]): Unit = {
+    Using.resource(new ZipOutputStream(Files.newOutputStream(zip))) { zos =>
+      entries.foreach { case (name, content) =>
+        zos.putNextEntry(new ZipEntry(name))
+        zos.write(content.getBytes(StandardCharsets.UTF_8))
+        zos.closeEntry()
+      }
+    }
+  }
+
+  "FileUtil.unzipTo" should {
+
+    // Guards against per-entry resource accumulation silently truncating the output: every
+    // entry must be extracted. (Reliably reproducing the truncation itself requires exceeding
+    // an environment-specific resource limit, so this is a functional invariant check.)
+    "extract every entry of an archive with many entries" in {
+      FileUtil.usingTemporaryDirectory("unzip-many") { workDir =>
+        val n   = 5000
+        val zip = workDir.resolve("many.zip")
+        writeZip(zip, (0 until n).map(i => s"pkg/cls$i.txt" -> i.toString))
+
+        val dest = Files.createDirectory(workDir.resolve("out"))
+        zip.unzipTo(dest)
+
+        val extracted =
+          Using.resource(Files.walk(dest))(_.iterator().asScala.count(Files.isRegularFile(_)))
+        extracted shouldBe n
+      }
+    }
+
+    // Guards against the failure being swallowed: with the previous implementation the
+    // Using.Manager result Try was discarded and `destination` was returned unconditionally,
+    // so a mid-extraction failure was reported as a successful (partial) extraction. It must
+    // now propagate. Here "a" is extracted as a regular file, then "a/b" needs "a" to be a
+    // directory, which fails part-way through.
+    "surface a mid-extraction failure instead of returning a partial extraction as success" in {
+      FileUtil.usingTemporaryDirectory("unzip-fail") { workDir =>
+        val zip = workDir.resolve("collide.zip")
+        writeZip(zip, Seq("a" -> "x", "a/b" -> "y"))
+
+        val dest = Files.createDirectory(workDir.resolve("out"))
+        a[Throwable] should be thrownBy zip.unzipTo(dest)
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

`FileUtil.PathExt.unzipTo` can **silently truncate large archives**: only a prefix of the
entries (in archive iteration order) is extracted, and a **partially-extracted directory is
returned as if the extraction succeeded** — no exception, no log, successful exit. Downstream
consumers then operate on an incomplete file set.

This surfaced in `jimple2cpg`, whose `ProgramHandlingUtil.extractClassesInPackageLayout` uses
`unzipTo`. On large Android apps the CPG builds "successfully" but omits most classes: the
staging count (`Loading N program files`) pins to ~10,122 regardless of input size (e.g. a
50,157-class app and a 13,974-class app both stage 10,122), and the retained set is exactly the
first ~10,122 entries in zip order. An SDK whose classes sort after that boundary is entirely
absent from the CPG.

## Root cause

### Confirmed

1. **Per-entry streams accumulate in one archive-wide `Using.Manager`.** Each entry's
   `getInputStream` / `newOutputStream` is registered with a single `Using.Manager` scoped to the
   whole archive, so no per-entry resource is released until the entire archive finishes:

   ```scala
   Using.Manager { use =>
     val zipFile = use(new ZipFile(...))
     entries.foreach { entry =>
       ...
       val zipStream    = use(zipFile.getInputStream(entry))  // released only at block end
       val outputStream = use(Files.newOutputStream(child))   // released only at block end
       pipeTo(zipStream, outputStream, ...)
     }
   }
   ```

2. **The `Using.Manager` result is discarded and `destination` is returned unconditionally.**
   `Using.Manager { ... }` returns a `Try` (it captures failures rather than rethrowing), but the
   `Try` is ignored and `destination` is returned regardless. So if extraction fails part-way, the
   failure is swallowed and a **partial extraction is returned as success**. The `jimple2cpg`
   caller wraps the call in `Try(f.unzipTo(...))`, but there is nothing left to catch.

3. **Switching to per-entry `Using.resource` fixes it:** all classes are extracted and the
   previously-missing SDK is recovered (numbers below).

### Not yet confirmed

- **Which exact resource limit is exhausted at ~10,122 is not pinned down.** I am deliberately
  *not* claiming "file-descriptor limit exhaustion" as the mechanism — on the machine where this
  was observed the shell `ulimit -n` was 1,048,576 and `kern.maxfilesperproc` was 61,440, both far
  above ~10,122. The accurate statement is: **per-entry resource accumulation → an
  environment-specific resource exhaustion/failure**, whose result is then swallowed (point 2).
- **Observation (not a claim):** during extraction the process's open file-descriptor count was
  seen climbing to ~10k (a non-leaking extractor stays flat), consistent with per-entry
  accumulation — recorded here as an observation, not as the identified limit.

## Fix

Close each entry's input/output streams immediately with nested `Using.resource`, keeping only
the `ZipFile` open for the loop. This both removes the per-entry accumulation and — because
`Using.resource` rethrows — restores failure propagation, so a genuine mid-extraction error is no
longer silently swallowed.

## Verification

Rebuilt the patched frontend and re-ran real apps:

- `Loading N program files`: **10,122 → 50,157** (50k-class app) and **10,122 → 13,974**
  (14k-class app) — the full input is now staged.
- Target-SDK presence in the whole-app CPG (14k-class app): **0 → 895 methods** and
  **0 → 8 sink call-sites** — identical to building a CPG from just that SDK in isolation.
- Deterministic across repeated runs.

## Tests

`semanticcpg/.../utils/FileUtilTests.scala` adds two `unzipTo` regression tests:

- **surfaces a mid-extraction failure** instead of returning a partial extraction as success
  (deterministic; targets root-cause point 2 — this test fails on the previous implementation
  because the failure was swallowed).
- **extracts every entry of a many-entry archive** (functional invariant guarding point 1;
  reliably reproducing the truncation itself would require exceeding an environment-specific
  resource limit, so this checks the invariant rather than the limit).

## Repro

```
SL_LOGGING_LEVEL=INFO jimple2cpg <large-app>.jar --output /tmp/x.cpg 2>&1 | grep 'program files'
# before: "Loading 10122 program files" for any input larger than that
# after : "Loading <all N> program files"
```
