### PR TITLE
[c2cpg] HeaderFileFinder: select closest header with minByOption instead of sortBy.headOption

### DIFF
--- a/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/HeaderFileFinder.scala
+++ b/joern-cli/frontends/c2cpg/src/main/scala/io/joern/c2cpg/parser/HeaderFileFinder.scala
@@ -31,8 +31,11 @@ class HeaderFileFinder(config: Config) {
     path,
     unresolvedPath =>
       Paths.get(unresolvedPath).nameOption.flatMap { name =>
-        val matches = nameToPathMap.getOrElse(name, List())
-        matches.sortBy(candidate => Levenshtein.distance(candidate, unresolvedPath)).headOption
+        nameToPathMap.getOrElse(name, List()) match {
+          case Nil           => None
+          case single :: Nil => Some(single)
+          case matches       => matches.minByOption(candidate => Levenshtein.distance(candidate, unresolvedPath))
+        }
       }
   )
 

--- a/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/parser/HeaderFileFinderTests.scala
+++ b/joern-cli/frontends/c2cpg/src/test/scala/io/joern/c2cpg/parser/HeaderFileFinderTests.scala
@@ -1,0 +1,54 @@
+package io.joern.c2cpg.parser
+
+import io.joern.c2cpg.Config
+import io.shiftleft.semanticcpg.utils.FileUtil.*
+import io.shiftleft.semanticcpg.utils.FileUtil
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.nio.file.Files
+
+class HeaderFileFinderTests extends AnyWordSpec with Matchers {
+
+  "HeaderFileFinder" should {
+
+    "return None for a basename not present in the scanned tree" in {
+      FileUtil.usingTemporaryDirectory("headerFileFinder") { dir =>
+        Files.writeString(dir / "foo.h", "#pragma once")
+        val finder = new HeaderFileFinder(Config().withInputPath(dir.toString))
+        finder.find("/some/unresolved/path/bar.h") shouldBe None
+      }
+    }
+
+    "return the only candidate for a unique basename" in {
+      FileUtil.usingTemporaryDirectory("headerFileFinder") { dir =>
+        val header = dir / "foo.h"
+        Files.writeString(header, "#pragma once")
+        val finder = new HeaderFileFinder(Config().withInputPath(dir.toString))
+        finder.find("/some/unresolved/path/foo.h") shouldBe Some(header.toString)
+      }
+    }
+
+    "select the closest match among multiple same-named headers" in {
+      FileUtil.usingTemporaryDirectory("headerFileFinder") { dir =>
+        val configDirA = dir / "include" / "platform" / "family_0001" / "config"
+        val configDirB = dir / "include" / "platform" / "family_0002" / "config"
+        Files.createDirectories(configDirA)
+        Files.createDirectories(configDirB)
+        val headerA = configDirA / "shared_config.h"
+        val headerB = configDirB / "shared_config.h"
+        Files.writeString(headerA, "#pragma once")
+        Files.writeString(headerB, "#pragma once")
+
+        val finder = new HeaderFileFinder(Config().withInputPath(dir.toString))
+        // exact path matches resolve to themselves
+        finder.find(headerA.toString) shouldBe Some(headerA.toString)
+        finder.find(headerB.toString) shouldBe Some(headerB.toString)
+        // an unresolved path resolves to the candidate with the smallest edit distance
+        val unresolved = dir / "include" / "platform" / "family_0002" / "shared_config.h"
+        finder.find(unresolved.toString) shouldBe Some(headerB.toString)
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
`HeaderFileFinder.find` selected the closest-matching header with `sortBy(...).headOption` — a full sort to take a single minimum — and since Scala's `sortBy(f)` is `sorted(ord.on(f))`, the Levenshtein key was recomputed on every comparison instead of once per candidate. On trees presenting many same-named headers (e.g. RIOT-OS with one config header per board) this dominated CPG build time; the issue reporter measured **1717.5s → 211.9s (8.1x)** on RIOT-OS, with Levenshtein evaluations dropping from 25,235,778 to 3,114,815.

### Change

```scala
nameToPathMap.getOrElse(name, List()) match {
  case Nil           => None
  case single :: Nil => Some(single)
  case matches       => matches.minByOption(candidate => Levenshtein.distance(candidate, unresolvedPath))
}
```

- `minByOption` evaluates the key once per candidate.
- The length guard keeps single-candidate lookups at zero key evaluations, matching `sorted`'s current short-circuit at length 1 — on the RIOT-OS tree 65.6% of cache misses have exactly one candidate, so a bare `minByOption` would have *added* evaluations there.
- Selection behavior is unchanged: `sorted` is stable, so `headOption` returns the first minimum in iteration order; `minByOption` replaces the incumbent only on a strictly smaller key, also returning the first minimum.

This completes #6112, which added the `findCache` memoisation (44.6% hit rate on RIOT-OS) but left the sort itself unchanged.

Credit: analysis, benchmarks, and suggested patch by @iljavs in #6280.

Fixes #6280.