### PR TITLE
[rubysrc2cpg] Retry ruby_ast_gen download on HTTP errors

### DIFF
--- a/joern-cli/frontends/rubysrc2cpg/build.sbt
+++ b/joern-cli/frontends/rubysrc2cpg/build.sbt
@@ -1,6 +1,5 @@
 import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.sbt.packager.Keys.stagingDirectory
-import java.net.URI
 
 name := "rubysrc2cpg"
 
@@ -74,10 +73,7 @@ astGenResourceTask := {
   val unpackedGemFullPath = targetDir / "ruby_ast_gen"
   if (!hasCompatibleAstGenVersion(unpackedGemFullPath, astGenVersion.value)) {
     if (unpackedGemFullPath.exists()) IO.delete(unpackedGemFullPath)
-    val url = s"${astGenDlUrl.value}$gemName"
-    sbt.io.Using.urlInputStream(new URI(url).toURL) { inputStream =>
-      sbt.IO.transfer(inputStream, compressGemPath)
-    }
+    DownloadHelper.ensureIsAvailable(s"${astGenDlUrl.value}$gemName", compressGemPath)
     IO.unzip(compressGemPath, unpackedGemFullPath)
     IO.delete(compressGemPath)
   }


### PR DESCRIPTION
## Motivation

We've seen transient HTTP errors fail the build during `rubysrc2cpg`'s `astGenResourceTask`, which downloaded the `ruby_ast_gen` zip via a single-shot `urlInputStream` + `IO.transfer` with no retry logic.

## Change

Route the download through `DownloadHelper.ensureIsAvailable` (backed by `UrlRetry.downloadWithRetries`: 5 attempts, exponential backoff, non-2xx status check) — the same helper already used by `joernTypeStubsDlTask` and all other frontends' astgen downloads.

Behavior is otherwise unchanged: the download still only happens when the unpacked astgen version doesn't match, and the zip is still deleted after unzipping. Since the URL bookkeeping in `.local/source-urls` is only written after a successful download, a failed attempt always triggers a fresh retry on the next build.

## Verification

- Forced the download path by removing the unpacked `version.rb`, then ran `sbt rubysrc2cpg/astGenResourceTask`: download went through `ensureIsAvailable` (`[INFO] downloading ...`), unzip + zip cleanup succeeded.
- Re-ran the task: correctly short-circuits with no download once the version matches.
- Audited all other `.sbt` files for raw download primitives (`urlInputStream`, `IO.transfer`, `toURL`, `openStream`, `curl`/`wget`): no remaining occurrences — every build-time HTTP download in the repo now goes through the retrying helper.