### PR TITLE
[php2cpg] Fix double AST parent for closures containing global statements

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreatorHelper.scala
@@ -194,7 +194,10 @@ trait AstCreatorHelper(disableFileContent: Boolean)(implicit withSchemaValidatio
       val innerMethodRef   = innerMethodScope.methodRefNode
       innerMethodRef match {
         case Some(methodRef) =>
-          if (!isInClosure) {
+          // A closure's methodRef is already attached to the AST at the closure expression site, so
+          // appending it to the enclosing method's body as well would give it two AST parents.
+          val isAnonymousClosure = innerMethodNode.fullName.contains(Defines.ClosurePrefix)
+          if (!isInClosure && !isAnonymousClosure) {
             scope.getMethodRef(innerMethodNode.fullName) match {
               case None =>
                 currentMethod.additionalBodyChildren.append(methodRef)

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/dataflow/IntraMethodDataflowTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/dataflow/IntraMethodDataflowTests.scala
@@ -103,4 +103,18 @@ class IntraMethodDataflowTests extends PhpCode2CpgFixture(runOssDataflow = true)
     val flows  = sink.reachableByFlows(source)
     flows.size shouldBe 3
   }
+
+  "closure with a global statement should not break the reaching-def pass" in {
+    // Regression test for https://github.com/joernio/joern/issues/6269: the closure's METHOD_REF
+    // used to be attached to two AST parents, which crashed ReachingDefPass.
+    val cpg = code("""<?php
+        |$nums = [1, 2, 3];
+        |$out = array_map(function ($n) {
+        |  global $wpdb;
+        |  return $n;
+        |}, $nums);
+        |""".stripMargin)
+
+    cpg.methodRef.methodFullName(".*<lambda>.*").head._astIn.size shouldBe 1
+  }
 }

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/ClosureTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/ClosureTests.scala
@@ -536,6 +536,53 @@ class ClosureTests extends PhpCode2CpgFixture {
     }
   }
 
+  "closure containing a global statement" should {
+    val cpg = code(
+      """<?php
+        |$wpdb = new Db();
+        |$nums = [1, 2, 3];
+        |$out = array_map(function ($n) {
+        |  global $wpdb;
+        |  return $n;
+        |}, $nums);
+        |""".stripMargin,
+      fileName = "foo.php"
+    )
+
+    "attach the closure methodRef to exactly one AST parent" in {
+      inside(cpg.methodRef.methodFullName(".*<lambda>.*").l) { case List(methodRef) =>
+        methodRef._astIn.size shouldBe 1
+      }
+    }
+
+    "not give any node multiple AST parents" in {
+      cpg.all.collectAll[AstNode].filter(_._astIn.size >= 2).l shouldBe empty
+    }
+
+    "still create the closure binding for the captured global" in {
+      inside(cpg.all.collectAll[ClosureBinding].filter(_.closureBindingId.exists(_.endsWith("wpdb"))).l) {
+        case List(closureBinding) =>
+          val capturedNode = cpg.method.nameExact("<global>").local.name("wpdb").head
+          closureBinding.refOut.toList shouldBe List(capturedNode)
+      }
+    }
+  }
+
+  "named function containing a global statement" should {
+    val cpg = code("""<?php
+        |$a = 10;
+        |function foo() {
+        |  global $a;
+        |}
+        |""".stripMargin)
+
+    "attach the function methodRef to exactly one AST parent" in {
+      inside(cpg.methodRef.methodFullNameExact("foo").l) { case List(methodRef) =>
+        methodRef._astIn.size shouldBe 1
+      }
+    }
+  }
+
   "global in nested functions" should {
     val cpg = code("""<?php
         |$a = 10;


### PR DESCRIPTION
When a closure contains a `global $x;` statement, `createClosureCaptureForNode` appended the closure's `METHOD_REF` to the enclosing method's `additionalBodyChildren` — even though the same node is already attached to the AST at the closure expression site (`astForClosureExpr` returns `Ast(methodRef)`). The resulting `METHOD_REF` had **two AST parents**, which:

- fails post-frontend graph validation (`should have at most one incoming AST edge`), and
- crashes `ReachingDefPass` with `AssertionError: ... astParent ... has two parents` when the dataflow overlay is applied.

### Fix

Only attach the methodRef via `additionalBodyChildren` when the inner method is a **named function**, whose methodRef has no other AST attachment. Anonymous closures (identified by the `<lambda>` prefix, cf. `Defines.ClosurePrefix`) keep their single call-site parent.

Note: the naive fix suggested in the issue (removing the append entirely) would leave named functions' methodRefs detached (zero AST parents) — covered by the new `named function containing a global statement` test.

Fixes #6269.