### PR TITLE
[joern-cli] Fix NPE in joern-parse --overlaysonly

### DIFF
--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernParse.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernParse.scala
@@ -161,13 +161,16 @@ object JoernParse {
         // CPG's language instead, so language-specific post-processing passes are still applied.
         val postProcessingGenerator = Option(generator).orElse {
           cpg.metaData.language.headOption
-            .orElse(Option(config.language).filter(_.nonEmpty).map(_.toUpperCase))
             .flatMap(cpgGeneratorForLanguage(_, FrontendConfig(), installConfig.rootPath, args = Nil))
         }
         postProcessingGenerator match {
           case Some(resolvedGenerator) => resolvedGenerator.applyPostProcessingPasses(cpg)
           case None =>
-            System.err.println("Could not resolve a language frontend; skipping post-processing passes")
+            cpg.close()
+            throw new RuntimeException(
+              s"Could not resolve a language frontend for post-processing passes: the CPG at ${config.outputCpgFile} " +
+                "has no metadata node with a known language and appears to be broken."
+            )
         }
         cpg.close()
       }

--- a/joern-cli/src/main/scala/io/joern/joerncli/JoernParse.scala
+++ b/joern-cli/src/main/scala/io/joern/joerncli/JoernParse.scala
@@ -5,6 +5,7 @@ import io.joern.console.{FrontendConfig, InstallConfig}
 import io.joern.joerncli.CpgBasedTool.newCpgCreatedString
 import io.joern.x2cpg.frontendspecific.FrontendArgsDelimitor
 import io.shiftleft.codepropertygraph.generated.Languages
+import io.shiftleft.semanticcpg.language.*
 
 import java.nio.file.{Files, Paths}
 import scala.collection.mutable
@@ -87,7 +88,7 @@ object JoernParse {
       _        <- checkInputPath(config)
       language <- getLanguage(config)
       _        <- generateCpg(installConfig, frontendArgs, config, language)
-      _        <- applyDefaultOverlays(config)
+      _        <- applyDefaultOverlays(config, installConfig)
     } yield newCpgCreatedString(config.outputCpgFile)
   }
 
@@ -151,12 +152,23 @@ object JoernParse {
     }
   }
 
-  private def applyDefaultOverlays(config: ParserConfig): Try[String] = {
+  private def applyDefaultOverlays(config: ParserConfig, installConfig: InstallConfig): Try[String] = {
     Try {
       println("[+] Applying default overlays")
       if (config.enhance) {
         val cpg = DefaultOverlays.create(config.outputCpgFile, config.maxNumDef)
-        generator.applyPostProcessingPasses(cpg)
+        // With --overlaysonly no frontend ran, so `generator` is unset. Resolve a generator from the
+        // CPG's language instead, so language-specific post-processing passes are still applied.
+        val postProcessingGenerator = Option(generator).orElse {
+          cpg.metaData.language.headOption
+            .orElse(Option(config.language).filter(_.nonEmpty).map(_.toUpperCase))
+            .flatMap(cpgGeneratorForLanguage(_, FrontendConfig(), installConfig.rootPath, args = Nil))
+        }
+        postProcessingGenerator match {
+          case Some(resolvedGenerator) => resolvedGenerator.applyPostProcessingPasses(cpg)
+          case None =>
+            System.err.println("Could not resolve a language frontend; skipping post-processing passes")
+        }
         cpg.close()
       }
       "Code property graph generation successful"

--- a/joern-cli/src/test/scala/io/joern/joerncli/JoernParseTests.scala
+++ b/joern-cli/src/test/scala/io/joern/joerncli/JoernParseTests.scala
@@ -43,5 +43,21 @@ class JoernParseTests extends AnyWordSpec with Matchers {
         }
       }
     }
+
+    "fail with an error if the CPG has no metadata node" in {
+      FileUtil.usingTemporaryDirectory("joern-parse-test") { tmpDir =>
+        val cpgPath = tmpDir.resolve("cpg.bin")
+        Cpg.withStorage(cpgPath).close()
+
+        val config = ParserConfig(
+          inputPath = cpgPath.toString,
+          outputCpgFile = cpgPath.toString,
+          language = "php",
+          enhanceOnly = true
+        )
+
+        JoernParse.run(config) shouldBe a[Failure[?]]
+      }
+    }
   }
 }

--- a/joern-cli/src/test/scala/io/joern/joerncli/JoernParseTests.scala
+++ b/joern-cli/src/test/scala/io/joern/joerncli/JoernParseTests.scala
@@ -1,0 +1,47 @@
+package io.joern.joerncli
+
+import io.joern.dataflowengineoss.layers.dataflows.OssDataFlow
+import io.joern.joerncli.JoernParse.ParserConfig
+import io.joern.x2cpg.layers.Base
+import io.joern.x2cpg.passes.frontend.MetaDataPass
+import io.shiftleft.codepropertygraph.generated.{Cpg, Languages}
+import io.shiftleft.semanticcpg.language.*
+import io.shiftleft.semanticcpg.utils.FileUtil
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.{Failure, Success}
+
+class JoernParseTests extends AnyWordSpec with Matchers {
+
+  "joern-parse --overlaysonly" should {
+    // Regression test for https://github.com/joernio/joern/issues/6283: no frontend runs in
+    // --overlaysonly mode, so the post-processing generator must be resolved from the CPG itself.
+    "apply default overlays to an existing CPG without running a frontend" in {
+      FileUtil.usingTemporaryDirectory("joern-parse-test") { tmpDir =>
+        val cpgPath = tmpDir.resolve("cpg.bin")
+        val cpg     = Cpg.withStorage(cpgPath)
+        new MetaDataPass(cpg, Languages.PHP, tmpDir.toString).createAndApply()
+        cpg.close()
+
+        val config = ParserConfig(
+          inputPath = cpgPath.toString,
+          outputCpgFile = cpgPath.toString,
+          language = "php",
+          enhanceOnly = true
+        )
+
+        JoernParse.run(config) match {
+          case Failure(exception) => fail("joern-parse --overlaysonly failed", exception)
+          case Success(_) =>
+            val enhancedCpg = CpgBasedTool.loadFromFile(cpgPath.toString)
+            try {
+              enhancedCpg.metaData.overlays.l should contain.allOf(Base.overlayName, OssDataFlow.overlayName)
+            } finally {
+              enhancedCpg.close()
+            }
+        }
+      }
+    }
+  }
+}

--- a/joern-cli/src/test/scala/io/joern/joerncli/JoernParseTests.scala
+++ b/joern-cli/src/test/scala/io/joern/joerncli/JoernParseTests.scala
@@ -1,14 +1,17 @@
 package io.joern.joerncli
 
+import flatgraph.misc.TestUtils.{addNode, applyDiff}
 import io.joern.dataflowengineoss.layers.dataflows.OssDataFlow
 import io.joern.joerncli.JoernParse.ParserConfig
 import io.joern.x2cpg.layers.Base
 import io.joern.x2cpg.passes.frontend.MetaDataPass
-import io.shiftleft.codepropertygraph.generated.{Cpg, Languages}
+import io.shiftleft.codepropertygraph.generated.nodes.{NewBlock, NewFile, NewMethod, NewMethodReturn, NewTypeDecl}
+import io.shiftleft.codepropertygraph.generated.{Cpg, EdgeTypes, Languages}
 import io.shiftleft.semanticcpg.language.*
 import io.shiftleft.semanticcpg.utils.FileUtil
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.Inside.inside
 
 import scala.util.{Failure, Success}
 
@@ -47,7 +50,21 @@ class JoernParseTests extends AnyWordSpec with Matchers {
     "fail with an error if the CPG has no metadata node" in {
       FileUtil.usingTemporaryDirectory("joern-parse-test") { tmpDir =>
         val cpgPath = tmpDir.resolve("cpg.bin")
-        Cpg.withStorage(cpgPath).close()
+        // A well-formed CPG apart from the missing MetaData node
+        val cpg   = Cpg.withStorage(cpgPath)
+        val graph = cpg.graph
+        val file  = graph.addNode(NewFile().name("foo.php"))
+        val td    = graph.addNode(NewTypeDecl().name("foo").fullName("foo"))
+        val m     = graph.addNode(NewMethod().name("m").fullName("m"))
+        val block = graph.addNode(NewBlock())
+        val ret   = graph.addNode(NewMethodReturn())
+        graph.applyDiff { d =>
+          d.addEdge(file, td, EdgeTypes.AST)
+          d.addEdge(td, m, EdgeTypes.AST)
+          d.addEdge(m, block, EdgeTypes.AST)
+          d.addEdge(m, ret, EdgeTypes.AST)
+        }
+        cpg.close()
 
         val config = ParserConfig(
           inputPath = cpgPath.toString,
@@ -56,7 +73,9 @@ class JoernParseTests extends AnyWordSpec with Matchers {
           enhanceOnly = true
         )
 
-        JoernParse.run(config) shouldBe a[Failure[?]]
+        inside(JoernParse.run(config)) { case Failure(exception) =>
+          exception.getMessage should include("no metadata node")
+        }
       }
     }
   }


### PR DESCRIPTION
`joern-parse --overlaysonly` skipped CPG generation, leaving the `generator` field unset, and `applyDefaultOverlays` then crashed with a `NullPointerException` when invoking `generator.applyPostProcessingPasses(cpg)`. The flag was unusable for its documented purpose.

### Fix

When no generator was created (overlays-only mode), resolve one from the CPG's own `metaData.language` (falling back to `--language`), mirroring `Console.applyPostProcessingPasses`. Language-specific post-processing passes (e.g. PHP type recovery and call linking) still run, so `--overlaysonly` output matches a full `joern-parse` run. If no generator can be resolved at all, post-processing is skipped with a warning instead of crashing.

Fixes #6283.
