### PR TITLE
[joern-install] don't pass empty --dbversion to joern-scan

### DIFF
--- a/joern-install.sh
+++ b/joern-install.sh
@@ -222,7 +222,11 @@ if [ $INSTALL_DEFAULT_PLUGINS = true ]; then
   echo "Installing default plugins"
   CURDIR=$(pwd)
   cd $JOERN_INSTALL_DIR/joern-cli
-  ./joern-scan --updatedb --dbversion $JOERN_VERSION
+  if [ "$JOERN_VERSION" = "" ]; then
+    ./joern-scan --updatedb
+  else
+    ./joern-scan --updatedb --dbversion "$JOERN_VERSION"
+  fi
   cd "$CURDIR"
 fi
 


### PR DESCRIPTION
## Problem

The scheduled [Upload Container image](https://github.com/joernio/joern/actions/runs/34202284074) workflow has been failing since the v4.0.620 release. The docker build (`ci/Dockerfile.alma`, `ci/Dockerfile.alma8`) runs `./joern-install.sh` non-interactively without `--version`, so `JOERN_VERSION` is empty. The unquoted expansion in

```sh
./joern-scan --updatedb --dbversion $JOERN_VERSION
```

leaves a dangling `--dbversion` with no value, which scopt rejects (`Missing value for option --dbversion`). Until v4.0.620 this was invisible because joern-scan exited 0 for rejected argument lists; since da7623602 (#6242) it exits 1, and `set -eu` then aborts the installer, failing the image build.

Side effect of the old lenient exit code: since #3032 (2023), the default querydb installation has been **silently skipped** in every non-interactive install that didn't pass `--version` — including the published container images.

## Fix

Only pass `--dbversion` when a version was actually given, and quote the variable. With no `--version`, joern-scan's own default (`latest`) applies.

## Testing

No automated coverage exists for the installer script (no CI job executes it — which is how this rotted unnoticed). Verified manually with a mock `joern-scan` reproducing the post-#6242 rejection behavior:

- empty `JOERN_VERSION` → `joern-scan --updatedb` → exit 0 (previously: rejected args, exit 1)
- `JOERN_VERSION=4.0.622` → `joern-scan --updatedb --dbversion 4.0.622` → exit 0

`sh -n joern-install.sh` passes.