### PR TITLE
[php2cpg] Fix ClassCastException in ComposerAutoloadPass for modules with top-level type decls

### DIFF
--- a/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/passes/ComposerAutoloadPassTests.scala
+++ b/joern-cli/frontends/php2cpg/src/test/scala/io/joern/php2cpg/passes/ComposerAutoloadPassTests.scala
@@ -1,0 +1,30 @@
+package io.joern.php2cpg.passes
+
+import io.joern.php2cpg.testfixtures.PhpCode2CpgFixture
+import io.joern.x2cpg.frontendspecific.php2cpg.ComposerAutoloadPass
+import io.shiftleft.semanticcpg.language.*
+
+class ComposerAutoloadPassTests extends PhpCode2CpgFixture() {
+
+  "ComposerAutoloadPass" should {
+    val cpg = code(
+      """|<?php
+         |require 'vendor/autoload.php';
+         |
+         |class AutoloadedClass {
+         |    public function run() {
+         |        return 42;
+         |    }
+         |}
+         |""".stripMargin,
+      "bug.php"
+    )
+
+    "not crash on modules with top-level type declarations" in {
+      // Top-level type declarations sit on the module method's CONTAINS edge but are not CfgNodes,
+      // so findMethods must traverse the untyped `_containsOut` rather than the typed `containsOut`.
+      val pass = new ComposerAutoloadPass(cpg)
+      pass.generateParts().map(_.name).toList should contain("run")
+    }
+  }
+}

--- a/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/php2cpg/ComposerAutoloadPass.scala
+++ b/joern-cli/frontends/x2cpg/src/main/scala/io/joern/x2cpg/frontendspecific/php2cpg/ComposerAutoloadPass.scala
@@ -35,9 +35,9 @@ class ComposerAutoloadPass(cpg: Cpg) extends ForkJoinParallelCpgPass[Method](cpg
   /** Collects methods within a module.
     */
   private def findMethods(module: Method): Iterator[Method] = {
-    Iterator(module) ++ module.containsOut.flatMap {
+    Iterator(module) ++ module._containsOut.flatMap {
       case x: TypeDecl => x.method.flatMap(findMethods)
-      case x: Method   => Iterator(x) ++ x.containsOut.collectAll[Method].flatMap(findMethods)
+      case x: Method   => Iterator(x) ++ x._containsOut.collectAll[Method].flatMap(findMethods)
       case _           => Iterator.empty
     }
   }


### PR DESCRIPTION
`ComposerAutoloadPass.findMethods` walked the module method's CONTAINS edges via the **typed** `containsOut` traversal (`Traversal[CfgNode]`). When a PHP file both (a) requires `vendor/autoload.php` and (b) declares a top-level class/interface/trait, a `TypeDecl` node sits on that edge — and `TypeDecl` is not a `CfgNode`, so materializing the traversal throws:

```
java.lang.ClassCastException: TypeDecl cannot be cast to CfgNode
    at ...ComposerAutoloadPass.generateParts(ComposerAutoloadPass.scala:46)
```

The pass framework swallows the exception, so the import appears to succeed while the overlay silently never runs (type/method full names in autoloaded modules stay unqualified).

### Fix

Use the untyped `_containsOut` in `findMethods` so the pattern match can safely discriminate `TypeDecl`/`Method`/other nodes — the same idiom already used by `isAutoloaded` in this pass and by `MethodMethods.cfgNode`. Two-line change, no behavior change for non-crashing inputs.

Fixes #6273.