### PR TITLE
[ghidra2cpg] Silence ghidra output

### DIFF
--- a/joern-cli/frontends/ghidra2cpg/build.sbt
+++ b/joern-cli/frontends/ghidra2cpg/build.sbt
@@ -8,7 +8,10 @@ libraryDependencies ++= Seq(
   "commons-io"        % "commons-io"               % Versions.commonsIo,
   "io.shiftleft"     %% "codepropertygraph"        % Versions.cpg,
   "io.shiftleft"     %% "codepropertygraph-protos" % Versions.cpg,
-  "org.scalatest"    %% "scalatest"                % Versions.scalatest % Test
+  "org.scalatest"    %% "scalatest"                % Versions.scalatest % Test,
+  // silence the 'No SLF4J providers' warnings in tests: the ghidra fat jar only ships an slf4j 1.7 binding,
+  // which slf4j 2.x ignores, and we cannot use log4j-slf4j2-impl here (see excludeDependencies below)
+  "org.slf4j"         % "slf4j-nop"                % Versions.slf4j     % Test
 )
 
 // ghidra2cpg is a fat jar that already ships an old version of log4j, so we need
@@ -24,6 +27,10 @@ enablePlugins(JavaAppPackaging, LauncherJarPlugin)
 Test / scalacOptions += "-language:implicitConversions"
 Test / testForkedParallel := false // ghidra is not thread-safe
 
+// The serialFilterFactory is mandatory since ghidra 12.2: headless initialization installs it unconditionally and
+// fails if the JVM has already pinned its builtin factory (which any forked sbt test JVM has). Side effect: once
+// ghidra is initialized, the JVM-wide filter also rejects sbt's own end-of-run test protocol message, so every test
+// run ends with a cosmetic "Internal error when running tests: ... Broken pipe" line. Test results are unaffected.
 javaOptions := Seq(
   "-Djava.protocol.handler.pkgs=ghidra.framework.protocol",
   "-Djdk.serialFilterFactory=ghidra.framework.remote.GhidraSerialFilterFactory"

--- a/joern-cli/frontends/ghidra2cpg/build.sbt
+++ b/joern-cli/frontends/ghidra2cpg/build.sbt
@@ -8,10 +8,7 @@ libraryDependencies ++= Seq(
   "commons-io"        % "commons-io"               % Versions.commonsIo,
   "io.shiftleft"     %% "codepropertygraph"        % Versions.cpg,
   "io.shiftleft"     %% "codepropertygraph-protos" % Versions.cpg,
-  "org.scalatest"    %% "scalatest"                % Versions.scalatest % Test,
-  // silence the 'No SLF4J providers' warnings in tests: the ghidra fat jar only ships an slf4j 1.7 binding,
-  // which slf4j 2.x ignores, and we cannot use log4j-slf4j2-impl here (see excludeDependencies below)
-  "org.slf4j"         % "slf4j-nop"                % Versions.slf4j     % Test
+  "org.scalatest"    %% "scalatest"                % Versions.scalatest % Test
 )
 
 // ghidra2cpg is a fat jar that already ships an old version of log4j, so we need
@@ -21,6 +18,12 @@ excludeDependencies ++= Seq(
   ExclusionRule("org.apache.logging.log4j", "log4j-slf4j2-impl"),
   ExclusionRule("org.apache.logging.log4j", "log4j-core")
 )
+
+// Because of the exclusions above, slf4j has no binding in this module (the fat jar only ships an slf4j 1.7
+// binding, which slf4j 2.x ignores) and anything logged via slf4j is silently discarded. This module therefore
+// logs via log4j directly (org.apache.logging.log4j), using the log4j version bundled in the ghidra fat jar;
+// it is configured by log4j2-test.xml in tests and by conf/log4j2.xml in the CLI distribution. Side effect of
+// the missing binding: slf4j prints a few 'No SLF4J providers were found' warnings when a test JVM starts.
 
 enablePlugins(JavaAppPackaging, LauncherJarPlugin)
 

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/Ghidra2Cpg.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/Ghidra2Cpg.scala
@@ -22,7 +22,7 @@ import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.Languages
 import io.shiftleft.semanticcpg.utils.FileUtil
-import org.slf4j.LoggerFactory
+import org.apache.logging.log4j.LogManager
 
 import java.io.File
 import scala.collection.mutable
@@ -152,7 +152,7 @@ class Ghidra2Cpg extends X2CpgFrontend {
 }
 
 object Types {
-  private val logger = LoggerFactory.getLogger(getClass)
+  private val logger = LogManager.getLogger(getClass)
 
   // Types will be added to the CPG as soon as everything
   // else is done

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/Ghidra2Cpg.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/Ghidra2Cpg.scala
@@ -15,13 +15,14 @@ import io.joern.ghidra2cpg.passes.*
 import io.joern.ghidra2cpg.passes.arm.ArmFunctionPass
 import io.joern.ghidra2cpg.passes.mips.{LoHiPass, MipsFunctionPass}
 import io.joern.ghidra2cpg.passes.x86.{ReturnEdgesPass, X86FunctionPass}
-import io.joern.ghidra2cpg.utils.{CommandLineConfig, Decompiler}
+import io.joern.ghidra2cpg.utils.{CommandLineConfig, Decompiler, WarnAndUpErrorLogger}
 import io.joern.x2cpg.passes.frontend.{MetaDataPass, TypeNodePass}
 import io.joern.x2cpg.{X2Cpg, X2CpgFrontend}
 import io.shiftleft.semanticcpg.utils.FileUtil.*
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.Languages
 import io.shiftleft.semanticcpg.utils.FileUtil
+import org.slf4j.LoggerFactory
 
 import java.io.File
 import scala.collection.mutable
@@ -79,6 +80,9 @@ class Ghidra2Cpg extends X2CpgFrontend {
   }
 
   private def initGhidra(): Unit = {
+    // Ghidra's default console logging is very chatty; reduce it to warnings and errors
+    WarnAndUpErrorLogger.install()
+
     // We need this for the URL handler
     Handler.registerHandler()
 
@@ -148,6 +152,8 @@ class Ghidra2Cpg extends X2CpgFrontend {
 }
 
 object Types {
+  private val logger = LoggerFactory.getLogger(getClass)
+
   // Types will be added to the CPG as soon as everything
   // else is done
   val types: mutable.SortedSet[String] = mutable.SortedSet[String]()
@@ -155,7 +161,7 @@ object Types {
     try {
       types += typeName
     } catch {
-      case NonFatal(_) => println(s" Error adding type: $typeName")
+      case NonFatal(_) => logger.warn(s"Error adding type: $typeName")
     }
     typeName
   }

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/FunctionPass.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/FunctionPass.scala
@@ -88,8 +88,8 @@ abstract class FunctionPass(
           .filter(_.isParameter)
           .foreach { parameter =>
             val checkedParameter = Option(parameter.getStorage)
-              .flatMap(x => Option(x.getRegister))
-              .flatMap(x => Option(x.getName))
+              .flatMap(storage => Option(storage.getRegister))
+              .flatMap(register => Option(register.getName))
               .getOrElse(parameter.getName)
             val node =
               createParameterNode(
@@ -255,7 +255,7 @@ abstract class FunctionPass(
                   .lineNumber(Some(instruction.getMinAddress.getOffsetAsBigInteger.intValue))
                 connectCallToArgument(diffGraphBuilder, callNode, node)
               case _ =>
-                println(s"""Unsupported argument: $opObject $className""")
+                baseLogger.warn(s"Unsupported argument: $opObject $className")
             }
           }
       }

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/FunctionPass.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/FunctionPass.scala
@@ -14,6 +14,7 @@ import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{CfgNodeNew, NewBlock, NewMethod}
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, nodes}
 import io.shiftleft.passes.ForkJoinParallelCpgPass
+import org.apache.logging.log4j.LogManager
 
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
@@ -27,11 +28,14 @@ abstract class FunctionPass(
   decompiler: Decompiler
 ) extends ForkJoinParallelCpgPass[Function](cpg) {
 
+  // not using the inherited slf4j-based baseLogger: slf4j has no binding in this module (see build.sbt)
+  private val logger = LogManager.getLogger(getClass)
+
   protected val functionByName: mutable.Map[String, Function] = mutable.HashMap[String, Function]()
   for (fn <- functions) {
     val other = functionByName.getOrElseUpdate(fn.getName, fn)
     if (!(other eq fn)) {
-      baseLogger.warn(s"Multiple functions with same name ${fn.getName}, can't disambiguate: $fn, $other")
+      logger.warn(s"Multiple functions with same name ${fn.getName}, can't disambiguate: $fn, $other")
     }
   }
 
@@ -255,7 +259,7 @@ abstract class FunctionPass(
                   .lineNumber(Some(instruction.getMinAddress.getOffsetAsBigInteger.intValue))
                 connectCallToArgument(diffGraphBuilder, callNode, node)
               case _ =>
-                baseLogger.warn(s"Unsupported argument: $opObject $className")
+                logger.warn(s"Unsupported argument: $opObject $className")
             }
           }
       }

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/mips/MipsFunctionPass.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/mips/MipsFunctionPass.scala
@@ -128,7 +128,7 @@ class MipsFunctionPass(
     connectCallToArgument(diffGraphBuilder, callNode, arg)
   }
   def handleDefault(varNode: PcodeOp): Unit = {
-    println("Unsupported " + varNode.toString + " " + varNode.getOpcode)
+    logger.warn(s"Unsupported $varNode ${varNode.getOpcode}")
   }
   def resolveArgument(
     diffGraphBuilder: DiffGraphBuilder,
@@ -227,7 +227,7 @@ class MipsFunctionPass(
             )
             connectCallToArgument(diffGraphBuilder, instructionNode, node)
           case _ =>
-            println(s"""Unsupported argument: $opObject ${opObject.getClass.getSimpleName}""")
+            logger.warn(s"Unsupported argument: $opObject ${opObject.getClass.getSimpleName}")
         }
       }
     }

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/mips/MipsFunctionPass.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/mips/MipsFunctionPass.scala
@@ -13,7 +13,7 @@ import io.joern.ghidra2cpg.utils.Decompiler
 import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{CfgNodeNew, NewBlock}
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, nodes}
-import org.slf4j.LoggerFactory
+import org.apache.logging.log4j.LogManager
 
 import scala.jdk.CollectionConverters.*
 import scala.language.implicitConversions
@@ -26,7 +26,7 @@ class MipsFunctionPass(
   cpg: Cpg,
   decompiler: Decompiler
 ) extends FunctionPass(MipsProcessor, currentProgram, functions, cpg, decompiler) {
-  private val logger = LoggerFactory.getLogger(classOf[MipsFunctionPass])
+  private val logger = LogManager.getLogger(classOf[MipsFunctionPass])
 
   def resolveVarNode(instruction: Instruction, input: Varnode, index: Int): CfgNodeNew = {
     if (input.isRegister) {

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/mips/MipsReturnEdgesPass.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/mips/MipsReturnEdgesPass.scala
@@ -4,10 +4,10 @@ import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, PropertyNames}
 import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language.*
-import org.slf4j.{Logger, LoggerFactory}
+import org.apache.logging.log4j.{LogManager, Logger}
 
 class MipsReturnEdgesPass(cpg: Cpg) extends CpgPass(cpg) {
-  private val logger: Logger = LoggerFactory.getLogger(this.getClass)
+  private val logger: Logger = LogManager.getLogger(this.getClass)
 
   override def run(diffGraph: DiffGraphBuilder): Unit = {
     logger.info("Running ReturnEdgesPass")

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/x86/ReturnEdgesPass.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/passes/x86/ReturnEdgesPass.scala
@@ -4,10 +4,10 @@ import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, PropertyNames}
 import io.shiftleft.passes.CpgPass
 import io.shiftleft.semanticcpg.language.*
-import org.slf4j.LoggerFactory
+import org.apache.logging.log4j.LogManager
 
 class ReturnEdgesPass(cpg: Cpg) extends CpgPass(cpg) {
-  private val logger = LoggerFactory.getLogger(this.getClass)
+  private val logger = LogManager.getLogger(this.getClass)
 
   override def run(diffGraph: DiffGraphBuilder): Unit = {
     logger.info("Running ReturnEdgesPass")

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/utils/Decompiler.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/utils/Decompiler.scala
@@ -3,10 +3,12 @@ package io.joern.ghidra2cpg.utils
 import ghidra.app.decompiler.{DecompInterface, DecompileOptions, DecompileResults, DecompiledFunction}
 import ghidra.program.model.listing.{Function, Program}
 import ghidra.program.model.pcode.HighFunction
+import org.slf4j.LoggerFactory
 
 import scala.collection.immutable
 
 object Decompiler {
+  private val logger = LoggerFactory.getLogger(getClass)
 
   /** Create a new decompiler. Returns Some(decompiler) on success on None on failure.
     */
@@ -17,7 +19,7 @@ object Decompiler {
     opts.grabFromProgram(program)
     decompilerInterface.setOptions(opts)
     if (!decompilerInterface.openProgram(program)) {
-      println(s"Decompiler error: ${decompilerInterface.getLastMessage}")
+      logger.error(s"Decompiler error: ${decompilerInterface.getLastMessage}")
       None
     } else {
       Some(new Decompiler(decompilerInterface))

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/utils/Decompiler.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/utils/Decompiler.scala
@@ -3,12 +3,12 @@ package io.joern.ghidra2cpg.utils
 import ghidra.app.decompiler.{DecompInterface, DecompileOptions, DecompileResults, DecompiledFunction}
 import ghidra.program.model.listing.{Function, Program}
 import ghidra.program.model.pcode.HighFunction
-import org.slf4j.LoggerFactory
+import org.apache.logging.log4j.LogManager
 
 import scala.collection.immutable
 
 object Decompiler {
-  private val logger = LoggerFactory.getLogger(getClass)
+  private val logger = LogManager.getLogger(getClass)
 
   /** Create a new decompiler. Returns Some(decompiler) on success on None on failure.
     */

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/utils/PCodeMapper.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/utils/PCodeMapper.scala
@@ -9,7 +9,7 @@ import io.joern.ghidra2cpg.Types
 import io.joern.ghidra2cpg.utils.Utils.*
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.CfgNodeNew
-import org.slf4j.LoggerFactory
+import org.apache.logging.log4j.LogManager
 import io.shiftleft.codepropertygraph.generated.DiffGraphBuilder
 
 import scala.jdk.CollectionConverters.*
@@ -25,7 +25,7 @@ class PCodeMapper(
   highFunction: HighFunction,
   address2Literal: Map[Long, String]
 ) {
-  private val logger = LoggerFactory.getLogger(getClass)
+  private val logger = LogManager.getLogger(getClass)
   private val pcodeOps: List[PcodeOp] =
     nativeInstruction.getPcode().toList
 

--- a/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/utils/WarnAndUpErrorLogger.scala
+++ b/joern-cli/frontends/ghidra2cpg/src/main/scala/io/joern/ghidra2cpg/utils/WarnAndUpErrorLogger.scala
@@ -1,0 +1,67 @@
+package io.joern.ghidra2cpg.utils
+
+import ghidra.util.{DefaultErrorLogger, Msg}
+import org.apache.logging.log4j.{LogManager, Logger}
+
+/** Ghidra logs through its own `ghidra.util.Msg` facility (not slf4j), whose default logger prints everything from INFO
+  * upwards to stdout/stderr. That buries the actual output under hundreds of lines of progress messages (SSL
+  * initialization, loader details, analysis timing tables, ...).
+  *
+  * This logger keeps warnings and errors on the console like the default one, but forwards the chatty levels to log4j
+  * instead (info is demoted to debug). Those are silent with the default WARN root level and can be enabled when
+  * needed: in tests via `src/test/resources/log4j2-test.xml`, for the CLI via the `SL_LOGGING_LEVEL` env var.
+  *
+  * Additionally, warnings from ghidra's decompiler are demoted to debug as well: it emits one warning per function it
+  * cannot fully decompile (e.g. calls into EXTERNAL blocks), which is expected for typical binaries and otherwise
+  * floods the output.
+  */
+private class WarnAndUpErrorLogger extends DefaultErrorLogger {
+
+  // Same originator resolution as ghidra's own Log4jErrorLogger
+  private def loggerFor(originator: Any): Logger = originator match {
+    case null            => LogManager.getLogger("(null)")
+    case clazz: Class[?] => LogManager.getLogger(clazz)
+    case other           => LogManager.getLogger(other.getClass)
+  }
+
+  private def isDecompilerDiagnostics(originator: Any): Boolean = {
+    val clazz = originator match {
+      case clazz: Class[?] => clazz
+      case null            => return false
+      case other           => other.getClass
+    }
+    clazz.getPackageName == "ghidra.app.decompiler"
+  }
+
+  override def trace(originator: Any, message: Any): Unit =
+    loggerFor(originator).trace(message)
+
+  override def trace(originator: Any, message: Any, throwable: Throwable): Unit =
+    loggerFor(originator).trace(message, throwable)
+
+  override def debug(originator: Any, message: Any): Unit =
+    loggerFor(originator).debug(message)
+
+  override def debug(originator: Any, message: Any, throwable: Throwable): Unit =
+    loggerFor(originator).debug(message, throwable)
+
+  override def info(originator: Any, message: Any): Unit =
+    loggerFor(originator).debug(message)
+
+  override def info(originator: Any, message: Any, throwable: Throwable): Unit =
+    loggerFor(originator).debug(message, throwable)
+
+  override def warn(originator: Any, message: Any): Unit =
+    if (isDecompilerDiagnostics(originator)) loggerFor(originator).debug(message)
+    else super.warn(originator, message)
+
+  override def warn(originator: Any, message: Any, throwable: Throwable): Unit =
+    if (isDecompilerDiagnostics(originator)) loggerFor(originator).debug(message, throwable)
+    else super.warn(originator, message, throwable)
+}
+
+object WarnAndUpErrorLogger {
+
+  /** Replaces Ghidra's global error logger with one that only prints warnings and errors. */
+  def install(): Unit = Msg.setErrorLogger(new WarnAndUpErrorLogger)
+}

--- a/joern-cli/frontends/ghidra2cpg/src/test/resources/log4j2-test.xml
+++ b/joern-cli/frontends/ghidra2cpg/src/test/resources/log4j2-test.xml
@@ -6,7 +6,9 @@
         </Console>
     </Appenders>
     <Loggers>
-        <Root level="WARN">
+        <!-- ghidra's internal logging (ghidra.util.Msg) is forwarded to log4j at debug level;
+             enable locally with SL_LOGGING_LEVEL=DEBUG -->
+        <Root level="${env:SL_LOGGING_LEVEL:-WARN}">
             <AppenderRef ref="STDOUT"/>
         </Root>
     </Loggers>


### PR DESCRIPTION
## Problem

ghidra2cpg printed ~170 lines of log noise per test (and per binary in the CLI): Ghidra logs through its own `ghidra.util.Msg` facility rather than slf4j/log4j, and since logging initialization is disabled (`setInitializeLogging(false)`), the fallback `DefaultErrorLogger` prints everything from INFO upwards directly to stdout/stderr — SSL initialization, loader details, ELF analysis messages, the analyzer timing table, etc. The existing `log4j2-test.xml` never had a chance to filter any of it.

## Why log4j directly (not slf4j like the rest of joern)

slf4j has no binding in this module: the ghidra fat jar bundles an old log4j, forcing the `log4j-core`/`log4j-slf4j2-impl` exclusions (see `build.sbt`), and its bundled slf4j 1.7 `StaticLoggerBinder` is ignored by slf4j 2.x. Anything logged via slf4j in ghidra2cpg was silently discarded in tests *and* in the CLI. The fat jar's bundled log4j, on the other hand, is live in both environments (it is what reads `log4j2-test.xml` / `conf/log4j2.xml`), so this module now logs via log4j directly — same backend the other frontends end up in via their slf4j bridge, governed by the same config files.

## Changes

- **New `WarnAndUpErrorLogger`** (installed via `Msg.setErrorLogger` in `Ghidra2Cpg.initGhidra()`, so tests and CLI share it):
  - `warn`/`error` keep the default behavior (stderr)
  - `trace`/`debug`/`info` are forwarded to log4j instead of the console (`info` demoted to `debug`), with per-originator logger names mirroring ghidra's own `Log4jErrorLogger`
  - warnings from the `ghidra.app.decompiler` package are demoted to `debug`: the decompiler emits one warning per function it cannot fully decompile (e.g. calls into EXTERNAL blocks), which is expected for typical binaries
- **All module loggers converted from slf4j to log4j** (`PCodeMapper`, `MipsFunctionPass`, `MipsReturnEdgesPass`, `ReturnEdgesPass`, `Decompiler`, `Types`, `FunctionPass`), and raw `println` calls replaced with proper logger calls — these messages now actually exist (previously NOP) and are configurable
- **`log4j2-test.xml`**: root level is now `${env:SL_LOGGING_LEVEL:-WARN}` (same convention as the CLI's `log4j2.xml`), so the full detail is one env var away: `SL_LOGGING_LEVEL=DEBUG sbt "ghidra2cpg/testOnly *DataFlowTests"` — same for the CLI
- **`build.sbt`**: documented the module's logging setup, why `-Djdk.serialFilterFactory` is mandatory since ghidra 12.2, and that the resulting end-of-run `Internal error ... Broken pipe` line is cosmetic (it is emitted after all test results have been transmitted)

## Result

Test output per suite is now: a few slf4j provider warnings at JVM start (no binding, see above), genuine warnings like duplicate external function names (previously invisible), and the 2 documented cosmetic teardown lines. Everything else is one `SL_LOGGING_LEVEL=DEBUG` away.