### PR TITLE
[kotlin2cpg] Remove `usedAsExpression` usage.

### DIFF
--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForStatementsCreator.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/ast/AstForStatementsCreator.scala
@@ -433,9 +433,10 @@ trait AstForStatementsCreator(implicit withSchemaValidation: ValidationMode) {
   ): Ast = {
     val outAst =
       if (expr.getSubjectExpression != null) {
-        typeInfoProvider.usedAsExpression(expr) match {
-          case Some(true) => astForWhenAsExpression(expr, argIdx, argNameMaybe)
-          case _          => astForWhenAsStatement(expr, argIdx)
+        if (!KtPsiUtil.isStatement(expr)) {
+          astForWhenAsExpression(expr, argIdx, argNameMaybe)
+        } else {
+          astForWhenAsStatement(expr, argIdx)
         }
       } else {
         astForNoArgWhen(expr)

--- a/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/TypeInfoProvider.scala
+++ b/joern-cli/frontends/kotlin2cpg/src/main/scala/io/joern/kotlin2cpg/types/TypeInfoProvider.scala
@@ -37,11 +37,6 @@ class TypeInfoProvider(val bindingContext: BindingContext) {
 
   import io.joern.kotlin2cpg.types.TypeInfoProvider.bindingsForEntity
 
-  def usedAsExpression(expr: KtExpression): Option[Boolean] = {
-    val mapForEntity = bindingsForEntity(bindingContext, expr)
-    Option(mapForEntity.get(BindingContext.USED_AS_EXPRESSION.getKey)).map(_.booleanValue())
-  }
-
   def usedAsImplicitThis(expr: KtNameReferenceExpression): Boolean = {
     val mapForEntity = bindingsForEntity(bindingContext, expr)
     val isCallExprWithTarget = Option(mapForEntity)


### PR DESCRIPTION
Replaced `usedAsExpression` usage with `KtPsiUtil.isStatment` as this is
not dependent on succesfully creating the binding context.
