### PR TITLE
[c2cpg] Harden CDT type resolution: fold expr crash + StackOverflowError

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstCreatorHelper.scala
@@ -13,6 +13,7 @@ import org.eclipse.cdt.internal.core.dom.parser.cpp.{CPPASTArrayRangeDesignator,
 
 import java.nio.file.{Path, Paths}
 import scala.collection.mutable
+import scala.util.control.NonFatal
 import scala.util.{Success, Try}
 
 trait AstCreatorHelper { this: AstCreator =>
@@ -122,9 +123,24 @@ trait AstCreatorHelper { this: AstCreator =>
     accumulator.registerMethodDefinition(fullName)
   }
 
+  /** Wraps a call into Eclipse CDT's type/binding/evaluation resolution.
+    *
+    * In case of unresolved includes etc. this may fail throwing an unrecoverable exception. Additionally, CDT's heavily
+    * recursive analysis can run into unbounded mutual recursion for certain inputs (see
+    * https://github.com/joernio/joern/issues/6261), throwing a `StackOverflowError`. That is a `VirtualMachineError`
+    * which `scala.util.Try`/`NonFatal` do not catch, so we catch it explicitly here and degrade to `None` instead of
+    * losing the whole file.
+    */
+  protected def safeCdtCall[T](call: => T): Option[T] = {
+    try { Option(call) }
+    catch {
+      case _: StackOverflowError => None
+      case NonFatal(_)           => None
+    }
+  }
+
   protected def safeGetEvaluation(expr: ICPPASTExpression): Option[ICPPEvaluation] = {
-    // In case of unresolved includes etc. this may fail throwing an unrecoverable exception
-    Try(expr.getEvaluation).toOption.filter(_ != null)
+    safeCdtCall(expr.getEvaluation)
   }
 
   protected def safeGetBinding(idExpression: IASTIdExpression): Option[IBinding] = {
@@ -142,8 +158,7 @@ trait AstCreatorHelper { this: AstCreator =>
   }
 
   protected def safeGetBinding(name: IASTName): Option[IBinding] = {
-    // In case of unresolved includes etc. this may fail throwing an unrecoverable exception
-    Try(name.resolveBinding()).toOption.filter(_ != null)
+    safeCdtCall(name.resolveBinding())
   }
 
   protected def notHandledYet(node: IASTNode): Ast = {

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForExpressionsCreator.scala
@@ -236,7 +236,7 @@ trait AstForExpressionsCreator { this: AstCreator =>
             astForCppCallExpressionUntyped(call)
         }
       case Some(classType: ICPPClassType) if safeGetEvaluation(call).exists(_.isInstanceOf[EvalFunctionCall]) =>
-        val evaluation        = safeGetEvaluation(call).get.asInstanceOf[EvalFunctionCall]
+        val evaluation        = call.getEvaluation.asInstanceOf[EvalFunctionCall]
         val functionType      = safeCdtCall(evaluation.getOverload.getType)
         val functionSignature = functionType.map(functionTypeToSignature).getOrElse(X2CpgDefines.UnresolvedSignature)
         val name              = Defines.OperatorCall

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForExpressionsCreator.scala
@@ -170,8 +170,8 @@ trait AstForExpressionsCreator { this: AstCreator =>
 
   private def astForCppCallExpression(call: ICPPASTFunctionCallExpression): Ast = {
     val functionNameExpr = call.getFunctionNameExpression
-    Try(functionNameExpr.getExpressionType).toOption match {
-      case Some(_: IPointerType) => createPointerCallAst(call, safeGetType(call.getExpressionType))
+    safeCdtCall(functionNameExpr.getExpressionType) match {
+      case Some(_: IPointerType) => createPointerCallAst(call, safeGetExpressionType(call))
       case Some(functionType: ICPPFunctionType) =>
         functionNameExpr match {
           case idExpr: CPPASTIdExpression if safeGetBinding(idExpr).exists(_.isInstanceOf[ICPPFunction]) =>
@@ -198,7 +198,7 @@ trait AstForExpressionsCreator { this: AstCreator =>
               fullName,
               DispatchTypes.STATIC_DISPATCH,
               Some(signature),
-              Some(registerType(safeGetType(call.getExpressionType)))
+              Some(registerType(safeGetExpressionType(call)))
             )
             val args = call.getArguments.toList.map(a => astForNode(a))
             createCallAst(callCpgNode, args)
@@ -208,7 +208,7 @@ trait AstForExpressionsCreator { this: AstCreator =>
             val args        = call.getArguments.toList.map(a => astForNode(a))
 
             val method = fieldRefExpr.getFieldName.getBinding.asInstanceOf[ICPPMethod]
-            val constFlag = if (isConstType(method.getType)) { Defines.ConstSuffix }
+            val constFlag = if (safeCdtCall(method.getType).exists(isConstType)) { Defines.ConstSuffix }
             else { "" }
             // TODO This wont do if the name is a reference.
             val name          = stripTemplateTags(fieldRefExpr.getFieldName.toString)
@@ -229,15 +229,15 @@ trait AstForExpressionsCreator { this: AstCreator =>
               fullName,
               dispatchType,
               Some(signature),
-              Some(registerType(safeGetType(call.getExpressionType)))
+              Some(registerType(safeGetExpressionType(call)))
             )
             createCallAst(callCpgNode, args, base = Some(instanceAst), receiver)
           case _ =>
             astForCppCallExpressionUntyped(call)
         }
       case Some(classType: ICPPClassType) if safeGetEvaluation(call).exists(_.isInstanceOf[EvalFunctionCall]) =>
-        val evaluation        = call.getEvaluation.asInstanceOf[EvalFunctionCall]
-        val functionType      = Try(evaluation.getOverload.getType).toOption
+        val evaluation        = safeGetEvaluation(call).get.asInstanceOf[EvalFunctionCall]
+        val functionType      = safeCdtCall(evaluation.getOverload.getType)
         val functionSignature = functionType.map(functionTypeToSignature).getOrElse(X2CpgDefines.UnresolvedSignature)
         val name              = Defines.OperatorCall
         classType match {
@@ -254,7 +254,7 @@ trait AstForExpressionsCreator { this: AstCreator =>
               fullName,
               DispatchTypes.DYNAMIC_DISPATCH,
               Some(lambdaSignature),
-              Some(registerType(safeGetType(call.getExpressionType)))
+              Some(registerType(safeGetExpressionType(call)))
             )
             val receiverAst = astForExpression(functionNameExpr)
             val args        = call.getArguments.toList.map(a => astForNode(a))
@@ -262,8 +262,8 @@ trait AstForExpressionsCreator { this: AstCreator =>
           case _ =>
             val classFullName = safeGetType(classType)
             val fullName      = s"$classFullName.$name:$functionSignature"
-            val dispatchType = evaluation.getOverload match {
-              case method: ICPPMethod =>
+            val dispatchType = safeCdtCall(evaluation.getOverload) match {
+              case Some(method: ICPPMethod) =>
                 if (method.isVirtual || method.isPureVirtual) {
                   DispatchTypes.DYNAMIC_DISPATCH
                 } else {
@@ -279,7 +279,7 @@ trait AstForExpressionsCreator { this: AstCreator =>
               fullName,
               dispatchType,
               Some(functionSignature),
-              Some(registerType(safeGetType(call.getExpressionType)))
+              Some(registerType(safeGetExpressionType(call)))
             )
             val instanceAst = astForExpression(functionNameExpr)
             val args        = call.getArguments.toList.map(a => astForNode(a))
@@ -324,15 +324,15 @@ trait AstForExpressionsCreator { this: AstCreator =>
 
   private def astForCCallExpression(call: CASTFunctionCallExpression): Ast = {
     val functionNameExpr = call.getFunctionNameExpression
-    Try(functionNameExpr.getExpressionType).toOption match {
+    safeCdtCall(functionNameExpr.getExpressionType) match {
       case Some(_: CPointerType) =>
-        createPointerCallAst(call, safeGetType(call.getExpressionType))
+        createPointerCallAst(call, safeGetExpressionType(call))
       case Some(_: CFunctionType) =>
         functionNameExpr match {
           case idExpr: CASTIdExpression =>
-            createCFunctionCallAst(call, idExpr, safeGetType(call.getExpressionType))
+            createCFunctionCallAst(call, idExpr, safeGetExpressionType(call))
           case _ =>
-            createPointerCallAst(call, safeGetType(call.getExpressionType))
+            createPointerCallAst(call, safeGetExpressionType(call))
         }
       case _ =>
         astForCCallExpressionUntyped(call)
@@ -488,14 +488,14 @@ trait AstForExpressionsCreator { this: AstCreator =>
 
   protected def initializerSignature(init: ICPPASTConstructorInitializer): String = {
     val initParamTypes =
-      init.getArguments.collect { case e: IASTExpression => e }.map(t => cleanType(safeGetType(t.getExpressionType)))
+      init.getArguments.collect { case e: IASTExpression => e }.map(expr => cleanType(safeGetExpressionType(expr)))
     StringUtils.normalizeSpace(initParamTypes.mkString(","))
   }
 
   protected def initializerSignature(init: ICPPASTSimpleTypeConstructorExpression): String = {
     val initParamTypes = init.getInitializer match {
       case init: ICPPASTInitializerList =>
-        init.getClauses.collect { case e: IASTExpression => e }.map(t => cleanType(safeGetType(t.getExpressionType)))
+        init.getClauses.collect { case e: IASTExpression => e }.map(expr => cleanType(safeGetExpressionType(expr)))
       case _ => Array.empty[String]
     }
     StringUtils.normalizeSpace(initParamTypes.mkString(","))
@@ -504,7 +504,7 @@ trait AstForExpressionsCreator { this: AstCreator =>
   protected def initializerSignature(newExpression: ICPPASTNewExpression): String = {
     val initParamTypes = newExpression.getInitializer match {
       case init: ICPPASTConstructorInitializer =>
-        init.getArguments.collect { case e: IASTExpression => e }.map(t => cleanType(safeGetType(t.getExpressionType)))
+        init.getArguments.collect { case e: IASTExpression => e }.map(expr => cleanType(safeGetExpressionType(expr)))
       case _ => Array.empty[String]
     }
     StringUtils.normalizeSpace(initParamTypes.mkString(","))

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForFunctionsCreator.scala
@@ -80,7 +80,7 @@ trait AstForFunctionsCreator { this: AstCreator =>
         Ast()
       case Some(variable: (CVariable | CPPVariable)) =>
         val name       = shortName(funcDecl)
-        val tpe        = safeGetType(variable.getType)
+        val tpe        = safeCdtCall(safeGetType(variable.getType)).getOrElse(Defines.Any)
         val codeString = code(funcDecl.getParent)
         val node       = localNode(funcDecl, name, codeString, registerType(tpe))
         scope.addVariable(name, node, tpe, VariableScopeManager.ScopeType.BlockScope)
@@ -262,9 +262,9 @@ trait AstForFunctionsCreator { this: AstCreator =>
         val ma     = callNode(ident, code, op, op, DispatchTypes.STATIC_DISPATCH, None, Some(thisTpe))
         callAst(ma, Seq(Ast(thisIdentifier), Ast(member)))
       case None =>
-        val tpe = ident.getBinding match {
-          case f: CPPField => safeGetType(f.getType)
-          case _           => typeFor(ident)
+        val tpe = safeCdtCall(ident.getBinding) match {
+          case Some(f: CPPField) => safeCdtCall(safeGetType(f.getType)).getOrElse(Defines.Any)
+          case _                 => typeFor(ident)
         }
         val idNode = identifierNode(ident, identifierName, identifierName, tpe)
         scope.addVariableReference(identifierName, idNode, tpe, EvaluationStrategies.BY_REFERENCE)

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForPrimitivesCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForPrimitivesCreator.scala
@@ -13,7 +13,6 @@ import org.eclipse.cdt.internal.core.dom.parser.cpp.semantics.{CPPVisitor, EvalM
 import org.eclipse.cdt.internal.core.model.ASTStringUtil
 
 import scala.annotation.tailrec
-import scala.util.Try
 
 trait AstForPrimitivesCreator { this: AstCreator =>
 
@@ -47,7 +46,7 @@ trait AstForPrimitivesCreator { this: AstCreator =>
       case id: IASTIdExpression =>
         safeGetBinding(id.getName) match {
           case Some(binding: (CPPVariable | CVariable)) =>
-            Try(binding.getScope).toOption
+            safeCdtCall(binding.getScope)
               .collect {
                 case n: IASTInternalScope if isGlobal(n.getPhysicalNode) => s"${Defines.GlobalTag} "
               }
@@ -144,15 +143,17 @@ trait AstForPrimitivesCreator { this: AstCreator =>
     val variableOption = scope.lookupVariable(identifierName)
     variableOption match {
       case Some((_, variableTypeName)) => variableTypeName
-      case None if ident.isInstanceOf[IASTName] && ident.asInstanceOf[IASTName].getBinding != null =>
-        val id = ident.asInstanceOf[IASTName]
-        id.getBinding match {
-          case v: IVariable =>
-            v.getType match {
-              case f: IFunctionType => cleanType(f.getReturnType.toString)
-              case other            => cleanType(other.toString)
+      case None if ident.isInstanceOf[IASTName] && safeCdtCall(ident.asInstanceOf[IASTName].getBinding).isDefined =>
+        val idBinding = safeCdtCall(ident.asInstanceOf[IASTName].getBinding)
+        idBinding match {
+          case Some(v: IVariable) =>
+            safeCdtCall(v.getType) match {
+              case Some(f: IFunctionType) => cleanType(f.getReturnType.toString)
+              case Some(other)            => cleanType(other.toString)
+              case None                   => Defines.Any
             }
-          case other => cleanType(other.getName)
+          case Some(other) => cleanType(other.getName)
+          case None        => Defines.Any
         }
       case None if ident.isInstanceOf[IASTName] =>
         typeFor(ident.getParent)
@@ -163,11 +164,11 @@ trait AstForPrimitivesCreator { this: AstCreator =>
   }
 
   private def syntheticThisAccess(ident: CPPASTIdExpression, identifierName: String): String | Ast = {
-    val tpe = ident.getName.getBinding match {
-      case f: CPPField => safeGetType(f.getType)
-      case _           => typeFor(ident)
+    val tpe = safeGetBinding(ident.getName) match {
+      case Some(f: CPPField) => safeCdtCall(safeGetType(f.getType)).getOrElse(Defines.Any)
+      case _                 => typeFor(ident)
     }
-    Try(ident.getEvaluation).toOption match {
+    safeCdtCall(ident.getEvaluation) match {
       case Some(e: EvalMemberAccess) =>
         val ownerTypeRaw = safeGetType(e.getOwnerType)
         val deref        = if (e.isPointerDeref) "*" else ""
@@ -196,8 +197,8 @@ trait AstForPrimitivesCreator { this: AstCreator =>
   private def isInCurrentScope(ident: CPPASTIdExpression, owner: String): Boolean = {
     val ownerWithOutTemplateTags = owner.takeWhile(_ != '<')
     val isInMethodScope =
-      Try(CPPVisitor.getContainingScope(ident).getScopeName.toString).toOption.exists(s =>
-        s.startsWith(s"$ownerWithOutTemplateTags::") || s.contains(s"::$ownerWithOutTemplateTags::")
+      safeCdtCall(CPPVisitor.getContainingScope(ident).getScopeName.toString).exists(scopeName =>
+        scopeName.startsWith(s"$ownerWithOutTemplateTags::") || scopeName.contains(s"::$ownerWithOutTemplateTags::")
       )
     isInMethodScope || methodAstParentStack.collectFirst {
       case typeDecl: NewTypeDecl if typeDecl.fullName == ownerWithOutTemplateTags    => typeDecl
@@ -207,7 +208,7 @@ trait AstForPrimitivesCreator { this: AstCreator =>
 
   protected def astForFieldReference(fieldRef: IASTFieldReference): Ast = {
     val isInConstructor =
-      Try(CPPVisitor.findEnclosingFunctionOrClass(fieldRef)).toOption.exists(_.isInstanceOf[ICPPConstructor])
+      safeCdtCall(CPPVisitor.findEnclosingFunctionOrClass(fieldRef)).exists(_.isInstanceOf[ICPPConstructor])
     val dispatchType = DispatchTypes.STATIC_DISPATCH
     val isDeref      = fieldRef.isPointerDereference && !isInConstructor
     val op           = if (isDeref) Operators.indirectFieldAccess else Operators.fieldAccess

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForTypesCreator.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/AstForTypesCreator.scala
@@ -39,7 +39,7 @@ trait AstForTypesCreator { this: AstCreator =>
       case arrayDecl: IASTArrayDeclarator => registerType(typeFor(arrayDecl))
       case _ =>
         safeGetBinding(declarator.getName) match {
-          case Some(variable: ICPPVariable) if variable.getType.isInstanceOf[CPPClosureType] =>
+          case Some(variable: ICPPVariable) if safeCdtCall(variable.getType).exists(_.isInstanceOf[CPPClosureType]) =>
             registerType(Defines.Function)
           case _ =>
             registerType(typeForDeclSpecifier(declaration.getDeclSpecifier, index = index))
@@ -218,9 +218,9 @@ trait AstForTypesCreator { this: AstCreator =>
   private def initializerSignature(init: IASTInitializer): String = {
     val argTypes = init match {
       case c: ICPPASTConstructorInitializer =>
-        c.getArguments.collect { case e: IASTExpression => e }.map(t => cleanType(safeGetType(t.getExpressionType)))
+        c.getArguments.collect { case e: IASTExpression => e }.map(expr => cleanType(safeGetExpressionType(expr)))
       case list: IASTInitializerList =>
-        list.getClauses.collect { case e: IASTExpression => e }.map(t => cleanType(safeGetType(t.getExpressionType)))
+        list.getClauses.collect { case e: IASTExpression => e }.map(expr => cleanType(safeGetExpressionType(expr)))
       case _ => Array.empty[String]
     }
     StringUtils.normalizeSpace(argTypes.mkString(","))

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/FullNameProvider.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/FullNameProvider.scala
@@ -325,7 +325,7 @@ trait FullNameProvider { this: AstCreator =>
         safeGetBinding(declarator.getName) match {
           case Some(function: ICPPFunction) if declarator.getName.isInstanceOf[ICPPASTConversionName] =>
             val tpe        = cleanType(typeFor(declarator.getName.asInstanceOf[ICPPASTConversionName].getTypeId))
-            val returnType = cleanType(safeGetType(function.getType.getReturnType))
+            val returnType = cleanType(safeCdtCall(safeGetType(function.getType.getReturnType)).getOrElse(Defines.Any))
             val fullNameNoSig = replaceQualifiedNameSeparator(
               function.getQualifiedName.takeWhile(!_.startsWith("operator ")).mkString(".")
             )
@@ -354,7 +354,7 @@ trait FullNameProvider { this: AstCreator =>
             } else {
               val returnTpe = declarator.getParent match {
                 case definition: ICPPASTFunctionDefinition if !bindsToConstructor(definition) => returnType(definition)
-                case _ => safeGetType(function.getType.getReturnType)
+                case _ => safeCdtCall(safeGetType(function.getType.getReturnType)).getOrElse(Defines.Any)
               }
               val sig = signature(cleanType(returnTpe), declarator)
               s"${stripTemplateTags(fullNameNoSig)}:$sig"
@@ -363,7 +363,9 @@ trait FullNameProvider { this: AstCreator =>
           case Some(x @ (_: ICPPField | _: CPPVariable)) =>
             val fullNameNoSig = replaceQualifiedNameSeparator(x.getQualifiedName.mkString("."))
             val fn = if (x.isExternC) { x.getName }
-            else { s"${stripTemplateTags(fullNameNoSig)}:${cleanType(safeGetType(x.getType))}" }
+            else {
+              s"${stripTemplateTags(fullNameNoSig)}:${cleanType(safeCdtCall(safeGetType(x.getType)).getOrElse(Defines.Any))}"
+            }
             Option(fn)
           case Some(_: IProblemBinding) if bindsToConstructor(declarator.getName) =>
             val fullNameNoSig = replaceQualifiedNameSeparator(

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/TypeNameProvider.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/TypeNameProvider.scala
@@ -284,13 +284,12 @@ trait TypeNameProvider { this: AstCreator =>
     val x = safeGetNodeType(name)
     safeGetBinding(name) match {
       case Some(v: IVariable) =>
-        safeCdtCall(v.getType) match {
-          case Some(f: IFunctionType) =>
+        v.getType match {
+          case f: IFunctionType =>
             f.getReturnType.toString
-          case Some(c: ICPPBinding) =>
+          case c: ICPPBinding =>
             c.getQualifiedName.mkString(".")
-          case Some(other) => other.toString
-          case None        => Defines.Any
+          case other => other.toString
         }
       case _ => safeGetNodeType(name)
     }

--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/TypeNameProvider.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/astcreation/TypeNameProvider.scala
@@ -124,6 +124,16 @@ trait TypeNameProvider { this: AstCreator =>
   }
 
   protected def safeGetType(tpe: IType): String = {
+    // In case of unresolved includes etc. this may fail throwing an unrecoverable exception
+    safeCdtCall(safeGetTypeInternal(tpe)).getOrElse(Defines.Any)
+  }
+
+  protected def safeGetExpressionType(expr: IASTExpression): String = {
+    // In case of unresolved includes etc. this may fail throwing an unrecoverable exception
+    safeCdtCall(safeGetType(expr.getExpressionType)).getOrElse(Defines.Any)
+  }
+
+  private def safeGetTypeInternal(tpe: IType): String = {
     val tpeString = tpe match {
       case _: CPPClosureType                                      => Defines.Function
       case cppBasicType: ICPPBasicType if cppBasicType.isLong     => Defines.Long
@@ -160,7 +170,7 @@ trait TypeNameProvider { this: AstCreator =>
   }
 
   protected def functionInstanceToSignature(function: ICPPFunctionInstance, tpe: IFunctionType): String = {
-    Try(function.getSpecializedBinding).toOption match {
+    safeCdtCall(function.getSpecializedBinding) match {
       case Some(binding: ICPPFunctionTemplate) =>
         val returnType     = cleanType(safeGetType(tpe.getReturnType))
         val parameterTypes = binding.getParameters.map(t => cleanType(safeGetType(t.getType)))
@@ -237,6 +247,14 @@ trait TypeNameProvider { this: AstCreator =>
 
   @nowarn
   protected def typeFor(node: IASTNode): String = {
+    // CDT's type resolution may run into unbounded mutual recursion for certain inputs (see
+    // https://github.com/joernio/joern/issues/6261); degrade to ANY instead of losing the whole file.
+    try { typeForInternal(node) }
+    catch { case _: StackOverflowError => Defines.Any }
+  }
+
+  @nowarn
+  private def typeForInternal(node: IASTNode): String = {
     import org.eclipse.cdt.core.dom.ast.ASTSignatureUtil.getNodeSignature
     val tpeString = node match {
       case f: CPPASTFoldExpression          => typeForCPPASTFoldExpression(f)
@@ -266,12 +284,13 @@ trait TypeNameProvider { this: AstCreator =>
     val x = safeGetNodeType(name)
     safeGetBinding(name) match {
       case Some(v: IVariable) =>
-        v.getType match {
-          case f: IFunctionType =>
+        safeCdtCall(v.getType) match {
+          case Some(f: IFunctionType) =>
             f.getReturnType.toString
-          case c: ICPPBinding =>
+          case Some(c: ICPPBinding) =>
             c.getQualifiedName.mkString(".")
-          case other => other.toString
+          case Some(other) => other.toString
+          case None        => Defines.Any
         }
       case _ => safeGetNodeType(name)
     }
@@ -383,7 +402,7 @@ trait TypeNameProvider { this: AstCreator =>
 
   private def safeGetNodeType(node: IASTNode): String = {
     // In case of unresolved includes etc. this may fail throwing an unrecoverable exception
-    Try(ASTTypeUtil.getNodeType(node)).getOrElse(Defines.Any)
+    safeCdtCall(ASTTypeUtil.getNodeType(node)).getOrElse(Defines.Any)
   }
 
   private def typeForCPPASTFieldReference(f: CPPASTFieldReference): String = {
@@ -398,8 +417,11 @@ trait TypeNameProvider { this: AstCreator =>
       case Some(evaluation: EvalFoldExpression) =>
         Try(evaluation.getValue.getEvaluation).toOption match {
           case Some(value: EvalBinary) =>
-            val s = value.toString
-            s.substring(0, s.indexOf(": "))
+            // EvalBinary.toString only contains ": " if a nested evaluation (e.g. EvalFixed) contributes
+            // one; for folds over non-constant expressions (e.g. function calls) the separator is absent.
+            val evalString = value.toString
+            val sepIdx     = evalString.indexOf(": ")
+            if (sepIdx > 0) evalString.substring(0, sepIdx) else Defines.Any
           case Some(value: EvalBinding) if value.getType.isInstanceOf[ICPPParameterPackType] =>
             value.getType.asInstanceOf[ICPPParameterPackType].getType.toString
           case _ => Defines.Any

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/cpp/features17/Cpp17FeaturesTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/cpp/features17/Cpp17FeaturesTests.scala
@@ -149,6 +149,27 @@ class Cpp17FeaturesTests extends AstC2CpgSuite(fileSuffix = FileDefaults.CppExt)
       retExpr.argument(3).code shouldBe "args"
     }
 
+    "handle folding expressions over non-constant evaluations" in {
+      // Regression test for https://github.com/joernio/joern/issues/6260:
+      // EvalBinary.toString contains no ": " separator when the fold is over
+      // non-constant evaluations (e.g. lambda calls) which previously crashed
+      // type resolution with a StringIndexOutOfBoundsException.
+      val cpg = code("""
+          |namespace ns {
+          |std::wstring GetHelperExe() { return L"helper.exe"; }
+          |template<class... Args>
+          |int LOStart(Args... args) {
+          |    auto quote = [](const std::wstring& s) { return L"\"" + s + L"\""; };
+          |    std::wstring sCmdLine((quote(GetHelperExe()) + ... + (L" " + quote(args))));
+          |    return (int)sCmdLine.size();
+          |}
+          |}
+          |""".stripMargin)
+      val List(foldCall) = cpg.call.nameExact("<operator>.fold").l
+      foldCall.code shouldBe "(quote(GetHelperExe()) + ... + (L\" \" + quote(args)))"
+      foldCall.typeFullName shouldBe "ANY"
+    }
+
     "handle folding expressions (unary)" in {
       val cpg = code("""
           |template <typename... Args>
@@ -527,6 +548,26 @@ class Cpp17FeaturesTests extends AstC2CpgSuite(fileSuffix = FileDefaults.CppExt)
           "value"  -> "int"
         )
       }
+    }
+
+    "not crash on nested range-based for loops over structured bindings with unresolved types" in {
+      // Regression test for https://github.com/joernio/joern/issues/6261:
+      // CDT's auto type deduction runs into unbounded mutual recursion (StackOverflowError)
+      // when a structured binding introduced by a range-based for loop is itself used as the
+      // range of a nested range-based for loop and the container type cannot be resolved.
+      val cpg = code("""
+          |void f() {
+          |  Map m;
+          |  for (const auto& [k, v] : m)
+          |    for (auto& e : v)
+          |      ;
+          |}
+          |""".stripMargin)
+      cpg.method.nameExact("f").nonEmpty shouldBe true
+      val locals = cpg.local.map(l => (l.name, l.typeFullName)).toMap
+      locals("k") shouldBe "ANY"
+      locals("v") shouldBe "ANY"
+      locals("e") shouldBe "ANY&"
     }
 
     "handle selection statements with initializer" in {


### PR DESCRIPTION
Fixes two c2cpg issues reported while indexing LibreOffice core, both causing whole files to be dropped from the CPG:

* **#6260** — `typeForCPPASTFoldExpression` assumed `EvalBinary.toString` contains `": "` (only true when a nested leaf evaluation is an `EvalFixed`, e.g. `bool: true`). For folds over non-constant evaluations (e.g. the lambda calls in `(quote(GetHelperExe()) + ... + (L" " + quote(args)))`) the separator is absent → `StringIndexOutOfBoundsException: Range [0, -1)`. Now guarded, degrading to `ANY`.

* **#6261** — CDT's `auto` type deduction runs into unbounded mutual recursion (`CPPVisitor.createType → createAutoType → getAutoInitClauseForRangeBasedFor → EvalBinding.getType → CPPVariable.getType → …` → `StackOverflowError`) when a structured binding introduced by a range-based for loop is itself used as the range of a nested range-based for loop and the container type cannot be resolved. Minimal reproducer (no includes needed):

```cpp
void f() {
  Map m;
  for (const auto& [k, v] : m)
    for (auto& e : v)
      ;
}
```

  `StackOverflowError` is a `VirtualMachineError` which `scala.util.Try`/`NonFatal` do not catch, so the existing `safeGet*` wrappers did not help. Added `safeCdtCall` (catches SOE explicitly, degrades to `None`) and routed all direct CDT type/binding/evaluation resolution calls through it; `typeFor` now degrades to `ANY` on SOE instead of losing the whole file.

Note: the recursion itself is upstream Eclipse CDT (`io.joern:eclipse-cdt-core` is a vanilla re-publish, not a patchable fork).

Closes #6260
Closes #6261