### PR TITLE
[rust2cpg] remove unnecessary tmp var in match expressions.

### DIFF
--- a/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
+++ b/joern-cli/frontends/rust2cpg/src/main/scala/io/joern/rust2cpg/astcreation/RustVisitor.scala
@@ -1801,24 +1801,38 @@ trait RustVisitor(implicit withSchemaValidation: ValidationMode) { this: AstCrea
   //  }
   // }
   private def visitMatchExpr(matchExpr: MatchExpr): Ast = {
-    val tmpName       = contextStack.nextTmpName()
-    val typeFullName  = typeFullNameForExpr(matchExpr.expr)
-    val tmpLocalAst   = Ast(localNode(matchExpr.expr, tmpName, tmpName, typeFullName))
-    val mkTmpIdentAst = () => Ast(identifierNode(matchExpr.expr, tmpName, tmpName, typeFullName))
-    val tmpAssignAst = callAst(
-      assignmentNode(matchExpr.expr, s"$tmpName = ${code(matchExpr.expr)}"),
-      Seq(mkTmpIdentAst(), visitExpr(matchExpr.expr))
-    )
-    val armAsts      = matchExpr.matchArmList.matchArm.flatMap(lowerMatchArm(_, mkTmpIdentAst))
-    val matchBodyAst = blockAst(blockNode(matchExpr.matchArmList), armAsts.toList)
-    val matchExprAst = matchAst(matchExpr, Some(mkTmpIdentAst()), Seq(matchBodyAst))
-    Ast(blockNode(matchExpr)).withChildren(Seq(tmpLocalAst, tmpAssignAst, matchExprAst))
+    val mkSourceAst = () => visitExpr(matchExpr.expr)
+    // When it's already an identifier, we don't need to assign it a fresh tmp.
+    if (isIdentifierWithoutAdjustments(matchExpr.expr)) {
+      val armAsts      = matchExpr.matchArmList.matchArm.flatMap(lowerMatchArm(_, mkSourceAst))
+      val matchBodyAst = blockAst(blockNode(matchExpr.matchArmList), armAsts.toList)
+      val matchExprAst = matchAst(matchExpr, Some(mkSourceAst()), Seq(matchBodyAst))
+      Ast(blockNode(matchExpr)).withChild(matchExprAst)
+    } else {
+      val tmpName       = contextStack.nextTmpName()
+      val typeFullName  = typeFullNameForExpr(matchExpr.expr)
+      val tmpLocalAst   = Ast(localNode(matchExpr.expr, tmpName, tmpName, typeFullName))
+      val mkTmpIdentAst = () => Ast(identifierNode(matchExpr.expr, tmpName, tmpName, typeFullName))
+      val tmpAssignAst = callAst(
+        assignmentNode(matchExpr.expr, s"$tmpName = ${code(matchExpr.expr)}"),
+        Seq(mkTmpIdentAst(), mkSourceAst())
+      )
+      val armAsts      = matchExpr.matchArmList.matchArm.flatMap(lowerMatchArm(_, mkTmpIdentAst))
+      val matchBodyAst = blockAst(blockNode(matchExpr.matchArmList), armAsts.toList)
+      val matchExprAst = matchAst(matchExpr, Some(mkTmpIdentAst()), Seq(matchBodyAst))
+      Ast(blockNode(matchExpr)).withChildren(Seq(tmpLocalAst, tmpAssignAst, matchExprAst))
+    }
   }
 
-  private def lowerMatchArm(matchArm: MatchArm, tmpIdentAst: () => Ast): Seq[Ast] = {
+  private def isIdentifierWithoutAdjustments(expr: Expr): Boolean = expr match {
+    case pathExpr: PathExpr => pathExpr.path.path.isEmpty && pathExpr.adjustments.forall(_.isEmpty)
+    case _                  => false
+  }
+
+  private def lowerMatchArm(matchArm: MatchArm, mkSourceAst: () => Ast): Seq[Ast] = {
     val bindingAsts = createLocalsForBindings(collectPatternBindings(matchArm.pat)) ++ createAssignmentsForPattern(
       matchArm.pat,
-      tmpIdentAst
+      mkSourceAst
     )
     val bodyAst = matchArm.matchGuard match {
       case Some(matchGuard) =>

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/EnumTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/EnumTests.scala
@@ -358,44 +358,44 @@ class EnumTests extends Rust2CpgSuite(noSysRoot = true) {
     "have correct field accesses" in {
       inside(cpg.assignment.where(_.target.isIdentifier.nameExact("x")).source.l) { case (fieldAccess: Call) :: Nil =>
         fieldAccess.methodFullName shouldBe Operators.fieldAccess
-        fieldAccess.code shouldBe "(<tmp>0 as rust2cpgtest::E<T>::A).0"
+        fieldAccess.code shouldBe "(e as rust2cpgtest::E<T>::A).0"
         fieldAccess.typeFullName shouldBe "i32"
 
         inside(fieldAccess.argument.sortBy(_.argumentIndex).l) { case (cast: Call) :: (field: FieldIdentifier) :: Nil =>
           field.canonicalName shouldBe "0"
 
           cast.methodFullName shouldBe Operators.cast
-          cast.code shouldBe "(<tmp>0 as rust2cpgtest::E<T>::A)"
+          cast.code shouldBe "(e as rust2cpgtest::E<T>::A)"
           cast.typeFullName shouldBe "rust2cpgtest::E<T>::A"
 
-          inside(cast.argument.sortBy(_.argumentIndex).l) { case (typeRef: TypeRef) :: (tmp: Identifier) :: Nil =>
+          inside(cast.argument.sortBy(_.argumentIndex).l) { case (typeRef: TypeRef) :: (ident: Identifier) :: Nil =>
             typeRef.code shouldBe "E::A"
             typeRef.typeFullName shouldBe "rust2cpgtest::E<T>::A"
 
-            tmp.name shouldBe "<tmp>0"
-            tmp.typeFullName shouldBe "rust2cpgtest::E<i32>"
+            ident.name shouldBe "e"
+            ident.typeFullName shouldBe "rust2cpgtest::E<i32>"
           }
         }
       }
 
       inside(cpg.assignment.where(_.target.isIdentifier.nameExact("y")).source.l) { case (fieldAccess: Call) :: Nil =>
         fieldAccess.methodFullName shouldBe Operators.fieldAccess
-        fieldAccess.code shouldBe "(<tmp>0 as rust2cpgtest::E<T>::A).1"
+        fieldAccess.code shouldBe "(e as rust2cpgtest::E<T>::A).1"
         fieldAccess.typeFullName shouldBe "bool"
 
         inside(fieldAccess.argument.sortBy(_.argumentIndex).l) { case (cast: Call) :: (field: FieldIdentifier) :: Nil =>
           field.canonicalName shouldBe "1"
 
           cast.methodFullName shouldBe Operators.cast
-          cast.code shouldBe "(<tmp>0 as rust2cpgtest::E<T>::A)"
+          cast.code shouldBe "(e as rust2cpgtest::E<T>::A)"
           cast.typeFullName shouldBe "rust2cpgtest::E<T>::A"
 
-          inside(cast.argument.sortBy(_.argumentIndex).l) { case (typeRef: TypeRef) :: (tmp: Identifier) :: Nil =>
+          inside(cast.argument.sortBy(_.argumentIndex).l) { case (typeRef: TypeRef) :: (ident: Identifier) :: Nil =>
             typeRef.code shouldBe "E::A"
             typeRef.typeFullName shouldBe "rust2cpgtest::E<T>::A"
 
-            tmp.name shouldBe "<tmp>0"
-            tmp.typeFullName shouldBe "rust2cpgtest::E<i32>"
+            ident.name shouldBe "e"
+            ident.typeFullName shouldBe "rust2cpgtest::E<i32>"
           }
         }
       }

--- a/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/MatchTests.scala
+++ b/joern-cli/frontends/rust2cpg/src/test/scala/io/joern/rust2cpg/passes/ast/MatchTests.scala
@@ -17,25 +17,23 @@ class MatchTests extends Rust2CpgSuite(noSysRoot = true) {
         |}
         |""".stripMargin)
 
-    "lower as a block with a local, tmp assignment and MATCH" in {
+    "have correct children" in {
       inside(cpg.method.nameExact("foo").block.astChildren.isBlock.astChildren.l) {
-        case (tmp: Local) :: (tmpAssign: Call) :: (matchNode: ControlStructure) :: Nil =>
-          tmp.name shouldBe "<tmp>0"
-          tmp.typeFullName shouldBe "i32"
-
-          tmpAssign.code shouldBe "<tmp>0 = x"
-          tmpAssign.methodFullName shouldBe Operators.assignment
-
+        case (matchNode: ControlStructure) :: Nil =>
           matchNode.controlStructureType shouldBe ControlStructureTypes.MATCH
       }
     }
 
     "have correct match condition" in {
       inside(cpg.controlStructure.controlStructureTypeExact(ControlStructureTypes.MATCH).condition.l) {
-        case (tmp: Identifier) :: Nil =>
-          tmp.name shouldBe "<tmp>0"
-          tmp.typeFullName shouldBe "i32"
+        case (ident: Identifier) :: Nil =>
+          ident.name shouldBe "x"
+          ident.typeFullName shouldBe "i32"
       }
+    }
+
+    "have correct REF edges" in {
+      cpg.method.nameExact("foo").parameter.referencingIdentifiers.lineNumber.l shouldBe List(3)
     }
 
     "have jump targets for each match arm" in {
@@ -71,13 +69,7 @@ class MatchTests extends Rust2CpgSuite(noSysRoot = true) {
 
     "assign the match block to the LHS" in {
       inside(cpg.assignment.where(_.target.isIdentifier.nameExact("y")).source.l) { case (block: Block) :: Nil =>
-        inside(block.astChildren.l) { case (tmp: Local) :: (tmpAssign: Call) :: (matchNode: ControlStructure) :: Nil =>
-          tmp.name shouldBe "<tmp>0"
-          tmp.typeFullName shouldBe "(i32, i32)"
-
-          tmpAssign.code shouldBe "<tmp>0 = p"
-          tmpAssign.methodFullName shouldBe Operators.assignment
-
+        inside(block.astChildren.l) { case (matchNode: ControlStructure) :: Nil =>
           matchNode.controlStructureType shouldBe ControlStructureTypes.MATCH
         }
       }
@@ -92,14 +84,67 @@ class MatchTests extends Rust2CpgSuite(noSysRoot = true) {
             case (aLocal: Local) :: (bLocal: Local) :: (aAssign: Call) :: (bAssign: Call) :: (body: Call) :: Nil =>
               aLocal.name shouldBe "a"
               aLocal.typeFullName shouldBe "i32"
-              aAssign.code shouldBe "a = <tmp>0.0"
+              aAssign.code shouldBe "a = p.0"
 
               bLocal.name shouldBe "b"
               bLocal.typeFullName shouldBe "i32"
-              bAssign.code shouldBe "b = <tmp>0.1"
+              bAssign.code shouldBe "b = p.1"
 
               body.code shouldBe "a + b"
               body.methodFullName shouldBe Operators.addition
+          }
+
+          case2.name shouldBe "case _"
+          case2.code shouldBe "_"
+          inside(arm2.astChildren.l) { case (body: Call) :: Nil =>
+            body.name shouldBe "bar"
+            body.code shouldBe "bar()"
+          }
+      }
+    }
+  }
+
+  "match on a call" should {
+    val cpg = code("""
+        |fn baz() -> i32 { 1 }
+        |
+        |fn foo() {
+        |  match baz() {
+        |  1 => one(),
+        |  _ => bar(),
+        |  };
+        |}
+        |""".stripMargin)
+
+    "have correct children" in {
+      inside(cpg.method.nameExact("foo").block.astChildren.isBlock.astChildren.l) {
+        case (tmp: Local) :: (tmpAssign: Call) :: (matchNode: ControlStructure) :: Nil =>
+          tmp.name shouldBe "<tmp>0"
+          tmp.typeFullName shouldBe "i32"
+
+          tmpAssign.code shouldBe "<tmp>0 = baz()"
+          tmpAssign.methodFullName shouldBe Operators.assignment
+
+          matchNode.controlStructureType shouldBe ControlStructureTypes.MATCH
+      }
+    }
+
+    "have correct match condition" in {
+      inside(cpg.controlStructure.controlStructureTypeExact(ControlStructureTypes.MATCH).condition.l) {
+        case (tmp: Identifier) :: Nil =>
+          tmp.name shouldBe "<tmp>0"
+          tmp.typeFullName shouldBe "i32"
+      }
+    }
+
+    "have jump targets for each match arm" in {
+      inside(cpg.controlStructure.controlStructureTypeExact(ControlStructureTypes.MATCH).whenTrue.astChildren.l) {
+        case (case1: JumpTarget) :: (arm1: Block) :: (case2: JumpTarget) :: (arm2: Block) :: Nil =>
+          case1.name shouldBe "case 1"
+          case1.code shouldBe "1"
+          inside(arm1.astChildren.l) { case (body: Call) :: Nil =>
+            body.name shouldBe "one"
+            body.code shouldBe "one()"
           }
 
           case2.name shouldBe "case _"
@@ -128,16 +173,14 @@ class MatchTests extends Rust2CpgSuite(noSysRoot = true) {
     }
 
     "have correct locals" in {
-      inside(cpg.local.sortBy(_.order).l) { case tmp :: nLocal :: Nil =>
-        tmp.name shouldBe "<tmp>0"
-        tmp.typeFullName shouldBe "(i32, i32)"
+      inside(cpg.local.sortBy(_.order).l) { case nLocal :: Nil =>
         nLocal.name shouldBe "n"
         nLocal.typeFullName shouldBe "i32"
       }
     }
 
     "have correct local assignments" in {
-      cpg.method.nameExact("foo").block.assignment.sortBy(_.order).code.l shouldBe List("<tmp>0 = x", "n = <tmp>0.0")
+      cpg.method.nameExact("foo").block.assignment.sortBy(_.order).code.l shouldBe List("n = x.0")
     }
 
     "have correct if control structures" in {
@@ -168,29 +211,27 @@ class MatchTests extends Rust2CpgSuite(noSysRoot = true) {
         |""".stripMargin)
 
     "have correct locals" in {
-      inside(cpg.local.l) { case tmp0 :: aLocal :: tmp1 :: Nil =>
-        tmp0.name shouldBe "<tmp>0"
-        tmp0.typeFullName shouldBe "rust2cpgtest::Point"
+      inside(cpg.local.l) { case aLocal :: tmp :: Nil =>
         aLocal.name shouldBe "a"
         aLocal.typeFullName shouldBe "i32"
-        tmp1.name shouldBe "<tmp>1"
-        tmp1.typeFullName shouldBe "rust2cpgtest::Point"
+        tmp.name shouldBe "<tmp>0"
+        tmp.typeFullName shouldBe "rust2cpgtest::Point"
       }
     }
 
     "have correct assignments" in {
       cpg.method.nameExact("foo").block.assignment.code.sorted.l shouldBe
-        List("<tmp>0 = p", "<tmp>1 = <tmp>0", "a = <tmp>1.x", "a = <tmp>1.y")
+        List("<tmp>0 = p", "a = <tmp>0.x", "a = <tmp>0.y")
     }
 
     "have correct if control structure" in {
       inside(cpg.ifBlock.l) { case ifNode :: elseIfNode :: Nil =>
         ifNode.condition.code.l shouldBe List("Point { x: 0, y: a }")
-        ifNode.whenTrue.isBlock.assignment.code.l shouldBe List("a = <tmp>1.y")
+        ifNode.whenTrue.isBlock.assignment.code.l shouldBe List("a = <tmp>0.y")
         ifNode.whenFalse.l shouldBe List(elseIfNode)
 
         elseIfNode.condition.code.l shouldBe List("Point { x: a, y: 0 }")
-        elseIfNode.whenTrue.isBlock.assignment.code.l shouldBe List("a = <tmp>1.x")
+        elseIfNode.whenTrue.isBlock.assignment.code.l shouldBe List("a = <tmp>0.x")
         elseIfNode.whenFalse.l shouldBe empty
       }
     }


### PR DESCRIPTION
Previously, when lowering a `match expr` expression we always allocated a tmp variable to hold `expr` and be passed around when lowering the match arms. When `expr` is already an identifier, the fresh tmp variable isn't adding anything, so we remove it here.