### PR TITLE
[php2cpg] Fix empty call nodes for calls with expression callees

### DIFF
--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreatorHelper.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstCreatorHelper.scala
@@ -95,9 +95,8 @@ trait AstCreatorHelper(disableFileContent: Boolean)(implicit withSchemaValidatio
     s"${targetAst.rootCodeOrEmpty}$callOperator$name"
   }
 
-  protected def codeForStaticMethodCall(call: PhpCallExpr, name: String): String = {
-    call.target
-      .map(astForExpr)
+  protected def codeForStaticMethodCall(call: PhpCallExpr, targetAst: Option[Ast], name: String): String = {
+    targetAst
       .flatMap(_.rootCode)
       .map(className => s"$className$StaticMethodDelimiter$name")
       .getOrElse(name)
@@ -301,9 +300,6 @@ trait AstCreatorHelper(disableFileContent: Boolean)(implicit withSchemaValidatio
   }
 
   protected def isBuiltinFunc(name: String): Boolean = PhpBuiltins.FuncNames.contains(name)
-
-  protected def isCallOnVariable(call: PhpCallExpr): Boolean =
-    call.target.isEmpty && call.methodName.isInstanceOf[PhpVariable]
 
   protected def createListExprCodeField(listExpr: PhpListExpr): String = {
     val name = PhpOperators.listFunc

--- a/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/joern-cli/frontends/php2cpg/src/main/scala/io/joern/php2cpg/astcreation/AstForExpressionsCreator.scala
@@ -82,53 +82,52 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
      * scope.
      */
     call.target match {
-      case None if isCallOnVariable(call) => astForDynamicCall(call, name, arguments, None)
-      case None                           => astForStaticCall(call, name, arguments)
-      case _ if call.isStatic             => astForStaticCall(call, name, arguments)
-      case maybeTarget                    => astForDynamicCall(call, name, arguments, maybeTarget)
+      case None =>
+        nameAst match {
+          // The callee is an expression producing a callable value, e.g. `$f()` or `[$obj, 'm']()`
+          case Some(calleeAst) => astForCallableValueCall(call, name, arguments, calleeAst)
+          case None            => astForStaticCall(call, name, arguments)
+        }
+      case _ if call.isStatic => astForStaticCall(call, name, arguments)
+      case Some(target)       => astForDynamicCall(call, name, arguments, target)
     }
   }
 
-  private def astForDynamicCall(
-    call: PhpCallExpr,
-    name: String,
-    arguments: Seq[Ast],
-    maybeTarget: Option[PhpExpr]
-  ): Ast = {
-    val argsCode   = getArgsCode(call, arguments)
-    val targetAst  = maybeTarget.map(astForExpr)
-    val codePrefix = targetAst.map(codeForMethodCall(call, _, name)).getOrElse(name)
+  /** Lowers a call on an expression that evaluates to a callable, e.g. `$f()` or `[$obj, 'm']()`, to a synthetic
+    * `__invoke` call with the callee expression as the receiver.
+    */
+  private def astForCallableValueCall(call: PhpCallExpr, name: String, arguments: Seq[Ast], calleeAst: Ast): Ast = {
+    val argsCode = getArgsCode(call, arguments)
+    // Expression callees may be rooted at nodes without code (e.g. the block lowering a callable
+    // array), in which case we fall back to the original source text.
+    val codePrefix = Option.when(name.nonEmpty)(name).getOrElse(codeForExpr(call.methodName))
     val code       = s"$codePrefix($argsCode)"
 
-    val dispatchType = DispatchTypes.DYNAMIC_DISPATCH
-
-    val (receiverAst, callRoot) = targetAst match {
-      case None =>
-        val receiverAst = astForExpr(call.methodName)
-
-        val fullName = s"${getMfn(call, name)}.${NameConstants.Invoke}"
-        val callRoot = callNode(call, code, NameConstants.Invoke, fullName, dispatchType, None, Some(Defines.Any))
-
-        (receiverAst, callRoot)
-      case Some(target) =>
-        val receiverAst = target
-        val nameAst     = astForExpr(call.methodName)
-        val fullName    = getMfn(call, name)
-        val callRoot    = callNode(call, code, name, fullName, dispatchType, None, Some(Defines.Any))
-
-        (receiverAst, callRoot)
+    val fullName = call.methodName match {
+      case _: PhpVariable => s"${getMfn(call, name)}.${NameConstants.Invoke}"
+      case _              => s"${Defines.UnresolvedNamespace}$MethodDelimiter${NameConstants.Invoke}"
     }
+    val callRoot =
+      callNode(call, code, NameConstants.Invoke, fullName, DispatchTypes.DYNAMIC_DISPATCH, None, Some(Defines.Any))
 
-    if (isCallOnVariable(call))
-      callAst(callRoot, arguments, receiver = Option(receiverAst))
-    else
-      callAst(callRoot, arguments, base = Option(receiverAst))
+    callAst(callRoot, arguments, receiver = Option(calleeAst))
+  }
 
+  private def astForDynamicCall(call: PhpCallExpr, name: String, arguments: Seq[Ast], target: PhpExpr): Ast = {
+    val argsCode  = getArgsCode(call, arguments)
+    val targetAst = astForExpr(target)
+    val code      = s"${codeForMethodCall(call, targetAst, name)}($argsCode)"
+
+    val fullName = getMfn(call, name)
+    val callRoot = callNode(call, code, name, fullName, DispatchTypes.DYNAMIC_DISPATCH, None, Some(Defines.Any))
+
+    callAst(callRoot, arguments, base = Option(targetAst))
   }
 
   private def astForStaticCall(call: PhpCallExpr, name: String, arguments: Seq[Ast]): Ast = {
     val argsCode   = getArgsCode(call, arguments)
-    val codePrefix = codeForStaticMethodCall(call, name)
+    val targetAst  = call.target.map(astForExpr)
+    val codePrefix = codeForStaticMethodCall(call, targetAst, name)
     val code       = s"$codePrefix($argsCode)"
 
     val dispatchType = DispatchTypes.STATIC_DISPATCH
@@ -148,7 +147,12 @@ trait AstForExpressionsCreator(implicit withSchemaValidation: ValidationMode) { 
 
     val callRoot = callNode(call, code, name, fullName, dispatchType, None, Some(Defines.Any), staticReceiver)
 
-    callAst(callRoot, arguments)
+    // Expression targets (e.g. the `self::$client` in `self::$client::$method(...)`) are attached as
+    // the base so that they are not lost. Plain name targets (e.g. `Foo::`) are represented by the
+    // static receiver property instead.
+    val baseAst = targetAst.filter(_ => !call.target.exists(_.isInstanceOf[PhpNameExpr]))
+
+    callAst(callRoot, arguments, base = baseAst)
   }
 
   protected def simpleAssignAst(origin: PhpNode, target: Ast, source: Ast): Ast = {

--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/querying/CallTests.scala
@@ -417,4 +417,62 @@ class CallTests extends PhpCode2CpgFixture {
     construct.typeFullName shouldBe Defines.Any
     construct.dynamicTypeHintFullName shouldBe Seq.empty
   }
+
+  "calls on callable arrays" should {
+    val cpg = code("""<?php
+        |class Foo {
+        |  function __construct($b) {}
+        |  function baz() {}
+        |}
+        |$b = $_GET["p1"];
+        |array(new Foo($b), "baz")();
+        |[$obj, 'myMethod']();
+        |""".stripMargin)
+
+    "be represented as __invoke calls on the callee expression" in {
+      inside(cpg.call.nameExact(NameConstants.Invoke).l) { case List(longForm, shortForm) =>
+        longForm.code shouldBe """array(new Foo($b), "baz")()"""
+        longForm.methodFullName shouldBe s"${Defines.UnresolvedNamespace}.${NameConstants.Invoke}"
+        longForm.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
+        longForm.receiver.isEmpty shouldBe false
+
+        shortForm.code shouldBe "[$obj, 'myMethod']()"
+        shortForm.methodFullName shouldBe s"${Defines.UnresolvedNamespace}.${NameConstants.Invoke}"
+        shortForm.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
+        shortForm.receiver.isEmpty shouldBe false
+      }
+    }
+
+    "keep the callee expression in the AST" in {
+      // `new Foo($b)` inside the callable array must not be dropped from the graph
+      val construct = cpg.call.nameExact(Domain.ConstructorMethodName).head
+      construct.code shouldBe "new Foo($b)"
+    }
+  }
+
+  "static calls with expression targets" should {
+    val cpg = code("""<?php
+        |class Bar {
+        |  static function go($client, $method, $url, $options) {
+        |    self::$client::$method($url, $options);
+        |  }
+        |}
+        |""".stripMargin)
+
+    "retain the callee expression and arguments" in {
+      inside(cpg.call.nameExact("$method").l) { case List(staticCall) =>
+        staticCall.code shouldBe "self::$client::$method($url, $options)"
+        staticCall.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
+
+        inside(staticCall.argument.l) { case List(base: Call, urlArg: Identifier, optionsArg: Identifier) =>
+          base.code shouldBe "self::$client"
+          base.argumentIndex shouldBe 0
+          urlArg.name shouldBe "url"
+          urlArg.argumentIndex shouldBe 1
+          optionsArg.name shouldBe "options"
+          optionsArg.argumentIndex shouldBe 2
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
Calls whose callee is a non-name expression — e.g. callable arrays like `array(new Foo($b), "baz")()` or `[$obj, 'myMethod']()` — were lowered to static calls whose name/code were taken from the callee AST root. Since array expressions lower to a code-less block, the resulting call node was indistinguishable (`name`/`code`/`methodFullName` all empty, no children), and the callee expression AST (including e.g. the `new Foo($b)` inside) was computed and then dropped, leaving detached nodes that fail post-frontend validation.

### Fix

- Route target-less calls whose callee is an expression (anything that is not a plain name) through the dynamic-call path, generalizing the existing `$f()` handling: the callee expression becomes the **receiver** of a synthetic `__invoke` call and stays in the graph. `$f()` behavior is unchanged (`$f.__invoke`).
- The `code` field falls back to the original source text (`codeForExpr`) when the callee AST root carries no code, so `array(new Foo($b), "baz")()` keeps its source representation.
- Static calls with expression targets (`self::$client::$method($url, $options)`) now attach the target expression (`self::$client`) as the call base instead of dropping it; plain name targets (`Foo::`) are unchanged (still represented via the static receiver property).
- `astForDynamicCall` no longer lowers the callee expression twice (the second lowering was dead code); removed the now-unused `isCallOnVariable` helper.

Regression tests cover all three snippet forms from the issue.

Fixes #6022.